### PR TITLE
Release v1.1.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,11 +71,11 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ runner.os }}-php${{ matrix.php }}-composer-${{ hashFiles('**/composer.lock') }}
+          key: ${{ runner.os }}-php${{ matrix.php }}-composer-${{ hashFiles('**/composer.json') }}
           restore-keys: ${{ runner.os }}-php${{ matrix.php }}-composer-
 
       - name: Install dependencies
-        run: composer install --no-interaction --prefer-dist
+        run: composer update --no-interaction --prefer-dist
 
       - name: Run Unit tests
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,15 +3,14 @@ name: CI
 on:
   push:
     branches: [main]
-    tags:
-      - 'v*'
   pull_request:
     branches: [main]
 
 jobs:
-  build:
+  lint:
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    name: Lint
 
     steps:
       - uses: actions/checkout@v4
@@ -37,17 +36,22 @@ jobs:
       - name: Install dependencies
         run: composer install --no-interaction --prefer-dist --optimize-autoloader
 
-      - name: Upload vendor directory
-        uses: actions/upload-artifact@v4
-        with:
-          name: vendor
-          path: vendor/
-          retention-days: 1
+      - name: Run PHP-CS-Fixer
+        run: ./vendor/bin/php-cs-fixer fix --dry-run --diff
+
+      - name: Run PHPCS
+        continue-on-error: true
+        run: ./vendor/bin/phpcs src/ database/ tests/ config/
 
   test:
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    name: Test
+    name: Test (PHP ${{ matrix.php }})
+
+    strategy:
+      fail-fast: true
+      matrix:
+        php: ['8.2', '8.3', '8.4']
 
     steps:
       - uses: actions/checkout@v4
@@ -55,7 +59,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.4'
+          php-version: ${{ matrix.php }}
           extensions: dom, curl, libxml, mbstring, zip, pdo, sqlite, pdo_sqlite
           coverage: none
 
@@ -67,8 +71,8 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
-          restore-keys: ${{ runner.os }}-composer-
+          key: ${{ runner.os }}-php${{ matrix.php }}-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: ${{ runner.os }}-php${{ matrix.php }}-composer-
 
       - name: Install dependencies
         run: composer install --no-interaction --prefer-dist
@@ -76,48 +80,9 @@ jobs:
       - name: Run Unit tests
         env:
           XDEBUG_MODE: off
-        run: php vendor/bin/pest tests/Unit --no-coverage
+        run: vendor/bin/pest tests/Unit --no-coverage
 
       - name: Run Feature tests
         env:
           XDEBUG_MODE: off
-        run: php vendor/bin/pest tests/Feature --no-coverage
-
-  release:
-    needs: test
-    runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/v')
-    name: Create Release
-
-    permissions:
-      contents: write
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Extract release notes from CHANGELOG
-        id: changelog
-        run: |
-          VERSION=${GITHUB_REF#refs/tags/v}
-          echo "Extracting notes for version $VERSION"
-
-          if [ -f "CHANGELOG.md" ]; then
-            # Extract section for this version
-            NOTES=$(sed -n "/## \[$VERSION\]/,/## \[/p" CHANGELOG.md | sed '1d;$d' | sed '/^$/d')
-            if [ -z "$NOTES" ]; then
-              NOTES="Release $VERSION. See CHANGELOG.md for details."
-            fi
-          else
-            NOTES="Release $VERSION"
-          fi
-
-          # Save to file for multi-line support
-          echo "$NOTES" > release_notes.txt
-
-      - name: Create Release
-        uses: softprops/action-gh-release@v2
-        with:
-          body_path: release_notes.txt
-          generate_release_notes: false
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: vendor/bin/pest tests/Feature --no-coverage

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,103 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    name: Test before release
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.4'
+          extensions: dom, curl, libxml, mbstring, zip, pdo, sqlite, pdo_sqlite
+          coverage: none
+
+      - name: Get Composer cache directory
+        id: composer-cache
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+
+      - name: Cache Composer dependencies
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: ${{ runner.os }}-composer-
+
+      - name: Install dependencies
+        run: composer install --no-interaction --prefer-dist
+
+      - name: Run tests
+        env:
+          XDEBUG_MODE: off
+        run: vendor/bin/pest --no-coverage
+
+  release:
+    needs: test
+    runs-on: ubuntu-latest
+    name: Create Release
+
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Extract version from tag
+        id: version
+        run: echo "version=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
+
+      - name: Extract release notes from CHANGELOG
+        id: changelog
+        run: |
+          VERSION=${{ steps.version.outputs.version }}
+          echo "Extracting notes for version $VERSION"
+
+          if [ ! -f "CHANGELOG.md" ]; then
+            echo "body=Release v$VERSION" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          # Extract the section between this version header and the next version header
+          NOTES=$(awk -v ver="$VERSION" '
+            /^## \[/ {
+              if (found) exit
+              if (index($0, "[" ver "]")) { found=1; next }
+            }
+            found { print }
+          ' CHANGELOG.md)
+
+          # Remove leading/trailing blank lines
+          NOTES=$(echo "$NOTES" | sed '/./,$!d' | sed -e :a -e '/^\n*$/{$d;N;ba' -e '}')
+
+          if [ -z "$NOTES" ]; then
+            NOTES="Release v$VERSION — see CHANGELOG.md for details."
+          fi
+
+          # Write to file for multi-line support
+          echo "$NOTES" > release_notes.txt
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          name: v${{ steps.version.outputs.version }}
+          body_path: release_notes.txt
+          generate_release_notes: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Update Packagist
+        if: success()
+        run: |
+          curl -s -X POST \
+            "https://packagist.org/api/update-package?username=${{ secrets.PACKAGIST_USERNAME }}&apiToken=${{ secrets.PACKAGIST_API_TOKEN }}" \
+            -d "{\"repository\":{\"url\":\"https://github.com/${{ github.repository }}\"}}" \
+            -H "Content-Type: application/json"

--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,8 @@ vendor/
 tests/coverage/
 .phpunit.cache/
 
+# PHP-CS-Fixer cache
+.php-cs-fixer.cache
+
 # Claude local settings
 .claude/settings.local.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+## [1.1.0] - 2026-04-06
+
+### Added
+
+- Bulk action API endpoints for posts, pages, and users (publish, unpublish, trash, restore, delete)
+- OpenAPI specification generation for all API endpoints via Scramble
+- `include` query parameter for on-demand relationship loading across API endpoints
+- TypeScript type definitions for all API responses and models
+- GitHub Actions CI workflow with lint and test jobs
+- GitHub Actions release workflow with changelog-based release notes and Packagist integration
+- Claude Code and Claude Code Review GitHub Actions workflows
+- Auto-assign milestone workflow for new issues
+- GitHub issue and pull request templates
+
+### Changed
+
+- Standardized JSON error response format across all API endpoints
+- Extracted shared manifest parsing and discovery logic into `HasManifestParsing` trait
+- Extracted shared content query and filter logic into reusable traits
+- Converted `UpdateInfo::hasUpdate` from stored state to a computed method
+- Replaced magic strings with enums: `ContentStatus`, `SettingType`, `FieldType`, `ColumnType`, `UpdateType`
+- Hoisted policy and permission resolution before loops in bulk actions
+- Added php-cs-fixer and ran code style formatting across the package
+- Updated PHP version requirement to 8.4 for CI
+- Migrated repository from GitLab to GitHub
+
+### Fixed
+
+- Sanitized error responses and normalized `published_at` in bulk actions
+- Corrected LIKE wildcard escaping order and added ESCAPE clause
+- Hardened URL parsing and cache serialization in update sources
+- Fixed incorrect `@since 2.0.0` tags to `@since 1.0.0` in update test files
+
 ## [1.0.1] - 2026-01-09
 
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -42,14 +42,16 @@
     "pestphp/pest": "^3.8",
     "pestphp/pest-plugin-laravel": "^3.2",
     "fakerphp/faker": "^1.23",
+    "friendsofphp/php-cs-fixer": "^3.75",
     "laravel/pail": "^1.2.2",
-    "laravel/pint": "^1.18",
+    "laravel/pint": "^1.26",
     "laravel/sail": "^1.41",
     "mockery/mockery": "^1.6",
     "nunomaduro/collision": "^8.6",
     "squizlabs/php_codesniffer": "3.11.3",
     "orchestra/testbench": "^10.2",
-    "artisanpack-ui/code-style": "^1.0.3",
+    "artisanpack-ui/code-style": "^1.1",
+    "artisanpack-ui/code-style-pint": "^1.1",
     "dealerdirect/phpcodesniffer-composer-installer": "^1.0"
   },
   "config": {
@@ -74,7 +76,12 @@
     "test:coverage-min": "vendor/bin/pest --coverage --min=80",
     "test:unit": "vendor/bin/pest tests/Unit",
     "test:feature": "vendor/bin/pest tests/Feature",
-    "phpcs": "vendor/bin/phpcs",
-    "phpcs:fix": "vendor/bin/phpcbf"
+    "lint": [
+      "./vendor/bin/php-cs-fixer fix --dry-run --diff",
+      "./vendor/bin/phpcs"
+    ],
+    "fix": "./vendor/bin/php-cs-fixer fix",
+    "cs": "./vendor/bin/phpcs",
+    "cs:fix": "./vendor/bin/phpcbf"
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,8 @@
     "artisanpack-ui/accessibility": "^2.1.0",
     "artisanpack-ui/security": "^1.0.3",
     "artisanpack-ui/core": "^1.0",
-    "artisanpack-ui/hooks": "^1.1"
+    "artisanpack-ui/hooks": "^1.1",
+    "dedoc/scramble": "^0.12 || ^0.13"
   },
   "require-dev": {
     "pestphp/pest": "^3.8",

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "description": "Adds in the back end support for building a CMS with any front end framework.",
   "type": "library",
   "license": "MIT",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "autoload": {
     "psr-4": {
       "ArtisanPackUI\\CMSFramework\\": "src/",
@@ -78,10 +78,10 @@
     "test:feature": "vendor/bin/pest tests/Feature",
     "lint": [
       "./vendor/bin/php-cs-fixer fix --dry-run --diff",
-      "./vendor/bin/phpcs"
+      "./vendor/bin/phpcs src/ database/ tests/ config/"
     ],
     "fix": "./vendor/bin/php-cs-fixer fix",
-    "cs": "./vendor/bin/phpcs",
+    "cs": "./vendor/bin/phpcs src/ database/ tests/ config/",
     "cs:fix": "./vendor/bin/phpcbf"
   }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b236656b4f9f0997262e11399112d7b2",
+    "content-hash": "93b3dbd8864ebe1fd031830abf454eb4",
     "packages": [
         {
             "name": "artisanpack-ui/accessibility",
@@ -6578,12 +6578,12 @@
             "version": "1.1.0",
             "source": {
                 "type": "git",
-                "url": "https://gitlab.com/jacob-martella-web-design/artisanpack-ui/artisanpack-ui-code-style.git",
+                "url": "https://github.com/ArtisanPack-UI/code-style.git",
                 "reference": "c515b88b18ba99b758f1a22279701bbb7c79cf1b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://gitlab.com/api/v4/projects/jacob-martella-web-design%2Fartisanpack-ui%2Fartisanpack-ui-code-style/repository/archive.zip?sha=c515b88b18ba99b758f1a22279701bbb7c79cf1b",
+                "url": "https://api.github.com/repos/ArtisanPack-UI/code-style/zipball/c515b88b18ba99b758f1a22279701bbb7c79cf1b",
                 "reference": "c515b88b18ba99b758f1a22279701bbb7c79cf1b",
                 "shasum": ""
             },
@@ -6622,10 +6622,72 @@
             ],
             "description": "A custom PHP code style standard based on PHPStorm settings. This package provides custom sniffs for PHP_CodeSniffer that enforce consistent code style across your PHP projects.",
             "support": {
-                "issues": "https://gitlab.com/jacob-martella-web-design/artisanpack-ui/artisanpack-ui-code-style/-/issues",
-                "source": "https://gitlab.com/jacob-martella-web-design/artisanpack-ui/artisanpack-ui-code-style/-/tree/v1.1.0"
+                "issues": "https://github.com/ArtisanPack-UI/code-style/issues",
+                "source": "https://github.com/ArtisanPack-UI/code-style/tree/v1.1.0"
             },
             "time": "2025-11-22T21:01:09+00:00"
+        },
+        {
+            "name": "artisanpack-ui/code-style-pint",
+            "version": "1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ArtisanPack-UI/code-style-pint.git",
+                "reference": "31997861d7564c044a7c7b93df792cafcb93dab6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ArtisanPack-UI/code-style-pint/zipball/31997861d7564c044a7c7b93df792cafcb93dab6",
+                "reference": "31997861d7564c044a7c7b93df792cafcb93dab6",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/support": "^10.0|^11.0|^12.0",
+                "php": "^8.2"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^3.0",
+                "laravel/pint": "^1.0",
+                "orchestra/testbench": "^9.0|^10.0",
+                "pestphp/pest": "^3.8",
+                "pestphp/pest-plugin-laravel": "^3.1"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "ArtisanPackUI\\CodeStylePint\\CodeStylePintServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "ArtisanPackUI\\CodeStylePint\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Jacob Martella",
+                    "email": "me@jacobmartella.com"
+                }
+            ],
+            "description": "Laravel Pint preset for ArtisanPack UI code standards",
+            "keywords": [
+                "Pint",
+                "artisanpack",
+                "code-style",
+                "laravel",
+                "php-cs-fixer"
+            ],
+            "support": {
+                "issues": "https://github.com/ArtisanPack-UI/code-style-pint/issues",
+                "source": "https://github.com/ArtisanPack-UI/code-style-pint/tree/v1.1.0"
+            },
+            "time": "2025-11-23T21:13:56+00:00"
         },
         {
             "name": "brianium/paratest",
@@ -6721,6 +6783,149 @@
             "time": "2025-06-23T06:07:21+00:00"
         },
         {
+            "name": "clue/ndjson-react",
+            "version": "v1.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/clue/reactphp-ndjson.git",
+                "reference": "392dc165fce93b5bb5c637b67e59619223c931b0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/clue/reactphp-ndjson/zipball/392dc165fce93b5bb5c637b67e59619223c931b0",
+                "reference": "392dc165fce93b5bb5c637b67e59619223c931b0",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3",
+                "react/stream": "^1.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.5 || ^5.7 || ^4.8.35",
+                "react/event-loop": "^1.2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Clue\\React\\NDJson\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Christian Lück",
+                    "email": "christian@clue.engineering"
+                }
+            ],
+            "description": "Streaming newline-delimited JSON (NDJSON) parser and encoder for ReactPHP.",
+            "homepage": "https://github.com/clue/reactphp-ndjson",
+            "keywords": [
+                "NDJSON",
+                "json",
+                "jsonlines",
+                "newline",
+                "reactphp",
+                "streaming"
+            ],
+            "support": {
+                "issues": "https://github.com/clue/reactphp-ndjson/issues",
+                "source": "https://github.com/clue/reactphp-ndjson/tree/v1.3.0"
+            },
+            "funding": [
+                {
+                    "url": "https://clue.engineering/support",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/clue",
+                    "type": "github"
+                }
+            ],
+            "time": "2022-12-23T10:58:28+00:00"
+        },
+        {
+            "name": "composer/pcre",
+            "version": "3.3.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/pcre.git",
+                "reference": "b2bed4734f0cc156ee1fe9c0da2550420d99a21e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/pcre/zipball/b2bed4734f0cc156ee1fe9c0da2550420d99a21e",
+                "reference": "b2bed4734f0cc156ee1fe9c0da2550420d99a21e",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4 || ^8.0"
+            },
+            "conflict": {
+                "phpstan/phpstan": "<1.11.10"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^1.12 || ^2",
+                "phpstan/phpstan-strict-rules": "^1 || ^2",
+                "phpunit/phpunit": "^8 || ^9"
+            },
+            "type": "library",
+            "extra": {
+                "phpstan": {
+                    "includes": [
+                        "extension.neon"
+                    ]
+                },
+                "branch-alias": {
+                    "dev-main": "3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Composer\\Pcre\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "http://seld.be"
+                }
+            ],
+            "description": "PCRE wrapping library that offers type-safe preg_* replacements.",
+            "keywords": [
+                "PCRE",
+                "preg",
+                "regex",
+                "regular expression"
+            ],
+            "support": {
+                "issues": "https://github.com/composer/pcre/issues",
+                "source": "https://github.com/composer/pcre/tree/3.3.2"
+            },
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/composer",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-11-12T16:29:46+00:00"
+        },
+        {
             "name": "composer/semver",
             "version": "3.4.4",
             "source": {
@@ -6796,6 +7001,72 @@
                 }
             ],
             "time": "2025-08-20T19:15:30+00:00"
+        },
+        {
+            "name": "composer/xdebug-handler",
+            "version": "3.0.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/xdebug-handler.git",
+                "reference": "6c1925561632e83d60a44492e0b344cf48ab85ef"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/xdebug-handler/zipball/6c1925561632e83d60a44492e0b344cf48ab85ef",
+                "reference": "6c1925561632e83d60a44492e0b344cf48ab85ef",
+                "shasum": ""
+            },
+            "require": {
+                "composer/pcre": "^1 || ^2 || ^3",
+                "php": "^7.2.5 || ^8.0",
+                "psr/log": "^1 || ^2 || ^3"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^1.0",
+                "phpstan/phpstan-strict-rules": "^1.1",
+                "phpunit/phpunit": "^8.5 || ^9.6 || ^10.5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Composer\\XdebugHandler\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "John Stevenson",
+                    "email": "john-stevenson@blueyonder.co.uk"
+                }
+            ],
+            "description": "Restarts a process without Xdebug.",
+            "keywords": [
+                "Xdebug",
+                "performance"
+            ],
+            "support": {
+                "irc": "ircs://irc.libera.chat:6697/composer",
+                "issues": "https://github.com/composer/xdebug-handler/issues",
+                "source": "https://github.com/composer/xdebug-handler/tree/3.0.5"
+            },
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/composer",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-05-06T16:37:16+00:00"
         },
         {
             "name": "dealerdirect/phpcodesniffer-composer-installer",
@@ -6940,6 +7211,53 @@
                 "source": "https://github.com/doctrine/deprecations/tree/1.1.5"
             },
             "time": "2025-04-07T20:06:18+00:00"
+        },
+        {
+            "name": "evenement/evenement",
+            "version": "v3.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/igorw/evenement.git",
+                "reference": "0a16b0d71ab13284339abb99d9d2bd813640efbc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/igorw/evenement/zipball/0a16b0d71ab13284339abb99d9d2bd813640efbc",
+                "reference": "0a16b0d71ab13284339abb99d9d2bd813640efbc",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9 || ^6"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Evenement\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Igor Wiedler",
+                    "email": "igor@wiedler.ch"
+                }
+            ],
+            "description": "Événement is a very simple event dispatching library for PHP",
+            "keywords": [
+                "event-dispatcher",
+                "event-emitter"
+            ],
+            "support": {
+                "issues": "https://github.com/igorw/evenement/issues",
+                "source": "https://github.com/igorw/evenement/tree/v3.0.2"
+            },
+            "time": "2023-08-08T05:53:35+00:00"
         },
         {
             "name": "fakerphp/faker",
@@ -7137,6 +7455,110 @@
             "time": "2025-08-08T12:00:00+00:00"
         },
         {
+            "name": "friendsofphp/php-cs-fixer",
+            "version": "v3.94.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer.git",
+                "reference": "7787ceff91365ba7d623ec410b8f429cdebb4f63"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHP-CS-Fixer/PHP-CS-Fixer/zipball/7787ceff91365ba7d623ec410b8f429cdebb4f63",
+                "reference": "7787ceff91365ba7d623ec410b8f429cdebb4f63",
+                "shasum": ""
+            },
+            "require": {
+                "clue/ndjson-react": "^1.3",
+                "composer/semver": "^3.4",
+                "composer/xdebug-handler": "^3.0.5",
+                "ext-filter": "*",
+                "ext-hash": "*",
+                "ext-json": "*",
+                "ext-tokenizer": "*",
+                "fidry/cpu-core-counter": "^1.3",
+                "php": "^7.4 || ^8.0",
+                "react/child-process": "^0.6.6",
+                "react/event-loop": "^1.5",
+                "react/socket": "^1.16",
+                "react/stream": "^1.4",
+                "sebastian/diff": "^4.0.6 || ^5.1.1 || ^6.0.2 || ^7.0 || ^8.0",
+                "symfony/console": "^5.4.47 || ^6.4.24 || ^7.0 || ^8.0",
+                "symfony/event-dispatcher": "^5.4.45 || ^6.4.24 || ^7.0 || ^8.0",
+                "symfony/filesystem": "^5.4.45 || ^6.4.24 || ^7.0 || ^8.0",
+                "symfony/finder": "^5.4.45 || ^6.4.24 || ^7.0 || ^8.0",
+                "symfony/options-resolver": "^5.4.45 || ^6.4.24 || ^7.0 || ^8.0",
+                "symfony/polyfill-mbstring": "^1.33",
+                "symfony/polyfill-php80": "^1.33",
+                "symfony/polyfill-php81": "^1.33",
+                "symfony/polyfill-php84": "^1.33",
+                "symfony/process": "^5.4.47 || ^6.4.24 || ^7.2 || ^8.0",
+                "symfony/stopwatch": "^5.4.45 || ^6.4.24 || ^7.0 || ^8.0"
+            },
+            "require-dev": {
+                "facile-it/paraunit": "^1.3.1 || ^2.7.1",
+                "infection/infection": "^0.32.3",
+                "justinrainbow/json-schema": "^6.6.4",
+                "keradus/cli-executor": "^2.3",
+                "mikey179/vfsstream": "^1.6.12",
+                "php-coveralls/php-coveralls": "^2.9.1",
+                "php-cs-fixer/phpunit-constraint-isidenticalstring": "^1.7",
+                "php-cs-fixer/phpunit-constraint-xmlmatchesxsd": "^1.7",
+                "phpunit/phpunit": "^9.6.34 || ^10.5.63 || ^11.5.51",
+                "symfony/polyfill-php85": "^1.33",
+                "symfony/var-dumper": "^5.4.48 || ^6.4.32 || ^7.4.4 || ^8.0.4",
+                "symfony/yaml": "^5.4.45 || ^6.4.30 || ^7.4.1 || ^8.0.1"
+            },
+            "suggest": {
+                "ext-dom": "For handling output formats in XML",
+                "ext-mbstring": "For handling non-UTF8 characters."
+            },
+            "bin": [
+                "php-cs-fixer"
+            ],
+            "type": "application",
+            "autoload": {
+                "psr-4": {
+                    "PhpCsFixer\\": "src/"
+                },
+                "exclude-from-classmap": [
+                    "src/**/Internal/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Dariusz Rumiński",
+                    "email": "dariusz.ruminski@gmail.com"
+                }
+            ],
+            "description": "A tool to automatically fix PHP code style",
+            "keywords": [
+                "Static code analysis",
+                "fixer",
+                "standards",
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues",
+                "source": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/tree/v3.94.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/keradus",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-02-20T16:13:53+00:00"
+        },
+        {
             "name": "hamcrest/hamcrest-php",
             "version": "v2.1.1",
             "source": {
@@ -7328,16 +7750,16 @@
         },
         {
             "name": "laravel/pint",
-            "version": "v1.26.0",
+            "version": "v1.29.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/pint.git",
-                "reference": "69dcca060ecb15e4b564af63d1f642c81a241d6f"
+                "reference": "bdec963f53172c5e36330f3a400604c69bf02d39"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/pint/zipball/69dcca060ecb15e4b564af63d1f642c81a241d6f",
-                "reference": "69dcca060ecb15e4b564af63d1f642c81a241d6f",
+                "url": "https://api.github.com/repos/laravel/pint/zipball/bdec963f53172c5e36330f3a400604c69bf02d39",
+                "reference": "bdec963f53172c5e36330f3a400604c69bf02d39",
                 "shasum": ""
             },
             "require": {
@@ -7348,13 +7770,14 @@
                 "php": "^8.2.0"
             },
             "require-dev": {
-                "friendsofphp/php-cs-fixer": "^3.90.0",
-                "illuminate/view": "^12.40.1",
-                "larastan/larastan": "^3.8.0",
-                "laravel-zero/framework": "^12.0.4",
+                "friendsofphp/php-cs-fixer": "^3.94.2",
+                "illuminate/view": "^12.54.1",
+                "larastan/larastan": "^3.9.3",
+                "laravel-zero/framework": "^12.0.5",
                 "mockery/mockery": "^1.6.12",
-                "nunomaduro/termwind": "^2.3.3",
-                "pestphp/pest": "^3.8.4"
+                "nunomaduro/termwind": "^2.4.0",
+                "pestphp/pest": "^3.8.6",
+                "shipfastlabs/agent-detector": "^1.1.0"
             },
             "bin": [
                 "builds/pint"
@@ -7391,7 +7814,7 @@
                 "issues": "https://github.com/laravel/pint/issues",
                 "source": "https://github.com/laravel/pint"
             },
-            "time": "2025-11-25T21:15:52+00:00"
+            "time": "2026-03-12T15:51:39+00:00"
         },
         {
             "name": "laravel/sail",
@@ -9191,6 +9614,532 @@
             "time": "2025-08-16T05:19:02+00:00"
         },
         {
+            "name": "react/cache",
+            "version": "v1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/reactphp/cache.git",
+                "reference": "d47c472b64aa5608225f47965a484b75c7817d5b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/reactphp/cache/zipball/d47c472b64aa5608225f47965a484b75c7817d5b",
+                "reference": "d47c472b64aa5608225f47965a484b75c7817d5b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0",
+                "react/promise": "^3.0 || ^2.0 || ^1.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.5 || ^5.7 || ^4.8.35"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "React\\Cache\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Christian Lück",
+                    "email": "christian@clue.engineering",
+                    "homepage": "https://clue.engineering/"
+                },
+                {
+                    "name": "Cees-Jan Kiewiet",
+                    "email": "reactphp@ceesjankiewiet.nl",
+                    "homepage": "https://wyrihaximus.net/"
+                },
+                {
+                    "name": "Jan Sorgalla",
+                    "email": "jsorgalla@gmail.com",
+                    "homepage": "https://sorgalla.com/"
+                },
+                {
+                    "name": "Chris Boden",
+                    "email": "cboden@gmail.com",
+                    "homepage": "https://cboden.dev/"
+                }
+            ],
+            "description": "Async, Promise-based cache interface for ReactPHP",
+            "keywords": [
+                "cache",
+                "caching",
+                "promise",
+                "reactphp"
+            ],
+            "support": {
+                "issues": "https://github.com/reactphp/cache/issues",
+                "source": "https://github.com/reactphp/cache/tree/v1.2.0"
+            },
+            "funding": [
+                {
+                    "url": "https://opencollective.com/reactphp",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2022-11-30T15:59:55+00:00"
+        },
+        {
+            "name": "react/child-process",
+            "version": "v0.6.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/reactphp/child-process.git",
+                "reference": "970f0e71945556422ee4570ccbabaedc3cf04ad3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/reactphp/child-process/zipball/970f0e71945556422ee4570ccbabaedc3cf04ad3",
+                "reference": "970f0e71945556422ee4570ccbabaedc3cf04ad3",
+                "shasum": ""
+            },
+            "require": {
+                "evenement/evenement": "^3.0 || ^2.0 || ^1.0",
+                "php": ">=5.3.0",
+                "react/event-loop": "^1.2",
+                "react/stream": "^1.4"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.6 || ^5.7 || ^4.8.36",
+                "react/socket": "^1.16",
+                "sebastian/environment": "^5.0 || ^3.0 || ^2.0 || ^1.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "React\\ChildProcess\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Christian Lück",
+                    "email": "christian@clue.engineering",
+                    "homepage": "https://clue.engineering/"
+                },
+                {
+                    "name": "Cees-Jan Kiewiet",
+                    "email": "reactphp@ceesjankiewiet.nl",
+                    "homepage": "https://wyrihaximus.net/"
+                },
+                {
+                    "name": "Jan Sorgalla",
+                    "email": "jsorgalla@gmail.com",
+                    "homepage": "https://sorgalla.com/"
+                },
+                {
+                    "name": "Chris Boden",
+                    "email": "cboden@gmail.com",
+                    "homepage": "https://cboden.dev/"
+                }
+            ],
+            "description": "Event-driven library for executing child processes with ReactPHP.",
+            "keywords": [
+                "event-driven",
+                "process",
+                "reactphp"
+            ],
+            "support": {
+                "issues": "https://github.com/reactphp/child-process/issues",
+                "source": "https://github.com/reactphp/child-process/tree/v0.6.7"
+            },
+            "funding": [
+                {
+                    "url": "https://opencollective.com/reactphp",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2025-12-23T15:25:20+00:00"
+        },
+        {
+            "name": "react/dns",
+            "version": "v1.14.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/reactphp/dns.git",
+                "reference": "7562c05391f42701c1fccf189c8225fece1cd7c3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/reactphp/dns/zipball/7562c05391f42701c1fccf189c8225fece1cd7c3",
+                "reference": "7562c05391f42701c1fccf189c8225fece1cd7c3",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0",
+                "react/cache": "^1.0 || ^0.6 || ^0.5",
+                "react/event-loop": "^1.2",
+                "react/promise": "^3.2 || ^2.7 || ^1.2.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.6 || ^5.7 || ^4.8.36",
+                "react/async": "^4.3 || ^3 || ^2",
+                "react/promise-timer": "^1.11"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "React\\Dns\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Christian Lück",
+                    "email": "christian@clue.engineering",
+                    "homepage": "https://clue.engineering/"
+                },
+                {
+                    "name": "Cees-Jan Kiewiet",
+                    "email": "reactphp@ceesjankiewiet.nl",
+                    "homepage": "https://wyrihaximus.net/"
+                },
+                {
+                    "name": "Jan Sorgalla",
+                    "email": "jsorgalla@gmail.com",
+                    "homepage": "https://sorgalla.com/"
+                },
+                {
+                    "name": "Chris Boden",
+                    "email": "cboden@gmail.com",
+                    "homepage": "https://cboden.dev/"
+                }
+            ],
+            "description": "Async DNS resolver for ReactPHP",
+            "keywords": [
+                "async",
+                "dns",
+                "dns-resolver",
+                "reactphp"
+            ],
+            "support": {
+                "issues": "https://github.com/reactphp/dns/issues",
+                "source": "https://github.com/reactphp/dns/tree/v1.14.0"
+            },
+            "funding": [
+                {
+                    "url": "https://opencollective.com/reactphp",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2025-11-18T19:34:28+00:00"
+        },
+        {
+            "name": "react/event-loop",
+            "version": "v1.6.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/reactphp/event-loop.git",
+                "reference": "ba276bda6083df7e0050fd9b33f66ad7a4ac747a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/reactphp/event-loop/zipball/ba276bda6083df7e0050fd9b33f66ad7a4ac747a",
+                "reference": "ba276bda6083df7e0050fd9b33f66ad7a4ac747a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.6 || ^5.7 || ^4.8.36"
+            },
+            "suggest": {
+                "ext-pcntl": "For signal handling support when using the StreamSelectLoop"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "React\\EventLoop\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Christian Lück",
+                    "email": "christian@clue.engineering",
+                    "homepage": "https://clue.engineering/"
+                },
+                {
+                    "name": "Cees-Jan Kiewiet",
+                    "email": "reactphp@ceesjankiewiet.nl",
+                    "homepage": "https://wyrihaximus.net/"
+                },
+                {
+                    "name": "Jan Sorgalla",
+                    "email": "jsorgalla@gmail.com",
+                    "homepage": "https://sorgalla.com/"
+                },
+                {
+                    "name": "Chris Boden",
+                    "email": "cboden@gmail.com",
+                    "homepage": "https://cboden.dev/"
+                }
+            ],
+            "description": "ReactPHP's core reactor event loop that libraries can use for evented I/O.",
+            "keywords": [
+                "asynchronous",
+                "event-loop"
+            ],
+            "support": {
+                "issues": "https://github.com/reactphp/event-loop/issues",
+                "source": "https://github.com/reactphp/event-loop/tree/v1.6.0"
+            },
+            "funding": [
+                {
+                    "url": "https://opencollective.com/reactphp",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2025-11-17T20:46:25+00:00"
+        },
+        {
+            "name": "react/promise",
+            "version": "v3.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/reactphp/promise.git",
+                "reference": "23444f53a813a3296c1368bb104793ce8d88f04a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/reactphp/promise/zipball/23444f53a813a3296c1368bb104793ce8d88f04a",
+                "reference": "23444f53a813a3296c1368bb104793ce8d88f04a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1.0"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "1.12.28 || 1.4.10",
+                "phpunit/phpunit": "^9.6 || ^7.5"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/functions_include.php"
+                ],
+                "psr-4": {
+                    "React\\Promise\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jan Sorgalla",
+                    "email": "jsorgalla@gmail.com",
+                    "homepage": "https://sorgalla.com/"
+                },
+                {
+                    "name": "Christian Lück",
+                    "email": "christian@clue.engineering",
+                    "homepage": "https://clue.engineering/"
+                },
+                {
+                    "name": "Cees-Jan Kiewiet",
+                    "email": "reactphp@ceesjankiewiet.nl",
+                    "homepage": "https://wyrihaximus.net/"
+                },
+                {
+                    "name": "Chris Boden",
+                    "email": "cboden@gmail.com",
+                    "homepage": "https://cboden.dev/"
+                }
+            ],
+            "description": "A lightweight implementation of CommonJS Promises/A for PHP",
+            "keywords": [
+                "promise",
+                "promises"
+            ],
+            "support": {
+                "issues": "https://github.com/reactphp/promise/issues",
+                "source": "https://github.com/reactphp/promise/tree/v3.3.0"
+            },
+            "funding": [
+                {
+                    "url": "https://opencollective.com/reactphp",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2025-08-19T18:57:03+00:00"
+        },
+        {
+            "name": "react/socket",
+            "version": "v1.17.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/reactphp/socket.git",
+                "reference": "ef5b17b81f6f60504c539313f94f2d826c5faa08"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/reactphp/socket/zipball/ef5b17b81f6f60504c539313f94f2d826c5faa08",
+                "reference": "ef5b17b81f6f60504c539313f94f2d826c5faa08",
+                "shasum": ""
+            },
+            "require": {
+                "evenement/evenement": "^3.0 || ^2.0 || ^1.0",
+                "php": ">=5.3.0",
+                "react/dns": "^1.13",
+                "react/event-loop": "^1.2",
+                "react/promise": "^3.2 || ^2.6 || ^1.2.1",
+                "react/stream": "^1.4"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.6 || ^5.7 || ^4.8.36",
+                "react/async": "^4.3 || ^3.3 || ^2",
+                "react/promise-stream": "^1.4",
+                "react/promise-timer": "^1.11"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "React\\Socket\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Christian Lück",
+                    "email": "christian@clue.engineering",
+                    "homepage": "https://clue.engineering/"
+                },
+                {
+                    "name": "Cees-Jan Kiewiet",
+                    "email": "reactphp@ceesjankiewiet.nl",
+                    "homepage": "https://wyrihaximus.net/"
+                },
+                {
+                    "name": "Jan Sorgalla",
+                    "email": "jsorgalla@gmail.com",
+                    "homepage": "https://sorgalla.com/"
+                },
+                {
+                    "name": "Chris Boden",
+                    "email": "cboden@gmail.com",
+                    "homepage": "https://cboden.dev/"
+                }
+            ],
+            "description": "Async, streaming plaintext TCP/IP and secure TLS socket server and client connections for ReactPHP",
+            "keywords": [
+                "Connection",
+                "Socket",
+                "async",
+                "reactphp",
+                "stream"
+            ],
+            "support": {
+                "issues": "https://github.com/reactphp/socket/issues",
+                "source": "https://github.com/reactphp/socket/tree/v1.17.0"
+            },
+            "funding": [
+                {
+                    "url": "https://opencollective.com/reactphp",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2025-11-19T20:47:34+00:00"
+        },
+        {
+            "name": "react/stream",
+            "version": "v1.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/reactphp/stream.git",
+                "reference": "1e5b0acb8fe55143b5b426817155190eb6f5b18d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/reactphp/stream/zipball/1e5b0acb8fe55143b5b426817155190eb6f5b18d",
+                "reference": "1e5b0acb8fe55143b5b426817155190eb6f5b18d",
+                "shasum": ""
+            },
+            "require": {
+                "evenement/evenement": "^3.0 || ^2.0 || ^1.0",
+                "php": ">=5.3.8",
+                "react/event-loop": "^1.2"
+            },
+            "require-dev": {
+                "clue/stream-filter": "~1.2",
+                "phpunit/phpunit": "^9.6 || ^5.7 || ^4.8.36"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "React\\Stream\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Christian Lück",
+                    "email": "christian@clue.engineering",
+                    "homepage": "https://clue.engineering/"
+                },
+                {
+                    "name": "Cees-Jan Kiewiet",
+                    "email": "reactphp@ceesjankiewiet.nl",
+                    "homepage": "https://wyrihaximus.net/"
+                },
+                {
+                    "name": "Jan Sorgalla",
+                    "email": "jsorgalla@gmail.com",
+                    "homepage": "https://sorgalla.com/"
+                },
+                {
+                    "name": "Chris Boden",
+                    "email": "cboden@gmail.com",
+                    "homepage": "https://cboden.dev/"
+                }
+            ],
+            "description": "Event-driven readable and writable streams for non-blocking I/O in ReactPHP",
+            "keywords": [
+                "event-driven",
+                "io",
+                "non-blocking",
+                "pipe",
+                "reactphp",
+                "readable",
+                "stream",
+                "writable"
+            ],
+            "support": {
+                "issues": "https://github.com/reactphp/stream/issues",
+                "source": "https://github.com/reactphp/stream/tree/v1.4.0"
+            },
+            "funding": [
+                {
+                    "url": "https://opencollective.com/reactphp",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2024-06-11T12:45:25+00:00"
+        },
+        {
             "name": "sebastian/cli-parser",
             "version": "3.0.2",
             "source": {
@@ -10311,6 +11260,293 @@
                 }
             ],
             "time": "2024-10-20T05:08:20+00:00"
+        },
+        {
+            "name": "symfony/filesystem",
+            "version": "v8.0.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/filesystem.git",
+                "reference": "66b769ae743ce2d13e435528fbef4af03d623e5a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/66b769ae743ce2d13e435528fbef4af03d623e5a",
+                "reference": "66b769ae743ce2d13e435528fbef4af03d623e5a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.4",
+                "symfony/polyfill-ctype": "~1.8",
+                "symfony/polyfill-mbstring": "~1.8"
+            },
+            "require-dev": {
+                "symfony/process": "^7.4|^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Filesystem\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides basic utilities for the filesystem",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/filesystem/tree/v8.0.8"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-03-30T15:14:47+00:00"
+        },
+        {
+            "name": "symfony/options-resolver",
+            "version": "v8.0.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/options-resolver.git",
+                "reference": "b48bce0a70b914f6953dafbd10474df232ed4de8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/options-resolver/zipball/b48bce0a70b914f6953dafbd10474df232ed4de8",
+                "reference": "b48bce0a70b914f6953dafbd10474df232ed4de8",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.4",
+                "symfony/deprecation-contracts": "^2.5|^3"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\OptionsResolver\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides an improved replacement for the array_replace PHP function",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "config",
+                "configuration",
+                "options"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/options-resolver/tree/v8.0.8"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-03-30T15:14:47+00:00"
+        },
+        {
+            "name": "symfony/polyfill-php81",
+            "version": "v1.33.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-php81.git",
+                "reference": "4a4cfc2d253c21a5ad0e53071df248ed48c6ce5c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-php81/zipball/4a4cfc2d253c21a5ad0e53071df248ed48c6ce5c",
+                "reference": "4a4cfc2d253c21a5ad0e53071df248ed48c6ce5c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php81\\": ""
+                },
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 8.1+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-php81/tree/v1.33.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-09-09T11:45:10+00:00"
+        },
+        {
+            "name": "symfony/stopwatch",
+            "version": "v8.0.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/stopwatch.git",
+                "reference": "85954ed72d5440ea4dc9a10b7e49e01df766ffa3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/stopwatch/zipball/85954ed72d5440ea4dc9a10b7e49e01df766ffa3",
+                "reference": "85954ed72d5440ea4dc9a10b7e49e01df766ffa3",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.4",
+                "symfony/service-contracts": "^2.5|^3"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Stopwatch\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides a way to profile code",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/stopwatch/tree/v8.0.8"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-03-30T15:14:47+00:00"
         },
         {
             "name": "symfony/yaml",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "780cd712dd7e3bda435bcadfac763a30",
+    "content-hash": "b236656b4f9f0997262e11399112d7b2",
     "packages": [
         {
             "name": "artisanpack-ui/accessibility",
@@ -401,6 +401,86 @@
                 }
             ],
             "time": "2024-02-09T16:56:22+00:00"
+        },
+        {
+            "name": "dedoc/scramble",
+            "version": "v0.13.17",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/dedoc/scramble.git",
+                "reference": "f7b1652316e3ed0243389837158128c8c1c8bfda"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/dedoc/scramble/zipball/f7b1652316e3ed0243389837158128c8c1c8bfda",
+                "reference": "f7b1652316e3ed0243389837158128c8c1c8bfda",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/contracts": "^10.0|^11.0|^12.0|^13.0",
+                "myclabs/deep-copy": "^1.12",
+                "nikic/php-parser": "^5.0",
+                "php": "^8.1",
+                "phpstan/phpdoc-parser": "^1.0|^2.0",
+                "spatie/laravel-package-tools": "^1.9.2"
+            },
+            "require-dev": {
+                "larastan/larastan": "^3.3",
+                "laravel/pint": "^v1.1.0",
+                "nunomaduro/collision": "^7.0|^8.0",
+                "orchestra/testbench": "^8.0|^9.0|^10.0|^11.0",
+                "pestphp/pest": "^2.34|^3.7|^4.4",
+                "pestphp/pest-plugin-laravel": "^2.3|^3.1|^4.1",
+                "phpstan/extension-installer": "^1.4",
+                "phpstan/phpstan-deprecation-rules": "^2.0",
+                "phpstan/phpstan-phpunit": "^2.0",
+                "phpunit/phpunit": "^10.5|^11.5.3|^12.5.12",
+                "spatie/laravel-permission": "^6.10|^7.2",
+                "spatie/pest-plugin-snapshots": "^2.1"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Dedoc\\Scramble\\ScrambleServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Dedoc\\Scramble\\": "src",
+                    "Dedoc\\Scramble\\Database\\Factories\\": "database/factories"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Roman Lytvynenko",
+                    "email": "litvinenko95@gmail.com",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Automatic generation of API documentation for Laravel applications.",
+            "homepage": "https://github.com/dedoc/scramble",
+            "keywords": [
+                "documentation",
+                "laravel",
+                "openapi"
+            ],
+            "support": {
+                "issues": "https://github.com/dedoc/scramble/issues",
+                "source": "https://github.com/dedoc/scramble/tree/v0.13.17"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/romalytvynenko",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-03-27T13:32:04+00:00"
         },
         {
             "name": "dflydev/dot-access-data",
@@ -2451,6 +2531,66 @@
             "time": "2025-03-24T10:02:05+00:00"
         },
         {
+            "name": "myclabs/deep-copy",
+            "version": "1.13.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/myclabs/DeepCopy.git",
+                "reference": "07d290f0c47959fd5eed98c95ee5602db07e0b6a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/07d290f0c47959fd5eed98c95ee5602db07e0b6a",
+                "reference": "07d290f0c47959fd5eed98c95ee5602db07e0b6a",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0"
+            },
+            "conflict": {
+                "doctrine/collections": "<1.6.8",
+                "doctrine/common": "<2.13.3 || >=3 <3.2.2"
+            },
+            "require-dev": {
+                "doctrine/collections": "^1.6.8",
+                "doctrine/common": "^2.13.3 || ^3.2.2",
+                "phpspec/prophecy": "^1.10",
+                "phpunit/phpunit": "^7.5.20 || ^8.5.23 || ^9.5.13"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/DeepCopy/deep_copy.php"
+                ],
+                "psr-4": {
+                    "DeepCopy\\": "src/DeepCopy/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Create deep copies (clones) of your objects",
+            "keywords": [
+                "clone",
+                "copy",
+                "duplicate",
+                "object",
+                "object graph"
+            ],
+            "support": {
+                "issues": "https://github.com/myclabs/DeepCopy/issues",
+                "source": "https://github.com/myclabs/DeepCopy/tree/1.13.4"
+            },
+            "funding": [
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/myclabs/deep-copy",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-01T08:46:24+00:00"
+        },
+        {
             "name": "nesbot/carbon",
             "version": "3.11.0",
             "source": {
@@ -2928,6 +3068,53 @@
                 }
             ],
             "time": "2025-08-21T11:53:16+00:00"
+        },
+        {
+            "name": "phpstan/phpdoc-parser",
+            "version": "2.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpdoc-parser.git",
+                "reference": "1e0cd5370df5dd2e556a36b9c62f62e555870495"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/1e0cd5370df5dd2e556a36b9c62f62e555870495",
+                "reference": "1e0cd5370df5dd2e556a36b9c62f62e555870495",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4 || ^8.0"
+            },
+            "require-dev": {
+                "doctrine/annotations": "^2.0",
+                "nikic/php-parser": "^5.3.0",
+                "php-parallel-lint/php-parallel-lint": "^1.2",
+                "phpstan/extension-installer": "^1.0",
+                "phpstan/phpstan": "^2.0",
+                "phpstan/phpstan-phpunit": "^2.0",
+                "phpstan/phpstan-strict-rules": "^2.0",
+                "phpunit/phpunit": "^9.6",
+                "symfony/process": "^5.2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "PHPStan\\PhpDocParser\\": [
+                        "src/"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPDoc parser with support for nullable, intersection and generic types",
+            "support": {
+                "issues": "https://github.com/phpstan/phpdoc-parser/issues",
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/2.3.0"
+            },
+            "time": "2025-08-30T15:50:23+00:00"
         },
         {
             "name": "psr/clock",
@@ -3617,6 +3804,67 @@
                 "source": "https://github.com/ramsey/uuid/tree/4.9.2"
             },
             "time": "2025-12-14T04:43:48+00:00"
+        },
+        {
+            "name": "spatie/laravel-package-tools",
+            "version": "1.93.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/spatie/laravel-package-tools.git",
+                "reference": "0d097bce95b2bf6802fb1d83e1e753b0f5a948e7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/spatie/laravel-package-tools/zipball/0d097bce95b2bf6802fb1d83e1e753b0f5a948e7",
+                "reference": "0d097bce95b2bf6802fb1d83e1e753b0f5a948e7",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/contracts": "^10.0|^11.0|^12.0|^13.0",
+                "php": "^8.1"
+            },
+            "require-dev": {
+                "mockery/mockery": "^1.5",
+                "orchestra/testbench": "^8.0|^9.2|^10.0|^11.0",
+                "pestphp/pest": "^2.1|^3.1|^4.0",
+                "phpunit/php-code-coverage": "^10.0|^11.0|^12.0",
+                "phpunit/phpunit": "^10.5|^11.5|^12.5",
+                "spatie/pest-plugin-test-time": "^2.2|^3.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Spatie\\LaravelPackageTools\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Freek Van der Herten",
+                    "email": "freek@spatie.be",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Tools for creating Laravel packages",
+            "homepage": "https://github.com/spatie/laravel-package-tools",
+            "keywords": [
+                "laravel-package-tools",
+                "spatie"
+            ],
+            "support": {
+                "issues": "https://github.com/spatie/laravel-package-tools/issues",
+                "source": "https://github.com/spatie/laravel-package-tools/tree/1.93.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/spatie",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-02-21T12:49:54+00:00"
         },
         {
             "name": "symfony/clock",
@@ -7292,66 +7540,6 @@
             "time": "2024-05-16T03:13:13+00:00"
         },
         {
-            "name": "myclabs/deep-copy",
-            "version": "1.13.4",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "07d290f0c47959fd5eed98c95ee5602db07e0b6a"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/07d290f0c47959fd5eed98c95ee5602db07e0b6a",
-                "reference": "07d290f0c47959fd5eed98c95ee5602db07e0b6a",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.1 || ^8.0"
-            },
-            "conflict": {
-                "doctrine/collections": "<1.6.8",
-                "doctrine/common": "<2.13.3 || >=3 <3.2.2"
-            },
-            "require-dev": {
-                "doctrine/collections": "^1.6.8",
-                "doctrine/common": "^2.13.3 || ^3.2.2",
-                "phpspec/prophecy": "^1.10",
-                "phpunit/phpunit": "^7.5.20 || ^8.5.23 || ^9.5.13"
-            },
-            "type": "library",
-            "autoload": {
-                "files": [
-                    "src/DeepCopy/deep_copy.php"
-                ],
-                "psr-4": {
-                    "DeepCopy\\": "src/DeepCopy/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "description": "Create deep copies (clones) of your objects",
-            "keywords": [
-                "clone",
-                "copy",
-                "duplicate",
-                "object",
-                "object graph"
-            ],
-            "support": {
-                "issues": "https://github.com/myclabs/DeepCopy/issues",
-                "source": "https://github.com/myclabs/DeepCopy/tree/1.13.4"
-            },
-            "funding": [
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/myclabs/deep-copy",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2025-08-01T08:46:24+00:00"
-        },
-        {
             "name": "nunomaduro/collision",
             "version": "v8.8.3",
             "source": {
@@ -8557,53 +8745,6 @@
                 "source": "https://github.com/phpDocumentor/TypeResolver/tree/1.12.0"
             },
             "time": "2025-11-21T15:09:14+00:00"
-        },
-        {
-            "name": "phpstan/phpdoc-parser",
-            "version": "2.3.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/phpstan/phpdoc-parser.git",
-                "reference": "1e0cd5370df5dd2e556a36b9c62f62e555870495"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/1e0cd5370df5dd2e556a36b9c62f62e555870495",
-                "reference": "1e0cd5370df5dd2e556a36b9c62f62e555870495",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.4 || ^8.0"
-            },
-            "require-dev": {
-                "doctrine/annotations": "^2.0",
-                "nikic/php-parser": "^5.3.0",
-                "php-parallel-lint/php-parallel-lint": "^1.2",
-                "phpstan/extension-installer": "^1.0",
-                "phpstan/phpstan": "^2.0",
-                "phpstan/phpstan-phpunit": "^2.0",
-                "phpstan/phpstan-strict-rules": "^2.0",
-                "phpunit/phpunit": "^9.6",
-                "symfony/process": "^5.2"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "PHPStan\\PhpDocParser\\": [
-                        "src/"
-                    ]
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "description": "PHPDoc parser with support for nullable, intersection and generic types",
-            "support": {
-                "issues": "https://github.com/phpstan/phpdoc-parser/issues",
-                "source": "https://github.com/phpstan/phpdoc-parser/tree/2.3.0"
-            },
-            "time": "2025-08-30T15:50:23+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -10424,5 +10565,5 @@
         "php": "^8.2"
     },
     "platform-dev": {},
-    "plugin-api-version": "2.9.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/config/cms-framework.php
+++ b/config/cms-framework.php
@@ -16,4 +16,44 @@ return [
     |
     */
     'user_model' => null,
+
+    /*
+    |--------------------------------------------------------------------------
+    | OpenAPI Documentation
+    |--------------------------------------------------------------------------
+    |
+    | Configure the auto-generated OpenAPI specification for the CMS Framework
+    | API. When enabled, interactive documentation is available at /docs/api/cms
+    | and the raw spec at /docs/api/cms.json.
+    |
+    */
+    'openapi' => [
+        'enabled' => true,
+
+        'info' => [
+            'title'       => 'ArtisanPack CMS Framework API',
+            'version'     => '1.1.0',
+            'description' => 'RESTful API for the ArtisanPack CMS Framework. Provides endpoints for managing posts, pages, content types, users, roles, permissions, settings, notifications, plugins, and themes.',
+        ],
+
+        /*
+        |--------------------------------------------------------------------------
+        | Documentation UI Path
+        |--------------------------------------------------------------------------
+        |
+        | The path where the Swagger UI documentation will be served.
+        |
+        */
+        'ui_path' => '/docs/api/cms',
+
+        /*
+        |--------------------------------------------------------------------------
+        | OpenAPI Document Path
+        |--------------------------------------------------------------------------
+        |
+        | The path where the raw OpenAPI JSON specification will be served.
+        |
+        */
+        'document_path' => '/docs/api/cms.json',
+    ],
 ];

--- a/config/cms-framework.php
+++ b/config/cms-framework.php
@@ -28,7 +28,7 @@ return [
     |
     */
     'openapi' => [
-        'enabled' => true,
+        'enabled' => env('CMS_OPENAPI_ENABLED', false),
 
         'info' => [
             'title'       => 'ArtisanPack CMS Framework API',

--- a/database/Factories/NotificationFactory.php
+++ b/database/Factories/NotificationFactory.php
@@ -94,6 +94,6 @@ class NotificationFactory extends Factory
     {
         return $this->state( fn ( array $attributes ) => [
             'send_email' => false,
-        ]);
+        ] );
     }
 }

--- a/database/Factories/NotificationPreferenceFactory.php
+++ b/database/Factories/NotificationPreferenceFactory.php
@@ -75,6 +75,6 @@ class NotificationPreferenceFactory extends Factory
     {
         return $this->state( fn ( array $attributes ) => [
             'email_enabled' => false,
-        ]);
+        ] );
     }
 }

--- a/database/migrations/2025_09_15_215844_create_user_role_permission_pivots.php
+++ b/database/migrations/2025_09_15_215844_create_user_role_permission_pivots.php
@@ -27,6 +27,6 @@ return new class extends Migration {
     public function down(): void
     {
         Schema::dropIfExists( 'permission_role' );
-        Schema::dropIfExists( 'role_user');
+        Schema::dropIfExists( 'role_user' );
     }
 };

--- a/database/migrations/2025_10_19_210956_create_settings_table.php
+++ b/database/migrations/2025_10_19_210956_create_settings_table.php
@@ -20,6 +20,6 @@ return new class extends Migration {
 
     public function down(): void
     {
-        Schema::dropIfExists( 'settings');
+        Schema::dropIfExists( 'settings' );
     }
 };

--- a/docs/api/Bulk-Actions.md
+++ b/docs/api/Bulk-Actions.md
@@ -1,0 +1,146 @@
+# Bulk Actions
+
+The CMS Framework provides bulk action API endpoints for performing operations on multiple resources at once. Introduced in v1.1.0, bulk endpoints are available for posts, pages, and users.
+
+## Overview
+
+Bulk actions allow you to apply the same operation (such as deleting or publishing) to a set of resource IDs in a single request. Each item is individually authorized through its corresponding policy, and partial failures are tracked so you always know which items succeeded and which did not.
+
+## Endpoints
+
+| Endpoint | Allowed Actions |
+|----------|----------------|
+| `POST /api/v1/posts/bulk` | `delete`, `publish`, `draft` |
+| `POST /api/v1/pages/bulk` | `delete`, `publish`, `draft` |
+| `POST /api/v1/users/bulk` | `delete`, `activate`, `deactivate` |
+
+All endpoints require authentication.
+
+## Request Format
+
+Send a JSON body with an `action` string and an `ids` array:
+
+```json
+{
+  "action": "publish",
+  "ids": [1, 2, 3]
+}
+```
+
+### Validation Rules
+
+| Field | Rules |
+|-------|-------|
+| `action` | Required, string, must be one of the endpoint's allowed actions |
+| `ids` | Required, array, must contain at least one item |
+| `ids.*` | Required, integer, must exist in the corresponding database table |
+
+If validation fails, a `422` response is returned with field-level error messages.
+
+## Response Format
+
+### Success
+
+```json
+{
+  "processed": 3,
+  "failed": 0,
+  "errors": []
+}
+```
+
+### Partial Failure
+
+When some items fail (for example, due to authorization), the response includes details for each failure keyed by ID:
+
+```json
+{
+  "processed": 2,
+  "failed": 1,
+  "errors": {
+    "5": "You do not have permission to publish this post."
+  }
+}
+```
+
+### Common Error Scenarios
+
+- **Item not found** -- If an ID passes validation but the resource cannot be loaded, the error message will indicate it was not found.
+- **Authorization failure** -- Each item is authorized individually via the relevant policy. Unauthorized items are skipped and recorded in the `errors` object.
+- **Execution failure** -- If the action itself throws an exception (for example, a database constraint), the error is caught, reported, and recorded.
+
+## Authorization
+
+Bulk actions do **not** use a single blanket authorization check. Instead, each item in the `ids` array is authorized individually against the resource's policy. This means a user might be able to delete some posts but not others, depending on ownership or role.
+
+The policy method used is determined by the action:
+
+- `delete` checks the `delete` policy method
+- `publish` checks the `publish` policy method
+- `draft` checks the `draft` policy method
+- `activate` / `deactivate` check their respective policy methods
+
+## Examples
+
+### cURL
+
+**Publish multiple posts:**
+
+```bash
+curl -X POST https://your-app.test/api/v1/posts/bulk \
+  -H "Authorization: Bearer YOUR_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "action": "publish",
+    "ids": [1, 2, 3]
+  }'
+```
+
+**Delete multiple users:**
+
+```bash
+curl -X POST https://your-app.test/api/v1/users/bulk \
+  -H "Authorization: Bearer YOUR_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "action": "delete",
+    "ids": [10, 11, 12]
+  }'
+```
+
+### PHP (Laravel HTTP Client)
+
+```php
+use Illuminate\Support\Facades\Http;
+
+$response = Http::withToken( $token )
+    ->post( 'https://your-app.test/api/v1/pages/bulk', [
+        'action' => 'draft',
+        'ids'    => [4, 5, 6],
+    ] );
+
+$result = $response->json();
+// $result['processed'] -- number of successfully processed items
+// $result['failed']    -- number of items that failed
+// $result['errors']    -- associative array of ID => error message
+```
+
+### JavaScript (Fetch)
+
+```javascript
+const response = await fetch('/api/v1/posts/bulk', {
+  method: 'POST',
+  headers: {
+    'Authorization': 'Bearer YOUR_TOKEN',
+    'Content-Type': 'application/json',
+    'Accept': 'application/json',
+  },
+  body: JSON.stringify({
+    action: 'publish',
+    ids: [1, 2, 3],
+  }),
+});
+
+const result = await response.json();
+console.log(`Processed: ${result.processed}, Failed: ${result.failed}`);
+```

--- a/docs/api/Error-Responses.md
+++ b/docs/api/Error-Responses.md
@@ -1,0 +1,227 @@
+# Error Responses
+
+The CMS Framework provides a standardized JSON error response format for all API exceptions. Introduced in v1.1.0, every exception that extends `CMSFrameworkException` automatically renders as a consistent JSON payload when thrown during an API request.
+
+## Response Format
+
+All error responses follow this structure:
+
+```json
+{
+  "error": {
+    "code": "ERROR_CODE",
+    "message": "A human-readable description of the error."
+  }
+}
+```
+
+- **`code`** -- A machine-readable string identifying the error category.
+- **`message`** -- A human-readable description suitable for logging or display.
+
+Some exception types include additional fields. For example, `ValidationException` adds an `errors` object with field-level details.
+
+## Exception Types
+
+### CMSFrameworkException
+
+The base exception class. All other CMS Framework exceptions extend this class.
+
+| Property | Value |
+|----------|-------|
+| Error Code | `SERVER_ERROR` |
+| HTTP Status | `500` |
+
+**Example response:**
+
+```json
+{
+  "error": {
+    "code": "SERVER_ERROR",
+    "message": "Something went wrong."
+  }
+}
+```
+
+### NotFoundException
+
+Thrown when a requested resource cannot be found.
+
+| Property | Value |
+|----------|-------|
+| Error Code | `NOT_FOUND` |
+| HTTP Status | `404` |
+
+**Example response:**
+
+```json
+{
+  "error": {
+    "code": "NOT_FOUND",
+    "message": "Model App\\Models\\Post with ID 42 not found."
+  }
+}
+```
+
+The class provides two static constructors for convenience:
+
+```php
+// For Eloquent models
+throw NotFoundException::model( Post::class, $id );
+
+// For arbitrary resources
+throw NotFoundException::resource( 'Page', 'about-us' );
+```
+
+### UnauthorizedException
+
+Thrown when the user lacks permission to perform an action.
+
+| Property | Value |
+|----------|-------|
+| Error Code | `FORBIDDEN` |
+| HTTP Status | `403` |
+
+**Example response:**
+
+```json
+{
+  "error": {
+    "code": "FORBIDDEN",
+    "message": "You are not authorized to delete posts."
+  }
+}
+```
+
+Static constructors:
+
+```php
+throw UnauthorizedException::forAction( 'delete posts' );
+throw UnauthorizedException::forResource( 'this post', 'update' );
+throw UnauthorizedException::requiresPermission( 'posts.delete' );
+```
+
+### ValidationException
+
+Thrown when user input fails validation. Includes an additional `errors` field with per-field error arrays.
+
+| Property | Value |
+|----------|-------|
+| Error Code | `VALIDATION_ERROR` |
+| HTTP Status | `422` |
+
+**Example response:**
+
+```json
+{
+  "error": {
+    "code": "VALIDATION_ERROR",
+    "message": "The given data was invalid.",
+    "errors": {
+      "title": ["The title field is required."],
+      "slug": ["The slug has already been taken."]
+    }
+  }
+}
+```
+
+Usage:
+
+```php
+throw ValidationException::withErrors(
+    'The given data was invalid.',
+    [
+        'title' => ['The title field is required.'],
+        'slug'  => ['The slug has already been taken.'],
+    ],
+);
+```
+
+## How It Works
+
+### The `render()` Method
+
+`CMSFrameworkException` implements Laravel's renderable exception pattern. When the incoming request expects JSON (`$request->expectsJson()`), the exception renders itself as a `JsonResponse` with the appropriate HTTP status code. For non-JSON requests the method returns `null`, allowing Laravel's default exception handler to take over.
+
+```php
+public function render( Request $request ): ?JsonResponse
+{
+    if ( ! $request->expectsJson() ) {
+        return null;
+    }
+
+    return new JsonResponse(
+        $this->buildErrorPayload(),
+        $this->statusCode,
+    );
+}
+```
+
+### The `buildErrorPayload()` Method
+
+The base implementation returns the standard `code` and `message` fields. Subclasses override this method to add extra data. For example, `ValidationException` appends the `errors` object:
+
+```php
+protected function buildErrorPayload(): array
+{
+    $payload = parent::buildErrorPayload();
+
+    if ( ! empty( $this->errors ) ) {
+        $payload['error']['errors'] = $this->errors;
+    }
+
+    return $payload;
+}
+```
+
+## Creating Custom Exceptions
+
+To create a custom exception that follows the same format:
+
+1. Extend `CMSFrameworkException` (or one of its subclasses).
+2. Override `$errorCode` and `$statusCode` as needed.
+3. Optionally override `buildErrorPayload()` to include additional fields.
+
+```php
+<?php
+
+namespace App\Exceptions;
+
+use ArtisanPackUI\CMSFramework\Exceptions\CMSFrameworkException;
+
+class RateLimitException extends CMSFrameworkException
+{
+    protected string $errorCode = 'RATE_LIMITED';
+
+    protected int $statusCode = 429;
+
+    protected int $retryAfter;
+
+    public static function tooManyRequests( int $retryAfter ): self
+    {
+        $exception              = new self( 'Too many requests. Please try again later.' );
+        $exception->retryAfter  = $retryAfter;
+
+        return $exception;
+    }
+
+    protected function buildErrorPayload(): array
+    {
+        $payload = parent::buildErrorPayload();
+        $payload['error']['retry_after'] = $this->retryAfter;
+
+        return $payload;
+    }
+}
+```
+
+This would produce:
+
+```json
+{
+  "error": {
+    "code": "RATE_LIMITED",
+    "message": "Too many requests. Please try again later.",
+    "retry_after": 60
+  }
+}
+```

--- a/docs/api/Includable-Relationships.md
+++ b/docs/api/Includable-Relationships.md
@@ -1,0 +1,123 @@
+# Includable Relationships
+
+The `HasIncludableRelationships` trait provides on-demand relationship loading via the `?include=` query parameter. Introduced in v1.1.0, it allows API consumers to control which relationships are eager-loaded in a response while maintaining backwards compatibility through default includes.
+
+## How It Works
+
+Controllers using this trait define two properties:
+
+- **`$includableRelationships`** -- An allowlist of relationship names that the API consumer is permitted to request.
+- **`$defaultIncludes`** -- An array of relationships to load when the `include` query parameter is absent, preserving backwards-compatible behavior.
+
+The trait provides a single method, `getRequestedIncludes()`, that the controller calls when building a query to determine which relationships to eager-load.
+
+## Behavior
+
+| Request | Result |
+|---------|--------|
+| No `include` parameter | Loads `$defaultIncludes` (backwards compatible) |
+| `?include=roles` | Loads only `roles` (if it is in the allowlist) |
+| `?include=roles,permissions` | Loads `roles` and `permissions` (both must be in the allowlist) |
+| `?include=` (empty string) | Loads **no** relationships |
+| `?include=roles,invalid` | Loads only `roles`; `invalid` is silently filtered out |
+
+Invalid relationship names are silently ignored -- they never produce an error. This prevents leaking information about internal model structure and provides a stable API surface.
+
+## Currently Used On
+
+The trait is currently applied to these controllers:
+
+| Controller | Includable Relationships | Default Includes |
+|------------|------------------------|------------------|
+| `UserController` | `roles` | `roles` |
+| `RoleController` | `permissions` | `permissions` |
+| `PermissionController` | `roles` | `roles` |
+| `PostController` | varies | varies |
+| `PageController` | varies | varies |
+| `PostCategoryController` | varies | varies |
+| `PageCategoryController` | varies | varies |
+
+## Example API Calls
+
+**Load users with their roles (default behavior -- no parameter needed):**
+
+```bash
+curl -H "Authorization: Bearer TOKEN" \
+  https://your-app.test/api/v1/users
+```
+
+**Explicitly request roles:**
+
+```bash
+curl -H "Authorization: Bearer TOKEN" \
+  "https://your-app.test/api/v1/users?include=roles"
+```
+
+**Load users with no relationships (override the default):**
+
+```bash
+curl -H "Authorization: Bearer TOKEN" \
+  "https://your-app.test/api/v1/users?include="
+```
+
+**Request multiple relationships (on a controller that supports them):**
+
+```bash
+curl -H "Authorization: Bearer TOKEN" \
+  "https://your-app.test/api/v1/roles?include=permissions"
+```
+
+## Adding to Your Own Controllers
+
+1. Import and use the trait in your controller.
+2. Define `$includableRelationships` with the allowed relationship names.
+3. Define `$defaultIncludes` with the relationships to load by default.
+4. Call `$this->getRequestedIncludes( $request )` when building your query.
+
+```php
+<?php
+
+namespace App\Http\Controllers;
+
+use ArtisanPackUI\CMSFramework\Http\Controllers\Concerns\HasIncludableRelationships;
+use App\Models\Product;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class ProductController extends Controller
+{
+    use HasIncludableRelationships;
+
+    /**
+     * Relationships the API consumer may request.
+     *
+     * @var array<int, string>
+     */
+    protected array $includableRelationships = ['category', 'tags', 'reviews'];
+
+    /**
+     * Relationships loaded when no include parameter is provided.
+     *
+     * @var array<int, string>
+     */
+    protected array $defaultIncludes = ['category'];
+
+    public function index( Request $request ): JsonResponse
+    {
+        $includes = $this->getRequestedIncludes( $request );
+
+        $products = Product::query()
+            ->with( $includes )
+            ->paginate();
+
+        return response()->json( $products );
+    }
+}
+```
+
+With this setup:
+
+- `GET /products` loads products with `category` (the default).
+- `GET /products?include=tags,reviews` loads products with `tags` and `reviews` only.
+- `GET /products?include=` loads products with no relationships.
+- `GET /products?include=category,nonexistent` loads products with `category` only; `nonexistent` is silently dropped.

--- a/docs/api/OpenAPI.md
+++ b/docs/api/OpenAPI.md
@@ -1,0 +1,108 @@
+# OpenAPI Specification
+
+The CMS Framework provides auto-generated OpenAPI 3.x API documentation powered by [Scramble](https://scramble.dedoc.co). Introduced in v1.1.0, it gives you a Swagger UI for interactive exploration and a machine-readable JSON specification for SDK generation and tooling.
+
+## Configuration
+
+The OpenAPI module is configured in `config/artisanpack/cms-framework.php` under the `openapi` key:
+
+```php
+'openapi' => [
+    'enabled' => env( 'CMS_OPENAPI_ENABLED', false ),
+
+    'info' => [
+        'title'       => 'ArtisanPack CMS Framework API',
+        'version'     => '1.1.0',
+        'description' => 'RESTful API for the ArtisanPack CMS Framework. Provides endpoints for managing posts, pages, content types, users, roles, permissions, settings, notifications, plugins, and themes.',
+    ],
+
+    'ui_path'       => '/docs/api/cms',
+    'document_path' => '/docs/api/cms.json',
+],
+```
+
+### Configuration Options
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `enabled` | `false` | Whether the Swagger UI and JSON spec endpoints are registered. Controlled by the `CMS_OPENAPI_ENABLED` environment variable. |
+| `info.title` | `ArtisanPack CMS Framework API` | The title displayed in the Swagger UI header. |
+| `info.version` | `1.1.0` | The API version shown in the specification. |
+| `info.description` | *(see config)* | A description of the API included in the specification. |
+| `ui_path` | `/docs/api/cms` | The URL path where Swagger UI is served. |
+| `document_path` | `/docs/api/cms.json` | The URL path where the raw OpenAPI JSON document is served. |
+
+## Enabling the Documentation
+
+Set the environment variable in your `.env` file:
+
+```
+CMS_OPENAPI_ENABLED=true
+```
+
+Once enabled, two routes become available:
+
+- **Swagger UI**: Visit the `ui_path` (default: `/docs/api/cms`) in your browser for an interactive API explorer.
+- **JSON Spec**: Fetch the `document_path` (default: `/docs/api/cms.json`) to get the raw OpenAPI 3.x specification as JSON.
+
+## Route Filtering
+
+The OpenAPI specification only includes routes that belong to the CMS Framework. A route is included when:
+
+1. Its URI starts with `api/v1`.
+2. Its controller lives in the `ArtisanPackUI\CMSFramework\` namespace.
+
+Application-specific routes and routes from other packages are excluded.
+
+## Security Scheme
+
+The generated specification declares an HTTP Bearer authentication scheme using JWT. All endpoints are marked as requiring this scheme, matching the Sanctum-based authentication used by the CMS Framework API.
+
+## Artisan Command
+
+Export the OpenAPI specification to a static JSON file using the `cms:openapi:export` command:
+
+```bash
+# Export to the default location (cms-openapi.json in the project root)
+php artisan cms:openapi:export
+
+# Export to a custom path
+php artisan cms:openapi:export storage/app/api-spec.json
+
+# Pretty-print the output
+php artisan cms:openapi:export --pretty
+
+# Combine both options
+php artisan cms:openapi:export docs/openapi.json --pretty
+```
+
+This is useful for:
+
+- Committing the specification to version control
+- Publishing the spec to external documentation platforms
+- Generating client SDKs with tools like [OpenAPI Generator](https://openapi-generator.tech)
+
+## Usage Examples
+
+**Access the interactive documentation:**
+
+```
+https://your-app.test/docs/api/cms
+```
+
+**Fetch the raw specification:**
+
+```bash
+curl https://your-app.test/docs/api/cms.json
+```
+
+**Generate a TypeScript client (using OpenAPI Generator):**
+
+```bash
+php artisan cms:openapi:export --pretty storage/app/cms-openapi.json
+
+npx @openapitools/openapi-generator-cli generate \
+  -i storage/app/cms-openapi.json \
+  -g typescript-fetch \
+  -o generated/cms-client
+```

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -41,14 +41,32 @@ $token = $user->createToken('token-name')->plainTextToken;
 
 ### Error Response
 
+All CMS Framework exceptions render in a standardized JSON format:
+
 ```json
 {
-  "message": "Error message",
-  "errors": {
-    "field": ["Validation error"]
+  "error": {
+    "code": "NOT_FOUND",
+    "message": "Model Post with ID 999 not found."
   }
 }
 ```
+
+Validation errors include field-level details:
+
+```json
+{
+  "error": {
+    "code": "VALIDATION_ERROR",
+    "message": "The given data was invalid.",
+    "errors": {
+      "title": ["The title field is required."]
+    }
+  }
+}
+```
+
+See [[api/Error Responses]] for the complete error response reference.
 
 ## HTTP Status Codes
 
@@ -82,6 +100,14 @@ $token = $user->createToken('token-name')->plainTextToken;
 - **[Plugins API](Plugins)** - Plugin lifecycle management (Experimental)
 - **[Themes API](Themes)** - Theme management (Experimental)
 - **[Core Updates API](Core-Updates)** - System update management
+
+### API Features (v1.1.0)
+
+- **[Error Responses](Error-Responses)** - Standardized JSON error format
+- **[Bulk Actions](Bulk-Actions)** - Bulk operations for posts, pages, and users
+- **[Includable Relationships](Includable-Relationships)** - On-demand relationship loading
+- **[OpenAPI Specification](OpenAPI)** - Auto-generated API documentation
+- **[TypeScript Types](TypeScript-Types)** - Publishable type definitions for frontend
 
 ## Common Patterns
 
@@ -140,6 +166,8 @@ Load related data using the `include` parameter:
 ```http
 GET /api/cms/posts?include=author,categories,tags
 ```
+
+Only whitelisted relationships can be included. When no `include` parameter is provided, default relationships are loaded for backwards compatibility. See [[api/Includable Relationships]] for full details.
 
 ## Rate Limiting
 
@@ -237,31 +265,42 @@ class PostApiTest extends TestCase
 
 ## Error Handling
 
-### Validation Errors
+All CMS Framework exceptions use a standardized JSON format. See [[api/Error Responses]] for full documentation.
+
+### Validation Errors (422)
 
 ```json
 {
-  "message": "The given data was invalid.",
-  "errors": {
-    "title": ["The title field is required."],
-    "email": ["The email must be a valid email address."]
+  "error": {
+    "code": "VALIDATION_ERROR",
+    "message": "The given data was invalid.",
+    "errors": {
+      "title": ["The title field is required."],
+      "email": ["The email must be a valid email address."]
+    }
   }
 }
 ```
 
-### Authorization Errors
+### Authorization Errors (403)
 
 ```json
 {
-  "message": "This action is unauthorized."
+  "error": {
+    "code": "FORBIDDEN",
+    "message": "You are not authorized to delete posts."
+  }
 }
 ```
 
-### Not Found Errors
+### Not Found Errors (404)
 
 ```json
 {
-  "message": "Model User with ID 999 not found."
+  "error": {
+    "code": "NOT_FOUND",
+    "message": "Model User with ID 999 not found."
+  }
 }
 ```
 

--- a/docs/api/TypeScript-Types.md
+++ b/docs/api/TypeScript-Types.md
@@ -1,0 +1,145 @@
+# TypeScript Type Definitions
+
+The CMS Framework ships TypeScript type definitions for all API response shapes, request payloads, and enums. Introduced in v1.1.0, these types give frontend applications compile-time safety when working with the CMS API.
+
+## Publishing
+
+Publish the type definitions into your application:
+
+```bash
+php artisan vendor:publish --tag=cms-types
+```
+
+This copies the type files to:
+
+```
+resources/types/cms-framework/
+```
+
+## Files
+
+| File | Description |
+|------|-------------|
+| `index.d.ts` | Barrel file that re-exports all types from every module. |
+| `common.d.ts` | Shared types used across modules. |
+| `blog.d.ts` | Post, post category, and post tag types. |
+| `pages.d.ts` | Page, page category, page tag, and breadcrumb types. |
+| `content-types.d.ts` | Content type, custom field, and taxonomy types. |
+| `users.d.ts` | User, role, and permission types. |
+| `settings.d.ts` | Setting types. |
+| `notifications.d.ts` | Notification and notification preference types. |
+| `plugins.d.ts` | Plugin and update types. |
+
+## Common Types
+
+The `common.d.ts` file provides the foundational types used throughout the API:
+
+```typescript
+/** ISO 8601 date-time string (e.g. "2024-01-15T12:00:00.000000Z"). */
+export type DateTimeString = string;
+
+/** An array guaranteed to contain at least one element. */
+export type NonEmptyArray<T> = [T, ...T[]];
+
+/** A JSON-serializable metadata object. */
+export type Metadata = Record<string, unknown> | null;
+
+/** Standard Laravel paginated response wrapper. */
+export interface PaginatedResponse<T> {
+    data: T[];
+    meta: {
+        current_page: number;
+        from: number | null;
+        last_page: number;
+        links: Array<{ url: string | null; label: string; active: boolean }>;
+        path: string;
+        per_page: number;
+        to: number | null;
+        total: number;
+    };
+    links: {
+        first: string;
+        last: string;
+        prev: string | null;
+        next: string | null;
+    };
+}
+
+/** Standard Laravel single-resource response wrapper. */
+export interface ResourceResponse<T> {
+    data: T;
+}
+```
+
+## Module Types
+
+Each module file exports types matching its API responses. Some key examples:
+
+- **`blog.d.ts`**: `PostResponse`, `PostRequestData`, `PostCategoryResponse`, `PostTagResponse`, `PostAuthorResponse`
+- **`pages.d.ts`**: `PageResponse`, `PageRequestData`, `PageCategoryResponse`, `PageTagResponse`, `BreadcrumbItem`
+- **`content-types.d.ts`**: `ContentTypeResponse`, `CustomFieldResponse`, `TaxonomyResponse`, `FieldType`, `ColumnType`, `ContentStatus`
+- **`users.d.ts`**: `UserResponse`, `RoleResponse`, `PermissionResponse`, `RoleSummary`, `PermissionSummary`
+- **`settings.d.ts`**: `SettingResponse`, `SettingRequestData`, `SettingType`
+- **`notifications.d.ts`**: `NotificationResponse`, `NotificationPreferenceResponse`, `NotificationType`
+- **`plugins.d.ts`**: `PluginResponse`, `UpdateType`
+
+## Frontend Integration
+
+Import the types directly from the published directory:
+
+```typescript
+import type {
+    PostResponse,
+    PaginatedResponse,
+    ResourceResponse,
+} from '@/types/cms-framework';
+
+// Typed paginated list
+async function fetchPosts(): Promise<PaginatedResponse<PostResponse>> {
+    const response = await fetch('/api/v1/posts', {
+        headers: {
+            'Authorization': `Bearer ${token}`,
+            'Accept': 'application/json',
+        },
+    });
+
+    return response.json();
+}
+
+// Typed single resource
+async function fetchPost(id: number): Promise<ResourceResponse<PostResponse>> {
+    const response = await fetch(`/api/v1/posts/${id}`, {
+        headers: {
+            'Authorization': `Bearer ${token}`,
+            'Accept': 'application/json',
+        },
+    });
+
+    return response.json();
+}
+```
+
+### Path Alias
+
+If your project uses TypeScript path aliases, add one for the published types in your `tsconfig.json`:
+
+```json
+{
+  "compilerOptions": {
+    "paths": {
+      "@/types/cms-framework": ["./resources/types/cms-framework/index.d.ts"],
+      "@/types/cms-framework/*": ["./resources/types/cms-framework/*"]
+    }
+  }
+}
+```
+
+## Keeping Types in Sync
+
+The type definitions are published as static files. When you upgrade the CMS Framework to a new version, re-run the publish command to get updated types:
+
+```bash
+php artisan vendor:publish --tag=cms-types --force
+```
+
+The `--force` flag overwrites existing files with the latest definitions from the package.

--- a/docs/core.md
+++ b/docs/core.md
@@ -9,3 +9,15 @@ The Core module provides cross‑cutting services used throughout the CMS Framew
 ## Core Guides
 
 - [Assets](Core-Assets) — Registering and retrieving admin, public, and authenticated assets
+
+## Shared Traits (v1.1.0)
+
+The Core module provides shared traits used across multiple modules:
+
+- **[HasManifestParsing](developer/traits#hasmanifestparsing-trait)** — Secure JSON manifest parsing, slug validation, and path traversal prevention. Used by PluginManager and ThemeManager.
+
+## Enums (v1.1.0)
+
+- **[UpdateType](developer/enums#updatetype-enum)** — Categorizes update checks as `application`, `plugin`, or `theme`.
+
+See the [[developer/traits]] and [[developer/enums]] pages for complete documentation.

--- a/docs/developer/content-types.md
+++ b/docs/developer/content-types.md
@@ -408,8 +408,34 @@ if ($contentType->supportsFeature('featured_image')) {
 }
 ```
 
+## Content Status Enum (v1.1.0)
+
+Content types that support publishing (posts, pages) use the `ContentStatus` enum instead of plain strings:
+
+```php
+use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Enums\ContentStatus;
+
+// Query with enum
+$posts = Post::where('status', ContentStatus::Published)->get();
+
+// Use scopes via HasContentStatus trait
+$published = Post::published()->get();
+$drafts = Post::draft()->get();
+
+// Check status
+if ($post->isPublished()) {
+    // ...
+}
+```
+
+Available statuses: `Draft`, `Published`, `Scheduled`, `Private`.
+
+See [[developer/enums]] for the complete enum reference and [[developer/traits]] for the `HasContentStatus` and `HasContentFilters` traits.
+
 ## See Also
 
 - [Custom Fields Developer Guide](Custom-Fields)
 - [Taxonomies Developer Guide](Taxonomies)
+- [Enums Reference](Enums)
+- [Traits Reference](Traits)
 - [Hooks Reference](Hooks-Reference)

--- a/docs/developer/custom-fields.md
+++ b/docs/developer/custom-fields.md
@@ -42,14 +42,19 @@ posts table: id, title, content, rating, price, featured
 
 ## Available Field Types
 
+> **v1.1.0**: Field types and column types are now backed by the `FieldType` and `ColumnType` enums for type safety. You can use either string values (for backwards compatibility) or enum instances. See [[developer/enums]] for the complete reference.
+
 ### Text Field
 
 Single-line text input.
 
 ```php
+use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Enums\FieldType;
+use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Enums\ColumnType;
+
 [
-    'type' => 'text',
-    'column_type' => 'string',
+    'type' => FieldType::Text,          // or 'text'
+    'column_type' => ColumnType::String, // or 'string'
 ]
 ```
 
@@ -682,4 +687,5 @@ Deleting a custom field **permanently removes data**. Always backup before delet
 
 - [Content Types Developer Guide](Content-Types)
 - [Taxonomies Developer Guide](Taxonomies)
+- [Enums Reference](Enums) - FieldType and ColumnType enums
 - [Hooks Reference](Hooks-Reference)

--- a/docs/developer/enums.md
+++ b/docs/developer/enums.md
@@ -1,0 +1,332 @@
+# Enums Developer Guide
+
+## Overview
+
+CMS Framework v1.1.0 introduces several PHP enums to replace magic strings and provide type-safe, self-documenting code throughout the package. All enums are string-backed and include helper methods for labels, validation, and serialization where appropriate.
+
+## Table of Contents
+
+- [ContentStatus](#contentstatus)
+- [FieldType](#fieldtype)
+- [ColumnType](#columntype)
+- [SettingType](#settingtype)
+- [UpdateType](#updatetype)
+
+## ContentStatus
+
+**Namespace:** `ArtisanPackUI\CMSFramework\Modules\ContentTypes\Enums\ContentStatus`
+
+Defines the available content statuses for blog posts and pages.
+
+### Cases
+
+| Case | Value | Label |
+|------|-------|-------|
+| `Draft` | `'draft'` | Draft |
+| `Published` | `'published'` | Published |
+| `Scheduled` | `'scheduled'` | Scheduled |
+| `Private` | `'private'` | Private |
+
+### Methods
+
+- `label(): string` -- Returns a translatable human-readable label for the status.
+- `validationRule(): Enum` -- Returns a Laravel `Rule::enum()` validation rule for use in form requests.
+
+### Usage Examples
+
+**Using in a Form Request:**
+
+```php
+use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Enums\ContentStatus;
+
+public function rules(): array
+{
+    return [
+        'title'  => ['required', 'string', 'max:255'],
+        'status' => ['required', ContentStatus::validationRule()],
+    ];
+}
+```
+
+**Querying by Status:**
+
+```php
+use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Enums\ContentStatus;
+
+// Get all draft posts
+$drafts = Post::where( 'status', ContentStatus::Draft )->get();
+
+// Use the published scope (provided by HasContentStatus trait)
+$published = Post::published()->get();
+```
+
+**Displaying a Label:**
+
+```php
+$post = Post::find( 1 );
+echo $post->status->label(); // "Published"
+```
+
+**Casting on a Model:**
+
+```php
+protected function casts(): array
+{
+    return [
+        'status' => ContentStatus::class,
+    ];
+}
+```
+
+## FieldType
+
+**Namespace:** `ArtisanPackUI\CMSFramework\Modules\ContentTypes\Enums\FieldType`
+
+Defines the available UI field types for custom fields. Each case represents a different form control that is rendered when editing content.
+
+### Cases
+
+| Case | Value | Label |
+|------|-------|-------|
+| `Text` | `'text'` | Text |
+| `Textarea` | `'textarea'` | Textarea |
+| `Number` | `'number'` | Number |
+| `Select` | `'select'` | Select |
+| `Checkbox` | `'checkbox'` | Checkbox |
+| `Radio` | `'radio'` | Radio |
+| `Boolean` | `'boolean'` | Boolean |
+| `Date` | `'date'` | Date |
+| `Datetime` | `'datetime'` | Datetime |
+| `Time` | `'time'` | Time |
+| `Email` | `'email'` | Email |
+| `Url` | `'url'` | URL |
+| `Tel` | `'tel'` | Telephone |
+| `Color` | `'color'` | Color |
+| `File` | `'file'` | File |
+| `Image` | `'image'` | Image |
+
+### Methods
+
+- `label(): string` -- Returns a translatable human-readable label for the field type.
+- `validationRule(): Enum` -- Returns a Laravel `Rule::enum()` validation rule.
+
+### Usage Examples
+
+**Registering a Custom Field:**
+
+```php
+use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Enums\FieldType;
+use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Enums\ColumnType;
+
+$field = [
+    'name'        => 'price',
+    'label'       => 'Product Price',
+    'type'        => FieldType::Number,
+    'column_type' => ColumnType::Decimal,
+];
+```
+
+**Validating a Field Type Input:**
+
+```php
+use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Enums\FieldType;
+
+public function rules(): array
+{
+    return [
+        'field_type' => ['required', FieldType::validationRule()],
+    ];
+}
+```
+
+**Getting the Label for Display:**
+
+```php
+$type = FieldType::Email;
+echo $type->label(); // "Email"
+```
+
+## ColumnType
+
+**Namespace:** `ArtisanPackUI\CMSFramework\Modules\ContentTypes\Enums\ColumnType`
+
+Defines the database column types used when creating custom field columns. Each case maps to a Laravel migration column method.
+
+### Cases
+
+| Case | Value | Label |
+|------|-------|-------|
+| `String` | `'string'` | String |
+| `Text` | `'text'` | Text |
+| `Integer` | `'integer'` | Integer |
+| `BigInteger` | `'bigInteger'` | Big Integer |
+| `Decimal` | `'decimal'` | Decimal |
+| `Float` | `'float'` | Float |
+| `Double` | `'double'` | Double |
+| `Boolean` | `'boolean'` | Boolean |
+| `Date` | `'date'` | Date |
+| `DateTime` | `'dateTime'` | DateTime |
+| `Time` | `'time'` | Time |
+| `Json` | `'json'` | JSON |
+| `Binary` | `'binary'` | Binary |
+
+### Methods
+
+- `label(): string` -- Returns a translatable human-readable label for the column type.
+- `validationRule(): Enum` -- Returns a Laravel `Rule::enum()` validation rule.
+
+### Usage Examples
+
+**Pairing with FieldType for Custom Fields:**
+
+```php
+use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Enums\FieldType;
+use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Enums\ColumnType;
+
+$fields = [
+    [
+        'name'        => 'rating',
+        'label'       => 'Rating',
+        'type'        => FieldType::Number,
+        'column_type' => ColumnType::Integer,
+    ],
+    [
+        'name'        => 'description',
+        'label'       => 'Description',
+        'type'        => FieldType::Textarea,
+        'column_type' => ColumnType::Text,
+    ],
+    [
+        'name'        => 'metadata',
+        'label'       => 'Metadata',
+        'type'        => FieldType::Textarea,
+        'column_type' => ColumnType::Json,
+    ],
+];
+```
+
+**Validating Column Type Input:**
+
+```php
+use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Enums\ColumnType;
+
+public function rules(): array
+{
+    return [
+        'column_type' => ['required', ColumnType::validationRule()],
+    ];
+}
+```
+
+## SettingType
+
+**Namespace:** `ArtisanPackUI\CMSFramework\Modules\Settings\Enums\SettingType`
+
+Defines the available data types for stored settings. Unlike the other enums, SettingType centralizes type detection, casting, and serialization logic for the settings system.
+
+### Cases
+
+| Case | Value |
+|------|-------|
+| `String` | `'string'` |
+| `Integer` | `'integer'` |
+| `Boolean` | `'boolean'` |
+| `Float` | `'float'` |
+| `Json` | `'json'` |
+
+### Methods
+
+- `fromValue(mixed $value): self` -- Auto-detects the SettingType from a PHP value. Booleans, integers, and floats are detected by type; arrays and objects become `Json`; everything else defaults to `String`.
+- `cast(mixed $value): mixed` -- Casts a raw database string back to its native PHP type. Uses `FILTER_VALIDATE_BOOLEAN` for booleans and `JSON_THROW_ON_ERROR` for JSON. Returns an empty string for null String values and null for other null values.
+- `serialize(mixed $value): string` -- Serializes a PHP value for database storage. Booleans become `'1'` or `'0'`, JSON values are encoded with `JSON_THROW_ON_ERROR`, and null String values become an empty string.
+
+### Usage Examples
+
+**Auto-Detecting Type from a Value:**
+
+```php
+use ArtisanPackUI\CMSFramework\Modules\Settings\Enums\SettingType;
+
+$type = SettingType::fromValue( true );       // SettingType::Boolean
+$type = SettingType::fromValue( 42 );         // SettingType::Integer
+$type = SettingType::fromValue( 3.14 );       // SettingType::Float
+$type = SettingType::fromValue( ['a', 'b'] ); // SettingType::Json
+$type = SettingType::fromValue( 'hello' );    // SettingType::String
+```
+
+**Casting a Stored Value:**
+
+```php
+$type  = SettingType::Boolean;
+$value = $type->cast( '1' );   // true
+$value = $type->cast( '0' );   // false
+$value = $type->cast( 'yes' ); // true (via FILTER_VALIDATE_BOOLEAN)
+
+$type  = SettingType::Json;
+$value = $type->cast( '{"key":"value"}' ); // ['key' => 'value']
+```
+
+**Serializing a Value for Storage:**
+
+```php
+$type       = SettingType::Boolean;
+$serialized = $type->serialize( true );  // '1'
+$serialized = $type->serialize( false ); // '0'
+
+$type       = SettingType::Json;
+$serialized = $type->serialize( ['key' => 'value'] ); // '{"key":"value"}'
+```
+
+**Full Round-Trip Example:**
+
+```php
+use ArtisanPackUI\CMSFramework\Modules\Settings\Enums\SettingType;
+
+$originalValue = ['theme' => 'dark', 'sidebar' => true];
+
+// Detect type and serialize for storage
+$type       = SettingType::fromValue( $originalValue ); // SettingType::Json
+$serialized = $type->serialize( $originalValue );       // '{"theme":"dark","sidebar":true}'
+
+// Later, cast back from the database
+$restored = $type->cast( $serialized ); // ['theme' => 'dark', 'sidebar' => true]
+```
+
+## UpdateType
+
+**Namespace:** `ArtisanPackUI\CMSFramework\Modules\Core\Updates\Enums\UpdateType`
+
+Categorizes the types of items that can be checked for updates in the update checker system.
+
+### Cases
+
+| Case | Value |
+|------|-------|
+| `Application` | `'application'` |
+| `Plugin` | `'plugin'` |
+| `Theme` | `'theme'` |
+
+### Usage Examples
+
+**Dispatching an Update Check:**
+
+```php
+use ArtisanPackUI\CMSFramework\Modules\Core\Updates\Enums\UpdateType;
+
+$updateType = UpdateType::Plugin;
+
+// Use the value in update check logic
+if ( UpdateType::Plugin === $updateType ) {
+    // Check plugin updates
+}
+```
+
+**Filtering Updates by Type:**
+
+```php
+use ArtisanPackUI\CMSFramework\Modules\Core\Updates\Enums\UpdateType;
+
+$updates = collect( $allUpdates )->filter(
+    fn ( $update ) => UpdateType::Theme === $update->type
+);
+```

--- a/docs/developer/traits.md
+++ b/docs/developer/traits.md
@@ -1,0 +1,297 @@
+# Traits Developer Guide
+
+## Overview
+
+CMS Framework v1.1.0 introduces several shared traits to eliminate code duplication across models and managers. These traits extract common behavior into reusable concerns that can be applied to any model or manager that needs them.
+
+## Table of Contents
+
+- [HasContentStatus](#hascontentstatus)
+- [HasContentFilters](#hascontentfilters)
+- [HasManifestParsing](#hasmanifestparsing)
+- [HasIncludableRelationships](#hasincludablerelationships)
+
+## HasContentStatus
+
+**Namespace:** `ArtisanPackUI\CMSFramework\Modules\ContentTypes\Models\Concerns\HasContentStatus`
+
+Provides shared content status scopes and helper methods for content type models. Applied to the Post and Page models.
+
+### Methods
+
+#### `scopePublished(Builder $query)`
+
+Scopes a query to only include published content. A record is considered published when its `status` is `ContentStatus::Published` AND its `published_at` is either null or in the past.
+
+#### `scopeDraft(Builder $query)`
+
+Scopes a query to only include draft content (status is `ContentStatus::Draft`).
+
+#### `isPublished(): bool`
+
+Returns `true` if the model instance is published. Checks both the status value and the `published_at` timestamp.
+
+### Usage Examples
+
+**Applying the Trait to a Model:**
+
+```php
+use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Enums\ContentStatus;
+use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Models\Concerns\HasContentStatus;
+use Illuminate\Database\Eloquent\Model;
+
+class Article extends Model
+{
+    use HasContentStatus;
+
+    protected function casts(): array
+    {
+        return [
+            'status'       => ContentStatus::class,
+            'published_at' => 'datetime',
+        ];
+    }
+}
+```
+
+**Querying Published Content:**
+
+```php
+// Get all published articles
+$published = Article::published()->get();
+
+// Chain with other scopes
+$recentPublished = Article::published()
+    ->orderBy( 'published_at', 'desc' )
+    ->limit( 10 )
+    ->get();
+```
+
+**Querying Draft Content:**
+
+```php
+$drafts = Article::draft()->get();
+```
+
+**Checking a Single Instance:**
+
+```php
+$article = Article::find( 1 );
+
+if ( $article->isPublished() ) {
+    // Display to public visitors
+}
+```
+
+**How Published Scope Works:**
+
+The `scopePublished` method applies two conditions:
+
+1. The `status` column must equal `ContentStatus::Published`.
+2. The `published_at` column must be either null (published immediately) or a date in the past.
+
+This means a post with `status = 'published'` and `published_at` set to a future date will not appear in published queries until that date has passed.
+
+## HasContentFilters
+
+**Namespace:** `ArtisanPackUI\CMSFramework\Modules\ContentTypes\Managers\Concerns\HasContentFilters`
+
+Provides shared content query filter logic for content managers. Applied to BlogManager and PageManager.
+
+### Methods
+
+#### `applyStatusFilter(Builder $query, array $filters, bool $defaultToPublished = true): void`
+
+Applies a status filter to the query based on the `$filters['status']` value. Accepts either a `ContentStatus` enum instance or a string value. When the status is `'published'` or unrecognized, it uses the `published()` scope. When no status is provided and `$defaultToPublished` is `true`, it defaults to the published scope.
+
+#### `applySearchFilter(Builder $query, array $filters): void`
+
+Applies a search filter from `$filters['search']` across the `title`, `content`, and `excerpt` columns. Special characters (`\`, `%`, `_`) are escaped for safe LIKE queries.
+
+#### `applyAuthorFilter(Builder $query, array $filters): void`
+
+Applies an author filter from `$filters['author']` using the model's `byAuthor` scope.
+
+### Usage Examples
+
+**Using in a Content Manager:**
+
+```php
+use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Managers\Concerns\HasContentFilters;
+
+class ArticleManager
+{
+    use HasContentFilters;
+
+    public function list( array $filters = [] ): Collection
+    {
+        $query = Article::query();
+
+        $this->applyStatusFilter( $query, $filters );
+        $this->applySearchFilter( $query, $filters );
+        $this->applyAuthorFilter( $query, $filters );
+
+        return $query->latest()->get();
+    }
+}
+```
+
+**Filtering by Status with an Enum:**
+
+```php
+use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Enums\ContentStatus;
+
+$articles = $manager->list( [
+    'status' => ContentStatus::Draft,
+] );
+```
+
+**Filtering by Status with a String:**
+
+```php
+$articles = $manager->list( [
+    'status' => 'draft',
+] );
+```
+
+**Searching Content:**
+
+```php
+$results = $manager->list( [
+    'search' => 'Laravel tutorial',
+] );
+```
+
+**Combining Filters:**
+
+```php
+$results = $manager->list( [
+    'status' => 'published',
+    'search' => 'getting started',
+    'author' => $userId,
+] );
+```
+
+**Disabling Default Published Filter:**
+
+```php
+// In an admin context where you want to see all statuses by default
+$this->applyStatusFilter( $query, $filters, false );
+```
+
+## HasManifestParsing
+
+**Namespace:** `ArtisanPackUI\CMSFramework\Modules\Core\Managers\Concerns\HasManifestParsing`
+
+Provides shared manifest parsing, slug validation, and path traversal prevention for package managers. Applied to PluginManager and ThemeManager.
+
+### Security Focus
+
+This trait includes security measures to prevent path traversal attacks when discovering plugins and themes from the filesystem. It validates slugs against a strict pattern and resolves real filesystem paths to ensure they remain within the expected base directory.
+
+### Methods
+
+#### `parseManifest(string $manifestPath): ?array`
+
+Reads and decodes a JSON manifest file (e.g., `plugin.json` or `theme.json`). Returns the parsed array on success, or `null` if the file does not exist or contains invalid JSON.
+
+#### `validateSlug(string $slug): bool`
+
+Validates that a slug only contains alphanumeric characters, hyphens, and underscores. Uses the pattern `/^[a-zA-Z0-9_-]+$/`. Returns `false` for slugs containing path separators, dots, or other special characters.
+
+#### `resolveSecurePath(string $itemPath, string $basePath): ?string`
+
+Resolves the real filesystem path and verifies it is contained within the expected base directory. Returns the resolved real path on success, or `null` if the path does not exist or is outside the base directory.
+
+### Usage Examples
+
+**Using in a Package Manager:**
+
+```php
+use ArtisanPackUI\CMSFramework\Modules\Core\Managers\Concerns\HasManifestParsing;
+
+class WidgetManager
+{
+    use HasManifestParsing;
+
+    protected string $basePath;
+
+    public function __construct()
+    {
+        $this->basePath = base_path( 'widgets' );
+    }
+
+    public function discover(): array
+    {
+        $widgets = [];
+
+        foreach ( glob( $this->basePath . '/*', GLOB_ONLYDIR ) as $dir ) {
+            $slug = basename( $dir );
+
+            if ( ! $this->validateSlug( $slug ) ) {
+                continue;
+            }
+
+            $securePath = $this->resolveSecurePath( $dir, $this->basePath );
+            if ( null === $securePath ) {
+                continue;
+            }
+
+            $manifest = $this->parseManifest( $securePath . '/widget.json' );
+            if ( null === $manifest ) {
+                continue;
+            }
+
+            $widgets[$slug] = $manifest;
+        }
+
+        return $widgets;
+    }
+}
+```
+
+**Validating Slugs:**
+
+```php
+$this->validateSlug( 'my-plugin' );    // true
+$this->validateSlug( 'my_plugin' );    // true
+$this->validateSlug( 'MyPlugin123' );  // true
+$this->validateSlug( '../etc/passwd' ); // false
+$this->validateSlug( 'plugin.bak' );   // false
+```
+
+**Preventing Path Traversal:**
+
+```php
+$basePath = '/var/www/plugins';
+
+// Valid path within the base directory
+$result = $this->resolveSecurePath( '/var/www/plugins/my-plugin', $basePath );
+// Returns: '/var/www/plugins/my-plugin'
+
+// Attempted traversal
+$result = $this->resolveSecurePath( '/var/www/plugins/../../etc', $basePath );
+// Returns: null
+```
+
+**Parsing a Manifest File:**
+
+```php
+$manifest = $this->parseManifest( base_path( 'plugins/my-plugin/plugin.json' ) );
+
+if ( null === $manifest ) {
+    // File missing or invalid JSON
+    return;
+}
+
+$name    = $manifest['name'] ?? 'Unknown';
+$version = $manifest['version'] ?? '0.0.0';
+```
+
+## HasIncludableRelationships
+
+**Namespace:** `ArtisanPackUI\CMSFramework\Http\Controllers\Concerns\HasIncludableRelationships`
+
+Provides support for dynamically including Eloquent relationships in API responses via query parameters. This trait is used by API controllers to allow clients to request related data using an `include` query parameter.
+
+For full details on how includable relationships work, see the [Includable Relationships API documentation](../api/README.md).

--- a/docs/exceptions.md
+++ b/docs/exceptions.md
@@ -16,6 +16,28 @@ try {
 }
 ```
 
+### Standardized JSON Rendering (v1.1.0)
+
+All framework exceptions automatically render as JSON when the request expects JSON (API requests). Each exception defines an `$errorCode` and `$statusCode`:
+
+```json
+{
+  "error": {
+    "code": "SERVER_ERROR",
+    "message": "Something went wrong."
+  }
+}
+```
+
+| Exception | Error Code | HTTP Status |
+|-----------|-----------|-------------|
+| `CMSFrameworkException` | `SERVER_ERROR` | 500 |
+| `NotFoundException` | `NOT_FOUND` | 404 |
+| `UnauthorizedException` | `FORBIDDEN` | 403 |
+| `ValidationException` | `VALIDATION_ERROR` | 422 |
+
+See [[api/Error Responses]] for complete error response documentation.
+
 ## Common Exceptions
 
 ### ValidationException
@@ -248,7 +270,19 @@ class YourModuleException extends CMSFrameworkException
 
 ## Exception Handling in Controllers
 
-In controllers, catch framework exceptions and return appropriate responses:
+Since v1.1.0, all CMS Framework exceptions automatically render as JSON when the request expects JSON. You no longer need to manually catch exceptions to format error responses — simply let the exception propagate:
+
+```php
+public function update(Request $request, int $id)
+{
+    // Exceptions auto-render as standardized JSON responses.
+    // NotFoundException → 404, UnauthorizedException → 403, etc.
+    $post = $this->manager->update($id, $request->all());
+    return response()->json($post);
+}
+```
+
+If you need custom handling, you can still catch exceptions:
 
 ```php
 use ArtisanPackUI\CMSFramework\Exceptions\NotFoundException;
@@ -261,14 +295,9 @@ public function update(Request $request, int $id)
         $post = $this->manager->update($id, $request->all());
         return response()->json($post);
     } catch (NotFoundException $e) {
-        return response()->json(['error' => $e->getMessage()], 404);
-    } catch (UnauthorizedException $e) {
-        return response()->json(['error' => $e->getMessage()], 403);
-    } catch (ValidationException $e) {
-        return response()->json([
-            'message' => $e->getMessage(),
-            'errors' => $e->getErrors(),
-        ], 422);
+        // Custom handling — the auto-rendered JSON is available via:
+        // $e->getErrorCode()  → 'NOT_FOUND'
+        // $e->getStatusCode() → 404
     }
 }
 ```

--- a/docs/home.md
+++ b/docs/home.md
@@ -16,7 +16,12 @@ The CMS Framework is designed to help developers quickly build content managemen
 - **Settings Management**: Application-wide configuration with type casting and sanitization
 - **Admin Framework**: Menu system, widgets, and authorization helpers
 - **Theme & Plugin Architecture**: Extensible system for themes and plugins
-- **RESTful API**: Clean API endpoints for all operations
+- **RESTful API**: Clean API endpoints for all operations with standardized error responses
+- **Bulk Actions**: Bulk operations for posts, pages, and users
+- **On-Demand Relationships**: Control eager loading via the `include` query parameter
+- **OpenAPI Documentation**: Auto-generated API documentation with Swagger UI
+- **TypeScript Types**: Publishable type definitions for frontend integration
+- **Type-Safe Enums**: ContentStatus, FieldType, ColumnType, SettingType, and UpdateType enums
 - **Laravel Integration**: Seamless integration with Laravel applications
 
 ---
@@ -117,6 +122,8 @@ Custom content type builder for extensible content.
 - [[developer/content types]] - Creating custom content types
 - [[developer/custom fields]] - Adding custom fields to content
 - [[developer/taxonomies]] - Creating custom taxonomies
+- [[developer/enums]] - ContentStatus, FieldType, and ColumnType enums
+- [[developer/traits]] - HasContentStatus and HasContentFilters traits
 
 ---
 
@@ -153,6 +160,11 @@ System update management for keeping the CMS current.
 ### API Documentation
 
 - [[api/README]] - REST API overview and authentication
+- [[api/Error Responses]] - Standardized JSON error response format
+- [[api/Bulk Actions]] - Bulk action endpoints for posts, pages, and users
+- [[api/Includable Relationships]] - On-demand relationship loading
+- [[api/OpenAPI]] - OpenAPI specification and Swagger UI
+- [[api/TypeScript Types]] - TypeScript type definitions for frontend
 - [[Routes]] - Complete route registry
 - [[Relationships]] - Model relationship documentation
 
@@ -160,6 +172,8 @@ System update management for keeping the CMS current.
 
 - [[Helpers]] - Helper functions reference (ap-prefixed)
 - [[Exceptions]] - Exception hierarchy and error handling
+- [[developer/enums]] - Type-safe enums reference
+- [[developer/traits]] - Shared traits reference
 
 ---
 
@@ -188,12 +202,15 @@ All API endpoints use the `/api/cms` prefix with Sanctum authentication.
 ### User Management
 - `GET/POST /users` - List/create users
 - `GET/PUT/DELETE /users/{id}` - User operations
+- `POST /users/bulk` - Bulk user actions (delete, activate, deactivate)
 - `GET/POST /roles` - Role management
 - `GET/POST /permissions` - Permission management
 
 ### Content
 - `GET/POST /posts` - Blog post management
+- `POST /posts/bulk` - Bulk post actions (delete, publish, draft)
 - `GET/POST /pages` - Page management
+- `POST /pages/bulk` - Bulk page actions (delete, publish, draft)
 - `GET/POST /content-types` - Content type management
 
 ### System
@@ -201,6 +218,10 @@ All API endpoints use the `/api/cms` prefix with Sanctum authentication.
 - `GET/POST /notifications` - Notification operations
 - `GET/POST /themes` - Theme management
 - `GET/POST /plugins` - Plugin management (experimental)
+
+### Documentation
+- `GET /docs/api/cms` - Swagger UI (when OpenAPI enabled)
+- `GET /docs/api/cms.json` - Raw OpenAPI specification
 
 See [[api/README]] for complete API documentation.
 
@@ -230,4 +251,4 @@ For issues, feature requests, and contributions:
 
 ---
 
-*This documentation covers CMS Framework v1.0.0*
+*This documentation covers CMS Framework v1.1.0*

--- a/docs/routes.md
+++ b/docs/routes.md
@@ -32,6 +32,7 @@ Standard RESTful resource routes:
 | GET | `/users/{id}` | show | `UserController@show` | Show a specific user |
 | PUT/PATCH | `/users/{id}` | update | `UserController@update` | Update a user |
 | DELETE | `/users/{id}` | destroy | `UserController@destroy` | Delete a user |
+| POST | `/users/bulk` | bulk | `UserController@bulk` | Bulk user actions |
 
 ### Role Management
 
@@ -75,6 +76,7 @@ Standard RESTful resource routes:
 | GET | `/posts/{id}` | `PostController@show` | Show a specific post |
 | PUT | `/posts/{id}` | `PostController@update` | Update a post |
 | DELETE | `/posts/{id}` | `PostController@destroy` | Delete a post |
+| POST | `/posts/bulk` | `PostController@bulk` | Bulk post actions |
 
 ### Post Archives
 
@@ -117,6 +119,7 @@ Special archive routes for filtering posts:
 Structure identical to Blog module with pages instead of posts:
 
 - `/pages` - Standard CRUD operations
+- `/pages/bulk` - Bulk page actions (delete, publish, draft)
 - `/page-categories` - Category management
 - `/page-tags` - Tag management
 

--- a/docs/settings/Sanitization-and-Types.md
+++ b/docs/settings/Sanitization-and-Types.md
@@ -78,6 +78,31 @@ The Setting model persists a `type` along with `value` and casts automatically w
 
 Tip: Keep your sanitizer consistent with the declared `type`.
 
+### SettingType Enum (v1.1.0)
+
+Type handling is centralized in the `SettingType` enum, which provides:
+
+- **Auto-detection**: `SettingType::fromValue($value)` detects the type from a PHP value
+- **Casting**: `$type->cast($dbValue)` converts stored strings back to native PHP types
+- **Serialization**: `$type->serialize($value)` converts PHP values for database storage
+
+```php
+use ArtisanPackUI\CMSFramework\Modules\Settings\Enums\SettingType;
+
+// Auto-detect type
+$type = SettingType::fromValue(true);      // SettingType::Boolean
+$type = SettingType::fromValue(['a', 'b']); // SettingType::Json
+
+// Cast from database
+$value = SettingType::Boolean->cast('1');   // true
+$value = SettingType::Json->cast('{"k":"v"}'); // ['k' => 'v']
+
+// Serialize for storage
+$stored = SettingType::Boolean->serialize(true); // '1'
+```
+
+See [[developer/enums]] for the complete SettingType reference.
+
 ## Nulls and Empty Values
 
 - If your sanitizer returns null for a non-string type, the model may read back null.

--- a/resources/types/blog.d.ts
+++ b/resources/types/blog.d.ts
@@ -1,0 +1,202 @@
+/**
+ * TypeScript types for the CMS Framework Blog module.
+ *
+ * Mirrors the API Resource and FormRequest shapes from:
+ * - PostResource
+ * - PostCategoryResource
+ * - PostTagResource
+ * - PostRequest
+ * - PostCategoryRequest
+ * - PostTagRequest
+ *
+ * @since 1.1.0
+ */
+
+import type { ContentStatus } from './content-types';
+import type { DateTimeString, Metadata } from './common';
+
+// ---------------------------------------------------------------------------
+// API Response Types (from Resources)
+// ---------------------------------------------------------------------------
+
+/**
+ * Post author summary, included when the `author` relationship is loaded.
+ */
+export interface PostAuthorResponse {
+	/** The author's user ID. */
+	id: number;
+	/** The author's display name. */
+	name: string;
+}
+
+/**
+ * Post response shape returned by PostResource.
+ *
+ * Conditional fields (via `whenLoaded`) are marked optional.
+ */
+export interface PostResponse {
+	/** The post ID. */
+	id: number;
+	/** The post title. */
+	title: string;
+	/** The URL-friendly slug. */
+	slug: string;
+	/** The full post content (HTML). */
+	content: string | null;
+	/** A short excerpt of the post. */
+	excerpt: string | null;
+	/** The ID of the post author. */
+	author_id: number;
+	/** The post author summary. Present when the `author` relationship is loaded. */
+	author?: PostAuthorResponse;
+	/** The publication status of the post. */
+	status: ContentStatus;
+	/** The date and time the post was published. */
+	published_at: DateTimeString | null;
+	/** Whether the post is currently published. */
+	is_published: boolean;
+	/** The full URL permalink. */
+	permalink: string;
+	/** Arbitrary metadata stored as JSON. */
+	metadata: Metadata;
+	/** The post categories. Present when the `categories` relationship is loaded. */
+	categories?: PostCategoryResponse[];
+	/** The post tags. Present when the `tags` relationship is loaded. */
+	tags?: PostTagResponse[];
+	/** The URL of the featured image, or null if not set. */
+	featured_image_url: string | null;
+	/** When the post was created. */
+	created_at: DateTimeString;
+	/** When the post was last updated. */
+	updated_at: DateTimeString;
+	/** When the post was soft-deleted, or null. */
+	deleted_at: DateTimeString | null;
+}
+
+/**
+ * Post category parent summary, included when the `parent` relationship is loaded.
+ */
+export interface PostCategoryParentResponse {
+	/** The parent category ID. */
+	id: number;
+	/** The parent category name. */
+	name: string;
+	/** The parent category slug. */
+	slug: string;
+}
+
+/**
+ * Post category response shape returned by PostCategoryResource.
+ */
+export interface PostCategoryResponse {
+	/** The category ID. */
+	id: number;
+	/** The category name. */
+	name: string;
+	/** The URL-friendly slug. */
+	slug: string;
+	/** A description of the category. */
+	description: string | null;
+	/** The parent category ID, or null if top-level. */
+	parent_id: number | null;
+	/** The parent category summary. Present when the `parent` relationship is loaded. */
+	parent?: PostCategoryParentResponse;
+	/** Child categories. Present when the `children` relationship is loaded. */
+	children?: PostCategoryResponse[];
+	/** The sort order. */
+	order: number;
+	/** The full URL permalink. */
+	permalink: string;
+	/** Arbitrary metadata stored as JSON. */
+	metadata: Metadata;
+	/** When the category was created. */
+	created_at: DateTimeString;
+	/** When the category was last updated. */
+	updated_at: DateTimeString;
+}
+
+/**
+ * Post tag response shape returned by PostTagResource.
+ */
+export interface PostTagResponse {
+	/** The tag ID. */
+	id: number;
+	/** The tag name. */
+	name: string;
+	/** The URL-friendly slug. */
+	slug: string;
+	/** A description of the tag. */
+	description: string | null;
+	/** The full URL permalink. */
+	permalink: string;
+	/** Arbitrary metadata stored as JSON. */
+	metadata: Metadata;
+	/** When the tag was created. */
+	created_at: DateTimeString;
+	/** When the tag was last updated. */
+	updated_at: DateTimeString;
+}
+
+// ---------------------------------------------------------------------------
+// Request Types (from FormRequests)
+// ---------------------------------------------------------------------------
+
+/**
+ * Request body for creating or updating a post (PostRequest).
+ */
+export interface PostRequestData {
+	/** The post title (required, max 255). */
+	title: string;
+	/** The URL-friendly slug (required, unique, lowercase alphanumeric with hyphens). */
+	slug: string;
+	/** The full post content. */
+	content?: string | null;
+	/** A short excerpt. */
+	excerpt?: string | null;
+	/** The author's user ID. */
+	author_id: number;
+	/** The publication status. */
+	status: ContentStatus;
+	/** The date and time to publish the post. */
+	published_at?: string | null;
+	/** Arbitrary metadata as a JSON object. */
+	metadata?: Record<string, unknown> | null;
+	/** Array of category IDs to attach. */
+	categories?: number[] | null;
+	/** Array of tag IDs to attach. */
+	tags?: number[] | null;
+}
+
+/**
+ * Request body for creating or updating a post category (PostCategoryRequest).
+ */
+export interface PostCategoryRequestData {
+	/** The category name (required, max 255). */
+	name: string;
+	/** The URL-friendly slug (required, unique, lowercase alphanumeric with hyphens). */
+	slug: string;
+	/** A description of the category. */
+	description?: string | null;
+	/** The parent category ID, or null for top-level. */
+	parent_id?: number | null;
+	/** The sort order (min 0). */
+	order?: number;
+	/** Arbitrary metadata as a JSON object. */
+	metadata?: Record<string, unknown> | null;
+}
+
+/**
+ * Request body for creating or updating a post tag (PostTagRequest).
+ */
+export interface PostTagRequestData {
+	/** The tag name (required, max 255). */
+	name: string;
+	/** The URL-friendly slug (required, unique, lowercase alphanumeric with hyphens). */
+	slug: string;
+	/** A description of the tag. */
+	description?: string | null;
+	/** The sort order (min 0). */
+	order?: number;
+	/** Arbitrary metadata as a JSON object. */
+	metadata?: Record<string, unknown> | null;
+}

--- a/resources/types/blog.d.ts
+++ b/resources/types/blog.d.ts
@@ -99,8 +99,8 @@ export interface PostCategoryResponse {
 	description: string | null;
 	/** The parent category ID, or null if top-level. */
 	parent_id: number | null;
-	/** The parent category summary. Present when the `parent` relationship is loaded. */
-	parent?: PostCategoryParentResponse;
+	/** The parent category summary. Present when the `parent` relationship is loaded; null for top-level categories. */
+	parent?: PostCategoryParentResponse | null;
 	/** Child categories. Present when the `children` relationship is loaded. */
 	children?: PostCategoryResponse[];
 	/** The sort order. */
@@ -158,7 +158,7 @@ export interface PostRequestData {
 	/** The publication status. */
 	status: ContentStatus;
 	/** The date and time to publish the post. */
-	published_at?: string | null;
+	published_at?: DateTimeString | null;
 	/** Arbitrary metadata as a JSON object. */
 	metadata?: Record<string, unknown> | null;
 	/** Array of category IDs to attach. */

--- a/resources/types/common.d.ts
+++ b/resources/types/common.d.ts
@@ -1,0 +1,64 @@
+/**
+ * Common types shared across the CMS Framework API.
+ *
+ * @since 1.1.0
+ */
+
+/** ISO 8601 date-time string (e.g. "2024-01-15T12:00:00.000000Z"). */
+export type DateTimeString = string;
+
+/** A JSON-serializable metadata object. */
+export type Metadata = Record<string, unknown> | null;
+
+/**
+ * Standard Laravel paginated response wrapper.
+ *
+ * Wraps any resource collection with pagination metadata and navigation links.
+ */
+export interface PaginatedResponse<T> {
+	/** The array of resource items for the current page. */
+	data: T[];
+
+	/** Pagination metadata. */
+	meta: {
+		/** The current page number. */
+		current_page: number;
+		/** The index of the first item on the current page. */
+		from: number | null;
+		/** The last available page number. */
+		last_page: number;
+		/** Pagination links for each page. */
+		links: Array<{
+			url: string | null;
+			label: string;
+			active: boolean;
+		}>;
+		/** Full URL path for the paginated resource. */
+		path: string;
+		/** Number of items per page. */
+		per_page: number;
+		/** The index of the last item on the current page. */
+		to: number | null;
+		/** Total number of items across all pages. */
+		total: number;
+	};
+
+	/** Navigation links. */
+	links: {
+		/** URL for the first page. */
+		first: string;
+		/** URL for the last page. */
+		last: string;
+		/** URL for the previous page, or null if on the first page. */
+		prev: string | null;
+		/** URL for the next page, or null if on the last page. */
+		next: string | null;
+	};
+}
+
+/**
+ * Standard Laravel single-resource response wrapper.
+ */
+export interface ResourceResponse<T> {
+	data: T;
+}

--- a/resources/types/common.d.ts
+++ b/resources/types/common.d.ts
@@ -7,6 +7,9 @@
 /** ISO 8601 date-time string (e.g. "2024-01-15T12:00:00.000000Z"). */
 export type DateTimeString = string;
 
+/** An array guaranteed to contain at least one element. */
+export type NonEmptyArray<T> = [T, ...T[]];
+
 /** A JSON-serializable metadata object. */
 export type Metadata = Record<string, unknown> | null;
 

--- a/resources/types/content-types.d.ts
+++ b/resources/types/content-types.d.ts
@@ -1,0 +1,299 @@
+/**
+ * TypeScript types for the CMS Framework ContentTypes module.
+ *
+ * Mirrors the API Resource, Enum, and FormRequest shapes from:
+ * - ContentTypeResource
+ * - CustomFieldResource
+ * - TaxonomyResource
+ * - ColumnType enum
+ * - ContentStatus enum
+ * - FieldType enum
+ * - ContentTypeRequest
+ * - CustomFieldRequest
+ * - TaxonomyRequest
+ *
+ * @since 1.1.0
+ */
+
+import type { DateTimeString, Metadata } from './common';
+
+// ---------------------------------------------------------------------------
+// Enums
+// ---------------------------------------------------------------------------
+
+/**
+ * Content publication status.
+ *
+ * Mirrors `ContentStatus` PHP enum.
+ */
+export type ContentStatus = 'draft' | 'published' | 'scheduled' | 'private';
+
+/**
+ * Database column types available for custom fields.
+ *
+ * Mirrors `ColumnType` PHP enum.
+ */
+export type ColumnType =
+	| 'string'
+	| 'text'
+	| 'integer'
+	| 'bigInteger'
+	| 'decimal'
+	| 'float'
+	| 'double'
+	| 'boolean'
+	| 'date'
+	| 'dateTime'
+	| 'time'
+	| 'json'
+	| 'binary';
+
+/**
+ * UI field types available for custom fields.
+ *
+ * Mirrors `FieldType` PHP enum.
+ */
+export type FieldType =
+	| 'text'
+	| 'textarea'
+	| 'number'
+	| 'select'
+	| 'checkbox'
+	| 'radio'
+	| 'boolean'
+	| 'date'
+	| 'datetime'
+	| 'time'
+	| 'email'
+	| 'url'
+	| 'tel'
+	| 'color'
+	| 'file'
+	| 'image';
+
+/**
+ * Features that a content type can support.
+ */
+export type ContentTypeSupport =
+	| 'title'
+	| 'content'
+	| 'excerpt'
+	| 'featured_image'
+	| 'author'
+	| 'thumbnail'
+	| 'comments'
+	| 'revisions'
+	| 'page_attributes'
+	| 'custom_fields';
+
+// ---------------------------------------------------------------------------
+// API Response Types (from Resources)
+// ---------------------------------------------------------------------------
+
+/**
+ * Content type response shape returned by ContentTypeResource.
+ */
+export interface ContentTypeResponse {
+	/** The content type ID. */
+	id: number;
+	/** The human-readable name. */
+	name: string;
+	/** The URL-friendly slug (unique identifier). */
+	slug: string;
+	/** The database table name for this content type's entries. */
+	table_name: string;
+	/** The fully-qualified Eloquent model class name. */
+	model_class: string;
+	/** A description of the content type. */
+	description: string | null;
+	/** Whether this content type supports hierarchical (parent/child) entries. */
+	hierarchical: boolean;
+	/** Whether this content type has a public archive page. */
+	has_archive: boolean;
+	/** The URL slug for the archive page, if enabled. */
+	archive_slug: string | null;
+	/** The list of features this content type supports. */
+	supports: ContentTypeSupport[] | null;
+	/** Arbitrary metadata stored as JSON. */
+	metadata: Metadata;
+	/** Whether this content type is publicly accessible. */
+	public: boolean;
+	/** Whether this content type is shown in the admin panel. */
+	show_in_admin: boolean;
+	/** The icon identifier for admin display. */
+	icon: string | null;
+	/** The position in the admin menu. */
+	menu_position: number | null;
+	/** The number of custom fields associated with this content type. */
+	custom_fields_count: number;
+	/** When the content type was created. */
+	created_at: DateTimeString;
+	/** When the content type was last updated. */
+	updated_at: DateTimeString;
+}
+
+/**
+ * Custom field response shape returned by CustomFieldResource.
+ */
+export interface CustomFieldResponse {
+	/** The custom field ID. */
+	id: number;
+	/** The human-readable name. */
+	name: string;
+	/** The unique key used in code and database columns. */
+	key: string;
+	/** The UI field type. */
+	type: FieldType;
+	/** The database column type. */
+	column_type: ColumnType;
+	/** A description of the custom field. */
+	description: string | null;
+	/** Array of content type slugs this field belongs to. */
+	content_types: string[];
+	/** Map of content type slugs to names for the associated content types. */
+	content_types_list: Record<string, string>;
+	/** Configuration options for the field (e.g., select choices). */
+	options: Record<string, unknown> | null;
+	/** The sort order. */
+	order: number;
+	/** Whether this field is required. */
+	required: boolean;
+	/** The default value for this field. */
+	default_value: string | null;
+	/** When the custom field was created. */
+	created_at: DateTimeString;
+	/** When the custom field was last updated. */
+	updated_at: DateTimeString;
+}
+
+/**
+ * Taxonomy content type summary, included when the `contentType` relationship is loaded.
+ */
+export interface TaxonomyContentTypeResponse {
+	/** The content type ID. */
+	id: number;
+	/** The content type name. */
+	name: string;
+	/** The content type slug. */
+	slug: string;
+}
+
+/**
+ * Taxonomy response shape returned by TaxonomyResource.
+ */
+export interface TaxonomyResponse {
+	/** The taxonomy ID. */
+	id: number;
+	/** The human-readable name. */
+	name: string;
+	/** The URL-friendly slug (unique identifier). */
+	slug: string;
+	/** The slug of the content type this taxonomy is attached to. */
+	content_type_slug: string;
+	/** The content type summary. Present when the `contentType` relationship is loaded. */
+	content_type?: TaxonomyContentTypeResponse;
+	/** A description of the taxonomy. */
+	description: string | null;
+	/** Whether this taxonomy supports hierarchical terms. */
+	hierarchical: boolean;
+	/** Whether this taxonomy is shown in the admin panel. */
+	show_in_admin: boolean;
+	/** The REST API base path for this taxonomy. */
+	rest_base: string | null;
+	/** Arbitrary metadata stored as JSON. */
+	metadata: Metadata;
+	/** The database table name for terms. */
+	terms_table: string;
+	/** The fully-qualified model class name for terms, or null. */
+	term_model: string | null;
+	/** When the taxonomy was created. */
+	created_at: DateTimeString;
+	/** When the taxonomy was last updated. */
+	updated_at: DateTimeString;
+}
+
+// ---------------------------------------------------------------------------
+// Request Types (from FormRequests)
+// ---------------------------------------------------------------------------
+
+/**
+ * Request body for creating or updating a content type (ContentTypeRequest).
+ */
+export interface ContentTypeRequestData {
+	/** The content type name (required, max 255). */
+	name: string;
+	/** The URL-friendly slug (required, unique, lowercase alphanumeric with hyphens). */
+	slug: string;
+	/** The database table name (required, lowercase alphanumeric with underscores). */
+	table_name: string;
+	/** The fully-qualified Eloquent model class name. */
+	model_class: string;
+	/** A description of the content type. */
+	description?: string | null;
+	/** Whether this content type supports hierarchy. */
+	hierarchical?: boolean;
+	/** Whether this content type has a public archive. */
+	has_archive?: boolean;
+	/** The archive URL slug. */
+	archive_slug?: string | null;
+	/** The list of features this content type supports. */
+	supports?: ContentTypeSupport[] | null;
+	/** Arbitrary metadata as a JSON object. */
+	metadata?: Record<string, unknown> | null;
+	/** Whether this content type is publicly accessible. */
+	public?: boolean;
+	/** Whether this content type is shown in the admin panel. */
+	show_in_admin?: boolean;
+	/** The icon identifier. */
+	icon?: string | null;
+	/** The admin menu position. */
+	menu_position?: number | null;
+}
+
+/**
+ * Request body for creating or updating a custom field (CustomFieldRequest).
+ */
+export interface CustomFieldRequestData {
+	/** The field name (required, max 255). */
+	name: string;
+	/** The unique key (required, lowercase alphanumeric with underscores). */
+	key: string;
+	/** The UI field type. */
+	type: FieldType;
+	/** The database column type. */
+	column_type: ColumnType;
+	/** A description of the field. */
+	description?: string | null;
+	/** Array of content type slugs this field belongs to (at least one required). */
+	content_types: string[];
+	/** Configuration options for the field. */
+	options?: Record<string, unknown> | null;
+	/** The sort order (min 0). */
+	order?: number;
+	/** Whether this field is required. */
+	required?: boolean;
+	/** The default value for this field. */
+	default_value?: string | null;
+}
+
+/**
+ * Request body for creating or updating a taxonomy (TaxonomyRequest).
+ */
+export interface TaxonomyRequestData {
+	/** The taxonomy name (required, max 255). */
+	name: string;
+	/** The URL-friendly slug (required, unique, lowercase alphanumeric with underscores). */
+	slug: string;
+	/** The content type slug this taxonomy belongs to (must exist). */
+	content_type_slug: string;
+	/** A description of the taxonomy. */
+	description?: string | null;
+	/** Whether this taxonomy supports hierarchical terms. */
+	hierarchical?: boolean;
+	/** Whether this taxonomy is shown in the admin panel. */
+	show_in_admin?: boolean;
+	/** The REST API base path (lowercase alphanumeric with hyphens). */
+	rest_base?: string | null;
+	/** Arbitrary metadata as a JSON object. */
+	metadata?: Record<string, unknown> | null;
+}

--- a/resources/types/content-types.d.ts
+++ b/resources/types/content-types.d.ts
@@ -15,7 +15,7 @@
  * @since 1.1.0
  */
 
-import type { DateTimeString, Metadata } from './common';
+import type { DateTimeString, Metadata, NonEmptyArray } from './common';
 
 // ---------------------------------------------------------------------------
 // Enums
@@ -265,7 +265,7 @@ export interface CustomFieldRequestData {
 	/** A description of the field. */
 	description?: string | null;
 	/** Array of content type slugs this field belongs to (at least one required). */
-	content_types: string[];
+	content_types: NonEmptyArray<string>;
 	/** Configuration options for the field. */
 	options?: Record<string, unknown> | null;
 	/** The sort order (min 0). */

--- a/resources/types/index.d.ts
+++ b/resources/types/index.d.ts
@@ -1,0 +1,92 @@
+/**
+ * ArtisanPack UI CMS Framework - TypeScript Type Definitions
+ *
+ * Provides TypeScript types for all API response shapes, request payloads,
+ * and enums used throughout the CMS Framework.
+ *
+ * Install: `php artisan vendor:publish --tag=cms-types`
+ *
+ * @since 1.1.0
+ */
+
+// Common / shared types
+export type {
+	DateTimeString,
+	Metadata,
+	PaginatedResponse,
+	ResourceResponse,
+} from './common';
+
+// Blog module
+export type {
+	PostAuthorResponse,
+	PostCategoryParentResponse,
+	PostCategoryRequestData,
+	PostCategoryResponse,
+	PostRequestData,
+	PostResponse,
+	PostTagRequestData,
+	PostTagResponse,
+} from './blog';
+
+// Pages module
+export type {
+	BreadcrumbItem,
+	PageAuthorResponse,
+	PageCategoryParentResponse,
+	PageCategoryRequestData,
+	PageCategoryResponse,
+	PageParentResponse,
+	PageRequestData,
+	PageResponse,
+	PageTagRequestData,
+	PageTagResponse,
+} from './pages';
+
+// Content Types module
+export type {
+	ColumnType,
+	ContentStatus,
+	ContentTypeRequestData,
+	ContentTypeResponse,
+	ContentTypeSupport,
+	CustomFieldRequestData,
+	CustomFieldResponse,
+	FieldType,
+	TaxonomyContentTypeResponse,
+	TaxonomyRequestData,
+	TaxonomyResponse,
+} from './content-types';
+
+// Users module
+export type {
+	PermissionRequestData,
+	PermissionResponse,
+	PermissionSummary,
+	RoleRequestData,
+	RoleResponse,
+	RoleSummary,
+	UserResponse,
+} from './users';
+
+// Settings module
+export type {
+	SettingRequestData,
+	SettingResponse,
+	SettingType,
+} from './settings';
+
+// Notifications module
+export type {
+	NotificationPreferenceResponse,
+	NotificationResponse,
+	NotificationType,
+	NotificationTypeInfo,
+	NotificationUserData,
+} from './notifications';
+
+// Plugins module
+export type {
+	PluginResponse,
+	UpdateType,
+} from './plugins';

--- a/resources/types/index.d.ts
+++ b/resources/types/index.d.ts
@@ -13,6 +13,7 @@
 export type {
 	DateTimeString,
 	Metadata,
+	NonEmptyArray,
 	PaginatedResponse,
 	ResourceResponse,
 } from './common';

--- a/resources/types/notifications.d.ts
+++ b/resources/types/notifications.d.ts
@@ -72,11 +72,11 @@ export interface NotificationResponse {
 	/** Whether an email was sent for this notification. */
 	send_email: boolean;
 	/** When the notification was created (ISO 8601). */
-	created_at: string;
+	created_at: DateTimeString;
 	/** Human-readable time since creation (e.g., "2 hours ago"). */
 	created_at_human: string;
 	/** When the notification was last updated (ISO 8601). */
-	updated_at: string;
+	updated_at: DateTimeString;
 	/** User-specific read/dismissed data. Present when loaded via the pivot table. */
 	user_data?: NotificationUserData;
 }

--- a/resources/types/notifications.d.ts
+++ b/resources/types/notifications.d.ts
@@ -1,0 +1,104 @@
+/**
+ * TypeScript types for the CMS Framework Notifications module.
+ *
+ * Mirrors the API Resource and Enum shapes from:
+ * - NotificationResource
+ * - NotificationType enum
+ *
+ * @since 1.1.0
+ */
+
+import type { DateTimeString, Metadata } from './common';
+
+// ---------------------------------------------------------------------------
+// Enums
+// ---------------------------------------------------------------------------
+
+/**
+ * Notification severity/category types.
+ *
+ * Mirrors `NotificationType` PHP enum.
+ */
+export type NotificationType = 'error' | 'warning' | 'success' | 'info';
+
+// ---------------------------------------------------------------------------
+// API Response Types (from Resources)
+// ---------------------------------------------------------------------------
+
+/**
+ * Rich notification type object included in notification responses.
+ */
+export interface NotificationTypeInfo {
+	/** The raw enum value. */
+	value: NotificationType;
+	/** The human-readable label. */
+	label: string;
+	/** The icon identifier (e.g., "fas.circle-check"). */
+	icon: string;
+	/** The Tailwind CSS color classes for this type. */
+	colorClass: string;
+}
+
+/**
+ * User-specific notification data from the pivot table.
+ *
+ * Present when the notification is fetched in the context of a specific user.
+ */
+export interface NotificationUserData {
+	/** Whether the user has read this notification. */
+	is_read: boolean;
+	/** When the user read this notification, or null. */
+	read_at: DateTimeString | null;
+	/** Whether the user has dismissed this notification. */
+	is_dismissed: boolean;
+	/** When the user dismissed this notification, or null. */
+	dismissed_at: DateTimeString | null;
+}
+
+/**
+ * Notification response shape returned by NotificationResource.
+ */
+export interface NotificationResponse {
+	/** The notification ID. */
+	id: number;
+	/** The notification type with label, icon, and color info. */
+	type: NotificationTypeInfo;
+	/** The notification title. */
+	title: string;
+	/** The notification content/message body. */
+	content: string;
+	/** Arbitrary metadata stored as JSON. */
+	metadata: Metadata;
+	/** Whether an email was sent for this notification. */
+	send_email: boolean;
+	/** When the notification was created (ISO 8601). */
+	created_at: string;
+	/** Human-readable time since creation (e.g., "2 hours ago"). */
+	created_at_human: string;
+	/** When the notification was last updated (ISO 8601). */
+	updated_at: string;
+	/** User-specific read/dismissed data. Present when loaded via the pivot table. */
+	user_data?: NotificationUserData;
+}
+
+/**
+ * Notification preference response shape.
+ *
+ * Represents a user's preference for a specific notification type.
+ */
+export interface NotificationPreferenceResponse {
+	/** The preference ID. */
+	id: number;
+	/** The user ID this preference belongs to. */
+	user_id: number;
+	/** The notification type this preference applies to. */
+	notification_type: string;
+	/** Whether in-app notifications of this type are enabled. */
+	is_enabled: boolean;
+	/** Whether email notifications of this type are enabled. */
+	email_enabled: boolean;
+	/** When the preference was created. */
+	created_at: DateTimeString;
+	/** When the preference was last updated. */
+	updated_at: DateTimeString;
+}

--- a/resources/types/pages.d.ts
+++ b/resources/types/pages.d.ts
@@ -1,0 +1,248 @@
+/**
+ * TypeScript types for the CMS Framework Pages module.
+ *
+ * Mirrors the API Resource and FormRequest shapes from:
+ * - PageResource
+ * - PageCategoryResource
+ * - PageTagResource
+ * - PageRequest
+ * - PageCategoryRequest
+ * - PageTagRequest
+ *
+ * @since 1.1.0
+ */
+
+import type { ContentStatus } from './content-types';
+import type { DateTimeString, Metadata } from './common';
+
+// ---------------------------------------------------------------------------
+// API Response Types (from Resources)
+// ---------------------------------------------------------------------------
+
+/**
+ * Page author summary, included when the `author` relationship is loaded.
+ */
+export interface PageAuthorResponse {
+	/** The author's user ID. */
+	id: number;
+	/** The author's display name. */
+	name: string;
+	/** The author's email address. */
+	email: string;
+}
+
+/**
+ * Page parent summary, included when the `parent` relationship is loaded.
+ */
+export interface PageParentResponse {
+	/** The parent page ID. */
+	id: number;
+	/** The parent page title. */
+	title: string;
+	/** The parent page slug. */
+	slug: string;
+}
+
+/**
+ * A single breadcrumb entry in the page hierarchy.
+ */
+export interface BreadcrumbItem {
+	/** The page title. */
+	title: string;
+	/** The full URL for the page. */
+	url: string;
+}
+
+/**
+ * Page response shape returned by PageResource.
+ *
+ * Conditional fields (via `whenLoaded`) are marked optional.
+ */
+export interface PageResponse {
+	/** The page ID. */
+	id: number;
+	/** The page title. */
+	title: string;
+	/** The URL-friendly slug. */
+	slug: string;
+	/** The full page content (HTML). */
+	content: string | null;
+	/** A short excerpt. */
+	excerpt: string | null;
+	/** The ID of the page author. */
+	author_id: number;
+	/** The page author summary. Present when the `author` relationship is loaded. */
+	author?: PageAuthorResponse;
+	/** The parent page ID, or null if top-level. */
+	parent_id: number | null;
+	/** The parent page summary. Present when the `parent` relationship is loaded. */
+	parent?: PageParentResponse | null;
+	/** Child pages. Present when the `children` relationship is loaded. */
+	children?: PageResponse[];
+	/** The sort order. */
+	order: number;
+	/** The template identifier used for rendering. */
+	template: string | null;
+	/** The publication status of the page. */
+	status: ContentStatus;
+	/** The date and time the page was published. */
+	published_at: DateTimeString | null;
+	/** Whether the page is currently published. */
+	is_published: boolean;
+	/** The full URL permalink. */
+	permalink: string;
+	/** The breadcrumb trail from root to this page. */
+	breadcrumb: BreadcrumbItem[];
+	/** The depth level in the page hierarchy (0 = top-level). */
+	depth: number;
+	/** Arbitrary metadata stored as JSON. */
+	metadata: Metadata;
+	/** The page categories. Present when the `categories` relationship is loaded. */
+	categories?: PageCategoryResponse[];
+	/** The page tags. Present when the `tags` relationship is loaded. */
+	tags?: PageTagResponse[];
+	/** The URL of the featured image, or null if not set. */
+	featured_image_url: string | null;
+	/** When the page was created. */
+	created_at: DateTimeString;
+	/** When the page was last updated. */
+	updated_at: DateTimeString;
+	/** When the page was soft-deleted, or null. */
+	deleted_at: DateTimeString | null;
+}
+
+/**
+ * Page category parent summary, included when the `parent` relationship is loaded.
+ */
+export interface PageCategoryParentResponse {
+	/** The parent category ID. */
+	id: number;
+	/** The parent category name. */
+	name: string;
+	/** The parent category slug. */
+	slug: string;
+}
+
+/**
+ * Page category response shape returned by PageCategoryResource.
+ */
+export interface PageCategoryResponse {
+	/** The category ID. */
+	id: number;
+	/** The category name. */
+	name: string;
+	/** The URL-friendly slug. */
+	slug: string;
+	/** A description of the category. */
+	description: string | null;
+	/** The parent category ID, or null if top-level. */
+	parent_id: number | null;
+	/** The parent category summary. Present when the `parent` relationship is loaded. */
+	parent?: PageCategoryParentResponse;
+	/** Child categories. Present when the `children` relationship is loaded. */
+	children?: PageCategoryResponse[];
+	/** The sort order. */
+	order: number;
+	/** The full URL permalink. */
+	permalink: string;
+	/** Arbitrary metadata stored as JSON. */
+	metadata: Metadata;
+	/** When the category was created. */
+	created_at: DateTimeString;
+	/** When the category was last updated. */
+	updated_at: DateTimeString;
+}
+
+/**
+ * Page tag response shape returned by PageTagResource.
+ */
+export interface PageTagResponse {
+	/** The tag ID. */
+	id: number;
+	/** The tag name. */
+	name: string;
+	/** The URL-friendly slug. */
+	slug: string;
+	/** A description of the tag. */
+	description: string | null;
+	/** The sort order. */
+	order: number;
+	/** The full URL permalink. */
+	permalink: string;
+	/** Arbitrary metadata stored as JSON. */
+	metadata: Metadata;
+	/** When the tag was created. */
+	created_at: DateTimeString;
+	/** When the tag was last updated. */
+	updated_at: DateTimeString;
+}
+
+// ---------------------------------------------------------------------------
+// Request Types (from FormRequests)
+// ---------------------------------------------------------------------------
+
+/**
+ * Request body for creating or updating a page (PageRequest).
+ */
+export interface PageRequestData {
+	/** The page title (required, max 255). */
+	title: string;
+	/** The URL-friendly slug (required, unique, lowercase alphanumeric with hyphens). */
+	slug: string;
+	/** The full page content. */
+	content?: string | null;
+	/** A short excerpt. */
+	excerpt?: string | null;
+	/** The author's user ID. */
+	author_id: number;
+	/** The parent page ID, or null for top-level. */
+	parent_id?: number | null;
+	/** The sort order (min 0). */
+	order?: number | null;
+	/** The template identifier (max 255). */
+	template?: string | null;
+	/** The publication status. */
+	status: ContentStatus;
+	/** The date and time to publish the page. */
+	published_at?: string | null;
+	/** Arbitrary metadata as a JSON object. */
+	metadata?: Record<string, unknown> | null;
+	/** Array of category IDs to attach. */
+	categories?: number[] | null;
+	/** Array of tag IDs to attach. */
+	tags?: number[] | null;
+}
+
+/**
+ * Request body for creating or updating a page category (PageCategoryRequest).
+ */
+export interface PageCategoryRequestData {
+	/** The category name (required, max 255). */
+	name: string;
+	/** The URL-friendly slug (required, unique, lowercase alphanumeric with hyphens). */
+	slug: string;
+	/** A description of the category. */
+	description?: string | null;
+	/** The parent category ID, or null for top-level. */
+	parent_id?: number | null;
+	/** The sort order (min 0). */
+	order?: number;
+	/** Arbitrary metadata as a JSON object. */
+	metadata?: Record<string, unknown> | null;
+}
+
+/**
+ * Request body for creating or updating a page tag (PageTagRequest).
+ */
+export interface PageTagRequestData {
+	/** The tag name (required, max 255). */
+	name: string;
+	/** The URL-friendly slug (required, unique, lowercase alphanumeric with hyphens). */
+	slug: string;
+	/** A description of the tag. */
+	description?: string | null;
+	/** The sort order (min 0). */
+	order?: number;
+	/** Arbitrary metadata as a JSON object. */
+	metadata?: Record<string, unknown> | null;
+}

--- a/resources/types/pages.d.ts
+++ b/resources/types/pages.d.ts
@@ -137,8 +137,8 @@ export interface PageCategoryResponse {
 	description: string | null;
 	/** The parent category ID, or null if top-level. */
 	parent_id: number | null;
-	/** The parent category summary. Present when the `parent` relationship is loaded. */
-	parent?: PageCategoryParentResponse;
+	/** The parent category summary. Present when the `parent` relationship is loaded; null for top-level categories. */
+	parent?: PageCategoryParentResponse | null;
 	/** Child categories. Present when the `children` relationship is loaded. */
 	children?: PageCategoryResponse[];
 	/** The sort order. */
@@ -204,7 +204,7 @@ export interface PageRequestData {
 	/** The publication status. */
 	status: ContentStatus;
 	/** The date and time to publish the page. */
-	published_at?: string | null;
+	published_at?: DateTimeString | null;
 	/** Arbitrary metadata as a JSON object. */
 	metadata?: Record<string, unknown> | null;
 	/** Array of category IDs to attach. */

--- a/resources/types/plugins.d.ts
+++ b/resources/types/plugins.d.ts
@@ -1,0 +1,50 @@
+/**
+ * TypeScript types for the CMS Framework Plugins module.
+ *
+ * Mirrors the Plugin model shape as it would appear in API responses.
+ *
+ * @since 1.1.0
+ */
+
+import type { DateTimeString, Metadata } from './common';
+
+// ---------------------------------------------------------------------------
+// Enums
+// ---------------------------------------------------------------------------
+
+/**
+ * Update types for the update checker system.
+ *
+ * Mirrors `UpdateType` PHP enum.
+ */
+export type UpdateType = 'application' | 'plugin' | 'theme';
+
+// ---------------------------------------------------------------------------
+// API Response Types
+// ---------------------------------------------------------------------------
+
+/**
+ * Plugin response shape.
+ */
+export interface PluginResponse {
+	/** The plugin ID. */
+	id: number;
+	/** The unique plugin slug. */
+	slug: string;
+	/** The plugin display name. */
+	name: string;
+	/** The installed version string. */
+	version: string;
+	/** Whether the plugin is currently active. */
+	is_active: boolean;
+	/** The fully-qualified service provider class name, or null. */
+	service_provider: string | null;
+	/** Plugin manifest/metadata. */
+	meta: Metadata;
+	/** When the plugin was installed. */
+	installed_at: DateTimeString;
+	/** When the record was created. */
+	created_at: DateTimeString;
+	/** When the record was last updated. */
+	updated_at: DateTimeString;
+}

--- a/resources/types/settings.d.ts
+++ b/resources/types/settings.d.ts
@@ -1,0 +1,65 @@
+/**
+ * TypeScript types for the CMS Framework Settings module.
+ *
+ * Mirrors the API Resource, Enum, and FormRequest shapes from:
+ * - SettingResource
+ * - SettingType enum
+ * - SettingRequest
+ *
+ * @since 1.1.0
+ */
+
+import type { DateTimeString } from './common';
+
+// ---------------------------------------------------------------------------
+// Enums
+// ---------------------------------------------------------------------------
+
+/**
+ * Setting value data types.
+ *
+ * Mirrors `SettingType` PHP enum. Determines how the raw string value
+ * is cast when retrieved.
+ */
+export type SettingType = 'string' | 'integer' | 'boolean' | 'float' | 'json';
+
+// ---------------------------------------------------------------------------
+// API Response Types (from Resources)
+// ---------------------------------------------------------------------------
+
+/**
+ * Setting response shape returned by SettingResource.
+ *
+ * Note: The `value` field is always returned as a string from the API.
+ * Use the `type` field to determine how to parse it on the client.
+ */
+export interface SettingResponse {
+	/** The setting ID (auto-incremented). */
+	id: number;
+	/** The unique setting key. */
+	key: string;
+	/** The setting value (serialized as a string). */
+	value: string;
+	/** The data type of the setting value. */
+	type: SettingType;
+	/** When the setting was created. */
+	created_at: DateTimeString;
+	/** When the setting was last updated. */
+	updated_at: DateTimeString;
+}
+
+// ---------------------------------------------------------------------------
+// Request Types (from FormRequests)
+// ---------------------------------------------------------------------------
+
+/**
+ * Request body for creating or updating a setting (SettingRequest).
+ */
+export interface SettingRequestData {
+	/** The unique setting key (required, lowercase alphanumeric with hyphens). */
+	key: string;
+	/** The setting value as a string. */
+	value: string;
+	/** The data type of the value (max 255). */
+	type?: string;
+}

--- a/resources/types/users.d.ts
+++ b/resources/types/users.d.ts
@@ -1,0 +1,130 @@
+/**
+ * TypeScript types for the CMS Framework Users module.
+ *
+ * Mirrors the API Resource and FormRequest shapes from:
+ * - UserResource
+ * - RoleResource
+ * - PermissionResource
+ * - PermissionRequest
+ * - RoleRequest
+ *
+ * @since 1.1.0
+ */
+
+import type { DateTimeString } from './common';
+
+// ---------------------------------------------------------------------------
+// API Response Types (from Resources)
+// ---------------------------------------------------------------------------
+
+/**
+ * Role summary used in inline relationship data.
+ */
+export interface RoleSummary {
+	/** The role ID. */
+	id: number;
+	/** The role name. */
+	name: string;
+	/** The role slug. */
+	slug: string;
+}
+
+/**
+ * Permission summary used in inline relationship data.
+ */
+export interface PermissionSummary {
+	/** The permission ID. */
+	id: number;
+	/** The permission name. */
+	name: string;
+	/** The permission slug. */
+	slug: string;
+}
+
+/**
+ * User response shape returned by UserResource.
+ *
+ * Conditional fields (via `whenLoaded`) are marked optional.
+ */
+export interface UserResponse {
+	/** The user ID. */
+	id: number;
+	/** The user's full name. */
+	name: string;
+	/** The user's email address. */
+	email: string;
+	/** When the email was verified, or null if unverified. */
+	email_verified_at: DateTimeString | null;
+	/** When the user account was created. */
+	created_at: DateTimeString;
+	/** When the user account was last updated. */
+	updated_at: DateTimeString;
+	/** The user's roles. Present when the `roles` relationship is loaded. */
+	roles?: RoleSummary[];
+}
+
+/**
+ * Role response shape returned by RoleResource.
+ *
+ * Conditional fields (via `whenLoaded`) are marked optional.
+ */
+export interface RoleResponse {
+	/** The role ID. */
+	id: number;
+	/** The role name. */
+	name: string;
+	/** The URL-friendly slug. */
+	slug: string;
+	/** When the role was created. */
+	created_at: DateTimeString;
+	/** When the role was last updated. */
+	updated_at: DateTimeString;
+	/** The role's permissions. Present when the `permissions` relationship is loaded. */
+	permissions?: PermissionSummary[];
+}
+
+/**
+ * Permission response shape returned by PermissionResource.
+ *
+ * Conditional fields (via `whenLoaded`) are marked optional.
+ */
+export interface PermissionResponse {
+	/** The permission ID. */
+	id: number;
+	/** The permission name. */
+	name: string;
+	/** The permission slug (e.g., "post.create", "user.edit"). */
+	slug: string;
+	/** When the permission was created. */
+	created_at: DateTimeString;
+	/** When the permission was last updated. */
+	updated_at: DateTimeString;
+	/** The roles that have this permission. Present when the `roles` relationship is loaded. */
+	roles?: RoleSummary[];
+}
+
+// ---------------------------------------------------------------------------
+// Request Types (from FormRequests)
+// ---------------------------------------------------------------------------
+
+/**
+ * Request body for creating or updating a permission (PermissionRequest).
+ */
+export interface PermissionRequestData {
+	/** The permission name (required, unique, max 255). */
+	name: string;
+	/** The permission slug (required, unique, dot-separated segments with hyphens, e.g. "post.create"). */
+	slug: string;
+}
+
+/**
+ * Request body for creating or updating a role (RoleRequest).
+ */
+export interface RoleRequestData {
+	/** The role name (required, unique, max 255). */
+	name: string;
+	/** The URL-friendly slug (required, unique, lowercase alphanumeric with hyphens). */
+	slug: string;
+	/** Array of permission IDs to attach. */
+	permissions?: number[] | null;
+}

--- a/src/CMSFrameworkServiceProvider.php
+++ b/src/CMSFrameworkServiceProvider.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare( strict_types=1 );
 
 /**
  * Service provider for the CMS Framework.
@@ -55,17 +55,17 @@ class CMSFrameworkServiceProvider extends ServiceProvider
         $this->mergeConfiguration();
         $this->validateConfiguration();
 
-        if ($this->app->runningInConsole()) {
-            $this->publishes([
-                __DIR__.'/../config/cms-framework.php' => config_path('artisanpack/cms-framework.php'),
-            ], 'artisanpack-package-config');
+        if ( $this->app->runningInConsole() ) {
+            $this->publishes( [
+                __DIR__ . '/../config/cms-framework.php' => config_path( 'artisanpack/cms-framework.php' ),
+            ], 'artisanpack-package-config' );
 
-            $this->publishes([
-                __DIR__.'/../resources/types' => resource_path('types/cms-framework'),
-            ], 'cms-types');
+            $this->publishes( [
+                __DIR__ . '/../resources/types' => resource_path( 'types/cms-framework' ),
+            ], 'cms-types' );
         }
 
-        $this->loadMigrationsFrom(__DIR__.'/../database/migrations');
+        $this->loadMigrationsFrom( __DIR__ . '/../database/migrations' );
     }
 
     /**
@@ -80,21 +80,21 @@ class CMSFrameworkServiceProvider extends ServiceProvider
     public function register(): void
     {
         $this->mergeConfigFrom(
-            __DIR__.'/../config/cms-framework.php', 'artisanpack-cms-framework-temp',
+            __DIR__ . '/../config/cms-framework.php', 'artisanpack-cms-framework-temp',
         );
 
-        $this->app->register(UserServiceProvider::class);
-        $this->app->register(AdminServiceProvider::class);
-        $this->app->register(AdminWidgetServiceProvider::class);
-        $this->app->register(CoreServiceProvider::class);
-        $this->app->register(SettingsServiceProvider::class);
-        $this->app->register(NotificationServiceProvider::class);
-        $this->app->register(ContentTypesServiceProvider::class);
-        $this->app->register(BlogServiceProvider::class);
-        $this->app->register(PagesServiceProvider::class);
-        $this->app->register(ThemesServiceProvider::class);
-        $this->app->register(PluginsServiceProvider::class);
-        $this->app->register(OpenApiServiceProvider::class);
+        $this->app->register( UserServiceProvider::class );
+        $this->app->register( AdminServiceProvider::class );
+        $this->app->register( AdminWidgetServiceProvider::class );
+        $this->app->register( CoreServiceProvider::class );
+        $this->app->register( SettingsServiceProvider::class );
+        $this->app->register( NotificationServiceProvider::class );
+        $this->app->register( ContentTypesServiceProvider::class );
+        $this->app->register( BlogServiceProvider::class );
+        $this->app->register( PagesServiceProvider::class );
+        $this->app->register( ThemesServiceProvider::class );
+        $this->app->register( PluginsServiceProvider::class );
+        $this->app->register( OpenApiServiceProvider::class );
     }
 
     /**
@@ -108,16 +108,16 @@ class CMSFrameworkServiceProvider extends ServiceProvider
     protected function mergeConfiguration(): void
     {
         // Get the package's default configuration.
-        $packageDefaults = config('artisanpack-cms-framework-temp', []);
+        $packageDefaults = config( 'artisanpack-cms-framework-temp', [] );
 
         // Get the user's custom configuration from config/artisanpack.php.
-        $userConfig = config('artisanpack.cms-framework', []);
+        $userConfig = config( 'artisanpack.cms-framework', [] );
 
         // Merge them, with the user's config overwriting the defaults.
-        $mergedConfig = array_replace_recursive($packageDefaults, $userConfig);
+        $mergedConfig = array_replace_recursive( $packageDefaults, $userConfig );
 
         // Set the final, correctly merged configuration.
-        config(['artisanpack.cms-framework' => $mergedConfig]);
+        config( ['artisanpack.cms-framework' => $mergedConfig] );
     }
 
     /**
@@ -135,18 +135,18 @@ class CMSFrameworkServiceProvider extends ServiceProvider
     {
         // Skip validation in console mode to allow setup commands (vendor:publish,
         // package:discover, etc.) to run before the config has been published.
-        if ($this->app->runningInConsole()) {
+        if ( $this->app->runningInConsole() ) {
             return;
         }
 
-        $userModel = config('artisanpack.cms-framework.user_model');
+        $userModel = config( 'artisanpack.cms-framework.user_model' );
 
-        if (null === $userModel) {
+        if ( null === $userModel ) {
             throw new InvalidArgumentException(
-                'The CMS Framework user_model configuration is not set. '.
-                'Please publish the configuration file using: '.
-                'php artisan vendor:publish --tag=artisanpack-package-config '.
-                'Then set the user_model value in config/artisanpack/cms-framework.php to your User model class. '.
+                'The CMS Framework user_model configuration is not set. ' .
+                'Please publish the configuration file using: ' .
+                'php artisan vendor:publish --tag=artisanpack-package-config ' .
+                'Then set the user_model value in config/artisanpack/cms-framework.php to your User model class. ' .
                 'Example: \'user_model\' => \\App\\Models\\User::class',
             );
         }

--- a/src/CMSFrameworkServiceProvider.php
+++ b/src/CMSFrameworkServiceProvider.php
@@ -58,6 +58,10 @@ class CMSFrameworkServiceProvider extends ServiceProvider
             $this->publishes([
                 __DIR__.'/../config/cms-framework.php' => config_path('artisanpack/cms-framework.php'),
             ], 'artisanpack-package-config');
+
+            $this->publishes([
+                __DIR__.'/../resources/types' => resource_path('types/cms-framework'),
+            ], 'cms-types');
         }
 
         $this->loadMigrationsFrom(__DIR__.'/../database/migrations');

--- a/src/CMSFrameworkServiceProvider.php
+++ b/src/CMSFrameworkServiceProvider.php
@@ -20,6 +20,7 @@ use ArtisanPackUI\CMSFramework\Modules\Blog\Providers\BlogServiceProvider;
 use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Providers\ContentTypesServiceProvider;
 use ArtisanPackUI\CMSFramework\Modules\Core\Providers\CoreServiceProvider;
 use ArtisanPackUI\CMSFramework\Modules\Notifications\Providers\NotificationServiceProvider;
+use ArtisanPackUI\CMSFramework\Modules\OpenApi\Providers\OpenApiServiceProvider;
 use ArtisanPackUI\CMSFramework\Modules\Pages\Providers\PagesServiceProvider;
 use ArtisanPackUI\CMSFramework\Modules\Plugins\Providers\PluginsServiceProvider;
 use ArtisanPackUI\CMSFramework\Modules\Settings\Providers\SettingsServiceProvider;
@@ -93,6 +94,7 @@ class CMSFrameworkServiceProvider extends ServiceProvider
         $this->app->register(PagesServiceProvider::class);
         $this->app->register(ThemesServiceProvider::class);
         $this->app->register(PluginsServiceProvider::class);
+        $this->app->register(OpenApiServiceProvider::class);
     }
 
     /**

--- a/src/Exceptions/CMSFrameworkException.php
+++ b/src/Exceptions/CMSFrameworkException.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare( strict_types=1 );
 
 /**
  * Base exception for the CMS Framework.
@@ -62,9 +62,9 @@ class CMSFrameworkException extends Exception
      *
      * @since 1.0.0
      */
-    public function __construct(string $message = '', int $code = 0, ?Exception $previous = null)
+    public function __construct( string $message = '', int $code = 0, ?Exception $previous = null )
     {
-        parent::__construct($message, $code, $previous);
+        parent::__construct( $message, $code, $previous );
     }
 
     /**
@@ -99,9 +99,9 @@ class CMSFrameworkException extends Exception
      *
      * @return JsonResponse|null The JSON response or null to fall back to default rendering.
      */
-    public function render(Request $request): ?JsonResponse
+    public function render( Request $request ): ?JsonResponse
     {
-        if (! $request->expectsJson()) {
+        if ( ! $request->expectsJson() ) {
             return null;
         }
 

--- a/src/Exceptions/CMSFrameworkException.php
+++ b/src/Exceptions/CMSFrameworkException.php
@@ -1,6 +1,6 @@
 <?php
 
-declare( strict_types = 1 );
+declare(strict_types=1);
 
 /**
  * Base exception for the CMS Framework.
@@ -15,6 +15,8 @@ declare( strict_types = 1 );
 namespace ArtisanPackUI\CMSFramework\Exceptions;
 
 use Exception;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
 
 /**
  * Base exception class for all CMS Framework exceptions.
@@ -23,21 +25,109 @@ use Exception;
  * allowing applications to catch all framework exceptions if needed while
  * still maintaining granular exception handling for specific cases.
  *
+ * All exceptions render as a consistent JSON format when thrown during
+ * API requests:
+ *
+ * {
+ *   "error": {
+ *     "code": "SERVER_ERROR",
+ *     "message": "Something went wrong."
+ *   }
+ * }
+ *
  * @since 1.0.0
  */
 class CMSFrameworkException extends Exception
 {
-	/**
-	 * Create a new CMS Framework exception.
-	 *
-	 * @param  string  $message  The exception message.
-	 * @param  int  $code  The exception code (default: 0).
-	 * @param  Exception|null  $previous  The previous exception for chaining (default: null).
-	 *
-	 * @since 1.0.0
-	 */
-	public function __construct( string $message = '', int $code = 0, ?Exception $previous = null )
-	{
-		parent::__construct( $message, $code, $previous );
-	}
+    /**
+     * The machine-readable error code for this exception.
+     *
+     * @since 1.1.0
+     */
+    protected string $errorCode = 'SERVER_ERROR';
+
+    /**
+     * The HTTP status code for this exception.
+     *
+     * @since 1.1.0
+     */
+    protected int $statusCode = 500;
+
+    /**
+     * Create a new CMS Framework exception.
+     *
+     * @param  string  $message  The exception message.
+     * @param  int  $code  The exception code (default: 0).
+     * @param  Exception|null  $previous  The previous exception for chaining (default: null).
+     *
+     * @since 1.0.0
+     */
+    public function __construct(string $message = '', int $code = 0, ?Exception $previous = null)
+    {
+        parent::__construct($message, $code, $previous);
+    }
+
+    /**
+     * Get the machine-readable error code.
+     *
+     * @since 1.1.0
+     */
+    public function getErrorCode(): string
+    {
+        return $this->errorCode;
+    }
+
+    /**
+     * Get the HTTP status code.
+     *
+     * @since 1.1.0
+     */
+    public function getStatusCode(): int
+    {
+        return $this->statusCode;
+    }
+
+    /**
+     * Render the exception as an HTTP response.
+     *
+     * Returns a consistent JSON error format for all CMS Framework exceptions
+     * when the request expects JSON.
+     *
+     * @since 1.1.0
+     *
+     * @param  Request  $request  The incoming HTTP request.
+     *
+     * @return JsonResponse|null The JSON response or null to fall back to default rendering.
+     */
+    public function render(Request $request): ?JsonResponse
+    {
+        if (! $request->expectsJson()) {
+            return null;
+        }
+
+        return new JsonResponse(
+            $this->buildErrorPayload(),
+            $this->statusCode,
+        );
+    }
+
+    /**
+     * Build the error response payload.
+     *
+     * Subclasses can override this method to add additional fields
+     * (e.g., validation errors) to the response.
+     *
+     * @since 1.1.0
+     *
+     * @return array{error: array{code: string, message: string}}
+     */
+    protected function buildErrorPayload(): array
+    {
+        return [
+            'error' => [
+                'code'    => $this->errorCode,
+                'message' => $this->getMessage(),
+            ],
+        ];
+    }
 }

--- a/src/Exceptions/NotFoundException.php
+++ b/src/Exceptions/NotFoundException.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare( strict_types=1 );
 
 /**
  * Not found exception for the CMS Framework.
@@ -42,9 +42,9 @@ class NotFoundException extends CMSFrameworkException
      *
      * @since 1.0.0
      */
-    public static function model(string $model, int|string $id): self
+    public static function model( string $model, int|string $id ): self
     {
-        return new self("Model {$model} with ID {$id} not found.");
+        return new self( "Model {$model} with ID {$id} not found." );
     }
 
     /**
@@ -55,8 +55,8 @@ class NotFoundException extends CMSFrameworkException
      *
      * @since 1.0.0
      */
-    public static function resource(string $resource, string $identifier): self
+    public static function resource( string $resource, string $identifier ): self
     {
-        return new self("{$resource} '{$identifier}' not found.");
+        return new self( "{$resource} '{$identifier}' not found." );
     }
 }

--- a/src/Exceptions/NotFoundException.php
+++ b/src/Exceptions/NotFoundException.php
@@ -1,6 +1,6 @@
 <?php
 
-declare( strict_types = 1 );
+declare(strict_types=1);
 
 /**
  * Not found exception for the CMS Framework.
@@ -20,33 +20,43 @@ namespace ArtisanPackUI\CMSFramework\Exceptions;
  */
 class NotFoundException extends CMSFrameworkException
 {
-	/**
-	 * Create a not found exception for a model.
-	 *
-	 * @param  string  $model  The model class name.
-	 * @param  int|string  $id  The model ID.
-	 *
-	 * @return self
-	 *
-	 * @since 1.0.0
-	 */
-	public static function model( string $model, int|string $id ): self
-	{
-		return new self( "Model {$model} with ID {$id} not found." );
-	}
+    /**
+     * The machine-readable error code for this exception.
+     *
+     * @since 1.1.0
+     */
+    protected string $errorCode = 'NOT_FOUND';
 
-	/**
-	 * Create a not found exception for a resource.
-	 *
-	 * @param  string  $resource  The resource type.
-	 * @param  string  $identifier  The resource identifier.
-	 *
-	 * @return self
-	 *
-	 * @since 1.0.0
-	 */
-	public static function resource( string $resource, string $identifier ): self
-	{
-		return new self( "{$resource} '{$identifier}' not found." );
-	}
+    /**
+     * The HTTP status code for this exception.
+     *
+     * @since 1.1.0
+     */
+    protected int $statusCode = 404;
+
+    /**
+     * Create a not found exception for a model.
+     *
+     * @param  string  $model  The model class name.
+     * @param  int|string  $id  The model ID.
+     *
+     * @since 1.0.0
+     */
+    public static function model(string $model, int|string $id): self
+    {
+        return new self("Model {$model} with ID {$id} not found.");
+    }
+
+    /**
+     * Create a not found exception for a resource.
+     *
+     * @param  string  $resource  The resource type.
+     * @param  string  $identifier  The resource identifier.
+     *
+     * @since 1.0.0
+     */
+    public static function resource(string $resource, string $identifier): self
+    {
+        return new self("{$resource} '{$identifier}' not found.");
+    }
 }

--- a/src/Exceptions/UnauthorizedException.php
+++ b/src/Exceptions/UnauthorizedException.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare( strict_types=1 );
 
 /**
  * Unauthorized exception for the CMS Framework.
@@ -41,9 +41,9 @@ class UnauthorizedException extends CMSFrameworkException
      *
      * @since 1.0.0
      */
-    public static function forAction(string $action): self
+    public static function forAction( string $action ): self
     {
-        return new self("You are not authorized to {$action}.");
+        return new self( "You are not authorized to {$action}." );
     }
 
     /**
@@ -54,9 +54,9 @@ class UnauthorizedException extends CMSFrameworkException
      *
      * @since 1.0.0
      */
-    public static function forResource(string $resource, string $action): self
+    public static function forResource( string $resource, string $action ): self
     {
-        return new self("You are not authorized to {$action} {$resource}.");
+        return new self( "You are not authorized to {$action} {$resource}." );
     }
 
     /**
@@ -66,8 +66,8 @@ class UnauthorizedException extends CMSFrameworkException
      *
      * @since 1.0.0
      */
-    public static function requiresPermission(string $permission): self
+    public static function requiresPermission( string $permission ): self
     {
-        return new self("This action requires the '{$permission}' permission.");
+        return new self( "This action requires the '{$permission}' permission." );
     }
 }

--- a/src/Exceptions/UnauthorizedException.php
+++ b/src/Exceptions/UnauthorizedException.php
@@ -1,6 +1,6 @@
 <?php
 
-declare( strict_types = 1 );
+declare(strict_types=1);
 
 /**
  * Unauthorized exception for the CMS Framework.
@@ -20,46 +20,54 @@ namespace ArtisanPackUI\CMSFramework\Exceptions;
  */
 class UnauthorizedException extends CMSFrameworkException
 {
-	/**
-	 * Create an unauthorized exception for an action.
-	 *
-	 * @param  string  $action  The action that was attempted.
-	 *
-	 * @return self
-	 *
-	 * @since 1.0.0
-	 */
-	public static function forAction( string $action ): self
-	{
-		return new self( "You are not authorized to {$action}." );
-	}
+    /**
+     * The machine-readable error code for this exception.
+     *
+     * @since 1.1.0
+     */
+    protected string $errorCode = 'FORBIDDEN';
 
-	/**
-	 * Create an unauthorized exception for a resource.
-	 *
-	 * @param  string  $resource  The resource type.
-	 * @param  string  $action  The action that was attempted.
-	 *
-	 * @return self
-	 *
-	 * @since 1.0.0
-	 */
-	public static function forResource( string $resource, string $action ): self
-	{
-		return new self( "You are not authorized to {$action} {$resource}." );
-	}
+    /**
+     * The HTTP status code for this exception.
+     *
+     * @since 1.1.0
+     */
+    protected int $statusCode = 403;
 
-	/**
-	 * Create an unauthorized exception for permission requirement.
-	 *
-	 * @param  string  $permission  The required permission.
-	 *
-	 * @return self
-	 *
-	 * @since 1.0.0
-	 */
-	public static function requiresPermission( string $permission ): self
-	{
-		return new self( "This action requires the '{$permission}' permission." );
-	}
+    /**
+     * Create an unauthorized exception for an action.
+     *
+     * @param  string  $action  The action that was attempted.
+     *
+     * @since 1.0.0
+     */
+    public static function forAction(string $action): self
+    {
+        return new self("You are not authorized to {$action}.");
+    }
+
+    /**
+     * Create an unauthorized exception for a resource.
+     *
+     * @param  string  $resource  The resource type.
+     * @param  string  $action  The action that was attempted.
+     *
+     * @since 1.0.0
+     */
+    public static function forResource(string $resource, string $action): self
+    {
+        return new self("You are not authorized to {$action} {$resource}.");
+    }
+
+    /**
+     * Create an unauthorized exception for permission requirement.
+     *
+     * @param  string  $permission  The required permission.
+     *
+     * @since 1.0.0
+     */
+    public static function requiresPermission(string $permission): self
+    {
+        return new self("This action requires the '{$permission}' permission.");
+    }
 }

--- a/src/Exceptions/ValidationException.php
+++ b/src/Exceptions/ValidationException.php
@@ -1,6 +1,6 @@
 <?php
 
-declare( strict_types = 1 );
+declare(strict_types=1);
 
 /**
  * Validation exception for the CMS Framework.
@@ -16,56 +16,97 @@ namespace ArtisanPackUI\CMSFramework\Exceptions;
 /**
  * Exception thrown when validation fails.
  *
+ * Renders as:
+ * {
+ *   "error": {
+ *     "code": "VALIDATION_ERROR",
+ *     "message": "The given data was invalid.",
+ *     "errors": {
+ *       "title": ["The title field is required."]
+ *     }
+ *   }
+ * }
+ *
  * @since 1.0.0
  */
 class ValidationException extends CMSFrameworkException
 {
-	/**
-	 * The validation errors.
-	 *
-	 * @var array<string, array<string>>
-	 */
-	protected array $errors = [];
+    /**
+     * The machine-readable error code for this exception.
+     *
+     * @since 1.1.0
+     */
+    protected string $errorCode = 'VALIDATION_ERROR';
 
-	/**
-	 * Create a new validation exception with errors.
-	 *
-	 * @param  string  $message  The exception message.
-	 * @param  array<string, array<string>>  $errors  The validation errors.
-	 *
-	 * @since 1.0.0
-	 */
-	public static function withErrors( string $message, array $errors ): self
-	{
-		$exception         = new self( $message );
-		$exception->errors = $errors;
+    /**
+     * The HTTP status code for this exception.
+     *
+     * @since 1.1.0
+     */
+    protected int $statusCode = 422;
 
-		return $exception;
-	}
+    /**
+     * The validation errors.
+     *
+     * @var array<string, array<string>>
+     */
+    protected array $errors = [];
 
-	/**
-	 * Get the validation errors.
-	 *
-	 * @return array<string, array<string>>
-	 *
-	 * @since 1.0.0
-	 */
-	public function getErrors(): array
-	{
-		return $this->errors;
-	}
+    /**
+     * Create a new validation exception with errors.
+     *
+     * @param  string  $message  The exception message.
+     * @param  array<string, array<string>>  $errors  The validation errors.
+     *
+     * @since 1.0.0
+     */
+    public static function withErrors(string $message, array $errors): self
+    {
+        $exception         = new self($message);
+        $exception->errors = $errors;
 
-	/**
-	 * Check if a specific field has errors.
-	 *
-	 * @param  string  $field  The field name.
-	 *
-	 * @return bool
-	 *
-	 * @since 1.0.0
-	 */
-	public function hasError( string $field ): bool
-	{
-		return isset( $this->errors[ $field ] );
-	}
+        return $exception;
+    }
+
+    /**
+     * Get the validation errors.
+     *
+     * @return array<string, array<string>>
+     *
+     * @since 1.0.0
+     */
+    public function getErrors(): array
+    {
+        return $this->errors;
+    }
+
+    /**
+     * Check if a specific field has errors.
+     *
+     * @param  string  $field  The field name.
+     *
+     * @since 1.0.0
+     */
+    public function hasError(string $field): bool
+    {
+        return isset($this->errors[$field]);
+    }
+
+    /**
+     * Build the error response payload including field-level validation errors.
+     *
+     * @since 1.1.0
+     *
+     * @return array{error: array{code: string, message: string, errors?: array<string, array<string>>}}
+     */
+    protected function buildErrorPayload(): array
+    {
+        $payload = parent::buildErrorPayload();
+
+        if (! empty($this->errors)) {
+            $payload['error']['errors'] = $this->errors;
+        }
+
+        return $payload;
+    }
 }

--- a/src/Exceptions/ValidationException.php
+++ b/src/Exceptions/ValidationException.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare( strict_types=1 );
 
 /**
  * Validation exception for the CMS Framework.
@@ -60,9 +60,9 @@ class ValidationException extends CMSFrameworkException
      *
      * @since 1.0.0
      */
-    public static function withErrors(string $message, array $errors): self
+    public static function withErrors( string $message, array $errors ): self
     {
-        $exception         = new self($message);
+        $exception         = new self( $message );
         $exception->errors = $errors;
 
         return $exception;
@@ -87,9 +87,9 @@ class ValidationException extends CMSFrameworkException
      *
      * @since 1.0.0
      */
-    public function hasError(string $field): bool
+    public function hasError( string $field ): bool
     {
-        return isset($this->errors[$field]);
+        return isset( $this->errors[ $field ] );
     }
 
     /**
@@ -103,7 +103,7 @@ class ValidationException extends CMSFrameworkException
     {
         $payload = parent::buildErrorPayload();
 
-        if (! empty($this->errors)) {
+        if ( ! empty( $this->errors ) ) {
             $payload['error']['errors'] = $this->errors;
         }
 

--- a/src/Http/Controllers/Concerns/HasIncludableRelationships.php
+++ b/src/Http/Controllers/Concerns/HasIncludableRelationships.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare( strict_types=1 );
 
 /**
  * HasIncludableRelationships Trait for API Controllers.
@@ -40,23 +40,23 @@ trait HasIncludableRelationships
      *
      * @return array<int, string> The validated relationship names to eager load.
      */
-    protected function getRequestedIncludes(Request $request): array
+    protected function getRequestedIncludes( Request $request ): array
     {
         $allowable = $this->getIncludableRelationships();
 
-        if (! $request->has('include')) {
+        if ( ! $request->has( 'include' ) ) {
             return $this->getDefaultIncludes();
         }
 
-        $requested = $request->query('include', '');
+        $requested = $request->query( 'include', '' );
 
-        if (empty($requested)) {
+        if ( empty( $requested ) ) {
             return [];
         }
 
-        $includes = array_map('trim', explode(',', $requested));
+        $includes = array_map( 'trim', explode( ',', $requested ) );
 
-        return array_values(array_intersect($includes, $allowable));
+        return array_values( array_intersect( $includes, $allowable ) );
     }
 
     /**

--- a/src/Http/Controllers/Concerns/HasIncludableRelationships.php
+++ b/src/Http/Controllers/Concerns/HasIncludableRelationships.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * HasIncludableRelationships Trait for API Controllers.
+ *
+ * Provides on-demand relationship loading via the `include` query parameter.
+ * Controllers define an allowlist of includable relationships and optional
+ * defaults to maintain backwards compatibility.
+ *
+ * @since 1.1.0
+ */
+
+namespace ArtisanPackUI\CMSFramework\Http\Controllers\Concerns;
+
+use Illuminate\Http\Request;
+
+/**
+ * Trait for handling on-demand relationship loading via the include query parameter.
+ *
+ * Controllers using this trait should define:
+ * - `$includableRelationships`: array of allowed relationship names
+ * - `$defaultIncludes`: array of relationships to load when no `include` param is present
+ *
+ * @since 1.1.0
+ */
+trait HasIncludableRelationships
+{
+    /**
+     * Get the validated relationships to include based on the request.
+     *
+     * When the `include` query parameter is present, only the requested (and allowed)
+     * relationships are returned. When absent, the default includes are returned
+     * for backwards compatibility.
+     *
+     * @since 1.1.0
+     *
+     * @param  Request  $request  The HTTP request instance.
+     *
+     * @return array<int, string> The validated relationship names to eager load.
+     */
+    protected function getRequestedIncludes(Request $request): array
+    {
+        $allowable = $this->getIncludableRelationships();
+
+        if (! $request->has('include')) {
+            return $this->getDefaultIncludes();
+        }
+
+        $requested = $request->query('include', '');
+
+        if (empty($requested)) {
+            return [];
+        }
+
+        $includes = array_map('trim', explode(',', $requested));
+
+        return array_values(array_intersect($includes, $allowable));
+    }
+
+    /**
+     * Get the list of relationships that are allowed to be included.
+     *
+     * Override this method or define the `$includableRelationships` property
+     * on the controller to specify which relationships can be requested.
+     *
+     * @since 1.1.0
+     *
+     * @return array<int, string> The allowed relationship names.
+     */
+    protected function getIncludableRelationships(): array
+    {
+        return $this->includableRelationships ?? [];
+    }
+
+    /**
+     * Get the default relationships to load when no include parameter is provided.
+     *
+     * Override this method or define the `$defaultIncludes` property
+     * on the controller to specify default eager loading behaviour.
+     *
+     * @since 1.1.0
+     *
+     * @return array<int, string> The default relationship names to eager load.
+     */
+    protected function getDefaultIncludes(): array
+    {
+        return $this->defaultIncludes ?? [];
+    }
+}

--- a/src/Modules/Admin/Managers/AdminMenuManager.php
+++ b/src/Modules/Admin/Managers/AdminMenuManager.php
@@ -190,7 +190,7 @@ class AdminMenuManager
             }
         }
 
-        return array_merge( $topLevelItems, $menu);
+        return array_merge( $topLevelItems, $menu );
     }
 
     /**
@@ -202,7 +202,7 @@ class AdminMenuManager
      *
      * @return array|null The page's data array, or null if not found.
      */
-    public function getPageBySlug( string $slug): ?array
+    public function getPageBySlug( string $slug ): ?array
     {
         return $this->items[ $slug ] ?? null;
     }

--- a/src/Modules/Admin/Managers/AdminMenuManager.php
+++ b/src/Modules/Admin/Managers/AdminMenuManager.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare( strict_types=1 );
 
 /**
  * Manages the registration and structure of the admin navigation menu.
@@ -49,9 +49,9 @@ class AdminMenuManager
      * @param  string  $title  The display title for the section.
      * @param  int  $order  The display order for the section.
      */
-    public function addSection(string $slug, string $title, int $order = 99): void
+    public function addSection( string $slug, string $title, int $order = 99 ): void
     {
-        $this->sections[$slug] = ['title' => $title, 'order' => $order, 'items' => []];
+        $this->sections[ $slug ] = ['title' => $title, 'order' => $order, 'items' => []];
     }
 
     /**
@@ -64,7 +64,7 @@ class AdminMenuManager
      * @param  string|null  $sectionSlug  The slug of the menu section, or null for a top-level item.
      * @param  array  $options  An array of options (view, icon, capability, etc.).
      */
-    public function addPage(string $title, string $slug, ?string $sectionSlug, array $options = []): void
+    public function addPage( string $title, string $slug, ?string $sectionSlug, array $options = [] ): void
     {
         $defaults = [
             'action'     => '',
@@ -73,9 +73,9 @@ class AdminMenuManager
             'order'      => 99,
             'menuTitle'  => $title,
         ];
-        $options = array_merge($defaults, $options);
+        $options = array_merge( $defaults, $options );
 
-        $this->items[$slug] = [
+        $this->items[ $slug ] = [
             'title'      => $title,
             'slug'       => $slug,
             'parent'     => null,
@@ -83,11 +83,11 @@ class AdminMenuManager
             'icon'       => $options['icon'],
             'capability' => $options['capability'],
             'order'      => $options['order'],
-            'route'      => 'admin.'.$slug,
+            'route'      => 'admin.' . $slug,
             'menuTitle'  => $options['menuTitle'],
         ];
 
-        app(AdminPageManager::class)->register($slug, $options['action'], $options['capability']);
+        app( AdminPageManager::class )->register( $slug, $options['action'], $options['capability'] );
     }
 
     /**
@@ -100,7 +100,7 @@ class AdminMenuManager
      * @param  string  $parentSlug  The slug of the parent menu item.
      * @param  array  $options  An array of options (view, capability, showInMenu, etc.).
      */
-    public function addSubPage(string $title, string $slug, string $parentSlug, array $options = []): void
+    public function addSubPage( string $title, string $slug, string $parentSlug, array $options = [] ): void
     {
         $defaults = [
             'action'     => '',
@@ -110,9 +110,9 @@ class AdminMenuManager
             'menuTitle'  => $title,
             'icon'       => '',
         ];
-        $options = array_merge($defaults, $options);
+        $options = array_merge( $defaults, $options );
 
-        $this->items[$slug] = [
+        $this->items[ $slug ] = [
             'title'      => $title,
             'slug'       => $slug,
             'parent'     => $parentSlug,
@@ -120,12 +120,12 @@ class AdminMenuManager
             'capability' => $options['capability'],
             'order'      => $options['order'],
             'showInMenu' => $options['showInMenu'],
-            'route'      => 'admin.'.str_replace('/', '.', $slug),
+            'route'      => 'admin.' . str_replace( '/', '.', $slug ),
             'menuTitle'  => $options['menuTitle'],
             'icon'       => $options['icon'],
         ];
 
-        app(AdminPageManager::class)->register($slug, $options['action'], $options['capability']);
+        app( AdminPageManager::class )->register( $slug, $options['action'], $options['capability'] );
     }
 
     /**
@@ -142,55 +142,55 @@ class AdminMenuManager
         $topLevelItems = [];
 
         // 1. Filter all items based on the current user's capabilities.
-        $authorizedItems = array_filter($items, function ($item) {
+        $authorizedItems = array_filter( $items, function ( $item ) {
             // Only check the gate if a capability is set and not empty.
-            return ! empty($item['capability']) ? Gate::allows($item['capability']) : true;
-        });
+            return ! empty( $item['capability'] ) ? Gate::allows( $item['capability'] ) : true;
+        } );
 
         // 2. Structure the menu (top-level, sections, and sub-items).
-        foreach ($authorizedItems as $slug => $item) {
-            if ($item['parent'] && isset($authorizedItems[$item['parent']])) {
-                $authorizedItems[$item['parent']]['subItems'][$slug] = $item;
+        foreach ( $authorizedItems as $slug => $item ) {
+            if ( $item['parent'] && isset( $authorizedItems[ $item['parent'] ] ) ) {
+                $authorizedItems[ $item['parent'] ]['subItems'][ $slug ] = $item;
             }
         }
 
         // Now add items to their final destinations, using the updated items with subItems
-        foreach ($authorizedItems as $slug => $item) {
-            if ($item['parent'] && isset($authorizedItems[$item['parent']])) {
+        foreach ( $authorizedItems as $slug => $item ) {
+            if ( $item['parent'] && isset( $authorizedItems[ $item['parent'] ] ) ) {
                 // This item is a child, it was already added to its parent's subItems above
                 continue;
-            } elseif ($item['section'] && isset($menu[$item['section']])) {
-                $menu[$item['section']]['items'][$slug] = $authorizedItems[$slug];
-            } elseif (is_null($item['section'])) {
-                $topLevelItems[$slug] = $authorizedItems[$slug];
+            } elseif ( $item['section'] && isset( $menu[ $item['section'] ] ) ) {
+                $menu[ $item['section'] ]['items'][ $slug ] = $authorizedItems[ $slug ];
+            } elseif ( is_null( $item['section'] ) ) {
+                $topLevelItems[ $slug ] = $authorizedItems[ $slug ];
             }
         }
 
         // 3. Remove any sections that are now empty after filtering.
-        $menu = array_filter($menu, fn ($section) => ! empty($section['items']));
+        $menu = array_filter( $menu, fn ( $section ) => ! empty( $section['items'] ) );
 
         // 4. Sort everything by the 'order' property.
-        uasort($topLevelItems, fn ($a, $b) => $a['order'] <=> $b['order']);
-        uasort($menu, fn ($a, $b) => $a['order'] <=> $b['order']);
-        foreach ($menu as &$section) {
-            if (! empty($section['items'])) {
-                uasort($section['items'], fn ($a, $b) => $a['order'] <=> $b['order']);
+        uasort( $topLevelItems, fn ( $a, $b ) => $a['order'] <=> $b['order'] );
+        uasort( $menu, fn ( $a, $b ) => $a['order'] <=> $b['order'] );
+        foreach ( $menu as &$section ) {
+            if ( ! empty( $section['items'] ) ) {
+                uasort( $section['items'], fn ( $a, $b ) => $a['order'] <=> $b['order'] );
                 // Also sort subItems for each menu item in the section
-                foreach ($section['items'] as &$item) {
-                    if (! empty($item['subItems'])) {
-                        uasort($item['subItems'], fn ($a, $b) => $a['order'] <=> $b['order']);
+                foreach ( $section['items'] as &$item ) {
+                    if ( ! empty( $item['subItems'] ) ) {
+                        uasort( $item['subItems'], fn ( $a, $b ) => $a['order'] <=> $b['order'] );
                     }
                 }
             }
         }
         // Sort subItems for top-level items as well
-        foreach ($topLevelItems as &$item) {
-            if (! empty($item['subItems'])) {
-                uasort($item['subItems'], fn ($a, $b) => $a['order'] <=> $b['order']);
+        foreach ( $topLevelItems as &$item ) {
+            if ( ! empty( $item['subItems'] ) ) {
+                uasort( $item['subItems'], fn ( $a, $b ) => $a['order'] <=> $b['order'] );
             }
         }
 
-        return array_merge($topLevelItems, $menu);
+        return array_merge( $topLevelItems, $menu);
     }
 
     /**
@@ -202,8 +202,8 @@ class AdminMenuManager
      *
      * @return array|null The page's data array, or null if not found.
      */
-    public function getPageBySlug(string $slug): ?array
+    public function getPageBySlug( string $slug): ?array
     {
-        return $this->items[$slug] ?? null;
+        return $this->items[ $slug ] ?? null;
     }
 }

--- a/src/Modules/Blog/Http/Controllers/PostCategoryController.php
+++ b/src/Modules/Blog/Http/Controllers/PostCategoryController.php
@@ -109,8 +109,10 @@ class PostCategoryController extends Controller
      */
     public function show(Request $request, int $id): PostCategoryResource
     {
-        $category = PostCategory::with($this->getRequestedIncludes($request))->findOrFail($id);
+        $category = PostCategory::findOrFail($id);
         $this->authorize('view', $category);
+
+        $category->load($this->getRequestedIncludes($request));
 
         return new PostCategoryResource($category);
     }

--- a/src/Modules/Blog/Http/Controllers/PostCategoryController.php
+++ b/src/Modules/Blog/Http/Controllers/PostCategoryController.php
@@ -1,6 +1,6 @@
 <?php
 
-declare( strict_types = 1 );
+declare(strict_types=1);
 
 /**
  * PostCategory Controller for the CMS Framework Blog Module.
@@ -13,11 +13,13 @@ declare( strict_types = 1 );
 
 namespace ArtisanPackUI\CMSFramework\Modules\Blog\Http\Controllers;
 
+use ArtisanPackUI\CMSFramework\Http\Controllers\Concerns\HasIncludableRelationships;
 use ArtisanPackUI\CMSFramework\Modules\Blog\Http\Requests\PostCategoryRequest;
 use ArtisanPackUI\CMSFramework\Modules\Blog\Http\Resources\PostCategoryResource;
 use ArtisanPackUI\CMSFramework\Modules\Blog\Models\PostCategory;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
 use Illuminate\Http\Response;
 use Illuminate\Routing\Controller;
@@ -33,6 +35,25 @@ use Illuminate\Routing\Controller;
 class PostCategoryController extends Controller
 {
     use AuthorizesRequests;
+    use HasIncludableRelationships;
+
+    /**
+     * The relationships that can be included via the include query parameter.
+     *
+     * @since 1.1.0
+     *
+     * @var array<int, string>
+     */
+    protected array $includableRelationships = ['parent', 'children'];
+
+    /**
+     * The default relationships to load when no include parameter is provided.
+     *
+     * @since 1.1.0
+     *
+     * @var array<int, string>
+     */
+    protected array $defaultIncludes = ['parent', 'children'];
 
     /**
      * Display a listing of post categories.
@@ -43,13 +64,13 @@ class PostCategoryController extends Controller
      *
      * @return AnonymousResourceCollection The paginated collection of category resources.
      */
-    public function index(): AnonymousResourceCollection
+    public function index(Request $request): AnonymousResourceCollection
     {
-        $this->authorize( 'viewAny', PostCategory::class );
+        $this->authorize('viewAny', PostCategory::class);
 
-        $categories = PostCategory::with( ['parent', 'children'] )->orderBy( 'order' )->paginate( 15 );
+        $categories = PostCategory::with($this->getRequestedIncludes($request))->orderBy('order')->paginate(15);
 
-        return PostCategoryResource::collection( $categories );
+        return PostCategoryResource::collection($categories);
     }
 
     /**
@@ -64,15 +85,15 @@ class PostCategoryController extends Controller
      *
      * @return JsonResponse The JSON response containing the created category resource.
      */
-    public function store( PostCategoryRequest $request ): JsonResponse
+    public function store(PostCategoryRequest $request): JsonResponse
     {
-        $this->authorize( 'create', PostCategory::class );
+        $this->authorize('create', PostCategory::class);
 
         $validated = $request->validated();
-        $category  = PostCategory::create( $validated );
-        $category->load( ['parent', 'children'] );
+        $category  = PostCategory::create($validated);
+        $category->load($this->getRequestedIncludes($request));
 
-        return response()->json( new PostCategoryResource( $category ), 201 );
+        return response()->json(new PostCategoryResource($category), 201);
     }
 
     /**
@@ -86,12 +107,12 @@ class PostCategoryController extends Controller
      *
      * @return PostCategoryResource The category resource.
      */
-    public function show( int $id ): PostCategoryResource
+    public function show(Request $request, int $id): PostCategoryResource
     {
-        $category = PostCategory::with( ['parent', 'children'] )->findOrFail( $id );
-        $this->authorize( 'view', $category );
+        $category = PostCategory::with($this->getRequestedIncludes($request))->findOrFail($id);
+        $this->authorize('view', $category);
 
-        return new PostCategoryResource( $category );
+        return new PostCategoryResource($category);
     }
 
     /**
@@ -107,16 +128,16 @@ class PostCategoryController extends Controller
      *
      * @return PostCategoryResource The updated category resource.
      */
-    public function update( PostCategoryRequest $request, int $id ): PostCategoryResource
+    public function update(PostCategoryRequest $request, int $id): PostCategoryResource
     {
-        $category = PostCategory::findOrFail( $id );
-        $this->authorize( 'update', $category );
+        $category = PostCategory::findOrFail($id);
+        $this->authorize('update', $category);
 
         $validated = $request->validated();
-        $category->update( $validated );
-        $category->load( ['parent', 'children'] );
+        $category->update($validated);
+        $category->load($this->getRequestedIncludes($request));
 
-        return new PostCategoryResource( $category );
+        return new PostCategoryResource($category);
     }
 
     /**
@@ -131,10 +152,10 @@ class PostCategoryController extends Controller
      *
      * @return Response A response with 204 status code.
      */
-    public function destroy( int $id ): Response
+    public function destroy(int $id): Response
     {
-        $category = PostCategory::findOrFail( $id );
-        $this->authorize( 'delete', $category );
+        $category = PostCategory::findOrFail($id);
+        $this->authorize('delete', $category);
 
         $category->delete();
 

--- a/src/Modules/Blog/Http/Controllers/PostCategoryController.php
+++ b/src/Modules/Blog/Http/Controllers/PostCategoryController.php
@@ -17,6 +17,7 @@ use ArtisanPackUI\CMSFramework\Http\Controllers\Concerns\HasIncludableRelationsh
 use ArtisanPackUI\CMSFramework\Modules\Blog\Http\Requests\PostCategoryRequest;
 use ArtisanPackUI\CMSFramework\Modules\Blog\Http\Resources\PostCategoryResource;
 use ArtisanPackUI\CMSFramework\Modules\Blog\Models\PostCategory;
+use Dedoc\Scramble\Attributes\Group;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
@@ -32,6 +33,7 @@ use Illuminate\Routing\Controller;
  *
  * @since 1.0.0
  */
+#[Group('Post Categories', weight: 2)]
 class PostCategoryController extends Controller
 {
     use AuthorizesRequests;

--- a/src/Modules/Blog/Http/Controllers/PostCategoryController.php
+++ b/src/Modules/Blog/Http/Controllers/PostCategoryController.php
@@ -159,7 +159,7 @@ class PostCategoryController extends Controller
     public function destroy( int $id ): Response
     {
         $category = PostCategory::findOrFail( $id );
-        $this->authorize( 'delete', $category);
+        $this->authorize( 'delete', $category );
 
         $category->delete();
 

--- a/src/Modules/Blog/Http/Controllers/PostCategoryController.php
+++ b/src/Modules/Blog/Http/Controllers/PostCategoryController.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare( strict_types=1 );
 
 /**
  * PostCategory Controller for the CMS Framework Blog Module.
@@ -33,7 +33,7 @@ use Illuminate\Routing\Controller;
  *
  * @since 1.0.0
  */
-#[Group('Post Categories', weight: 2)]
+#[Group( 'Post Categories', weight: 2 )]
 class PostCategoryController extends Controller
 {
     use AuthorizesRequests;
@@ -66,13 +66,13 @@ class PostCategoryController extends Controller
      *
      * @return AnonymousResourceCollection The paginated collection of category resources.
      */
-    public function index(Request $request): AnonymousResourceCollection
+    public function index( Request $request ): AnonymousResourceCollection
     {
-        $this->authorize('viewAny', PostCategory::class);
+        $this->authorize( 'viewAny', PostCategory::class );
 
-        $categories = PostCategory::with($this->getRequestedIncludes($request))->orderBy('order')->paginate(15);
+        $categories = PostCategory::with( $this->getRequestedIncludes( $request ) )->orderBy( 'order' )->paginate( 15 );
 
-        return PostCategoryResource::collection($categories);
+        return PostCategoryResource::collection( $categories );
     }
 
     /**
@@ -87,15 +87,15 @@ class PostCategoryController extends Controller
      *
      * @return JsonResponse The JSON response containing the created category resource.
      */
-    public function store(PostCategoryRequest $request): JsonResponse
+    public function store( PostCategoryRequest $request ): JsonResponse
     {
-        $this->authorize('create', PostCategory::class);
+        $this->authorize( 'create', PostCategory::class );
 
         $validated = $request->validated();
-        $category  = PostCategory::create($validated);
-        $category->load($this->getRequestedIncludes($request));
+        $category  = PostCategory::create( $validated );
+        $category->load( $this->getRequestedIncludes( $request ) );
 
-        return response()->json(new PostCategoryResource($category), 201);
+        return response()->json( new PostCategoryResource( $category ), 201 );
     }
 
     /**
@@ -109,14 +109,14 @@ class PostCategoryController extends Controller
      *
      * @return PostCategoryResource The category resource.
      */
-    public function show(Request $request, int $id): PostCategoryResource
+    public function show( Request $request, int $id ): PostCategoryResource
     {
-        $category = PostCategory::findOrFail($id);
-        $this->authorize('view', $category);
+        $category = PostCategory::findOrFail( $id );
+        $this->authorize( 'view', $category );
 
-        $category->load($this->getRequestedIncludes($request));
+        $category->load( $this->getRequestedIncludes( $request ) );
 
-        return new PostCategoryResource($category);
+        return new PostCategoryResource( $category );
     }
 
     /**
@@ -132,16 +132,16 @@ class PostCategoryController extends Controller
      *
      * @return PostCategoryResource The updated category resource.
      */
-    public function update(PostCategoryRequest $request, int $id): PostCategoryResource
+    public function update( PostCategoryRequest $request, int $id ): PostCategoryResource
     {
-        $category = PostCategory::findOrFail($id);
-        $this->authorize('update', $category);
+        $category = PostCategory::findOrFail( $id );
+        $this->authorize( 'update', $category );
 
         $validated = $request->validated();
-        $category->update($validated);
-        $category->load($this->getRequestedIncludes($request));
+        $category->update( $validated );
+        $category->load( $this->getRequestedIncludes( $request ) );
 
-        return new PostCategoryResource($category);
+        return new PostCategoryResource( $category );
     }
 
     /**
@@ -156,10 +156,10 @@ class PostCategoryController extends Controller
      *
      * @return Response A response with 204 status code.
      */
-    public function destroy(int $id): Response
+    public function destroy( int $id ): Response
     {
-        $category = PostCategory::findOrFail($id);
-        $this->authorize('delete', $category);
+        $category = PostCategory::findOrFail( $id );
+        $this->authorize( 'delete', $category);
 
         $category->delete();
 

--- a/src/Modules/Blog/Http/Controllers/PostController.php
+++ b/src/Modules/Blog/Http/Controllers/PostController.php
@@ -18,6 +18,7 @@ use ArtisanPackUI\CMSFramework\Modules\Blog\Http\Requests\PostRequest;
 use ArtisanPackUI\CMSFramework\Modules\Blog\Http\Resources\PostResource;
 use ArtisanPackUI\CMSFramework\Modules\Blog\Managers\BlogManager;
 use ArtisanPackUI\CMSFramework\Modules\Blog\Models\Post;
+use Dedoc\Scramble\Attributes\Group;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
@@ -33,6 +34,7 @@ use Illuminate\Routing\Controller;
  *
  * @since 1.0.0
  */
+#[Group('Posts', weight: 1)]
 class PostController extends Controller
 {
     use AuthorizesRequests;

--- a/src/Modules/Blog/Http/Controllers/PostController.php
+++ b/src/Modules/Blog/Http/Controllers/PostController.php
@@ -223,11 +223,12 @@ class PostController extends Controller
      * @param  int|null  $month  Month to filter by (optional).
      * @param  int|null  $day  Day to filter by (optional).
      */
-    public function archiveByDate(int $year, ?int $month = null, ?int $day = null): AnonymousResourceCollection
+    public function archiveByDate(Request $request, int $year, ?int $month = null, ?int $day = null): AnonymousResourceCollection
     {
         $this->authorize('viewAny', Post::class);
 
         $posts = $this->blogManager->getPostsByDate($year, $month, $day);
+        $posts->load($this->getRequestedIncludes($request));
 
         return PostResource::collection($posts);
     }
@@ -239,11 +240,12 @@ class PostController extends Controller
      *
      * @param  int  $authorId  Author ID to filter by.
      */
-    public function archiveByAuthor(int $authorId): AnonymousResourceCollection
+    public function archiveByAuthor(Request $request, int $authorId): AnonymousResourceCollection
     {
         $this->authorize('viewAny', Post::class);
 
         $posts = $this->blogManager->getPostsByAuthor($authorId);
+        $posts->load($this->getRequestedIncludes($request));
 
         return PostResource::collection($posts);
     }
@@ -255,11 +257,12 @@ class PostController extends Controller
      *
      * @param  string  $slug  Category slug to filter by.
      */
-    public function archiveByCategory(string $slug): AnonymousResourceCollection
+    public function archiveByCategory(Request $request, string $slug): AnonymousResourceCollection
     {
         $this->authorize('viewAny', Post::class);
 
         $posts = $this->blogManager->getPostsByCategory($slug);
+        $posts->load($this->getRequestedIncludes($request));
 
         return PostResource::collection($posts);
     }
@@ -271,11 +274,12 @@ class PostController extends Controller
      *
      * @param  string  $slug  Tag slug to filter by.
      */
-    public function archiveByTag(string $slug): AnonymousResourceCollection
+    public function archiveByTag(Request $request, string $slug): AnonymousResourceCollection
     {
         $this->authorize('viewAny', Post::class);
 
         $posts = $this->blogManager->getPostsByTag($slug);
+        $posts->load($this->getRequestedIncludes($request));
 
         return PostResource::collection($posts);
     }

--- a/src/Modules/Blog/Http/Controllers/PostController.php
+++ b/src/Modules/Blog/Http/Controllers/PostController.php
@@ -1,6 +1,6 @@
 <?php
 
-declare( strict_types = 1 );
+declare(strict_types=1);
 
 /**
  * Post Controller for the CMS Framework Blog Module.
@@ -13,6 +13,7 @@ declare( strict_types = 1 );
 
 namespace ArtisanPackUI\CMSFramework\Modules\Blog\Http\Controllers;
 
+use ArtisanPackUI\CMSFramework\Http\Controllers\Concerns\HasIncludableRelationships;
 use ArtisanPackUI\CMSFramework\Modules\Blog\Http\Requests\PostRequest;
 use ArtisanPackUI\CMSFramework\Modules\Blog\Http\Resources\PostResource;
 use ArtisanPackUI\CMSFramework\Modules\Blog\Managers\BlogManager;
@@ -35,6 +36,25 @@ use Illuminate\Routing\Controller;
 class PostController extends Controller
 {
     use AuthorizesRequests;
+    use HasIncludableRelationships;
+
+    /**
+     * The relationships that can be included via the include query parameter.
+     *
+     * @since 1.1.0
+     *
+     * @var array<int, string>
+     */
+    protected array $includableRelationships = ['author', 'categories', 'tags'];
+
+    /**
+     * The default relationships to load when no include parameter is provided.
+     *
+     * @since 1.1.0
+     *
+     * @var array<int, string>
+     */
+    protected array $defaultIncludes = ['author', 'categories', 'tags'];
 
     /**
      * The blog manager instance.
@@ -48,7 +68,7 @@ class PostController extends Controller
      *
      * @since 1.0.0
      */
-    public function __construct( BlogManager $blogManager )
+    public function __construct(BlogManager $blogManager)
     {
         $this->blogManager = $blogManager;
     }
@@ -62,14 +82,15 @@ class PostController extends Controller
      *
      * @return AnonymousResourceCollection The paginated collection of post resources.
      */
-    public function index( Request $request ): AnonymousResourceCollection
+    public function index(Request $request): AnonymousResourceCollection
     {
-        $this->authorize( 'viewAny', Post::class );
+        $this->authorize('viewAny', Post::class);
 
-        $filters = $request->only( ['status', 'category', 'tag', 'author', 'year', 'month', 'search'] );
-        $posts   = $this->blogManager->getArchiveQuery( $filters )->paginate( 15 );
+        $filters  = $request->only(['status', 'category', 'tag', 'author', 'year', 'month', 'search']);
+        $includes = $this->getRequestedIncludes($request);
+        $posts    = $this->blogManager->getArchiveQuery($filters)->with($includes)->paginate(15);
 
-        return PostResource::collection( $posts );
+        return PostResource::collection($posts);
     }
 
     /**
@@ -84,30 +105,30 @@ class PostController extends Controller
      *
      * @return JsonResponse The JSON response containing the created post resource.
      */
-    public function store( PostRequest $request ): JsonResponse
+    public function store(PostRequest $request): JsonResponse
     {
-        $this->authorize( 'create', Post::class );
+        $this->authorize('create', Post::class);
 
         $validated  = $request->validated();
         $categories = $validated['categories'] ?? [];
         $tags       = $validated['tags'] ?? [];
 
-        unset( $validated['categories'], $validated['tags'] );
+        unset($validated['categories'], $validated['tags']);
 
-        $post = Post::create( $validated );
+        $post = Post::create($validated);
 
         // Sync categories and tags
-        if ( ! empty( $categories ) ) {
-            $post->categories()->sync( $categories );
+        if (! empty($categories)) {
+            $post->categories()->sync($categories);
         }
 
-        if ( ! empty( $tags ) ) {
-            $post->tags()->sync( $tags );
+        if (! empty($tags)) {
+            $post->tags()->sync($tags);
         }
 
-        $post->load( ['author', 'categories', 'tags'] );
+        $post->load($this->getRequestedIncludes($request));
 
-        return response()->json( new PostResource( $post ), 201 );
+        return response()->json(new PostResource($post), 201);
     }
 
     /**
@@ -121,12 +142,14 @@ class PostController extends Controller
      *
      * @return PostResource The post resource.
      */
-    public function show( int $id ): PostResource
+    public function show(Request $request, int $id): PostResource
     {
-        $post = Post::with( ['author', 'categories', 'tags'] )->findOrFail( $id );
-        $this->authorize( 'view', $post );
+        $post = Post::findOrFail($id);
+        $this->authorize('view', $post);
 
-        return new PostResource( $post );
+        $post->load($this->getRequestedIncludes($request));
+
+        return new PostResource($post);
     }
 
     /**
@@ -142,31 +165,31 @@ class PostController extends Controller
      *
      * @return PostResource The updated post resource.
      */
-    public function update( PostRequest $request, int $id ): PostResource
+    public function update(PostRequest $request, int $id): PostResource
     {
-        $post = Post::findOrFail( $id );
-        $this->authorize( 'update', $post );
+        $post = Post::findOrFail($id);
+        $this->authorize('update', $post);
 
         $validated  = $request->validated();
         $categories = $validated['categories'] ?? null;
         $tags       = $validated['tags'] ?? null;
 
-        unset( $validated['categories'], $validated['tags'] );
+        unset($validated['categories'], $validated['tags']);
 
-        $post->update( $validated );
+        $post->update($validated);
 
         // Sync categories and tags if provided
-        if ( null !== $categories ) {
-            $post->categories()->sync( $categories );
+        if (null !== $categories) {
+            $post->categories()->sync($categories);
         }
 
-        if ( null !== $tags ) {
-            $post->tags()->sync( $tags );
+        if (null !== $tags) {
+            $post->tags()->sync($tags);
         }
 
-        $post->load( ['author', 'categories', 'tags'] );
+        $post->load($this->getRequestedIncludes($request));
 
-        return new PostResource( $post );
+        return new PostResource($post);
     }
 
     /**
@@ -181,10 +204,10 @@ class PostController extends Controller
      *
      * @return Response A response with 204 status code.
      */
-    public function destroy( int $id ): Response
+    public function destroy(int $id): Response
     {
-        $post = Post::findOrFail( $id );
-        $this->authorize( 'delete', $post );
+        $post = Post::findOrFail($id);
+        $this->authorize('delete', $post);
 
         $post->delete();
 
@@ -200,13 +223,13 @@ class PostController extends Controller
      * @param  int|null  $month  Month to filter by (optional).
      * @param  int|null  $day  Day to filter by (optional).
      */
-    public function archiveByDate( int $year, ?int $month = null, ?int $day = null ): AnonymousResourceCollection
+    public function archiveByDate(int $year, ?int $month = null, ?int $day = null): AnonymousResourceCollection
     {
-        $this->authorize( 'viewAny', Post::class );
+        $this->authorize('viewAny', Post::class);
 
-        $posts = $this->blogManager->getPostsByDate( $year, $month, $day );
+        $posts = $this->blogManager->getPostsByDate($year, $month, $day);
 
-        return PostResource::collection( $posts );
+        return PostResource::collection($posts);
     }
 
     /**
@@ -216,13 +239,13 @@ class PostController extends Controller
      *
      * @param  int  $authorId  Author ID to filter by.
      */
-    public function archiveByAuthor( int $authorId ): AnonymousResourceCollection
+    public function archiveByAuthor(int $authorId): AnonymousResourceCollection
     {
-        $this->authorize( 'viewAny', Post::class );
+        $this->authorize('viewAny', Post::class);
 
-        $posts = $this->blogManager->getPostsByAuthor( $authorId );
+        $posts = $this->blogManager->getPostsByAuthor($authorId);
 
-        return PostResource::collection( $posts );
+        return PostResource::collection($posts);
     }
 
     /**
@@ -232,13 +255,13 @@ class PostController extends Controller
      *
      * @param  string  $slug  Category slug to filter by.
      */
-    public function archiveByCategory( string $slug ): AnonymousResourceCollection
+    public function archiveByCategory(string $slug): AnonymousResourceCollection
     {
-        $this->authorize( 'viewAny', Post::class );
+        $this->authorize('viewAny', Post::class);
 
-        $posts = $this->blogManager->getPostsByCategory( $slug );
+        $posts = $this->blogManager->getPostsByCategory($slug);
 
-        return PostResource::collection( $posts );
+        return PostResource::collection($posts);
     }
 
     /**
@@ -248,12 +271,12 @@ class PostController extends Controller
      *
      * @param  string  $slug  Tag slug to filter by.
      */
-    public function archiveByTag( string $slug ): AnonymousResourceCollection
+    public function archiveByTag(string $slug): AnonymousResourceCollection
     {
-        $this->authorize( 'viewAny', Post::class );
+        $this->authorize('viewAny', Post::class);
 
-        $posts = $this->blogManager->getPostsByTag( $slug );
+        $posts = $this->blogManager->getPostsByTag($slug);
 
-        return PostResource::collection( $posts);
+        return PostResource::collection($posts);
     }
 }

--- a/src/Modules/Blog/Http/Controllers/PostController.php
+++ b/src/Modules/Blog/Http/Controllers/PostController.php
@@ -262,7 +262,8 @@ class PostController extends Controller
                 $this->executeBulkAction($action, $post);
                 $processed++;
             } catch (Throwable $e) {
-                $errors[$id] = $e->getMessage();
+                report($e);
+                $errors[$id] = __('Failed to :action post.', ['action' => $action]);
             }
         }
 
@@ -376,7 +377,7 @@ class PostController extends Controller
             'delete'  => $post->delete(),
             'publish' => $post->update([
                 'status'       => ContentStatus::Published->value,
-                'published_at' => $post->published_at ?? now(),
+                'published_at' => now(),
             ]),
             'draft'   => $post->update([
                 'status'       => ContentStatus::Draft->value,

--- a/src/Modules/Blog/Http/Controllers/PostController.php
+++ b/src/Modules/Blog/Http/Controllers/PostController.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare( strict_types=1 );
 
 /**
  * Post Controller for the CMS Framework Blog Module.
@@ -38,7 +38,7 @@ use Throwable;
  *
  * @since 1.0.0
  */
-#[Group('Posts', weight: 1)]
+#[Group( 'Posts', weight: 1 )]
 class PostController extends Controller
 {
     use AuthorizesRequests;
@@ -74,7 +74,7 @@ class PostController extends Controller
      *
      * @since 1.0.0
      */
-    public function __construct(BlogManager $blogManager)
+    public function __construct( BlogManager $blogManager )
     {
         $this->blogManager = $blogManager;
     }
@@ -88,15 +88,15 @@ class PostController extends Controller
      *
      * @return AnonymousResourceCollection The paginated collection of post resources.
      */
-    public function index(Request $request): AnonymousResourceCollection
+    public function index( Request $request ): AnonymousResourceCollection
     {
-        $this->authorize('viewAny', Post::class);
+        $this->authorize( 'viewAny', Post::class );
 
-        $filters  = $request->only(['status', 'category', 'tag', 'author', 'year', 'month', 'search']);
-        $includes = $this->getRequestedIncludes($request);
-        $posts    = $this->blogManager->getArchiveQuery($filters)->with($includes)->paginate(15);
+        $filters  = $request->only( ['status', 'category', 'tag', 'author', 'year', 'month', 'search'] );
+        $includes = $this->getRequestedIncludes( $request );
+        $posts    = $this->blogManager->getArchiveQuery( $filters )->with( $includes )->paginate( 15 );
 
-        return PostResource::collection($posts);
+        return PostResource::collection( $posts );
     }
 
     /**
@@ -111,30 +111,30 @@ class PostController extends Controller
      *
      * @return JsonResponse The JSON response containing the created post resource.
      */
-    public function store(PostRequest $request): JsonResponse
+    public function store( PostRequest $request ): JsonResponse
     {
-        $this->authorize('create', Post::class);
+        $this->authorize( 'create', Post::class );
 
         $validated  = $request->validated();
         $categories = $validated['categories'] ?? [];
         $tags       = $validated['tags'] ?? [];
 
-        unset($validated['categories'], $validated['tags']);
+        unset( $validated['categories'], $validated['tags'] );
 
-        $post = Post::create($validated);
+        $post = Post::create( $validated );
 
         // Sync categories and tags
-        if (! empty($categories)) {
-            $post->categories()->sync($categories);
+        if ( ! empty( $categories ) ) {
+            $post->categories()->sync( $categories );
         }
 
-        if (! empty($tags)) {
-            $post->tags()->sync($tags);
+        if ( ! empty( $tags ) ) {
+            $post->tags()->sync( $tags );
         }
 
-        $post->load($this->getRequestedIncludes($request));
+        $post->load( $this->getRequestedIncludes( $request ) );
 
-        return response()->json(new PostResource($post), 201);
+        return response()->json( new PostResource( $post ), 201 );
     }
 
     /**
@@ -148,14 +148,14 @@ class PostController extends Controller
      *
      * @return PostResource The post resource.
      */
-    public function show(Request $request, int $id): PostResource
+    public function show( Request $request, int $id ): PostResource
     {
-        $post = Post::findOrFail($id);
-        $this->authorize('view', $post);
+        $post = Post::findOrFail( $id );
+        $this->authorize( 'view', $post );
 
-        $post->load($this->getRequestedIncludes($request));
+        $post->load( $this->getRequestedIncludes( $request ) );
 
-        return new PostResource($post);
+        return new PostResource( $post );
     }
 
     /**
@@ -171,31 +171,31 @@ class PostController extends Controller
      *
      * @return PostResource The updated post resource.
      */
-    public function update(PostRequest $request, int $id): PostResource
+    public function update( PostRequest $request, int $id ): PostResource
     {
-        $post = Post::findOrFail($id);
-        $this->authorize('update', $post);
+        $post = Post::findOrFail( $id );
+        $this->authorize( 'update', $post );
 
         $validated  = $request->validated();
         $categories = $validated['categories'] ?? null;
         $tags       = $validated['tags'] ?? null;
 
-        unset($validated['categories'], $validated['tags']);
+        unset( $validated['categories'], $validated['tags'] );
 
-        $post->update($validated);
+        $post->update( $validated );
 
         // Sync categories and tags if provided
-        if (null !== $categories) {
-            $post->categories()->sync($categories);
+        if ( null !== $categories ) {
+            $post->categories()->sync( $categories );
         }
 
-        if (null !== $tags) {
-            $post->tags()->sync($tags);
+        if ( null !== $tags ) {
+            $post->tags()->sync( $tags );
         }
 
-        $post->load($this->getRequestedIncludes($request));
+        $post->load( $this->getRequestedIncludes( $request ) );
 
-        return new PostResource($post);
+        return new PostResource( $post );
     }
 
     /**
@@ -210,10 +210,10 @@ class PostController extends Controller
      *
      * @return Response A response with 204 status code.
      */
-    public function destroy(int $id): Response
+    public function destroy( int $id ): Response
     {
-        $post = Post::findOrFail($id);
-        $this->authorize('delete', $post);
+        $post = Post::findOrFail( $id );
+        $this->authorize( 'delete', $post );
 
         $post->delete();
 
@@ -232,45 +232,45 @@ class PostController extends Controller
      *
      * @return JsonResponse Summary with processed count, failed count, and error details.
      */
-    public function bulk(BulkPostRequest $request): JsonResponse
+    public function bulk( BulkPostRequest $request ): JsonResponse
     {
-        $action       = $request->validated('action');
-        $ids          = $request->validated('ids');
-        $policyMethod = $this->getBulkPolicyMethod($action);
+        $action       = $request->validated( 'action' );
+        $ids          = $request->validated( 'ids' );
+        $policyMethod = $this->getBulkPolicyMethod( $action );
         $processed    = 0;
         $errors       = [];
 
-        $posts = Post::whereIn('id', $ids)->get()->keyBy('id');
+        $posts = Post::whereIn( 'id', $ids )->get()->keyBy( 'id' );
 
-        foreach ($ids as $id) {
-            $post = $posts->get($id);
+        foreach ( $ids as $id ) {
+            $post = $posts->get( $id );
 
-            if (null === $post) {
-                $errors[$id] = __('Post not found.');
+            if ( null === $post ) {
+                $errors[ $id ] = __( 'Post not found.' );
 
                 continue;
             }
 
-            if (! $request->user()->can($policyMethod, $post)) {
-                $errors[$id] = __('You do not have permission to :action this post.', ['action' => $action]);
+            if ( ! $request->user()->can( $policyMethod, $post ) ) {
+                $errors[ $id ] = __( 'You do not have permission to :action this post.', ['action' => $action] );
 
                 continue;
             }
 
             try {
-                $this->executeBulkAction($action, $post);
+                $this->executeBulkAction( $action, $post );
                 $processed++;
-            } catch (Throwable $e) {
-                report($e);
-                $errors[$id] = __('Failed to :action post.', ['action' => $action]);
+            } catch ( Throwable $e ) {
+                report( $e );
+                $errors[ $id ] = __( 'Failed to :action post.', ['action' => $action] );
             }
         }
 
-        return response()->json([
+        return response()->json( [
             'processed' => $processed,
-            'failed'    => count($errors),
+            'failed'    => count( $errors ),
             'errors'    => $errors,
-        ]);
+        ] );
     }
 
     /**
@@ -282,14 +282,14 @@ class PostController extends Controller
      * @param  int|null  $month  Month to filter by (optional).
      * @param  int|null  $day  Day to filter by (optional).
      */
-    public function archiveByDate(Request $request, int $year, ?int $month = null, ?int $day = null): AnonymousResourceCollection
+    public function archiveByDate( Request $request, int $year, ?int $month = null, ?int $day = null ): AnonymousResourceCollection
     {
-        $this->authorize('viewAny', Post::class);
+        $this->authorize( 'viewAny', Post::class );
 
-        $posts = $this->blogManager->getPostsByDate($year, $month, $day);
-        $posts->load($this->getRequestedIncludes($request));
+        $posts = $this->blogManager->getPostsByDate( $year, $month, $day );
+        $posts->load( $this->getRequestedIncludes( $request ) );
 
-        return PostResource::collection($posts);
+        return PostResource::collection( $posts );
     }
 
     /**
@@ -299,14 +299,14 @@ class PostController extends Controller
      *
      * @param  int  $authorId  Author ID to filter by.
      */
-    public function archiveByAuthor(Request $request, int $authorId): AnonymousResourceCollection
+    public function archiveByAuthor( Request $request, int $authorId ): AnonymousResourceCollection
     {
-        $this->authorize('viewAny', Post::class);
+        $this->authorize( 'viewAny', Post::class );
 
-        $posts = $this->blogManager->getPostsByAuthor($authorId);
-        $posts->load($this->getRequestedIncludes($request));
+        $posts = $this->blogManager->getPostsByAuthor( $authorId );
+        $posts->load( $this->getRequestedIncludes( $request ) );
 
-        return PostResource::collection($posts);
+        return PostResource::collection( $posts );
     }
 
     /**
@@ -316,14 +316,14 @@ class PostController extends Controller
      *
      * @param  string  $slug  Category slug to filter by.
      */
-    public function archiveByCategory(Request $request, string $slug): AnonymousResourceCollection
+    public function archiveByCategory( Request $request, string $slug ): AnonymousResourceCollection
     {
-        $this->authorize('viewAny', Post::class);
+        $this->authorize( 'viewAny', Post::class );
 
-        $posts = $this->blogManager->getPostsByCategory($slug);
-        $posts->load($this->getRequestedIncludes($request));
+        $posts = $this->blogManager->getPostsByCategory( $slug );
+        $posts->load( $this->getRequestedIncludes( $request ) );
 
-        return PostResource::collection($posts);
+        return PostResource::collection( $posts );
     }
 
     /**
@@ -333,14 +333,14 @@ class PostController extends Controller
      *
      * @param  string  $slug  Tag slug to filter by.
      */
-    public function archiveByTag(Request $request, string $slug): AnonymousResourceCollection
+    public function archiveByTag( Request $request, string $slug ): AnonymousResourceCollection
     {
-        $this->authorize('viewAny', Post::class);
+        $this->authorize( 'viewAny', Post::class );
 
-        $posts = $this->blogManager->getPostsByTag($slug);
-        $posts->load($this->getRequestedIncludes($request));
+        $posts = $this->blogManager->getPostsByTag( $slug );
+        $posts->load( $this->getRequestedIncludes( $request ) );
 
-        return PostResource::collection($posts);
+        return PostResource::collection( $posts );
     }
 
     /**
@@ -352,13 +352,13 @@ class PostController extends Controller
      *
      * @return string The policy method name.
      */
-    protected function getBulkPolicyMethod(string $action): string
+    protected function getBulkPolicyMethod( string $action ): string
     {
-        return match ($action) {
+        return match ( $action ) {
             'delete'  => 'delete',
             'publish' => 'publish',
             'draft'   => 'update',
-            default   => throw new InvalidArgumentException(__('Unsupported bulk action: :action', ['action' => $action])),
+            default   => throw new InvalidArgumentException( __( 'Unsupported bulk action: :action', ['action' => $action] ) ),
         };
     }
 
@@ -370,19 +370,19 @@ class PostController extends Controller
      * @param  string  $action  The bulk action to perform.
      * @param  Post  $post  The post to perform the action on.
      */
-    protected function executeBulkAction(string $action, Post $post): void
+    protected function executeBulkAction( string $action, Post $post ): void
     {
-        match ($action) {
+        match ( $action ) {
             'delete'  => $post->delete(),
-            'publish' => $post->update([
+            'publish' => $post->update( [
                 'status'       => ContentStatus::Published->value,
                 'published_at' => now(),
             ]),
-            'draft'   => $post->update([
+            'draft'   => $post->update( [
                 'status'       => ContentStatus::Draft->value,
                 'published_at' => null,
             ]),
-            default   => throw new InvalidArgumentException(__('Unsupported bulk action: :action', ['action' => $action])),
+            default   => throw new InvalidArgumentException( __( 'Unsupported bulk action: :action', ['action' => $action])),
         };
     }
 }

--- a/src/Modules/Blog/Http/Controllers/PostController.php
+++ b/src/Modules/Blog/Http/Controllers/PostController.php
@@ -27,6 +27,7 @@ use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
 use Illuminate\Http\Response;
 use Illuminate\Routing\Controller;
+use InvalidArgumentException;
 use Throwable;
 
 /**
@@ -354,9 +355,10 @@ class PostController extends Controller
     protected function getBulkPolicyMethod(string $action): string
     {
         return match ($action) {
-            'delete', 'archive' => 'delete',
-            'publish'           => 'publish',
-            'draft'             => 'update',
+            'delete'  => 'delete',
+            'publish' => 'publish',
+            'draft'   => 'update',
+            default   => throw new InvalidArgumentException(__('Unsupported bulk action: :action', ['action' => $action])),
         };
     }
 
@@ -380,7 +382,7 @@ class PostController extends Controller
                 'status'       => ContentStatus::Draft->value,
                 'published_at' => null,
             ]),
-            'archive' => $post->delete(),
+            default   => throw new InvalidArgumentException(__('Unsupported bulk action: :action', ['action' => $action])),
         };
     }
 }

--- a/src/Modules/Blog/Http/Controllers/PostController.php
+++ b/src/Modules/Blog/Http/Controllers/PostController.php
@@ -377,11 +377,11 @@ class PostController extends Controller
             'publish' => $post->update( [
                 'status'       => ContentStatus::Published->value,
                 'published_at' => now(),
-            ]),
+            ] ),
             'draft'   => $post->update( [
                 'status'       => ContentStatus::Draft->value,
                 'published_at' => null,
-            ]),
+            ] ),
             default   => throw new InvalidArgumentException( __( 'Unsupported bulk action: :action', ['action' => $action])),
         };
     }

--- a/src/Modules/Blog/Http/Controllers/PostController.php
+++ b/src/Modules/Blog/Http/Controllers/PostController.php
@@ -234,10 +234,11 @@ class PostController extends Controller
      */
     public function bulk(BulkPostRequest $request): JsonResponse
     {
-        $action    = $request->validated('action');
-        $ids       = $request->validated('ids');
-        $processed = 0;
-        $errors    = [];
+        $action       = $request->validated('action');
+        $ids          = $request->validated('ids');
+        $policyMethod = $this->getBulkPolicyMethod($action);
+        $processed    = 0;
+        $errors       = [];
 
         $posts = Post::whereIn('id', $ids)->get()->keyBy('id');
 
@@ -249,8 +250,6 @@ class PostController extends Controller
 
                 continue;
             }
-
-            $policyMethod = $this->getBulkPolicyMethod($action);
 
             if (! $request->user()->can($policyMethod, $post)) {
                 $errors[$id] = __('You do not have permission to :action this post.', ['action' => $action]);

--- a/src/Modules/Blog/Http/Controllers/PostController.php
+++ b/src/Modules/Blog/Http/Controllers/PostController.php
@@ -14,10 +14,12 @@ declare(strict_types=1);
 namespace ArtisanPackUI\CMSFramework\Modules\Blog\Http\Controllers;
 
 use ArtisanPackUI\CMSFramework\Http\Controllers\Concerns\HasIncludableRelationships;
+use ArtisanPackUI\CMSFramework\Modules\Blog\Http\Requests\BulkPostRequest;
 use ArtisanPackUI\CMSFramework\Modules\Blog\Http\Requests\PostRequest;
 use ArtisanPackUI\CMSFramework\Modules\Blog\Http\Resources\PostResource;
 use ArtisanPackUI\CMSFramework\Modules\Blog\Managers\BlogManager;
 use ArtisanPackUI\CMSFramework\Modules\Blog\Models\Post;
+use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Enums\ContentStatus;
 use Dedoc\Scramble\Attributes\Group;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 use Illuminate\Http\JsonResponse;
@@ -25,6 +27,7 @@ use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
 use Illuminate\Http\Response;
 use Illuminate\Routing\Controller;
+use Throwable;
 
 /**
  * API controller for managing posts.
@@ -217,6 +220,59 @@ class PostController extends Controller
     }
 
     /**
+     * Perform a bulk action on multiple posts.
+     *
+     * Processes the requested action on each post individually, respecting
+     * authorization policies. Returns a summary of successes and failures.
+     *
+     * @since 1.1.0
+     *
+     * @param  BulkPostRequest  $request  The validated bulk action request.
+     *
+     * @return JsonResponse Summary with processed count, failed count, and error details.
+     */
+    public function bulk(BulkPostRequest $request): JsonResponse
+    {
+        $action    = $request->validated('action');
+        $ids       = $request->validated('ids');
+        $processed = 0;
+        $errors    = [];
+
+        $posts = Post::whereIn('id', $ids)->get()->keyBy('id');
+
+        foreach ($ids as $id) {
+            $post = $posts->get($id);
+
+            if (null === $post) {
+                $errors[$id] = __('Post not found.');
+
+                continue;
+            }
+
+            $policyMethod = $this->getBulkPolicyMethod($action);
+
+            if (! $request->user()->can($policyMethod, $post)) {
+                $errors[$id] = __('You do not have permission to :action this post.', ['action' => $action]);
+
+                continue;
+            }
+
+            try {
+                $this->executeBulkAction($action, $post);
+                $processed++;
+            } catch (Throwable $e) {
+                $errors[$id] = $e->getMessage();
+            }
+        }
+
+        return response()->json([
+            'processed' => $processed,
+            'failed'    => count($errors),
+            'errors'    => $errors,
+        ]);
+    }
+
+    /**
      * Get posts by date archive.
      *
      * @since 1.0.0
@@ -284,5 +340,47 @@ class PostController extends Controller
         $posts->load($this->getRequestedIncludes($request));
 
         return PostResource::collection($posts);
+    }
+
+    /**
+     * Get the policy method for a bulk action.
+     *
+     * @since 1.1.0
+     *
+     * @param  string  $action  The bulk action name.
+     *
+     * @return string The policy method name.
+     */
+    protected function getBulkPolicyMethod(string $action): string
+    {
+        return match ($action) {
+            'delete', 'archive' => 'delete',
+            'publish'           => 'publish',
+            'draft'             => 'update',
+        };
+    }
+
+    /**
+     * Execute a bulk action on a single post.
+     *
+     * @since 1.1.0
+     *
+     * @param  string  $action  The bulk action to perform.
+     * @param  Post  $post  The post to perform the action on.
+     */
+    protected function executeBulkAction(string $action, Post $post): void
+    {
+        match ($action) {
+            'delete'  => $post->delete(),
+            'publish' => $post->update([
+                'status'       => ContentStatus::Published->value,
+                'published_at' => $post->published_at ?? now(),
+            ]),
+            'draft'   => $post->update([
+                'status'       => ContentStatus::Draft->value,
+                'published_at' => null,
+            ]),
+            'archive' => $post->delete(),
+        };
     }
 }

--- a/src/Modules/Blog/Http/Controllers/PostTagController.php
+++ b/src/Modules/Blog/Http/Controllers/PostTagController.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare( strict_types=1 );
 
 /**
  * PostTag Controller for the CMS Framework Blog Module.
@@ -31,7 +31,7 @@ use Illuminate\Routing\Controller;
  *
  * @since 1.0.0
  */
-#[Group('Post Tags', weight: 3)]
+#[Group( 'Post Tags', weight: 3 )]
 class PostTagController extends Controller
 {
     use AuthorizesRequests;
@@ -47,11 +47,11 @@ class PostTagController extends Controller
      */
     public function index(): AnonymousResourceCollection
     {
-        $this->authorize('viewAny', PostTag::class);
+        $this->authorize( 'viewAny', PostTag::class );
 
-        $tags = PostTag::orderBy('order')->paginate(15);
+        $tags = PostTag::orderBy( 'order' )->paginate( 15 );
 
-        return PostTagResource::collection($tags);
+        return PostTagResource::collection( $tags );
     }
 
     /**
@@ -66,14 +66,14 @@ class PostTagController extends Controller
      *
      * @return JsonResponse The JSON response containing the created tag resource.
      */
-    public function store(PostTagRequest $request): JsonResponse
+    public function store( PostTagRequest $request ): JsonResponse
     {
-        $this->authorize('create', PostTag::class);
+        $this->authorize( 'create', PostTag::class );
 
         $validated = $request->validated();
-        $tag       = PostTag::create($validated);
+        $tag       = PostTag::create( $validated );
 
-        return response()->json(new PostTagResource($tag), 201);
+        return response()->json( new PostTagResource( $tag ), 201 );
     }
 
     /**
@@ -87,12 +87,12 @@ class PostTagController extends Controller
      *
      * @return PostTagResource The tag resource.
      */
-    public function show(int $id): PostTagResource
+    public function show( int $id ): PostTagResource
     {
-        $tag = PostTag::findOrFail($id);
-        $this->authorize('view', $tag);
+        $tag = PostTag::findOrFail( $id );
+        $this->authorize( 'view', $tag );
 
-        return new PostTagResource($tag);
+        return new PostTagResource( $tag );
     }
 
     /**
@@ -108,15 +108,15 @@ class PostTagController extends Controller
      *
      * @return PostTagResource The updated tag resource.
      */
-    public function update(PostTagRequest $request, int $id): PostTagResource
+    public function update( PostTagRequest $request, int $id ): PostTagResource
     {
-        $tag = PostTag::findOrFail($id);
-        $this->authorize('update', $tag);
+        $tag = PostTag::findOrFail( $id );
+        $this->authorize( 'update', $tag );
 
         $validated = $request->validated();
-        $tag->update($validated);
+        $tag->update( $validated );
 
-        return new PostTagResource($tag);
+        return new PostTagResource( $tag );
     }
 
     /**
@@ -131,10 +131,10 @@ class PostTagController extends Controller
      *
      * @return Response A response with 204 status code.
      */
-    public function destroy(int $id): Response
+    public function destroy( int $id ): Response
     {
-        $tag = PostTag::findOrFail($id);
-        $this->authorize('delete', $tag);
+        $tag = PostTag::findOrFail( $id );
+        $this->authorize( 'delete', $tag );
 
         $tag->delete();
 

--- a/src/Modules/Blog/Http/Controllers/PostTagController.php
+++ b/src/Modules/Blog/Http/Controllers/PostTagController.php
@@ -1,6 +1,6 @@
 <?php
 
-declare( strict_types = 1 );
+declare(strict_types=1);
 
 /**
  * PostTag Controller for the CMS Framework Blog Module.
@@ -16,6 +16,7 @@ namespace ArtisanPackUI\CMSFramework\Modules\Blog\Http\Controllers;
 use ArtisanPackUI\CMSFramework\Modules\Blog\Http\Requests\PostTagRequest;
 use ArtisanPackUI\CMSFramework\Modules\Blog\Http\Resources\PostTagResource;
 use ArtisanPackUI\CMSFramework\Modules\Blog\Models\PostTag;
+use Dedoc\Scramble\Attributes\Group;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
@@ -30,6 +31,7 @@ use Illuminate\Routing\Controller;
  *
  * @since 1.0.0
  */
+#[Group('Post Tags', weight: 3)]
 class PostTagController extends Controller
 {
     use AuthorizesRequests;
@@ -45,11 +47,11 @@ class PostTagController extends Controller
      */
     public function index(): AnonymousResourceCollection
     {
-        $this->authorize( 'viewAny', PostTag::class );
+        $this->authorize('viewAny', PostTag::class);
 
-        $tags = PostTag::orderBy( 'order' )->paginate( 15 );
+        $tags = PostTag::orderBy('order')->paginate(15);
 
-        return PostTagResource::collection( $tags );
+        return PostTagResource::collection($tags);
     }
 
     /**
@@ -64,14 +66,14 @@ class PostTagController extends Controller
      *
      * @return JsonResponse The JSON response containing the created tag resource.
      */
-    public function store( PostTagRequest $request ): JsonResponse
+    public function store(PostTagRequest $request): JsonResponse
     {
-        $this->authorize( 'create', PostTag::class );
+        $this->authorize('create', PostTag::class);
 
         $validated = $request->validated();
-        $tag       = PostTag::create( $validated );
+        $tag       = PostTag::create($validated);
 
-        return response()->json( new PostTagResource( $tag ), 201 );
+        return response()->json(new PostTagResource($tag), 201);
     }
 
     /**
@@ -85,12 +87,12 @@ class PostTagController extends Controller
      *
      * @return PostTagResource The tag resource.
      */
-    public function show( int $id ): PostTagResource
+    public function show(int $id): PostTagResource
     {
-        $tag = PostTag::findOrFail( $id );
-        $this->authorize( 'view', $tag );
+        $tag = PostTag::findOrFail($id);
+        $this->authorize('view', $tag);
 
-        return new PostTagResource( $tag );
+        return new PostTagResource($tag);
     }
 
     /**
@@ -106,15 +108,15 @@ class PostTagController extends Controller
      *
      * @return PostTagResource The updated tag resource.
      */
-    public function update( PostTagRequest $request, int $id ): PostTagResource
+    public function update(PostTagRequest $request, int $id): PostTagResource
     {
-        $tag = PostTag::findOrFail( $id );
-        $this->authorize( 'update', $tag );
+        $tag = PostTag::findOrFail($id);
+        $this->authorize('update', $tag);
 
         $validated = $request->validated();
-        $tag->update( $validated );
+        $tag->update($validated);
 
-        return new PostTagResource( $tag );
+        return new PostTagResource($tag);
     }
 
     /**
@@ -129,10 +131,10 @@ class PostTagController extends Controller
      *
      * @return Response A response with 204 status code.
      */
-    public function destroy( int $id ): Response
+    public function destroy(int $id): Response
     {
-        $tag = PostTag::findOrFail( $id );
-        $this->authorize( 'delete', $tag );
+        $tag = PostTag::findOrFail($id);
+        $this->authorize('delete', $tag);
 
         $tag->delete();
 

--- a/src/Modules/Blog/Http/Requests/BulkPostRequest.php
+++ b/src/Modules/Blog/Http/Requests/BulkPostRequest.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Bulk Post Request for the CMS Framework Blog Module.
+ *
+ * This form request handles validation for bulk post operations,
+ * ensuring the action and IDs are valid.
+ *
+ * @since 1.1.0
+ */
+
+namespace ArtisanPackUI\CMSFramework\Modules\Blog\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+/**
+ * Form request for bulk post operations.
+ *
+ * Validates the action type and array of post IDs for bulk operations.
+ *
+ * @since 1.1.0
+ */
+class BulkPostRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @since 1.1.0
+     *
+     * @return bool True if the user is authorized, false otherwise.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the allowed actions for bulk post operations.
+     *
+     * @since 1.1.0
+     *
+     * @return array<int, string> The allowed action names.
+     */
+    public static function allowedActions(): array
+    {
+        return ['delete', 'publish', 'draft', 'archive'];
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @since 1.1.0
+     *
+     * @return array<string, mixed> The validation rules.
+     */
+    public function rules(): array
+    {
+        return [
+            'action' => ['required', 'string', Rule::in(self::allowedActions())],
+            'ids'    => ['required', 'array', 'min:1'],
+            'ids.*'  => ['required', 'integer', 'exists:posts,id'],
+        ];
+    }
+
+    /**
+     * Get custom messages for validator errors.
+     *
+     * @since 1.1.0
+     *
+     * @return array<string, string> The custom error messages.
+     */
+    public function messages(): array
+    {
+        return [
+            'action.required' => __('The bulk action is required.'),
+            'action.in'       => __('The selected action is invalid. Allowed actions: :values.', ['values' => implode(', ', self::allowedActions())]),
+            'ids.required'    => __('At least one post ID is required.'),
+            'ids.min'         => __('At least one post ID is required.'),
+            'ids.*.exists'    => __('One or more post IDs do not exist.'),
+        ];
+    }
+}

--- a/src/Modules/Blog/Http/Requests/BulkPostRequest.php
+++ b/src/Modules/Blog/Http/Requests/BulkPostRequest.php
@@ -46,7 +46,7 @@ class BulkPostRequest extends FormRequest
      */
     public static function allowedActions(): array
     {
-        return ['delete', 'publish', 'draft', 'archive'];
+        return ['delete', 'publish', 'draft'];
     }
 
     /**

--- a/src/Modules/Blog/Http/Requests/BulkPostRequest.php
+++ b/src/Modules/Blog/Http/Requests/BulkPostRequest.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare( strict_types=1 );
 
 /**
  * Bulk Post Request for the CMS Framework Blog Module.
@@ -59,7 +59,7 @@ class BulkPostRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'action' => ['required', 'string', Rule::in(self::allowedActions())],
+            'action' => ['required', 'string', Rule::in( self::allowedActions() )],
             'ids'    => ['required', 'array', 'min:1'],
             'ids.*'  => ['required', 'integer', 'exists:posts,id'],
         ];
@@ -75,11 +75,11 @@ class BulkPostRequest extends FormRequest
     public function messages(): array
     {
         return [
-            'action.required' => __('The bulk action is required.'),
-            'action.in'       => __('The selected action is invalid. Allowed actions: :values.', ['values' => implode(', ', self::allowedActions())]),
-            'ids.required'    => __('At least one post ID is required.'),
-            'ids.min'         => __('At least one post ID is required.'),
-            'ids.*.exists'    => __('One or more post IDs do not exist.'),
+            'action.required' => __( 'The bulk action is required.' ),
+            'action.in'       => __( 'The selected action is invalid. Allowed actions: :values.', ['values' => implode( ', ', self::allowedActions() )] ),
+            'ids.required'    => __( 'At least one post ID is required.' ),
+            'ids.min'         => __( 'At least one post ID is required.' ),
+            'ids.*.exists'    => __( 'One or more post IDs do not exist.' ),
         ];
     }
 }

--- a/src/Modules/Blog/Http/Requests/PostRequest.php
+++ b/src/Modules/Blog/Http/Requests/PostRequest.php
@@ -1,6 +1,6 @@
 <?php
 
-declare( strict_types = 1 );
+declare(strict_types=1);
 
 /**
  * Post Request for the CMS Framework Blog Module.
@@ -13,6 +13,7 @@ declare( strict_types = 1 );
 
 namespace ArtisanPackUI\CMSFramework\Modules\Blog\Http\Requests;
 
+use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Enums\ContentStatus;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
 
@@ -47,7 +48,7 @@ class PostRequest extends FormRequest
      */
     public function rules(): array
     {
-        $id = $this->route( 'id' );
+        $id = $this->route('id');
 
         return [
             'title' => [
@@ -60,12 +61,12 @@ class PostRequest extends FormRequest
                 'string',
                 'max:255',
                 'regex:/^[a-z0-9]+(?:-[a-z0-9]+)*$/',
-                Rule::unique( 'posts', 'slug' )->ignore( $id ),
+                Rule::unique('posts', 'slug')->ignore($id),
             ],
             'content'      => ['nullable', 'string'],
             'excerpt'      => ['nullable', 'string'],
             'author_id'    => ['required', 'integer', 'exists:users,id'],
-            'status'       => ['required', 'string', 'in:draft,published,scheduled,private'],
+            'status'       => ['required', 'string', Rule::enum(ContentStatus::class)],
             'published_at' => ['nullable', 'date'],
             'metadata'     => ['nullable', 'array'],
             'categories'   => ['nullable', 'array'],
@@ -85,12 +86,12 @@ class PostRequest extends FormRequest
     public function messages(): array
     {
         return [
-            'title.required'     => __( 'The post title is required.' ),
-            'slug.required'      => __( 'The post slug is required.' ),
-            'slug.regex'         => __( 'The slug must be lowercase letters, numbers, and hyphens only.' ),
-            'slug.unique'        => __( 'A post with this slug already exists.' ),
-            'author_id.required' => __( 'The author is required.' ),
-            'status.required'    => __( 'The post status is required.' ),
+            'title.required'     => __('The post title is required.'),
+            'slug.required'      => __('The post slug is required.'),
+            'slug.regex'         => __('The slug must be lowercase letters, numbers, and hyphens only.'),
+            'slug.unique'        => __('A post with this slug already exists.'),
+            'author_id.required' => __('The author is required.'),
+            'status.required'    => __('The post status is required.'),
         ];
     }
 }

--- a/src/Modules/Blog/Http/Requests/PostRequest.php
+++ b/src/Modules/Blog/Http/Requests/PostRequest.php
@@ -66,7 +66,7 @@ class PostRequest extends FormRequest
             'content'      => ['nullable', 'string'],
             'excerpt'      => ['nullable', 'string'],
             'author_id'    => ['required', 'integer', 'exists:users,id'],
-            'status'       => ['required', 'string', Rule::enum(ContentStatus::class)],
+            'status'       => ['required', 'string', ContentStatus::validationRule()],
             'published_at' => ['nullable', 'date'],
             'metadata'     => ['nullable', 'array'],
             'categories'   => ['nullable', 'array'],

--- a/src/Modules/Blog/Http/Requests/PostRequest.php
+++ b/src/Modules/Blog/Http/Requests/PostRequest.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare( strict_types=1 );
 
 /**
  * Post Request for the CMS Framework Blog Module.
@@ -48,7 +48,7 @@ class PostRequest extends FormRequest
      */
     public function rules(): array
     {
-        $id = $this->route('id');
+        $id = $this->route( 'id' );
 
         return [
             'title' => [
@@ -61,7 +61,7 @@ class PostRequest extends FormRequest
                 'string',
                 'max:255',
                 'regex:/^[a-z0-9]+(?:-[a-z0-9]+)*$/',
-                Rule::unique('posts', 'slug')->ignore($id),
+                Rule::unique( 'posts', 'slug' )->ignore( $id ),
             ],
             'content'      => ['nullable', 'string'],
             'excerpt'      => ['nullable', 'string'],
@@ -86,12 +86,12 @@ class PostRequest extends FormRequest
     public function messages(): array
     {
         return [
-            'title.required'     => __('The post title is required.'),
-            'slug.required'      => __('The post slug is required.'),
-            'slug.regex'         => __('The slug must be lowercase letters, numbers, and hyphens only.'),
-            'slug.unique'        => __('A post with this slug already exists.'),
-            'author_id.required' => __('The author is required.'),
-            'status.required'    => __('The post status is required.'),
+            'title.required'     => __( 'The post title is required.' ),
+            'slug.required'      => __( 'The post slug is required.' ),
+            'slug.regex'         => __( 'The slug must be lowercase letters, numbers, and hyphens only.' ),
+            'slug.unique'        => __( 'A post with this slug already exists.' ),
+            'author_id.required' => __( 'The author is required.' ),
+            'status.required'    => __( 'The post status is required.' ),
         ];
     }
 }

--- a/src/Modules/Blog/Managers/BlogManager.php
+++ b/src/Modules/Blog/Managers/BlogManager.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 namespace ArtisanPackUI\CMSFramework\Modules\Blog\Managers;
 
 use ArtisanPackUI\CMSFramework\Modules\Blog\Models\Post;
-use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Enums\ContentStatus;
+use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Managers\Concerns\HasContentFilters;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Collection;
 
@@ -24,6 +24,8 @@ use Illuminate\Support\Collection;
  */
 class BlogManager
 {
+    use HasContentFilters;
+
     /**
      * Build an archive query with filters.
      *
@@ -35,20 +37,10 @@ class BlogManager
     {
         $query = Post::query()->with(['author', 'categories', 'tags']);
 
-        // Apply status filter (default to published)
-        if (isset($filters['status'])) {
-            $status = $filters['status'] instanceof ContentStatus
-                ? $filters['status']
-                : ContentStatus::tryFrom(sanitizeText($filters['status']));
-
-            if (null === $status || ContentStatus::Published === $status) {
-                $query->published();
-            } else {
-                $query->where('status', $status);
-            }
-        } else {
-            $query->published();
-        }
+        // Apply shared filters
+        $this->applyStatusFilter($query, $filters);
+        $this->applyAuthorFilter($query, $filters);
+        $this->applySearchFilter($query, $filters);
 
         // Apply category filter
         if (isset($filters['category'])) {
@@ -58,11 +50,6 @@ class BlogManager
         // Apply tag filter
         if (isset($filters['tag'])) {
             $query->byTag($filters['tag']);
-        }
-
-        // Apply author filter
-        if (isset($filters['author'])) {
-            $query->byAuthor($filters['author']);
         }
 
         // Apply date filters
@@ -75,16 +62,6 @@ class BlogManager
             } else {
                 $query->byYear($filters['year']);
             }
-        }
-
-        // Apply search filter
-        if (isset($filters['search'])) {
-            $search = $filters['search'];
-            $query->where(function ($q) use ($search): void {
-                $q->where('title', 'like', "%{$search}%")
-                    ->orWhere('content', 'like', "%{$search}%")
-                    ->orWhere('excerpt', 'like', "%{$search}%");
-            });
         }
 
         // Order by published date descending

--- a/src/Modules/Blog/Managers/BlogManager.php
+++ b/src/Modules/Blog/Managers/BlogManager.php
@@ -39,9 +39,9 @@ class BlogManager
         if (isset($filters['status'])) {
             $status = $filters['status'] instanceof ContentStatus
                 ? $filters['status']
-                : ContentStatus::from(sanitizeText($filters['status']));
+                : ContentStatus::tryFrom(sanitizeText($filters['status']));
 
-            if (ContentStatus::Published === $status) {
+            if (null === $status || ContentStatus::Published === $status) {
                 $query->published();
             } else {
                 $query->where('status', $status);

--- a/src/Modules/Blog/Managers/BlogManager.php
+++ b/src/Modules/Blog/Managers/BlogManager.php
@@ -1,6 +1,6 @@
 <?php
 
-declare( strict_types = 1 );
+declare(strict_types=1);
 
 /**
  * Blog Manager
@@ -13,6 +13,7 @@ declare( strict_types = 1 );
 namespace ArtisanPackUI\CMSFramework\Modules\Blog\Managers;
 
 use ArtisanPackUI\CMSFramework\Modules\Blog\Models\Post;
+use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Enums\ContentStatus;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Collection;
 
@@ -30,60 +31,64 @@ class BlogManager
      *
      * @param  array  $filters  Array of filters to apply (category, tag, author, year, month, day, status).
      */
-    public function getArchiveQuery( array $filters = [] ): Builder
+    public function getArchiveQuery(array $filters = []): Builder
     {
-        $query = Post::query()->with( ['author', 'categories', 'tags'] );
+        $query = Post::query()->with(['author', 'categories', 'tags']);
 
         // Apply status filter (default to published)
-        if ( isset( $filters['status'] ) ) {
-            if ( 'published' === $filters['status'] ) {
+        if (isset($filters['status'])) {
+            $status = $filters['status'] instanceof ContentStatus
+                ? $filters['status']
+                : ContentStatus::from(sanitizeText($filters['status']));
+
+            if (ContentStatus::Published === $status) {
                 $query->published();
             } else {
-                $query->where( 'status', sanitizeText( $filters['status'] ) );
+                $query->where('status', $status);
             }
         } else {
             $query->published();
         }
 
         // Apply category filter
-        if ( isset( $filters['category'] ) ) {
-            $query->byCategory( $filters['category'] );
+        if (isset($filters['category'])) {
+            $query->byCategory($filters['category']);
         }
 
         // Apply tag filter
-        if ( isset( $filters['tag'] ) ) {
-            $query->byTag( $filters['tag'] );
+        if (isset($filters['tag'])) {
+            $query->byTag($filters['tag']);
         }
 
         // Apply author filter
-        if ( isset( $filters['author'] ) ) {
-            $query->byAuthor( $filters['author'] );
+        if (isset($filters['author'])) {
+            $query->byAuthor($filters['author']);
         }
 
         // Apply date filters
-        if ( isset( $filters['year'] ) ) {
-            if ( isset( $filters['month'] ) ) {
-                $query->byMonth( $filters['year'], $filters['month'] );
-                if ( isset( $filters['day'] ) ) {
-                    $query->whereDay( 'published_at', $filters['day'] );
+        if (isset($filters['year'])) {
+            if (isset($filters['month'])) {
+                $query->byMonth($filters['year'], $filters['month']);
+                if (isset($filters['day'])) {
+                    $query->whereDay('published_at', $filters['day']);
                 }
             } else {
-                $query->byYear( $filters['year'] );
+                $query->byYear($filters['year']);
             }
         }
 
         // Apply search filter
-        if ( isset( $filters['search'] ) ) {
+        if (isset($filters['search'])) {
             $search = $filters['search'];
-            $query->where( function ( $q ) use ( $search ): void {
-                $q->where( 'title', 'like', "%{$search}%" )
-                    ->orWhere( 'content', 'like', "%{$search}%" )
-                    ->orWhere( 'excerpt', 'like', "%{$search}%" );
-            } );
+            $query->where(function ($q) use ($search): void {
+                $q->where('title', 'like', "%{$search}%")
+                    ->orWhere('content', 'like', "%{$search}%")
+                    ->orWhere('excerpt', 'like', "%{$search}%");
+            });
         }
 
         // Order by published date descending
-        $query->orderBy( 'published_at', 'desc' );
+        $query->orderBy('published_at', 'desc');
 
         return $query;
     }
@@ -97,19 +102,19 @@ class BlogManager
      * @param  int|null  $month  Month to filter by (optional).
      * @param  int|null  $day  Day to filter by (optional).
      */
-    public function getPostsByDate( int $year, ?int $month = null, ?int $day = null ): Collection
+    public function getPostsByDate(int $year, ?int $month = null, ?int $day = null): Collection
     {
         $filters = ['year' => $year];
 
-        if ( null !== $month ) {
+        if (null !== $month) {
             $filters['month'] = $month;
         }
 
-        if ( null !== $day ) {
+        if (null !== $day) {
             $filters['day'] = $day;
         }
 
-        return $this->getArchiveQuery( $filters )->get();
+        return $this->getArchiveQuery($filters)->get();
     }
 
     /**
@@ -119,9 +124,9 @@ class BlogManager
      *
      * @param  int  $authorId  Author ID to filter by.
      */
-    public function getPostsByAuthor( int $authorId ): Collection
+    public function getPostsByAuthor(int $authorId): Collection
     {
-        return $this->getArchiveQuery( ['author' => $authorId] )->get();
+        return $this->getArchiveQuery(['author' => $authorId])->get();
     }
 
     /**
@@ -131,19 +136,19 @@ class BlogManager
      *
      * @param  int|string  $category  Category ID or slug.
      */
-    public function getPostsByCategory( $category ): Collection
+    public function getPostsByCategory($category): Collection
     {
         // If category is a string (slug), find the category ID
-        if ( is_string( $category ) ) {
-            $categoryModel = \ArtisanPackUI\CMSFramework\Modules\Blog\Models\PostCategory::where( 'slug', sanitizeText( $category ) )->first();
-            if ( $categoryModel ) {
+        if (is_string($category)) {
+            $categoryModel = \ArtisanPackUI\CMSFramework\Modules\Blog\Models\PostCategory::where('slug', sanitizeText($category))->first();
+            if ($categoryModel) {
                 $category = $categoryModel->id;
             } else {
                 return collect();
             }
         }
 
-        return $this->getArchiveQuery( ['category' => $category] )->get();
+        return $this->getArchiveQuery(['category' => $category])->get();
     }
 
     /**
@@ -153,19 +158,19 @@ class BlogManager
      *
      * @param  int|string  $tag  Tag ID or slug.
      */
-    public function getPostsByTag( $tag ): Collection
+    public function getPostsByTag($tag): Collection
     {
         // If tag is a string (slug), find the tag ID
-        if ( is_string( $tag ) ) {
-            $tagModel = \ArtisanPackUI\CMSFramework\Modules\Blog\Models\PostTag::where( 'slug', sanitizeText( $tag ) )->first();
-            if ( $tagModel ) {
+        if (is_string($tag)) {
+            $tagModel = \ArtisanPackUI\CMSFramework\Modules\Blog\Models\PostTag::where('slug', sanitizeText($tag))->first();
+            if ($tagModel) {
                 $tag = $tagModel->id;
             } else {
                 return collect();
             }
         }
 
-        return $this->getArchiveQuery( ['tag' => $tag] )->get();
+        return $this->getArchiveQuery(['tag' => $tag])->get();
     }
 
     /**
@@ -176,15 +181,15 @@ class BlogManager
      * @param  int  $limit  Number of posts to retrieve.
      * @param  array|string  $with  Optional relationships to eager load.
      */
-    public function getRecentPosts( int $limit = 10, array|string $with = [] ): Collection
+    public function getRecentPosts(int $limit = 10, array|string $with = []): Collection
     {
         $query = $this->getArchiveQuery();
 
-        if ( ! empty( $with ) ) {
-            $query->with( (array) $with );
+        if (! empty($with)) {
+            $query->with((array) $with);
         }
 
-        return $query->limit( $limit )->get();
+        return $query->limit($limit)->get();
     }
 
     /**
@@ -194,11 +199,11 @@ class BlogManager
      *
      * @param  int  $limit  Number of posts to retrieve.
      */
-    public function getPopularPosts( int $limit = 10 ): Collection
+    public function getPopularPosts(int $limit = 10): Collection
     {
         return $this->getArchiveQuery()
-            ->orderByRaw( 'CAST(JSON_EXTRACT(metadata, "$.view_count") AS UNSIGNED) DESC' )
-            ->limit( $limit )
+            ->orderByRaw('CAST(JSON_EXTRACT(metadata, "$.view_count") AS UNSIGNED) DESC')
+            ->limit($limit)
             ->get();
     }
 }

--- a/src/Modules/Blog/Managers/BlogManager.php
+++ b/src/Modules/Blog/Managers/BlogManager.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare( strict_types=1 );
 
 /**
  * Blog Manager
@@ -33,39 +33,39 @@ class BlogManager
      *
      * @param  array  $filters  Array of filters to apply (category, tag, author, year, month, day, status).
      */
-    public function getArchiveQuery(array $filters = []): Builder
+    public function getArchiveQuery( array $filters = [] ): Builder
     {
-        $query = Post::query()->with(['author', 'categories', 'tags']);
+        $query = Post::query()->with( ['author', 'categories', 'tags'] );
 
         // Apply shared filters
-        $this->applyStatusFilter($query, $filters);
-        $this->applyAuthorFilter($query, $filters);
-        $this->applySearchFilter($query, $filters);
+        $this->applyStatusFilter( $query, $filters );
+        $this->applyAuthorFilter( $query, $filters );
+        $this->applySearchFilter( $query, $filters );
 
         // Apply category filter
-        if (isset($filters['category'])) {
-            $query->byCategory($filters['category']);
+        if ( isset( $filters['category'] ) ) {
+            $query->byCategory( $filters['category'] );
         }
 
         // Apply tag filter
-        if (isset($filters['tag'])) {
-            $query->byTag($filters['tag']);
+        if ( isset( $filters['tag'] ) ) {
+            $query->byTag( $filters['tag'] );
         }
 
         // Apply date filters
-        if (isset($filters['year'])) {
-            if (isset($filters['month'])) {
-                $query->byMonth($filters['year'], $filters['month']);
-                if (isset($filters['day'])) {
-                    $query->whereDay('published_at', $filters['day']);
+        if ( isset( $filters['year'] ) ) {
+            if ( isset( $filters['month'] ) ) {
+                $query->byMonth( $filters['year'], $filters['month'] );
+                if ( isset( $filters['day'] ) ) {
+                    $query->whereDay( 'published_at', $filters['day'] );
                 }
             } else {
-                $query->byYear($filters['year']);
+                $query->byYear( $filters['year'] );
             }
         }
 
         // Order by published date descending
-        $query->orderBy('published_at', 'desc');
+        $query->orderBy( 'published_at', 'desc' );
 
         return $query;
     }
@@ -79,19 +79,19 @@ class BlogManager
      * @param  int|null  $month  Month to filter by (optional).
      * @param  int|null  $day  Day to filter by (optional).
      */
-    public function getPostsByDate(int $year, ?int $month = null, ?int $day = null): Collection
+    public function getPostsByDate( int $year, ?int $month = null, ?int $day = null ): Collection
     {
         $filters = ['year' => $year];
 
-        if (null !== $month) {
+        if ( null !== $month ) {
             $filters['month'] = $month;
         }
 
-        if (null !== $day) {
+        if ( null !== $day ) {
             $filters['day'] = $day;
         }
 
-        return $this->getArchiveQuery($filters)->get();
+        return $this->getArchiveQuery( $filters )->get();
     }
 
     /**
@@ -101,9 +101,9 @@ class BlogManager
      *
      * @param  int  $authorId  Author ID to filter by.
      */
-    public function getPostsByAuthor(int $authorId): Collection
+    public function getPostsByAuthor( int $authorId ): Collection
     {
-        return $this->getArchiveQuery(['author' => $authorId])->get();
+        return $this->getArchiveQuery( ['author' => $authorId] )->get();
     }
 
     /**
@@ -113,19 +113,19 @@ class BlogManager
      *
      * @param  int|string  $category  Category ID or slug.
      */
-    public function getPostsByCategory($category): Collection
+    public function getPostsByCategory( $category ): Collection
     {
         // If category is a string (slug), find the category ID
-        if (is_string($category)) {
-            $categoryModel = \ArtisanPackUI\CMSFramework\Modules\Blog\Models\PostCategory::where('slug', sanitizeText($category))->first();
-            if ($categoryModel) {
+        if ( is_string( $category ) ) {
+            $categoryModel = \ArtisanPackUI\CMSFramework\Modules\Blog\Models\PostCategory::where( 'slug', sanitizeText( $category ) )->first();
+            if ( $categoryModel ) {
                 $category = $categoryModel->id;
             } else {
                 return collect();
             }
         }
 
-        return $this->getArchiveQuery(['category' => $category])->get();
+        return $this->getArchiveQuery( ['category' => $category] )->get();
     }
 
     /**
@@ -135,19 +135,19 @@ class BlogManager
      *
      * @param  int|string  $tag  Tag ID or slug.
      */
-    public function getPostsByTag($tag): Collection
+    public function getPostsByTag( $tag ): Collection
     {
         // If tag is a string (slug), find the tag ID
-        if (is_string($tag)) {
-            $tagModel = \ArtisanPackUI\CMSFramework\Modules\Blog\Models\PostTag::where('slug', sanitizeText($tag))->first();
-            if ($tagModel) {
+        if ( is_string( $tag ) ) {
+            $tagModel = \ArtisanPackUI\CMSFramework\Modules\Blog\Models\PostTag::where( 'slug', sanitizeText( $tag ) )->first();
+            if ( $tagModel ) {
                 $tag = $tagModel->id;
             } else {
                 return collect();
             }
         }
 
-        return $this->getArchiveQuery(['tag' => $tag])->get();
+        return $this->getArchiveQuery( ['tag' => $tag] )->get();
     }
 
     /**
@@ -158,15 +158,15 @@ class BlogManager
      * @param  int  $limit  Number of posts to retrieve.
      * @param  array|string  $with  Optional relationships to eager load.
      */
-    public function getRecentPosts(int $limit = 10, array|string $with = []): Collection
+    public function getRecentPosts( int $limit = 10, array|string $with = [] ): Collection
     {
         $query = $this->getArchiveQuery();
 
-        if (! empty($with)) {
-            $query->with((array) $with);
+        if ( ! empty( $with ) ) {
+            $query->with( (array) $with );
         }
 
-        return $query->limit($limit)->get();
+        return $query->limit( $limit )->get();
     }
 
     /**
@@ -176,11 +176,11 @@ class BlogManager
      *
      * @param  int  $limit  Number of posts to retrieve.
      */
-    public function getPopularPosts(int $limit = 10): Collection
+    public function getPopularPosts( int $limit = 10): Collection
     {
         return $this->getArchiveQuery()
-            ->orderByRaw('CAST(JSON_EXTRACT(metadata, "$.view_count") AS UNSIGNED) DESC')
-            ->limit($limit)
+            ->orderByRaw( 'CAST(JSON_EXTRACT(metadata, "$.view_count") AS UNSIGNED) DESC')
+            ->limit( $limit)
             ->get();
     }
 }

--- a/src/Modules/Blog/Managers/BlogManager.php
+++ b/src/Modules/Blog/Managers/BlogManager.php
@@ -176,11 +176,11 @@ class BlogManager
      *
      * @param  int  $limit  Number of posts to retrieve.
      */
-    public function getPopularPosts( int $limit = 10): Collection
+    public function getPopularPosts( int $limit = 10 ): Collection
     {
         return $this->getArchiveQuery()
-            ->orderByRaw( 'CAST(JSON_EXTRACT(metadata, "$.view_count") AS UNSIGNED) DESC')
-            ->limit( $limit)
+            ->orderByRaw( 'CAST(JSON_EXTRACT(metadata, "$.view_count") AS UNSIGNED) DESC' )
+            ->limit( $limit )
             ->get();
     }
 }

--- a/src/Modules/Blog/Models/Post.php
+++ b/src/Modules/Blog/Models/Post.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace ArtisanPackUI\CMSFramework\Modules\Blog\Models;
 
 use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Enums\ContentStatus;
+use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Models\Concerns\HasContentStatus;
 use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Models\Concerns\HasCustomFields;
 use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Models\Concerns\HasFeaturedImage;
 use ArtisanPackUI\MediaLibrary\Models\Media;
@@ -44,6 +45,7 @@ use Illuminate\Database\Eloquent\SoftDeletes;
  */
 class Post extends Model
 {
+    use HasContentStatus;
     use HasCustomFields;
     use HasFactory;
     use HasFeaturedImage;
@@ -106,34 +108,6 @@ class Post extends Model
     public function tags(): BelongsToMany
     {
         return $this->belongsToMany(PostTag::class, 'post_tag_pivots', 'post_id', 'post_tag_id');
-    }
-
-    /**
-     * Scope a query to only include published posts.
-     *
-     * @since 1.0.0
-     *
-     * @return Builder
-     */
-    public function scopePublished(Builder $query)
-    {
-        return $query->where('status', ContentStatus::Published)
-            ->where(function ($q): void {
-                $q->whereNull('published_at')
-                    ->orWhere('published_at', '<=', now());
-            });
-    }
-
-    /**
-     * Scope a query to only include draft posts.
-     *
-     * @since 1.0.0
-     *
-     * @return Builder
-     */
-    public function scopeDraft(Builder $query)
-    {
-        return $query->where('status', ContentStatus::Draft);
     }
 
     /**
@@ -211,17 +185,6 @@ class Post extends Model
     public function scopeByDate(Builder $query, Carbon $date)
     {
         return $query->whereDate('published_at', $date);
-    }
-
-    /**
-     * Check if the post is published.
-     *
-     * @since 1.0.0
-     */
-    public function isPublished(): bool
-    {
-        return ContentStatus::Published === $this->status &&
-            (null === $this->published_at || $this->published_at->isPast());
     }
 
     /**

--- a/src/Modules/Blog/Models/Post.php
+++ b/src/Modules/Blog/Models/Post.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare( strict_types=1 );
 
 /**
  * Post Model
@@ -77,7 +77,7 @@ class Post extends Model
      */
     public function author(): BelongsTo
     {
-        return $this->belongsTo(config('auth.providers.users.model'), 'author_id');
+        return $this->belongsTo( config( 'auth.providers.users.model' ), 'author_id' );
     }
 
     /**
@@ -87,7 +87,7 @@ class Post extends Model
      */
     public function featuredImageMedia(): BelongsTo
     {
-        return $this->belongsTo(Media::class, 'featured_image_id');
+        return $this->belongsTo( Media::class, 'featured_image_id' );
     }
 
     /**
@@ -97,7 +97,7 @@ class Post extends Model
      */
     public function categories(): BelongsToMany
     {
-        return $this->belongsToMany(PostCategory::class, 'post_category_pivots', 'post_id', 'post_category_id');
+        return $this->belongsToMany( PostCategory::class, 'post_category_pivots', 'post_id', 'post_category_id' );
     }
 
     /**
@@ -107,7 +107,7 @@ class Post extends Model
      */
     public function tags(): BelongsToMany
     {
-        return $this->belongsToMany(PostTag::class, 'post_tag_pivots', 'post_id', 'post_tag_id');
+        return $this->belongsToMany( PostTag::class, 'post_tag_pivots', 'post_id', 'post_tag_id' );
     }
 
     /**
@@ -117,9 +117,9 @@ class Post extends Model
      *
      * @return Builder
      */
-    public function scopeByAuthor(Builder $query, int $authorId)
+    public function scopeByAuthor( Builder $query, int $authorId )
     {
-        return $query->where('author_id', sanitizeInt($authorId));
+        return $query->where( 'author_id', sanitizeInt( $authorId ) );
     }
 
     /**
@@ -129,11 +129,11 @@ class Post extends Model
      *
      * @return Builder
      */
-    public function scopeByCategory(Builder $query, int $categoryId)
+    public function scopeByCategory( Builder $query, int $categoryId )
     {
-        return $query->whereHas('categories', function ($q) use ($categoryId): void {
-            $q->where('post_categories.id', sanitizeInt($categoryId));
-        });
+        return $query->whereHas( 'categories', function ( $q ) use ( $categoryId ): void {
+            $q->where( 'post_categories.id', sanitizeInt( $categoryId ) );
+        } );
     }
 
     /**
@@ -143,11 +143,11 @@ class Post extends Model
      *
      * @return Builder
      */
-    public function scopeByTag(Builder $query, int $tagId)
+    public function scopeByTag( Builder $query, int $tagId )
     {
-        return $query->whereHas('tags', function ($q) use ($tagId): void {
-            $q->where('post_tags.id', sanitizeInt($tagId));
-        });
+        return $query->whereHas( 'tags', function ( $q ) use ( $tagId ): void {
+            $q->where( 'post_tags.id', sanitizeInt( $tagId ) );
+        } );
     }
 
     /**
@@ -157,9 +157,9 @@ class Post extends Model
      *
      * @return Builder
      */
-    public function scopeByYear(Builder $query, int $year)
+    public function scopeByYear( Builder $query, int $year )
     {
-        return $query->whereYear('published_at', $year);
+        return $query->whereYear( 'published_at', $year );
     }
 
     /**
@@ -169,10 +169,10 @@ class Post extends Model
      *
      * @return Builder
      */
-    public function scopeByMonth(Builder $query, int $year, int $month)
+    public function scopeByMonth( Builder $query, int $year, int $month )
     {
-        return $query->whereYear('published_at', $year)
-            ->whereMonth('published_at', $month);
+        return $query->whereYear( 'published_at', $year )
+            ->whereMonth( 'published_at', $month );
     }
 
     /**
@@ -182,9 +182,9 @@ class Post extends Model
      *
      * @return Builder
      */
-    public function scopeByDate(Builder $query, Carbon $date)
+    public function scopeByDate( Builder $query, Carbon $date )
     {
-        return $query->whereDate('published_at', $date);
+        return $query->whereDate( 'published_at', $date );
     }
 
     /**
@@ -194,7 +194,7 @@ class Post extends Model
      */
     public function getPermalinkAttribute(): string
     {
-        return url("/blog/{$this->slug}");
+        return url( "/blog/{$this->slug}" );
     }
 
     /**

--- a/src/Modules/Blog/Models/Post.php
+++ b/src/Modules/Blog/Models/Post.php
@@ -33,7 +33,7 @@ use Illuminate\Database\Eloquent\SoftDeletes;
  * @property string|null $content
  * @property string|null $excerpt
  * @property int $author_id
- * @property string $status
+ * @property ContentStatus $status
  * @property Carbon|null $published_at
  * @property array|null $metadata
  * @property \Illuminate\Support\Carbon $created_at

--- a/src/Modules/Blog/Models/Post.php
+++ b/src/Modules/Blog/Models/Post.php
@@ -1,6 +1,6 @@
 <?php
 
-declare( strict_types = 1 );
+declare(strict_types=1);
 
 /**
  * Post Model
@@ -12,6 +12,7 @@ declare( strict_types = 1 );
 
 namespace ArtisanPackUI\CMSFramework\Modules\Blog\Models;
 
+use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Enums\ContentStatus;
 use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Models\Concerns\HasCustomFields;
 use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Models\Concerns\HasFeaturedImage;
 use ArtisanPackUI\MediaLibrary\Models\Media;
@@ -74,7 +75,7 @@ class Post extends Model
      */
     public function author(): BelongsTo
     {
-        return $this->belongsTo( config( 'auth.providers.users.model' ), 'author_id' );
+        return $this->belongsTo(config('auth.providers.users.model'), 'author_id');
     }
 
     /**
@@ -84,7 +85,7 @@ class Post extends Model
      */
     public function featuredImageMedia(): BelongsTo
     {
-        return $this->belongsTo( Media::class, 'featured_image_id' );
+        return $this->belongsTo(Media::class, 'featured_image_id');
     }
 
     /**
@@ -94,7 +95,7 @@ class Post extends Model
      */
     public function categories(): BelongsToMany
     {
-        return $this->belongsToMany( PostCategory::class, 'post_category_pivots', 'post_id', 'post_category_id' );
+        return $this->belongsToMany(PostCategory::class, 'post_category_pivots', 'post_id', 'post_category_id');
     }
 
     /**
@@ -104,7 +105,7 @@ class Post extends Model
      */
     public function tags(): BelongsToMany
     {
-        return $this->belongsToMany( PostTag::class, 'post_tag_pivots', 'post_id', 'post_tag_id' );
+        return $this->belongsToMany(PostTag::class, 'post_tag_pivots', 'post_id', 'post_tag_id');
     }
 
     /**
@@ -112,17 +113,15 @@ class Post extends Model
      *
      * @since 1.0.0
      *
-     * @param  Builder  $query
-     *
      * @return Builder
      */
-    public function scopePublished( Builder $query )
+    public function scopePublished(Builder $query)
     {
-        return $query->where( 'status', 'published' )
-            ->where( function ( $q ): void {
-                $q->whereNull( 'published_at' )
-                    ->orWhere( 'published_at', '<=', now() );
-            } );
+        return $query->where('status', ContentStatus::Published)
+            ->where(function ($q): void {
+                $q->whereNull('published_at')
+                    ->orWhere('published_at', '<=', now());
+            });
     }
 
     /**
@@ -130,13 +129,11 @@ class Post extends Model
      *
      * @since 1.0.0
      *
-     * @param  Builder  $query
-     *
      * @return Builder
      */
-    public function scopeDraft( Builder $query )
+    public function scopeDraft(Builder $query)
     {
-        return $query->where( 'status', 'draft' );
+        return $query->where('status', ContentStatus::Draft);
     }
 
     /**
@@ -144,13 +141,11 @@ class Post extends Model
      *
      * @since 1.0.0
      *
-     * @param  Builder  $query
-     *
      * @return Builder
      */
-    public function scopeByAuthor( Builder $query, int $authorId )
+    public function scopeByAuthor(Builder $query, int $authorId)
     {
-        return $query->where( 'author_id', sanitizeInt( $authorId ) );
+        return $query->where('author_id', sanitizeInt($authorId));
     }
 
     /**
@@ -158,15 +153,13 @@ class Post extends Model
      *
      * @since 1.0.0
      *
-     * @param  Builder  $query
-     *
      * @return Builder
      */
-    public function scopeByCategory( Builder $query, int $categoryId )
+    public function scopeByCategory(Builder $query, int $categoryId)
     {
-        return $query->whereHas( 'categories', function ( $q ) use ( $categoryId ): void {
-            $q->where( 'post_categories.id', sanitizeInt( $categoryId ) );
-        } );
+        return $query->whereHas('categories', function ($q) use ($categoryId): void {
+            $q->where('post_categories.id', sanitizeInt($categoryId));
+        });
     }
 
     /**
@@ -174,15 +167,13 @@ class Post extends Model
      *
      * @since 1.0.0
      *
-     * @param  Builder  $query
-     *
      * @return Builder
      */
-    public function scopeByTag( Builder $query, int $tagId )
+    public function scopeByTag(Builder $query, int $tagId)
     {
-        return $query->whereHas( 'tags', function ( $q ) use ( $tagId ): void {
-            $q->where( 'post_tags.id', sanitizeInt( $tagId ) );
-        } );
+        return $query->whereHas('tags', function ($q) use ($tagId): void {
+            $q->where('post_tags.id', sanitizeInt($tagId));
+        });
     }
 
     /**
@@ -190,13 +181,11 @@ class Post extends Model
      *
      * @since 1.0.0
      *
-     * @param  Builder  $query
-     *
      * @return Builder
      */
-    public function scopeByYear( Builder $query, int $year )
+    public function scopeByYear(Builder $query, int $year)
     {
-        return $query->whereYear( 'published_at', $year );
+        return $query->whereYear('published_at', $year);
     }
 
     /**
@@ -204,14 +193,12 @@ class Post extends Model
      *
      * @since 1.0.0
      *
-     * @param  Builder  $query
-     *
      * @return Builder
      */
-    public function scopeByMonth( Builder $query, int $year, int $month )
+    public function scopeByMonth(Builder $query, int $year, int $month)
     {
-        return $query->whereYear( 'published_at', $year )
-            ->whereMonth( 'published_at', $month );
+        return $query->whereYear('published_at', $year)
+            ->whereMonth('published_at', $month);
     }
 
     /**
@@ -219,13 +206,11 @@ class Post extends Model
      *
      * @since 1.0.0
      *
-     * @param  Builder  $query
-     *
      * @return Builder
      */
-    public function scopeByDate( Builder $query, Carbon $date )
+    public function scopeByDate(Builder $query, Carbon $date)
     {
-        return $query->whereDate( 'published_at', $date );
+        return $query->whereDate('published_at', $date);
     }
 
     /**
@@ -235,8 +220,8 @@ class Post extends Model
      */
     public function isPublished(): bool
     {
-        return 'published' === $this->status &&
-            ( null === $this->published_at || $this->published_at->isPast() );
+        return ContentStatus::Published === $this->status &&
+            (null === $this->published_at || $this->published_at->isPast());
     }
 
     /**
@@ -246,7 +231,7 @@ class Post extends Model
      */
     public function getPermalinkAttribute(): string
     {
-        return url( "/blog/{$this->slug}" );
+        return url("/blog/{$this->slug}");
     }
 
     /**
@@ -261,6 +246,7 @@ class Post extends Model
         return [
             'published_at' => 'datetime',
             'metadata'     => 'array',
+            'status'       => ContentStatus::class,
         ];
     }
 }

--- a/src/Modules/Blog/Policies/PostPolicy.php
+++ b/src/Modules/Blog/Policies/PostPolicy.php
@@ -185,6 +185,6 @@ class PostPolicy
          *
          * @return string Filtered capability slug.
          */
-        return $user->can( applyFilters( 'posts.publish', 'posts.publish', $post ));
+        return $user->can( applyFilters( 'posts.publish', 'posts.publish', $post ) );
     }
 }

--- a/src/Modules/Blog/database/factories/PostFactory.php
+++ b/src/Modules/Blog/database/factories/PostFactory.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare( strict_types=1 );
 
 /**
  * Post Factory for the CMS Framework Blog Module.
@@ -51,12 +51,12 @@ class PostFactory extends Factory
      */
     public function definition(): array
     {
-        $title = fake()->sentence(6, true);
+        $title = fake()->sentence( 6, true );
 
         return [
             'title'        => $title,
-            'slug'         => Str::slug($title),
-            'content'      => fake()->paragraphs(5, true),
+            'slug'         => Str::slug( $title ),
+            'content'      => fake()->paragraphs( 5, true ),
             'excerpt'      => fake()->paragraph(),
             'author_id'    => User::factory(),
             'status'       => ContentStatus::Published->value,
@@ -79,10 +79,10 @@ class PostFactory extends Factory
      */
     public function draft(): static
     {
-        return $this->state(fn (array $attributes) => [
+        return $this->state( fn ( array $attributes ) => [
             'status'       => ContentStatus::Draft->value,
             'published_at' => null,
-        ]);
+        ] );
     }
 
     /**
@@ -96,10 +96,10 @@ class PostFactory extends Factory
      */
     public function scheduled(): static
     {
-        return $this->state(fn (array $attributes) => [
+        return $this->state( fn ( array $attributes ) => [
             'status'       => ContentStatus::Published->value,
-            'published_at' => now()->addDays(rand(1, 30)),
-        ]);
+            'published_at' => now()->addDays( rand( 1, 30 ) ),
+        ] );
     }
 
     /**
@@ -113,10 +113,10 @@ class PostFactory extends Factory
      */
     public function published(): static
     {
-        return $this->state(fn (array $attributes) => [
+        return $this->state( fn ( array $attributes ) => [
             'status'       => ContentStatus::Published->value,
-            'published_at' => now()->subDays(rand(0, 365)),
-        ]);
+            'published_at' => now()->subDays( rand( 0, 365 ) ),
+        ] );
     }
 
     /**
@@ -128,12 +128,12 @@ class PostFactory extends Factory
      *
      * @return static The factory instance for method chaining.
      */
-    public function publishedAt($date): static
+    public function publishedAt( $date ): static
     {
-        return $this->state(fn (array $attributes) => [
+        return $this->state( fn ( array $attributes ) => [
             'status'       => ContentStatus::Published->value,
             'published_at' => $date,
-        ]);
+        ] );
     }
 
     /**
@@ -145,9 +145,9 @@ class PostFactory extends Factory
      *
      * @return static The factory instance for method chaining.
      */
-    public function byAuthor(int $authorId): static
+    public function byAuthor( int $authorId ): static
     {
-        return $this->state(fn (array $attributes) => [
+        return $this->state( fn ( array $attributes ) => [
             'author_id' => $authorId,
         ]);
     }

--- a/src/Modules/Blog/database/factories/PostFactory.php
+++ b/src/Modules/Blog/database/factories/PostFactory.php
@@ -1,6 +1,6 @@
 <?php
 
-declare( strict_types = 1 );
+declare(strict_types=1);
 
 /**
  * Post Factory for the CMS Framework Blog Module.
@@ -15,6 +15,7 @@ namespace ArtisanPackUI\CMSFramework\Modules\Blog\Database\Factories;
 
 use App\Models\User;
 use ArtisanPackUI\CMSFramework\Modules\Blog\Models\Post;
+use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Enums\ContentStatus;
 use DateTimeInterface;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Support\Str;
@@ -50,15 +51,15 @@ class PostFactory extends Factory
      */
     public function definition(): array
     {
-        $title = fake()->sentence( 6, true );
+        $title = fake()->sentence(6, true);
 
         return [
             'title'        => $title,
-            'slug'         => Str::slug( $title ),
-            'content'      => fake()->paragraphs( 5, true ),
+            'slug'         => Str::slug($title),
+            'content'      => fake()->paragraphs(5, true),
             'excerpt'      => fake()->paragraph(),
             'author_id'    => User::factory(),
-            'status'       => 'published',
+            'status'       => ContentStatus::Published,
             'published_at' => now(),
             'metadata'     => [
                 'seo_title'       => $title,
@@ -78,10 +79,10 @@ class PostFactory extends Factory
      */
     public function draft(): static
     {
-        return $this->state( fn ( array $attributes ) => [
-            'status'       => 'draft',
+        return $this->state(fn (array $attributes) => [
+            'status'       => ContentStatus::Draft,
             'published_at' => null,
-        ] );
+        ]);
     }
 
     /**
@@ -95,10 +96,10 @@ class PostFactory extends Factory
      */
     public function scheduled(): static
     {
-        return $this->state( fn ( array $attributes ) => [
-            'status'       => 'published',
-            'published_at' => now()->addDays( rand( 1, 30 ) ),
-        ] );
+        return $this->state(fn (array $attributes) => [
+            'status'       => ContentStatus::Published,
+            'published_at' => now()->addDays(rand(1, 30)),
+        ]);
     }
 
     /**
@@ -112,10 +113,10 @@ class PostFactory extends Factory
      */
     public function published(): static
     {
-        return $this->state( fn ( array $attributes ) => [
-            'status'       => 'published',
-            'published_at' => now()->subDays( rand( 0, 365 ) ),
-        ] );
+        return $this->state(fn (array $attributes) => [
+            'status'       => ContentStatus::Published,
+            'published_at' => now()->subDays(rand(0, 365)),
+        ]);
     }
 
     /**
@@ -127,12 +128,12 @@ class PostFactory extends Factory
      *
      * @return static The factory instance for method chaining.
      */
-    public function publishedAt( $date ): static
+    public function publishedAt($date): static
     {
-        return $this->state( fn ( array $attributes ) => [
-            'status'       => 'published',
+        return $this->state(fn (array $attributes) => [
+            'status'       => ContentStatus::Published,
             'published_at' => $date,
-        ] );
+        ]);
     }
 
     /**
@@ -144,9 +145,9 @@ class PostFactory extends Factory
      *
      * @return static The factory instance for method chaining.
      */
-    public function byAuthor( int $authorId ): static
+    public function byAuthor(int $authorId): static
     {
-        return $this->state( fn ( array $attributes ) => [
+        return $this->state(fn (array $attributes) => [
             'author_id' => $authorId,
         ]);
     }

--- a/src/Modules/Blog/database/factories/PostFactory.php
+++ b/src/Modules/Blog/database/factories/PostFactory.php
@@ -59,7 +59,7 @@ class PostFactory extends Factory
             'content'      => fake()->paragraphs(5, true),
             'excerpt'      => fake()->paragraph(),
             'author_id'    => User::factory(),
-            'status'       => ContentStatus::Published,
+            'status'       => ContentStatus::Published->value,
             'published_at' => now(),
             'metadata'     => [
                 'seo_title'       => $title,
@@ -80,7 +80,7 @@ class PostFactory extends Factory
     public function draft(): static
     {
         return $this->state(fn (array $attributes) => [
-            'status'       => ContentStatus::Draft,
+            'status'       => ContentStatus::Draft->value,
             'published_at' => null,
         ]);
     }
@@ -97,7 +97,7 @@ class PostFactory extends Factory
     public function scheduled(): static
     {
         return $this->state(fn (array $attributes) => [
-            'status'       => ContentStatus::Published,
+            'status'       => ContentStatus::Published->value,
             'published_at' => now()->addDays(rand(1, 30)),
         ]);
     }
@@ -114,7 +114,7 @@ class PostFactory extends Factory
     public function published(): static
     {
         return $this->state(fn (array $attributes) => [
-            'status'       => ContentStatus::Published,
+            'status'       => ContentStatus::Published->value,
             'published_at' => now()->subDays(rand(0, 365)),
         ]);
     }
@@ -131,7 +131,7 @@ class PostFactory extends Factory
     public function publishedAt($date): static
     {
         return $this->state(fn (array $attributes) => [
-            'status'       => ContentStatus::Published,
+            'status'       => ContentStatus::Published->value,
             'published_at' => $date,
         ]);
     }

--- a/src/Modules/Blog/database/migrations/2025_01_10_000003_create_posts_table.php
+++ b/src/Modules/Blog/database/migrations/2025_01_10_000003_create_posts_table.php
@@ -35,6 +35,6 @@ return new class extends Migration {
      */
     public function down(): void
     {
-        Schema::dropIfExists( 'posts');
+        Schema::dropIfExists( 'posts' );
     }
 };

--- a/src/Modules/Blog/database/migrations/2025_01_10_000004_create_post_categories_table.php
+++ b/src/Modules/Blog/database/migrations/2025_01_10_000004_create_post_categories_table.php
@@ -30,6 +30,6 @@ return new class extends Migration {
      */
     public function down(): void
     {
-        Schema::dropIfExists( 'post_categories');
+        Schema::dropIfExists( 'post_categories' );
     }
 };

--- a/src/Modules/Blog/database/migrations/2025_01_10_000006_create_post_tags_table.php
+++ b/src/Modules/Blog/database/migrations/2025_01_10_000006_create_post_tags_table.php
@@ -28,6 +28,6 @@ return new class extends Migration {
      */
     public function down(): void
     {
-        Schema::dropIfExists( 'post_tags');
+        Schema::dropIfExists( 'post_tags' );
     }
 };

--- a/src/Modules/Blog/database/migrations/2025_01_10_000008_add_featured_image_to_posts_table.php
+++ b/src/Modules/Blog/database/migrations/2025_01_10_000008_add_featured_image_to_posts_table.php
@@ -23,6 +23,6 @@ return new class extends Migration {
         Schema::table( 'posts', function ( Blueprint $table ): void {
             $table->dropForeign( ['featured_image_id'] );
             $table->dropColumn( 'featured_image_id' );
-        });
+        } );
     }
 };

--- a/src/Modules/Blog/helpers.php
+++ b/src/Modules/Blog/helpers.php
@@ -278,6 +278,6 @@ if ( ! function_exists( 'postTagExists' ) ) {
             return PostTag::where( 'id', sanitizeInt( $identifier ) )->exists();
         }
 
-        return PostTag::where( 'slug', sanitizeText( $identifier))->exists();
+        return PostTag::where( 'slug', sanitizeText( $identifier ))->exists();
     }
 }

--- a/src/Modules/Blog/routes/api.php
+++ b/src/Modules/Blog/routes/api.php
@@ -65,6 +65,6 @@ Route::prefix( 'post-tags' )->middleware( 'auth' )->group( function (): void {
     Route::get( '/', [PostTagController::class, 'index'] );
     Route::post( '/', [PostTagController::class, 'store'] );
     Route::get( '/{id}', [PostTagController::class, 'show'] );
-    Route::put( '/{id}', [PostTagController::class, 'update']);
-    Route::delete( '/{id}', [PostTagController::class, 'destroy']);
-});
+    Route::put( '/{id}', [PostTagController::class, 'update'] );
+    Route::delete( '/{id}', [PostTagController::class, 'destroy'] );
+} );

--- a/src/Modules/Blog/routes/api.php
+++ b/src/Modules/Blog/routes/api.php
@@ -1,6 +1,6 @@
 <?php
 
-declare( strict_types = 1 );
+declare(strict_types=1);
 
 /**
  * Blog Module API Routes
@@ -19,13 +19,14 @@ use Illuminate\Support\Facades\Route;
 |--------------------------------------------------------------------------
 */
 
-Route::prefix( 'posts' )->middleware( 'auth' )->group( function (): void {
-    Route::get( '/', [PostController::class, 'index'] );
-    Route::post( '/', [PostController::class, 'store'] );
-    Route::get( '/{id}', [PostController::class, 'show'] );
-    Route::put( '/{id}', [PostController::class, 'update'] );
-    Route::delete( '/{id}', [PostController::class, 'destroy'] );
-} );
+Route::prefix('posts')->middleware('auth')->group(function (): void {
+    Route::get('/', [PostController::class, 'index']);
+    Route::post('/', [PostController::class, 'store']);
+    Route::post('/bulk', [PostController::class, 'bulk']);
+    Route::get('/{id}', [PostController::class, 'show']);
+    Route::put('/{id}', [PostController::class, 'update']);
+    Route::delete('/{id}', [PostController::class, 'destroy']);
+});
 
 /*
 |--------------------------------------------------------------------------
@@ -33,12 +34,12 @@ Route::prefix( 'posts' )->middleware( 'auth' )->group( function (): void {
 |--------------------------------------------------------------------------
 */
 
-Route::prefix( 'posts/archives' )->middleware( 'auth' )->group( function (): void {
-    Route::get( '/date/{year}/{month?}/{day?}', [PostController::class, 'archiveByDate'] );
-    Route::get( '/author/{authorId}', [PostController::class, 'archiveByAuthor'] );
-    Route::get( '/category/{slug}', [PostController::class, 'archiveByCategory'] );
-    Route::get( '/tag/{slug}', [PostController::class, 'archiveByTag'] );
-} );
+Route::prefix('posts/archives')->middleware('auth')->group(function (): void {
+    Route::get('/date/{year}/{month?}/{day?}', [PostController::class, 'archiveByDate']);
+    Route::get('/author/{authorId}', [PostController::class, 'archiveByAuthor']);
+    Route::get('/category/{slug}', [PostController::class, 'archiveByCategory']);
+    Route::get('/tag/{slug}', [PostController::class, 'archiveByTag']);
+});
 
 /*
 |--------------------------------------------------------------------------
@@ -46,13 +47,13 @@ Route::prefix( 'posts/archives' )->middleware( 'auth' )->group( function (): voi
 |--------------------------------------------------------------------------
 */
 
-Route::prefix( 'post-categories' )->middleware( 'auth' )->group( function (): void {
-    Route::get( '/', [PostCategoryController::class, 'index'] );
-    Route::post( '/', [PostCategoryController::class, 'store'] );
-    Route::get( '/{id}', [PostCategoryController::class, 'show'] );
-    Route::put( '/{id}', [PostCategoryController::class, 'update'] );
-    Route::delete( '/{id}', [PostCategoryController::class, 'destroy'] );
-} );
+Route::prefix('post-categories')->middleware('auth')->group(function (): void {
+    Route::get('/', [PostCategoryController::class, 'index']);
+    Route::post('/', [PostCategoryController::class, 'store']);
+    Route::get('/{id}', [PostCategoryController::class, 'show']);
+    Route::put('/{id}', [PostCategoryController::class, 'update']);
+    Route::delete('/{id}', [PostCategoryController::class, 'destroy']);
+});
 
 /*
 |--------------------------------------------------------------------------
@@ -60,10 +61,10 @@ Route::prefix( 'post-categories' )->middleware( 'auth' )->group( function (): vo
 |--------------------------------------------------------------------------
 */
 
-Route::prefix( 'post-tags' )->middleware( 'auth' )->group( function (): void {
-    Route::get( '/', [PostTagController::class, 'index'] );
-    Route::post( '/', [PostTagController::class, 'store'] );
-    Route::get( '/{id}', [PostTagController::class, 'show'] );
-    Route::put( '/{id}', [PostTagController::class, 'update'] );
-    Route::delete( '/{id}', [PostTagController::class, 'destroy'] );
-} );
+Route::prefix('post-tags')->middleware('auth')->group(function (): void {
+    Route::get('/', [PostTagController::class, 'index']);
+    Route::post('/', [PostTagController::class, 'store']);
+    Route::get('/{id}', [PostTagController::class, 'show']);
+    Route::put('/{id}', [PostTagController::class, 'update']);
+    Route::delete('/{id}', [PostTagController::class, 'destroy']);
+});

--- a/src/Modules/Blog/routes/api.php
+++ b/src/Modules/Blog/routes/api.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare( strict_types=1 );
 
 /**
  * Blog Module API Routes
@@ -19,14 +19,14 @@ use Illuminate\Support\Facades\Route;
 |--------------------------------------------------------------------------
 */
 
-Route::prefix('posts')->middleware('auth')->group(function (): void {
-    Route::get('/', [PostController::class, 'index']);
-    Route::post('/', [PostController::class, 'store']);
-    Route::post('/bulk', [PostController::class, 'bulk']);
-    Route::get('/{id}', [PostController::class, 'show']);
-    Route::put('/{id}', [PostController::class, 'update']);
-    Route::delete('/{id}', [PostController::class, 'destroy']);
-});
+Route::prefix( 'posts' )->middleware( 'auth' )->group( function (): void {
+    Route::get( '/', [PostController::class, 'index'] );
+    Route::post( '/', [PostController::class, 'store'] );
+    Route::post( '/bulk', [PostController::class, 'bulk'] );
+    Route::get( '/{id}', [PostController::class, 'show'] );
+    Route::put( '/{id}', [PostController::class, 'update'] );
+    Route::delete( '/{id}', [PostController::class, 'destroy'] );
+} );
 
 /*
 |--------------------------------------------------------------------------
@@ -34,12 +34,12 @@ Route::prefix('posts')->middleware('auth')->group(function (): void {
 |--------------------------------------------------------------------------
 */
 
-Route::prefix('posts/archives')->middleware('auth')->group(function (): void {
-    Route::get('/date/{year}/{month?}/{day?}', [PostController::class, 'archiveByDate']);
-    Route::get('/author/{authorId}', [PostController::class, 'archiveByAuthor']);
-    Route::get('/category/{slug}', [PostController::class, 'archiveByCategory']);
-    Route::get('/tag/{slug}', [PostController::class, 'archiveByTag']);
-});
+Route::prefix( 'posts/archives' )->middleware( 'auth' )->group( function (): void {
+    Route::get( '/date/{year}/{month?}/{day?}', [PostController::class, 'archiveByDate'] );
+    Route::get( '/author/{authorId}', [PostController::class, 'archiveByAuthor'] );
+    Route::get( '/category/{slug}', [PostController::class, 'archiveByCategory'] );
+    Route::get( '/tag/{slug}', [PostController::class, 'archiveByTag'] );
+} );
 
 /*
 |--------------------------------------------------------------------------
@@ -47,13 +47,13 @@ Route::prefix('posts/archives')->middleware('auth')->group(function (): void {
 |--------------------------------------------------------------------------
 */
 
-Route::prefix('post-categories')->middleware('auth')->group(function (): void {
-    Route::get('/', [PostCategoryController::class, 'index']);
-    Route::post('/', [PostCategoryController::class, 'store']);
-    Route::get('/{id}', [PostCategoryController::class, 'show']);
-    Route::put('/{id}', [PostCategoryController::class, 'update']);
-    Route::delete('/{id}', [PostCategoryController::class, 'destroy']);
-});
+Route::prefix( 'post-categories' )->middleware( 'auth' )->group( function (): void {
+    Route::get( '/', [PostCategoryController::class, 'index'] );
+    Route::post( '/', [PostCategoryController::class, 'store'] );
+    Route::get( '/{id}', [PostCategoryController::class, 'show'] );
+    Route::put( '/{id}', [PostCategoryController::class, 'update'] );
+    Route::delete( '/{id}', [PostCategoryController::class, 'destroy'] );
+} );
 
 /*
 |--------------------------------------------------------------------------
@@ -61,10 +61,10 @@ Route::prefix('post-categories')->middleware('auth')->group(function (): void {
 |--------------------------------------------------------------------------
 */
 
-Route::prefix('post-tags')->middleware('auth')->group(function (): void {
-    Route::get('/', [PostTagController::class, 'index']);
-    Route::post('/', [PostTagController::class, 'store']);
-    Route::get('/{id}', [PostTagController::class, 'show']);
-    Route::put('/{id}', [PostTagController::class, 'update']);
-    Route::delete('/{id}', [PostTagController::class, 'destroy']);
+Route::prefix( 'post-tags' )->middleware( 'auth' )->group( function (): void {
+    Route::get( '/', [PostTagController::class, 'index'] );
+    Route::post( '/', [PostTagController::class, 'store'] );
+    Route::get( '/{id}', [PostTagController::class, 'show'] );
+    Route::put( '/{id}', [PostTagController::class, 'update']);
+    Route::delete( '/{id}', [PostTagController::class, 'destroy']);
 });

--- a/src/Modules/ContentTypes/Enums/ColumnType.php
+++ b/src/Modules/ContentTypes/Enums/ColumnType.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Column Type Enum
+ *
+ * Defines the available database column types for custom fields.
+ *
+ * @since 1.1.0
+ */
+
+namespace ArtisanPackUI\CMSFramework\Modules\ContentTypes\Enums;
+
+use Illuminate\Validation\Rule;
+use Illuminate\Validation\Rules\Enum;
+
+/**
+ * Enum for custom field database column types.
+ *
+ * @since 1.1.0
+ */
+enum ColumnType: string
+{
+    /**
+     * Get the label for the column type.
+     *
+     * @since 1.1.0
+     *
+     * @return string The human-readable label.
+     */
+    public function label(): string
+    {
+        return match ($this) {
+            self::String     => __('String'),
+            self::Text       => __('Text'),
+            self::Integer    => __('Integer'),
+            self::BigInteger => __('Big Integer'),
+            self::Decimal    => __('Decimal'),
+            self::Float      => __('Float'),
+            self::Double     => __('Double'),
+            self::Boolean    => __('Boolean'),
+            self::Date       => __('Date'),
+            self::DateTime   => __('DateTime'),
+            self::Time       => __('Time'),
+            self::Json       => __('JSON'),
+            self::Binary     => __('Binary'),
+        };
+    }
+
+    /**
+     * Get the validation rule for column type fields.
+     *
+     * @since 1.1.0
+     *
+     * @return Enum The validation rule.
+     */
+    public static function validationRule(): Enum
+    {
+        return Rule::enum(self::class);
+    }
+    case String     = 'string';
+    case Text       = 'text';
+    case Integer    = 'integer';
+    case BigInteger = 'bigInteger';
+    case Decimal    = 'decimal';
+    case Float      = 'float';
+    case Double     = 'double';
+    case Boolean    = 'boolean';
+    case Date       = 'date';
+    case DateTime   = 'dateTime';
+    case Time       = 'time';
+    case Json       = 'json';
+    case Binary     = 'binary';
+}

--- a/src/Modules/ContentTypes/Enums/ColumnType.php
+++ b/src/Modules/ContentTypes/Enums/ColumnType.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare( strict_types=1 );
 
 /**
  * Column Type Enum
@@ -31,20 +31,20 @@ enum ColumnType: string
      */
     public function label(): string
     {
-        return match ($this) {
-            self::String     => __('String'),
-            self::Text       => __('Text'),
-            self::Integer    => __('Integer'),
-            self::BigInteger => __('Big Integer'),
-            self::Decimal    => __('Decimal'),
-            self::Float      => __('Float'),
-            self::Double     => __('Double'),
-            self::Boolean    => __('Boolean'),
-            self::Date       => __('Date'),
-            self::DateTime   => __('DateTime'),
-            self::Time       => __('Time'),
-            self::Json       => __('JSON'),
-            self::Binary     => __('Binary'),
+        return match ( $this ) {
+            self::String     => __( 'String' ),
+            self::Text       => __( 'Text' ),
+            self::Integer    => __( 'Integer' ),
+            self::BigInteger => __( 'Big Integer' ),
+            self::Decimal    => __( 'Decimal' ),
+            self::Float      => __( 'Float' ),
+            self::Double     => __( 'Double' ),
+            self::Boolean    => __( 'Boolean' ),
+            self::Date       => __( 'Date' ),
+            self::DateTime   => __( 'DateTime' ),
+            self::Time       => __( 'Time' ),
+            self::Json       => __( 'JSON' ),
+            self::Binary     => __( 'Binary' ),
         };
     }
 
@@ -57,7 +57,7 @@ enum ColumnType: string
      */
     public static function validationRule(): Enum
     {
-        return Rule::enum(self::class);
+        return Rule::enum( self::class );
     }
     case String     = 'string';
     case Text       = 'text';

--- a/src/Modules/ContentTypes/Enums/ContentStatus.php
+++ b/src/Modules/ContentTypes/Enums/ContentStatus.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Content Status Enum
+ *
+ * Defines the available content statuses for blog posts and pages.
+ *
+ * @since 1.1.0
+ */
+
+namespace ArtisanPackUI\CMSFramework\Modules\ContentTypes\Enums;
+
+/**
+ * Enum for content statuses.
+ *
+ * @since 1.1.0
+ */
+enum ContentStatus: string
+{
+    /**
+     * Get the label for the content status.
+     *
+     * @since 1.1.0
+     *
+     * @return string The human-readable label.
+     */
+    public function label(): string
+    {
+        return match ($this) {
+            self::Draft     => __('Draft'),
+            self::Published => __('Published'),
+            self::Scheduled => __('Scheduled'),
+            self::Private   => __('Private'),
+        };
+    }
+    case Draft     = 'draft';
+    case Published = 'published';
+    case Scheduled = 'scheduled';
+    case Private   = 'private';
+}

--- a/src/Modules/ContentTypes/Enums/ContentStatus.php
+++ b/src/Modules/ContentTypes/Enums/ContentStatus.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare( strict_types=1 );
 
 /**
  * Content Status Enum
@@ -31,11 +31,11 @@ enum ContentStatus: string
      */
     public function label(): string
     {
-        return match ($this) {
-            self::Draft     => __('Draft'),
-            self::Published => __('Published'),
-            self::Scheduled => __('Scheduled'),
-            self::Private   => __('Private'),
+        return match ( $this ) {
+            self::Draft     => __( 'Draft' ),
+            self::Published => __( 'Published' ),
+            self::Scheduled => __( 'Scheduled' ),
+            self::Private   => __( 'Private' ),
         };
     }
 
@@ -48,7 +48,7 @@ enum ContentStatus: string
      */
     public static function validationRule(): Enum
     {
-        return Rule::enum(self::class);
+        return Rule::enum( self::class );
     }
     case Draft     = 'draft';
     case Published = 'published';

--- a/src/Modules/ContentTypes/Enums/ContentStatus.php
+++ b/src/Modules/ContentTypes/Enums/ContentStatus.php
@@ -12,6 +12,9 @@ declare(strict_types=1);
 
 namespace ArtisanPackUI\CMSFramework\Modules\ContentTypes\Enums;
 
+use Illuminate\Validation\Rule;
+use Illuminate\Validation\Rules\Enum;
+
 /**
  * Enum for content statuses.
  *
@@ -34,6 +37,18 @@ enum ContentStatus: string
             self::Scheduled => __('Scheduled'),
             self::Private   => __('Private'),
         };
+    }
+
+    /**
+     * Get the validation rule for content status fields.
+     *
+     * @since 1.1.0
+     *
+     * @return Enum The validation rule.
+     */
+    public static function validationRule(): Enum
+    {
+        return Rule::enum(self::class);
     }
     case Draft     = 'draft';
     case Published = 'published';

--- a/src/Modules/ContentTypes/Enums/FieldType.php
+++ b/src/Modules/ContentTypes/Enums/FieldType.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare( strict_types=1 );
 
 /**
  * Field Type Enum
@@ -31,23 +31,23 @@ enum FieldType: string
      */
     public function label(): string
     {
-        return match ($this) {
-            self::Text     => __('Text'),
-            self::Textarea => __('Textarea'),
-            self::Number   => __('Number'),
-            self::Select   => __('Select'),
-            self::Checkbox => __('Checkbox'),
-            self::Radio    => __('Radio'),
-            self::Boolean  => __('Boolean'),
-            self::Date     => __('Date'),
-            self::Datetime => __('Datetime'),
-            self::Time     => __('Time'),
-            self::Email    => __('Email'),
-            self::Url      => __('URL'),
-            self::Tel      => __('Telephone'),
-            self::Color    => __('Color'),
-            self::File     => __('File'),
-            self::Image    => __('Image'),
+        return match ( $this ) {
+            self::Text     => __( 'Text' ),
+            self::Textarea => __( 'Textarea' ),
+            self::Number   => __( 'Number' ),
+            self::Select   => __( 'Select' ),
+            self::Checkbox => __( 'Checkbox' ),
+            self::Radio    => __( 'Radio' ),
+            self::Boolean  => __( 'Boolean' ),
+            self::Date     => __( 'Date' ),
+            self::Datetime => __( 'Datetime' ),
+            self::Time     => __( 'Time' ),
+            self::Email    => __( 'Email' ),
+            self::Url      => __( 'URL' ),
+            self::Tel      => __( 'Telephone' ),
+            self::Color    => __( 'Color' ),
+            self::File     => __( 'File' ),
+            self::Image    => __( 'Image' ),
         };
     }
 
@@ -60,7 +60,7 @@ enum FieldType: string
      */
     public static function validationRule(): Enum
     {
-        return Rule::enum(self::class);
+        return Rule::enum( self::class );
     }
     case Text     = 'text';
     case Textarea = 'textarea';

--- a/src/Modules/ContentTypes/Enums/FieldType.php
+++ b/src/Modules/ContentTypes/Enums/FieldType.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Field Type Enum
+ *
+ * Defines the available field types for custom fields.
+ *
+ * @since 1.1.0
+ */
+
+namespace ArtisanPackUI\CMSFramework\Modules\ContentTypes\Enums;
+
+use Illuminate\Validation\Rule;
+use Illuminate\Validation\Rules\Enum;
+
+/**
+ * Enum for custom field types.
+ *
+ * @since 1.1.0
+ */
+enum FieldType: string
+{
+    /**
+     * Get the label for the field type.
+     *
+     * @since 1.1.0
+     *
+     * @return string The human-readable label.
+     */
+    public function label(): string
+    {
+        return match ($this) {
+            self::Text     => __('Text'),
+            self::Textarea => __('Textarea'),
+            self::Number   => __('Number'),
+            self::Select   => __('Select'),
+            self::Checkbox => __('Checkbox'),
+            self::Radio    => __('Radio'),
+            self::Boolean  => __('Boolean'),
+            self::Date     => __('Date'),
+            self::Datetime => __('Datetime'),
+            self::Time     => __('Time'),
+            self::Email    => __('Email'),
+            self::Url      => __('URL'),
+            self::Tel      => __('Telephone'),
+            self::Color    => __('Color'),
+            self::File     => __('File'),
+            self::Image    => __('Image'),
+        };
+    }
+
+    /**
+     * Get the validation rule for field type fields.
+     *
+     * @since 1.1.0
+     *
+     * @return Enum The validation rule.
+     */
+    public static function validationRule(): Enum
+    {
+        return Rule::enum(self::class);
+    }
+    case Text     = 'text';
+    case Textarea = 'textarea';
+    case Number   = 'number';
+    case Select   = 'select';
+    case Checkbox = 'checkbox';
+    case Radio    = 'radio';
+    case Boolean  = 'boolean';
+    case Date     = 'date';
+    case Datetime = 'datetime';
+    case Time     = 'time';
+    case Email    = 'email';
+    case Url      = 'url';
+    case Tel      = 'tel';
+    case Color    = 'color';
+    case File     = 'file';
+    case Image    = 'image';
+}

--- a/src/Modules/ContentTypes/Http/Controllers/ContentTypeController.php
+++ b/src/Modules/ContentTypes/Http/Controllers/ContentTypeController.php
@@ -186,10 +186,10 @@ class ContentTypeController extends Controller
     public function customFields( string $slug ): JsonResponse
     {
         $contentType = ContentType::where( 'slug', sanitizeText( $slug ) )->firstOrFail();
-        $this->authorize( 'view', $contentType);
+        $this->authorize( 'view', $contentType );
 
         $customFields = $contentType->getCustomFields();
 
-        return response()->json( $customFields);
+        return response()->json( $customFields );
     }
 }

--- a/src/Modules/ContentTypes/Http/Controllers/ContentTypeController.php
+++ b/src/Modules/ContentTypes/Http/Controllers/ContentTypeController.php
@@ -1,6 +1,6 @@
 <?php
 
-declare( strict_types = 1 );
+declare(strict_types=1);
 
 /**
  * ContentType Controller for the CMS Framework ContentTypes Module.
@@ -17,6 +17,7 @@ use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Http\Requests\ContentTypeReq
 use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Http\Resources\ContentTypeResource;
 use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Managers\ContentTypeManager;
 use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Models\ContentType;
+use Dedoc\Scramble\Attributes\Group;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
@@ -31,6 +32,7 @@ use Illuminate\Routing\Controller;
  *
  * @since 1.0.0
  */
+#[Group('Content Types', weight: 7)]
 class ContentTypeController extends Controller
 {
     use AuthorizesRequests;
@@ -47,7 +49,7 @@ class ContentTypeController extends Controller
      *
      * @since 1.0.0
      */
-    public function __construct( ContentTypeManager $contentTypeManager )
+    public function __construct(ContentTypeManager $contentTypeManager)
     {
         $this->contentTypeManager = $contentTypeManager;
     }
@@ -63,17 +65,17 @@ class ContentTypeController extends Controller
      */
     public function index(): AnonymousResourceCollection
     {
-        $this->authorize( 'viewAny', ContentType::class );
+        $this->authorize('viewAny', ContentType::class);
 
-        $contentTypes = ContentType::select( 'content_types.*' )
+        $contentTypes = ContentType::select('content_types.*')
             ->selectSub(
-                \ArtisanPackUI\CMSFramework\Modules\ContentTypes\Models\CustomField::selectRaw( 'count(*)' )
-                    ->whereRaw( "JSON_CONTAINS(custom_fields.content_types, CONCAT('\"', content_types.slug, '\"'))" ),
+                \ArtisanPackUI\CMSFramework\Modules\ContentTypes\Models\CustomField::selectRaw('count(*)')
+                    ->whereRaw("JSON_CONTAINS(custom_fields.content_types, CONCAT('\"', content_types.slug, '\"'))"),
                 'custom_fields_count',
             )
-            ->paginate( 15 );
+            ->paginate(15);
 
-        return ContentTypeResource::collection( $contentTypes );
+        return ContentTypeResource::collection($contentTypes);
     }
 
     /**
@@ -88,14 +90,14 @@ class ContentTypeController extends Controller
      *
      * @return JsonResponse The JSON response containing the created content type resource.
      */
-    public function store( ContentTypeRequest $request ): JsonResponse
+    public function store(ContentTypeRequest $request): JsonResponse
     {
-        $this->authorize( 'create', ContentType::class );
+        $this->authorize('create', ContentType::class);
 
         $validated   = $request->validated();
-        $contentType = $this->contentTypeManager->createContentType( $validated );
+        $contentType = $this->contentTypeManager->createContentType($validated);
 
-        return response()->json( new ContentTypeResource( $contentType ), 201 );
+        return response()->json(new ContentTypeResource($contentType), 201);
     }
 
     /**
@@ -109,19 +111,19 @@ class ContentTypeController extends Controller
      *
      * @return ContentTypeResource The content type resource.
      */
-    public function show( string $slug ): ContentTypeResource
+    public function show(string $slug): ContentTypeResource
     {
-        $contentType = ContentType::select( 'content_types.*' )
+        $contentType = ContentType::select('content_types.*')
             ->selectSub(
-                \ArtisanPackUI\CMSFramework\Modules\ContentTypes\Models\CustomField::selectRaw( 'count(*)' )
-                    ->whereRaw( "JSON_CONTAINS(custom_fields.content_types, CONCAT('\"', content_types.slug, '\"'))" ),
+                \ArtisanPackUI\CMSFramework\Modules\ContentTypes\Models\CustomField::selectRaw('count(*)')
+                    ->whereRaw("JSON_CONTAINS(custom_fields.content_types, CONCAT('\"', content_types.slug, '\"'))"),
                 'custom_fields_count',
             )
-            ->where( 'slug', sanitizeText( $slug ) )
+            ->where('slug', sanitizeText($slug))
             ->firstOrFail();
-        $this->authorize( 'view', $contentType );
+        $this->authorize('view', $contentType);
 
-        return new ContentTypeResource( $contentType );
+        return new ContentTypeResource($contentType);
     }
 
     /**
@@ -137,15 +139,15 @@ class ContentTypeController extends Controller
      *
      * @return ContentTypeResource The updated content type resource.
      */
-    public function update( ContentTypeRequest $request, string $slug ): ContentTypeResource
+    public function update(ContentTypeRequest $request, string $slug): ContentTypeResource
     {
-        $contentType = ContentType::where( 'slug', sanitizeText( $slug ) )->firstOrFail();
-        $this->authorize( 'update', $contentType );
+        $contentType = ContentType::where('slug', sanitizeText($slug))->firstOrFail();
+        $this->authorize('update', $contentType);
 
         $validated   = $request->validated();
-        $contentType = $this->contentTypeManager->updateContentType( $slug, $validated );
+        $contentType = $this->contentTypeManager->updateContentType($slug, $validated);
 
-        return new ContentTypeResource( $contentType );
+        return new ContentTypeResource($contentType);
     }
 
     /**
@@ -160,12 +162,12 @@ class ContentTypeController extends Controller
      *
      * @return Response A response with 204 status code.
      */
-    public function destroy( string $slug ): Response
+    public function destroy(string $slug): Response
     {
-        $contentType = ContentType::where( 'slug', sanitizeText( $slug ) )->firstOrFail();
-        $this->authorize( 'delete', $contentType );
+        $contentType = ContentType::where('slug', sanitizeText($slug))->firstOrFail();
+        $this->authorize('delete', $contentType);
 
-        $this->contentTypeManager->deleteContentType( $slug );
+        $this->contentTypeManager->deleteContentType($slug);
 
         return response()->noContent();
     }
@@ -179,13 +181,13 @@ class ContentTypeController extends Controller
      *
      * @return JsonResponse The JSON response containing the custom fields.
      */
-    public function customFields( string $slug ): JsonResponse
+    public function customFields(string $slug): JsonResponse
     {
-        $contentType = ContentType::where( 'slug', sanitizeText( $slug ) )->firstOrFail();
-        $this->authorize( 'view', $contentType );
+        $contentType = ContentType::where('slug', sanitizeText($slug))->firstOrFail();
+        $this->authorize('view', $contentType);
 
         $customFields = $contentType->getCustomFields();
 
-        return response()->json( $customFields);
+        return response()->json($customFields);
     }
 }

--- a/src/Modules/ContentTypes/Http/Controllers/ContentTypeController.php
+++ b/src/Modules/ContentTypes/Http/Controllers/ContentTypeController.php
@@ -141,11 +141,12 @@ class ContentTypeController extends Controller
      */
     public function update(ContentTypeRequest $request, string $slug): ContentTypeResource
     {
-        $contentType = ContentType::where('slug', sanitizeText($slug))->firstOrFail();
+        $sanitizedSlug = sanitizeText($slug);
+        $contentType   = ContentType::where('slug', $sanitizedSlug)->firstOrFail();
         $this->authorize('update', $contentType);
 
         $validated   = $request->validated();
-        $contentType = $this->contentTypeManager->updateContentType($slug, $validated);
+        $contentType = $this->contentTypeManager->updateContentType($sanitizedSlug, $validated);
 
         return new ContentTypeResource($contentType);
     }
@@ -164,10 +165,11 @@ class ContentTypeController extends Controller
      */
     public function destroy(string $slug): Response
     {
-        $contentType = ContentType::where('slug', sanitizeText($slug))->firstOrFail();
+        $sanitizedSlug = sanitizeText($slug);
+        $contentType   = ContentType::where('slug', $sanitizedSlug)->firstOrFail();
         $this->authorize('delete', $contentType);
 
-        $this->contentTypeManager->deleteContentType($slug);
+        $this->contentTypeManager->deleteContentType($sanitizedSlug);
 
         return response()->noContent();
     }

--- a/src/Modules/ContentTypes/Http/Controllers/ContentTypeController.php
+++ b/src/Modules/ContentTypes/Http/Controllers/ContentTypeController.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare( strict_types=1 );
 
 /**
  * ContentType Controller for the CMS Framework ContentTypes Module.
@@ -32,7 +32,7 @@ use Illuminate\Routing\Controller;
  *
  * @since 1.0.0
  */
-#[Group('Content Types', weight: 7)]
+#[Group( 'Content Types', weight: 7 )]
 class ContentTypeController extends Controller
 {
     use AuthorizesRequests;
@@ -49,7 +49,7 @@ class ContentTypeController extends Controller
      *
      * @since 1.0.0
      */
-    public function __construct(ContentTypeManager $contentTypeManager)
+    public function __construct( ContentTypeManager $contentTypeManager )
     {
         $this->contentTypeManager = $contentTypeManager;
     }
@@ -65,17 +65,17 @@ class ContentTypeController extends Controller
      */
     public function index(): AnonymousResourceCollection
     {
-        $this->authorize('viewAny', ContentType::class);
+        $this->authorize( 'viewAny', ContentType::class );
 
-        $contentTypes = ContentType::select('content_types.*')
+        $contentTypes = ContentType::select( 'content_types.*' )
             ->selectSub(
-                \ArtisanPackUI\CMSFramework\Modules\ContentTypes\Models\CustomField::selectRaw('count(*)')
-                    ->whereRaw("JSON_CONTAINS(custom_fields.content_types, CONCAT('\"', content_types.slug, '\"'))"),
+                \ArtisanPackUI\CMSFramework\Modules\ContentTypes\Models\CustomField::selectRaw( 'count(*)' )
+                    ->whereRaw( "JSON_CONTAINS(custom_fields.content_types, CONCAT('\"', content_types.slug, '\"'))" ),
                 'custom_fields_count',
             )
-            ->paginate(15);
+            ->paginate( 15 );
 
-        return ContentTypeResource::collection($contentTypes);
+        return ContentTypeResource::collection( $contentTypes );
     }
 
     /**
@@ -90,14 +90,14 @@ class ContentTypeController extends Controller
      *
      * @return JsonResponse The JSON response containing the created content type resource.
      */
-    public function store(ContentTypeRequest $request): JsonResponse
+    public function store( ContentTypeRequest $request ): JsonResponse
     {
-        $this->authorize('create', ContentType::class);
+        $this->authorize( 'create', ContentType::class );
 
         $validated   = $request->validated();
-        $contentType = $this->contentTypeManager->createContentType($validated);
+        $contentType = $this->contentTypeManager->createContentType( $validated );
 
-        return response()->json(new ContentTypeResource($contentType), 201);
+        return response()->json( new ContentTypeResource( $contentType ), 201 );
     }
 
     /**
@@ -111,19 +111,19 @@ class ContentTypeController extends Controller
      *
      * @return ContentTypeResource The content type resource.
      */
-    public function show(string $slug): ContentTypeResource
+    public function show( string $slug ): ContentTypeResource
     {
-        $contentType = ContentType::select('content_types.*')
+        $contentType = ContentType::select( 'content_types.*' )
             ->selectSub(
-                \ArtisanPackUI\CMSFramework\Modules\ContentTypes\Models\CustomField::selectRaw('count(*)')
-                    ->whereRaw("JSON_CONTAINS(custom_fields.content_types, CONCAT('\"', content_types.slug, '\"'))"),
+                \ArtisanPackUI\CMSFramework\Modules\ContentTypes\Models\CustomField::selectRaw( 'count(*)' )
+                    ->whereRaw( "JSON_CONTAINS(custom_fields.content_types, CONCAT('\"', content_types.slug, '\"'))" ),
                 'custom_fields_count',
             )
-            ->where('slug', sanitizeText($slug))
+            ->where( 'slug', sanitizeText( $slug ) )
             ->firstOrFail();
-        $this->authorize('view', $contentType);
+        $this->authorize( 'view', $contentType );
 
-        return new ContentTypeResource($contentType);
+        return new ContentTypeResource( $contentType );
     }
 
     /**
@@ -139,16 +139,16 @@ class ContentTypeController extends Controller
      *
      * @return ContentTypeResource The updated content type resource.
      */
-    public function update(ContentTypeRequest $request, string $slug): ContentTypeResource
+    public function update( ContentTypeRequest $request, string $slug ): ContentTypeResource
     {
-        $sanitizedSlug = sanitizeText($slug);
-        $contentType   = ContentType::where('slug', $sanitizedSlug)->firstOrFail();
-        $this->authorize('update', $contentType);
+        $sanitizedSlug = sanitizeText( $slug );
+        $contentType   = ContentType::where( 'slug', $sanitizedSlug )->firstOrFail();
+        $this->authorize( 'update', $contentType );
 
         $validated   = $request->validated();
-        $contentType = $this->contentTypeManager->updateContentType($sanitizedSlug, $validated);
+        $contentType = $this->contentTypeManager->updateContentType( $sanitizedSlug, $validated );
 
-        return new ContentTypeResource($contentType);
+        return new ContentTypeResource( $contentType );
     }
 
     /**
@@ -163,13 +163,13 @@ class ContentTypeController extends Controller
      *
      * @return Response A response with 204 status code.
      */
-    public function destroy(string $slug): Response
+    public function destroy( string $slug ): Response
     {
-        $sanitizedSlug = sanitizeText($slug);
-        $contentType   = ContentType::where('slug', $sanitizedSlug)->firstOrFail();
-        $this->authorize('delete', $contentType);
+        $sanitizedSlug = sanitizeText( $slug );
+        $contentType   = ContentType::where( 'slug', $sanitizedSlug )->firstOrFail();
+        $this->authorize( 'delete', $contentType );
 
-        $this->contentTypeManager->deleteContentType($sanitizedSlug);
+        $this->contentTypeManager->deleteContentType( $sanitizedSlug );
 
         return response()->noContent();
     }
@@ -183,13 +183,13 @@ class ContentTypeController extends Controller
      *
      * @return JsonResponse The JSON response containing the custom fields.
      */
-    public function customFields(string $slug): JsonResponse
+    public function customFields( string $slug ): JsonResponse
     {
-        $contentType = ContentType::where('slug', sanitizeText($slug))->firstOrFail();
-        $this->authorize('view', $contentType);
+        $contentType = ContentType::where( 'slug', sanitizeText( $slug ) )->firstOrFail();
+        $this->authorize( 'view', $contentType);
 
         $customFields = $contentType->getCustomFields();
 
-        return response()->json($customFields);
+        return response()->json( $customFields);
     }
 }

--- a/src/Modules/ContentTypes/Http/Controllers/CustomFieldController.php
+++ b/src/Modules/ContentTypes/Http/Controllers/CustomFieldController.php
@@ -1,6 +1,6 @@
 <?php
 
-declare( strict_types = 1 );
+declare(strict_types=1);
 
 /**
  * CustomField Controller for the CMS Framework ContentTypes Module.
@@ -17,6 +17,7 @@ use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Http\Requests\CustomFieldReq
 use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Http\Resources\CustomFieldResource;
 use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Managers\CustomFieldManager;
 use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Models\CustomField;
+use Dedoc\Scramble\Attributes\Group;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
@@ -31,6 +32,7 @@ use Illuminate\Routing\Controller;
  *
  * @since 1.0.0
  */
+#[Group('Custom Fields', weight: 8)]
 class CustomFieldController extends Controller
 {
     use AuthorizesRequests;
@@ -47,7 +49,7 @@ class CustomFieldController extends Controller
      *
      * @since 1.0.0
      */
-    public function __construct( CustomFieldManager $customFieldManager )
+    public function __construct(CustomFieldManager $customFieldManager)
     {
         $this->customFieldManager = $customFieldManager;
     }
@@ -63,11 +65,11 @@ class CustomFieldController extends Controller
      */
     public function index(): AnonymousResourceCollection
     {
-        $this->authorize( 'viewAny', CustomField::class );
+        $this->authorize('viewAny', CustomField::class);
 
-        $customFields = CustomField::orderBy( 'order' )->paginate( 15 );
+        $customFields = CustomField::orderBy('order')->paginate(15);
 
-        return CustomFieldResource::collection( $customFields );
+        return CustomFieldResource::collection($customFields);
     }
 
     /**
@@ -83,14 +85,14 @@ class CustomFieldController extends Controller
      *
      * @return JsonResponse The JSON response containing the created custom field resource.
      */
-    public function store( CustomFieldRequest $request ): JsonResponse
+    public function store(CustomFieldRequest $request): JsonResponse
     {
-        $this->authorize( 'create', CustomField::class );
+        $this->authorize('create', CustomField::class);
 
         $validated   = $request->validated();
-        $customField = $this->customFieldManager->createField( $validated );
+        $customField = $this->customFieldManager->createField($validated);
 
-        return response()->json( new CustomFieldResource( $customField ), 201 );
+        return response()->json(new CustomFieldResource($customField), 201);
     }
 
     /**
@@ -104,12 +106,12 @@ class CustomFieldController extends Controller
      *
      * @return CustomFieldResource The custom field resource.
      */
-    public function show( int $id ): CustomFieldResource
+    public function show(int $id): CustomFieldResource
     {
-        $customField = CustomField::findOrFail( $id );
-        $this->authorize( 'view', $customField );
+        $customField = CustomField::findOrFail($id);
+        $this->authorize('view', $customField);
 
-        return new CustomFieldResource( $customField );
+        return new CustomFieldResource($customField);
     }
 
     /**
@@ -126,15 +128,15 @@ class CustomFieldController extends Controller
      *
      * @return CustomFieldResource The updated custom field resource.
      */
-    public function update( CustomFieldRequest $request, int $id ): CustomFieldResource
+    public function update(CustomFieldRequest $request, int $id): CustomFieldResource
     {
-        $customField = CustomField::findOrFail( $id );
-        $this->authorize( 'update', $customField );
+        $customField = CustomField::findOrFail($id);
+        $this->authorize('update', $customField);
 
         $validated   = $request->validated();
-        $customField = $this->customFieldManager->updateField( $id, $validated );
+        $customField = $this->customFieldManager->updateField($id, $validated);
 
-        return new CustomFieldResource( $customField );
+        return new CustomFieldResource($customField);
     }
 
     /**
@@ -149,12 +151,12 @@ class CustomFieldController extends Controller
      *
      * @return Response A response with 204 status code.
      */
-    public function destroy( int $id ): Response
+    public function destroy(int $id): Response
     {
-        $customField = CustomField::findOrFail( $id );
-        $this->authorize( 'delete', $customField );
+        $customField = CustomField::findOrFail($id);
+        $this->authorize('delete', $customField);
 
-        $this->customFieldManager->deleteField( $id );
+        $this->customFieldManager->deleteField($id);
 
         return response()->noContent();
     }

--- a/src/Modules/ContentTypes/Http/Controllers/CustomFieldController.php
+++ b/src/Modules/ContentTypes/Http/Controllers/CustomFieldController.php
@@ -156,7 +156,7 @@ class CustomFieldController extends Controller
         $customField = CustomField::findOrFail( $id );
         $this->authorize( 'delete', $customField );
 
-        $this->customFieldManager->deleteField( $id);
+        $this->customFieldManager->deleteField( $id );
 
         return response()->noContent();
     }

--- a/src/Modules/ContentTypes/Http/Controllers/CustomFieldController.php
+++ b/src/Modules/ContentTypes/Http/Controllers/CustomFieldController.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare( strict_types=1 );
 
 /**
  * CustomField Controller for the CMS Framework ContentTypes Module.
@@ -32,7 +32,7 @@ use Illuminate\Routing\Controller;
  *
  * @since 1.0.0
  */
-#[Group('Custom Fields', weight: 8)]
+#[Group( 'Custom Fields', weight: 8 )]
 class CustomFieldController extends Controller
 {
     use AuthorizesRequests;
@@ -49,7 +49,7 @@ class CustomFieldController extends Controller
      *
      * @since 1.0.0
      */
-    public function __construct(CustomFieldManager $customFieldManager)
+    public function __construct( CustomFieldManager $customFieldManager )
     {
         $this->customFieldManager = $customFieldManager;
     }
@@ -65,11 +65,11 @@ class CustomFieldController extends Controller
      */
     public function index(): AnonymousResourceCollection
     {
-        $this->authorize('viewAny', CustomField::class);
+        $this->authorize( 'viewAny', CustomField::class );
 
-        $customFields = CustomField::orderBy('order')->paginate(15);
+        $customFields = CustomField::orderBy( 'order' )->paginate( 15 );
 
-        return CustomFieldResource::collection($customFields);
+        return CustomFieldResource::collection( $customFields );
     }
 
     /**
@@ -85,14 +85,14 @@ class CustomFieldController extends Controller
      *
      * @return JsonResponse The JSON response containing the created custom field resource.
      */
-    public function store(CustomFieldRequest $request): JsonResponse
+    public function store( CustomFieldRequest $request ): JsonResponse
     {
-        $this->authorize('create', CustomField::class);
+        $this->authorize( 'create', CustomField::class );
 
         $validated   = $request->validated();
-        $customField = $this->customFieldManager->createField($validated);
+        $customField = $this->customFieldManager->createField( $validated );
 
-        return response()->json(new CustomFieldResource($customField), 201);
+        return response()->json( new CustomFieldResource( $customField ), 201 );
     }
 
     /**
@@ -106,12 +106,12 @@ class CustomFieldController extends Controller
      *
      * @return CustomFieldResource The custom field resource.
      */
-    public function show(int $id): CustomFieldResource
+    public function show( int $id ): CustomFieldResource
     {
-        $customField = CustomField::findOrFail($id);
-        $this->authorize('view', $customField);
+        $customField = CustomField::findOrFail( $id );
+        $this->authorize( 'view', $customField );
 
-        return new CustomFieldResource($customField);
+        return new CustomFieldResource( $customField );
     }
 
     /**
@@ -128,15 +128,15 @@ class CustomFieldController extends Controller
      *
      * @return CustomFieldResource The updated custom field resource.
      */
-    public function update(CustomFieldRequest $request, int $id): CustomFieldResource
+    public function update( CustomFieldRequest $request, int $id ): CustomFieldResource
     {
-        $customField = CustomField::findOrFail($id);
-        $this->authorize('update', $customField);
+        $customField = CustomField::findOrFail( $id );
+        $this->authorize( 'update', $customField );
 
         $validated   = $request->validated();
-        $customField = $this->customFieldManager->updateField($id, $validated);
+        $customField = $this->customFieldManager->updateField( $id, $validated );
 
-        return new CustomFieldResource($customField);
+        return new CustomFieldResource( $customField );
     }
 
     /**
@@ -151,12 +151,12 @@ class CustomFieldController extends Controller
      *
      * @return Response A response with 204 status code.
      */
-    public function destroy(int $id): Response
+    public function destroy( int $id ): Response
     {
-        $customField = CustomField::findOrFail($id);
-        $this->authorize('delete', $customField);
+        $customField = CustomField::findOrFail( $id );
+        $this->authorize( 'delete', $customField );
 
-        $this->customFieldManager->deleteField($id);
+        $this->customFieldManager->deleteField( $id);
 
         return response()->noContent();
     }

--- a/src/Modules/ContentTypes/Http/Controllers/TaxonomyController.php
+++ b/src/Modules/ContentTypes/Http/Controllers/TaxonomyController.php
@@ -1,6 +1,6 @@
 <?php
 
-declare( strict_types = 1 );
+declare(strict_types=1);
 
 /**
  * Taxonomy Controller for the CMS Framework ContentTypes Module.
@@ -17,6 +17,7 @@ use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Http\Requests\TaxonomyReques
 use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Http\Resources\TaxonomyResource;
 use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Managers\TaxonomyManager;
 use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Models\Taxonomy;
+use Dedoc\Scramble\Attributes\Group;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
@@ -31,6 +32,7 @@ use Illuminate\Routing\Controller;
  *
  * @since 1.0.0
  */
+#[Group('Taxonomies', weight: 9)]
 class TaxonomyController extends Controller
 {
     use AuthorizesRequests;
@@ -47,7 +49,7 @@ class TaxonomyController extends Controller
      *
      * @since 1.0.0
      */
-    public function __construct( TaxonomyManager $taxonomyManager )
+    public function __construct(TaxonomyManager $taxonomyManager)
     {
         $this->taxonomyManager = $taxonomyManager;
     }
@@ -63,11 +65,11 @@ class TaxonomyController extends Controller
      */
     public function index(): AnonymousResourceCollection
     {
-        $this->authorize( 'viewAny', Taxonomy::class );
+        $this->authorize('viewAny', Taxonomy::class);
 
-        $taxonomies = Taxonomy::paginate( 15 );
+        $taxonomies = Taxonomy::paginate(15);
 
-        return TaxonomyResource::collection( $taxonomies );
+        return TaxonomyResource::collection($taxonomies);
     }
 
     /**
@@ -82,14 +84,14 @@ class TaxonomyController extends Controller
      *
      * @return JsonResponse The JSON response containing the created taxonomy resource.
      */
-    public function store( TaxonomyRequest $request ): JsonResponse
+    public function store(TaxonomyRequest $request): JsonResponse
     {
-        $this->authorize( 'create', Taxonomy::class );
+        $this->authorize('create', Taxonomy::class);
 
         $validated = $request->validated();
-        $taxonomy  = $this->taxonomyManager->createTaxonomy( $validated );
+        $taxonomy  = $this->taxonomyManager->createTaxonomy($validated);
 
-        return response()->json( new TaxonomyResource( $taxonomy ), 201 );
+        return response()->json(new TaxonomyResource($taxonomy), 201);
     }
 
     /**
@@ -103,12 +105,12 @@ class TaxonomyController extends Controller
      *
      * @return TaxonomyResource The taxonomy resource.
      */
-    public function show( string $slug ): TaxonomyResource
+    public function show(string $slug): TaxonomyResource
     {
-        $taxonomy = Taxonomy::where( 'slug', sanitizeText( $slug ) )->firstOrFail();
-        $this->authorize( 'view', $taxonomy );
+        $taxonomy = Taxonomy::where('slug', sanitizeText($slug))->firstOrFail();
+        $this->authorize('view', $taxonomy);
 
-        return new TaxonomyResource( $taxonomy );
+        return new TaxonomyResource($taxonomy);
     }
 
     /**
@@ -124,15 +126,15 @@ class TaxonomyController extends Controller
      *
      * @return TaxonomyResource The updated taxonomy resource.
      */
-    public function update( TaxonomyRequest $request, string $slug ): TaxonomyResource
+    public function update(TaxonomyRequest $request, string $slug): TaxonomyResource
     {
-        $taxonomy = Taxonomy::where( 'slug', sanitizeText( $slug ) )->firstOrFail();
-        $this->authorize( 'update', $taxonomy );
+        $taxonomy = Taxonomy::where('slug', sanitizeText($slug))->firstOrFail();
+        $this->authorize('update', $taxonomy);
 
         $validated = $request->validated();
-        $taxonomy  = $this->taxonomyManager->updateTaxonomy( $slug, $validated );
+        $taxonomy  = $this->taxonomyManager->updateTaxonomy($slug, $validated);
 
-        return new TaxonomyResource( $taxonomy );
+        return new TaxonomyResource($taxonomy);
     }
 
     /**
@@ -147,12 +149,12 @@ class TaxonomyController extends Controller
      *
      * @return Response A response with 204 status code.
      */
-    public function destroy( string $slug ): Response
+    public function destroy(string $slug): Response
     {
-        $taxonomy = Taxonomy::where( 'slug', sanitizeText( $slug ) )->firstOrFail();
-        $this->authorize( 'delete', $taxonomy );
+        $taxonomy = Taxonomy::where('slug', sanitizeText($slug))->firstOrFail();
+        $this->authorize('delete', $taxonomy);
 
-        $this->taxonomyManager->deleteTaxonomy( $slug );
+        $this->taxonomyManager->deleteTaxonomy($slug);
 
         return response()->noContent();
     }
@@ -166,12 +168,12 @@ class TaxonomyController extends Controller
      *
      * @return AnonymousResourceCollection The collection of taxonomy resources.
      */
-    public function byContentType( string $contentTypeSlug ): AnonymousResourceCollection
+    public function byContentType(string $contentTypeSlug): AnonymousResourceCollection
     {
-        $this->authorize( 'viewAny', Taxonomy::class );
+        $this->authorize('viewAny', Taxonomy::class);
 
-        $taxonomies = $this->taxonomyManager->getTaxonomiesForContentType( $contentTypeSlug );
+        $taxonomies = $this->taxonomyManager->getTaxonomiesForContentType($contentTypeSlug);
 
-        return TaxonomyResource::collection( $taxonomies);
+        return TaxonomyResource::collection($taxonomies);
     }
 }

--- a/src/Modules/ContentTypes/Http/Controllers/TaxonomyController.php
+++ b/src/Modules/ContentTypes/Http/Controllers/TaxonomyController.php
@@ -172,8 +172,8 @@ class TaxonomyController extends Controller
     {
         $this->authorize( 'viewAny', Taxonomy::class );
 
-        $taxonomies = $this->taxonomyManager->getTaxonomiesForContentType( $contentTypeSlug);
+        $taxonomies = $this->taxonomyManager->getTaxonomiesForContentType( $contentTypeSlug );
 
-        return TaxonomyResource::collection( $taxonomies);
+        return TaxonomyResource::collection( $taxonomies );
     }
 }

--- a/src/Modules/ContentTypes/Http/Controllers/TaxonomyController.php
+++ b/src/Modules/ContentTypes/Http/Controllers/TaxonomyController.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare( strict_types=1 );
 
 /**
  * Taxonomy Controller for the CMS Framework ContentTypes Module.
@@ -32,7 +32,7 @@ use Illuminate\Routing\Controller;
  *
  * @since 1.0.0
  */
-#[Group('Taxonomies', weight: 9)]
+#[Group( 'Taxonomies', weight: 9 )]
 class TaxonomyController extends Controller
 {
     use AuthorizesRequests;
@@ -49,7 +49,7 @@ class TaxonomyController extends Controller
      *
      * @since 1.0.0
      */
-    public function __construct(TaxonomyManager $taxonomyManager)
+    public function __construct( TaxonomyManager $taxonomyManager )
     {
         $this->taxonomyManager = $taxonomyManager;
     }
@@ -65,11 +65,11 @@ class TaxonomyController extends Controller
      */
     public function index(): AnonymousResourceCollection
     {
-        $this->authorize('viewAny', Taxonomy::class);
+        $this->authorize( 'viewAny', Taxonomy::class );
 
-        $taxonomies = Taxonomy::paginate(15);
+        $taxonomies = Taxonomy::paginate( 15 );
 
-        return TaxonomyResource::collection($taxonomies);
+        return TaxonomyResource::collection( $taxonomies );
     }
 
     /**
@@ -84,14 +84,14 @@ class TaxonomyController extends Controller
      *
      * @return JsonResponse The JSON response containing the created taxonomy resource.
      */
-    public function store(TaxonomyRequest $request): JsonResponse
+    public function store( TaxonomyRequest $request ): JsonResponse
     {
-        $this->authorize('create', Taxonomy::class);
+        $this->authorize( 'create', Taxonomy::class );
 
         $validated = $request->validated();
-        $taxonomy  = $this->taxonomyManager->createTaxonomy($validated);
+        $taxonomy  = $this->taxonomyManager->createTaxonomy( $validated );
 
-        return response()->json(new TaxonomyResource($taxonomy), 201);
+        return response()->json( new TaxonomyResource( $taxonomy ), 201 );
     }
 
     /**
@@ -105,12 +105,12 @@ class TaxonomyController extends Controller
      *
      * @return TaxonomyResource The taxonomy resource.
      */
-    public function show(string $slug): TaxonomyResource
+    public function show( string $slug ): TaxonomyResource
     {
-        $taxonomy = Taxonomy::where('slug', sanitizeText($slug))->firstOrFail();
-        $this->authorize('view', $taxonomy);
+        $taxonomy = Taxonomy::where( 'slug', sanitizeText( $slug ) )->firstOrFail();
+        $this->authorize( 'view', $taxonomy );
 
-        return new TaxonomyResource($taxonomy);
+        return new TaxonomyResource( $taxonomy );
     }
 
     /**
@@ -126,15 +126,15 @@ class TaxonomyController extends Controller
      *
      * @return TaxonomyResource The updated taxonomy resource.
      */
-    public function update(TaxonomyRequest $request, string $slug): TaxonomyResource
+    public function update( TaxonomyRequest $request, string $slug ): TaxonomyResource
     {
-        $taxonomy = Taxonomy::where('slug', sanitizeText($slug))->firstOrFail();
-        $this->authorize('update', $taxonomy);
+        $taxonomy = Taxonomy::where( 'slug', sanitizeText( $slug ) )->firstOrFail();
+        $this->authorize( 'update', $taxonomy );
 
         $validated = $request->validated();
-        $taxonomy  = $this->taxonomyManager->updateTaxonomy($slug, $validated);
+        $taxonomy  = $this->taxonomyManager->updateTaxonomy( $slug, $validated );
 
-        return new TaxonomyResource($taxonomy);
+        return new TaxonomyResource( $taxonomy );
     }
 
     /**
@@ -149,12 +149,12 @@ class TaxonomyController extends Controller
      *
      * @return Response A response with 204 status code.
      */
-    public function destroy(string $slug): Response
+    public function destroy( string $slug ): Response
     {
-        $taxonomy = Taxonomy::where('slug', sanitizeText($slug))->firstOrFail();
-        $this->authorize('delete', $taxonomy);
+        $taxonomy = Taxonomy::where( 'slug', sanitizeText( $slug ) )->firstOrFail();
+        $this->authorize( 'delete', $taxonomy );
 
-        $this->taxonomyManager->deleteTaxonomy($slug);
+        $this->taxonomyManager->deleteTaxonomy( $slug );
 
         return response()->noContent();
     }
@@ -168,12 +168,12 @@ class TaxonomyController extends Controller
      *
      * @return AnonymousResourceCollection The collection of taxonomy resources.
      */
-    public function byContentType(string $contentTypeSlug): AnonymousResourceCollection
+    public function byContentType( string $contentTypeSlug ): AnonymousResourceCollection
     {
-        $this->authorize('viewAny', Taxonomy::class);
+        $this->authorize( 'viewAny', Taxonomy::class );
 
-        $taxonomies = $this->taxonomyManager->getTaxonomiesForContentType($contentTypeSlug);
+        $taxonomies = $this->taxonomyManager->getTaxonomiesForContentType( $contentTypeSlug);
 
-        return TaxonomyResource::collection($taxonomies);
+        return TaxonomyResource::collection( $taxonomies);
     }
 }

--- a/src/Modules/ContentTypes/Http/Requests/CustomFieldRequest.php
+++ b/src/Modules/ContentTypes/Http/Requests/CustomFieldRequest.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare( strict_types=1 );
 
 /**
  * CustomField Request for the CMS Framework ContentTypes Module.
@@ -50,7 +50,7 @@ class CustomFieldRequest extends FormRequest
      */
     public function rules(): array
     {
-        $id = $this->route('id');
+        $id = $this->route( 'id' );
 
         return [
             'name' => [
@@ -63,7 +63,7 @@ class CustomFieldRequest extends FormRequest
                 'string',
                 'max:255',
                 'regex:/^[a-z0-9_]+$/',
-                Rule::unique('custom_fields', 'key')->ignore($id),
+                Rule::unique( 'custom_fields', 'key' )->ignore( $id ),
             ],
             'type' => [
                 'required',
@@ -115,14 +115,14 @@ class CustomFieldRequest extends FormRequest
     public function messages(): array
     {
         return [
-            'name.required'          => __('The custom field name is required.'),
-            'key.required'           => __('The custom field key is required.'),
-            'key.regex'              => __('The key must be lowercase letters, numbers, and underscores only.'),
-            'key.unique'             => __('A custom field with this key already exists.'),
-            'type.required'          => __('The field type is required.'),
-            'column_type.required'   => __('The column type is required.'),
-            'content_types.required' => __('At least one content type must be selected.'),
-            'content_types.min'      => __('At least one content type must be selected.'),
+            'name.required'          => __( 'The custom field name is required.' ),
+            'key.required'           => __( 'The custom field key is required.' ),
+            'key.regex'              => __( 'The key must be lowercase letters, numbers, and underscores only.' ),
+            'key.unique'             => __( 'A custom field with this key already exists.' ),
+            'type.required'          => __( 'The field type is required.' ),
+            'column_type.required'   => __( 'The column type is required.' ),
+            'content_types.required' => __( 'At least one content type must be selected.' ),
+            'content_types.min'      => __( 'At least one content type must be selected.' ),
         ];
     }
 
@@ -136,16 +136,16 @@ class CustomFieldRequest extends FormRequest
     public function attributes(): array
     {
         return [
-            'name'          => __('name'),
-            'key'           => __('key'),
-            'type'          => __('type'),
-            'column_type'   => __('column type'),
-            'description'   => __('description'),
-            'content_types' => __('content types'),
-            'options'       => __('options'),
-            'order'         => __('order'),
-            'required'      => __('required'),
-            'default_value' => __('default value'),
+            'name'          => __( 'name' ),
+            'key'           => __( 'key' ),
+            'type'          => __( 'type' ),
+            'column_type'   => __( 'column type' ),
+            'description'   => __( 'description' ),
+            'content_types' => __( 'content types' ),
+            'options'       => __( 'options' ),
+            'order'         => __( 'order' ),
+            'required'      => __( 'required' ),
+            'default_value' => __( 'default value'),
         ];
     }
 }

--- a/src/Modules/ContentTypes/Http/Requests/CustomFieldRequest.php
+++ b/src/Modules/ContentTypes/Http/Requests/CustomFieldRequest.php
@@ -1,6 +1,6 @@
 <?php
 
-declare( strict_types = 1 );
+declare(strict_types=1);
 
 /**
  * CustomField Request for the CMS Framework ContentTypes Module.
@@ -13,6 +13,8 @@ declare( strict_types = 1 );
 
 namespace ArtisanPackUI\CMSFramework\Modules\ContentTypes\Http\Requests;
 
+use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Enums\ColumnType;
+use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Enums\FieldType;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
 
@@ -48,7 +50,7 @@ class CustomFieldRequest extends FormRequest
      */
     public function rules(): array
     {
-        $id = $this->route( 'id' );
+        $id = $this->route('id');
 
         return [
             'name' => [
@@ -61,17 +63,17 @@ class CustomFieldRequest extends FormRequest
                 'string',
                 'max:255',
                 'regex:/^[a-z0-9_]+$/',
-                Rule::unique( 'custom_fields', 'key' )->ignore( $id ),
+                Rule::unique('custom_fields', 'key')->ignore($id),
             ],
             'type' => [
                 'required',
                 'string',
-                'in:text,textarea,number,select,checkbox,radio,boolean,date,datetime,time,email,url,tel,color,file,image',
+                FieldType::validationRule(),
             ],
             'column_type' => [
                 'required',
                 'string',
-                'in:string,text,integer,bigInteger,decimal,float,double,boolean,date,dateTime,time,json,binary',
+                ColumnType::validationRule(),
             ],
             'description' => [
                 'nullable',
@@ -113,14 +115,14 @@ class CustomFieldRequest extends FormRequest
     public function messages(): array
     {
         return [
-            'name.required'          => __( 'The custom field name is required.' ),
-            'key.required'           => __( 'The custom field key is required.' ),
-            'key.regex'              => __( 'The key must be lowercase letters, numbers, and underscores only.' ),
-            'key.unique'             => __( 'A custom field with this key already exists.' ),
-            'type.required'          => __( 'The field type is required.' ),
-            'column_type.required'   => __( 'The column type is required.' ),
-            'content_types.required' => __( 'At least one content type must be selected.' ),
-            'content_types.min'      => __( 'At least one content type must be selected.' ),
+            'name.required'          => __('The custom field name is required.'),
+            'key.required'           => __('The custom field key is required.'),
+            'key.regex'              => __('The key must be lowercase letters, numbers, and underscores only.'),
+            'key.unique'             => __('A custom field with this key already exists.'),
+            'type.required'          => __('The field type is required.'),
+            'column_type.required'   => __('The column type is required.'),
+            'content_types.required' => __('At least one content type must be selected.'),
+            'content_types.min'      => __('At least one content type must be selected.'),
         ];
     }
 
@@ -134,16 +136,16 @@ class CustomFieldRequest extends FormRequest
     public function attributes(): array
     {
         return [
-            'name'          => __( 'name' ),
-            'key'           => __( 'key' ),
-            'type'          => __( 'type' ),
-            'column_type'   => __( 'column type' ),
-            'description'   => __( 'description' ),
-            'content_types' => __( 'content types' ),
-            'options'       => __( 'options' ),
-            'order'         => __( 'order' ),
-            'required'      => __( 'required' ),
-            'default_value' => __( 'default value' ),
+            'name'          => __('name'),
+            'key'           => __('key'),
+            'type'          => __('type'),
+            'column_type'   => __('column type'),
+            'description'   => __('description'),
+            'content_types' => __('content types'),
+            'options'       => __('options'),
+            'order'         => __('order'),
+            'required'      => __('required'),
+            'default_value' => __('default value'),
         ];
     }
 }

--- a/src/Modules/ContentTypes/Http/Requests/CustomFieldRequest.php
+++ b/src/Modules/ContentTypes/Http/Requests/CustomFieldRequest.php
@@ -145,7 +145,7 @@ class CustomFieldRequest extends FormRequest
             'options'       => __( 'options' ),
             'order'         => __( 'order' ),
             'required'      => __( 'required' ),
-            'default_value' => __( 'default value'),
+            'default_value' => __( 'default value' ),
         ];
     }
 }

--- a/src/Modules/ContentTypes/Managers/Concerns/HasContentFilters.php
+++ b/src/Modules/ContentTypes/Managers/Concerns/HasContentFilters.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * HasContentFilters Trait
+ *
+ * Provides shared content query filter logic for content managers.
+ *
+ * @since 1.1.0
+ */
+
+namespace ArtisanPackUI\CMSFramework\Modules\ContentTypes\Managers\Concerns;
+
+use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Enums\ContentStatus;
+use Illuminate\Database\Eloquent\Builder;
+
+/**
+ * Trait for applying common content filters to query builders.
+ *
+ * Provides shared status filtering and search filtering logic
+ * that is used by BlogManager, PageManager, and other content managers.
+ *
+ * @since 1.1.0
+ */
+trait HasContentFilters
+{
+    /**
+     * Apply status filter to a query.
+     *
+     * If a status is provided, it filters by that status. If the status is
+     * 'published' or null/invalid, it uses the published scope. Otherwise,
+     * it defaults to published when no status filter is provided.
+     *
+     * @since 1.1.0
+     *
+     * @param  Builder  $query  The query builder instance.
+     * @param  array  $filters  Array of filters (expects 'status' key).
+     * @param  bool  $defaultToPublished  Whether to default to published scope when no status filter is provided.
+     */
+    protected function applyStatusFilter(Builder $query, array $filters, bool $defaultToPublished = true): void
+    {
+        if (isset($filters['status'])) {
+            $status = $filters['status'] instanceof ContentStatus
+                ? $filters['status']
+                : ContentStatus::tryFrom(sanitizeText($filters['status']));
+
+            if (null === $status || ContentStatus::Published === $status) {
+                $query->published();
+            } else {
+                $query->where('status', $status);
+            }
+        } elseif ($defaultToPublished) {
+            $query->published();
+        }
+    }
+
+    /**
+     * Apply search filter to a query.
+     *
+     * Searches across title, content, and excerpt fields.
+     *
+     * @since 1.1.0
+     *
+     * @param  Builder  $query  The query builder instance.
+     * @param  array  $filters  Array of filters (expects 'search' key).
+     */
+    protected function applySearchFilter(Builder $query, array $filters): void
+    {
+        if (isset($filters['search'])) {
+            $search = str_replace(['%', '_', '\\'], ['\\%', '\\_', '\\\\'], $filters['search']);
+            $query->where(function ($q) use ($search): void {
+                $q->where('title', 'like', "%{$search}%")
+                    ->orWhere('content', 'like', "%{$search}%")
+                    ->orWhere('excerpt', 'like', "%{$search}%");
+            });
+        }
+    }
+
+    /**
+     * Apply author filter to a query.
+     *
+     * @since 1.1.0
+     *
+     * @param  Builder  $query  The query builder instance.
+     * @param  array  $filters  Array of filters (expects 'author' key).
+     */
+    protected function applyAuthorFilter(Builder $query, array $filters): void
+    {
+        if (isset($filters['author'])) {
+            $query->byAuthor($filters['author']);
+        }
+    }
+}

--- a/src/Modules/ContentTypes/Managers/Concerns/HasContentFilters.php
+++ b/src/Modules/ContentTypes/Managers/Concerns/HasContentFilters.php
@@ -68,11 +68,12 @@ trait HasContentFilters
     protected function applySearchFilter(Builder $query, array $filters): void
     {
         if (isset($filters['search'])) {
-            $search = str_replace(['%', '_', '\\'], ['\\%', '\\_', '\\\\'], $filters['search']);
-            $query->where(function ($q) use ($search): void {
-                $q->where('title', 'like', "%{$search}%")
-                    ->orWhere('content', 'like', "%{$search}%")
-                    ->orWhere('excerpt', 'like', "%{$search}%");
+            $escaped = str_replace(['\\', '%', '_'], ['\\\\', '\\%', '\\_'], $filters['search']);
+            $pattern = "%{$escaped}%";
+            $query->where(function ($q) use ($pattern): void {
+                $q->whereRaw('title LIKE ? ESCAPE ?', [$pattern, '\\'])
+                    ->orWhereRaw('content LIKE ? ESCAPE ?', [$pattern, '\\'])
+                    ->orWhereRaw('excerpt LIKE ? ESCAPE ?', [$pattern, '\\']);
             });
         }
     }

--- a/src/Modules/ContentTypes/Managers/Concerns/HasContentFilters.php
+++ b/src/Modules/ContentTypes/Managers/Concerns/HasContentFilters.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare( strict_types=1 );
 
 /**
  * HasContentFilters Trait
@@ -38,19 +38,19 @@ trait HasContentFilters
      * @param  array  $filters  Array of filters (expects 'status' key).
      * @param  bool  $defaultToPublished  Whether to default to published scope when no status filter is provided.
      */
-    protected function applyStatusFilter(Builder $query, array $filters, bool $defaultToPublished = true): void
+    protected function applyStatusFilter( Builder $query, array $filters, bool $defaultToPublished = true ): void
     {
-        if (isset($filters['status'])) {
+        if ( isset( $filters['status'] ) ) {
             $status = $filters['status'] instanceof ContentStatus
                 ? $filters['status']
-                : ContentStatus::tryFrom(sanitizeText($filters['status']));
+                : ContentStatus::tryFrom( sanitizeText( $filters['status'] ) );
 
-            if (null === $status || ContentStatus::Published === $status) {
+            if ( null === $status || ContentStatus::Published === $status ) {
                 $query->published();
             } else {
-                $query->where('status', $status);
+                $query->where( 'status', $status );
             }
-        } elseif ($defaultToPublished) {
+        } elseif ( $defaultToPublished ) {
             $query->published();
         }
     }
@@ -65,16 +65,16 @@ trait HasContentFilters
      * @param  Builder  $query  The query builder instance.
      * @param  array  $filters  Array of filters (expects 'search' key).
      */
-    protected function applySearchFilter(Builder $query, array $filters): void
+    protected function applySearchFilter( Builder $query, array $filters ): void
     {
-        if (isset($filters['search'])) {
-            $escaped = str_replace(['\\', '%', '_'], ['\\\\', '\\%', '\\_'], $filters['search']);
+        if ( isset( $filters['search'] ) ) {
+            $escaped = str_replace( ['\\', '%', '_'], ['\\\\', '\\%', '\\_'], $filters['search'] );
             $pattern = "%{$escaped}%";
-            $query->where(function ($q) use ($pattern): void {
-                $q->whereRaw('title LIKE ? ESCAPE ?', [$pattern, '\\'])
-                    ->orWhereRaw('content LIKE ? ESCAPE ?', [$pattern, '\\'])
-                    ->orWhereRaw('excerpt LIKE ? ESCAPE ?', [$pattern, '\\']);
-            });
+            $query->where( function ( $q ) use ( $pattern ): void {
+                $q->whereRaw( 'title LIKE ? ESCAPE ?', [$pattern, '\\'] )
+                    ->orWhereRaw( 'content LIKE ? ESCAPE ?', [$pattern, '\\'] )
+                    ->orWhereRaw( 'excerpt LIKE ? ESCAPE ?', [$pattern, '\\'] );
+            } );
         }
     }
 
@@ -86,10 +86,10 @@ trait HasContentFilters
      * @param  Builder  $query  The query builder instance.
      * @param  array  $filters  Array of filters (expects 'author' key).
      */
-    protected function applyAuthorFilter(Builder $query, array $filters): void
+    protected function applyAuthorFilter( Builder $query, array $filters ): void
     {
-        if (isset($filters['author'])) {
-            $query->byAuthor($filters['author']);
+        if ( isset( $filters['author'] ) ) {
+            $query->byAuthor( $filters['author']);
         }
     }
 }

--- a/src/Modules/ContentTypes/Managers/Concerns/HasContentFilters.php
+++ b/src/Modules/ContentTypes/Managers/Concerns/HasContentFilters.php
@@ -89,7 +89,7 @@ trait HasContentFilters
     protected function applyAuthorFilter( Builder $query, array $filters ): void
     {
         if ( isset( $filters['author'] ) ) {
-            $query->byAuthor( $filters['author']);
+            $query->byAuthor( $filters['author'] );
         }
     }
 }

--- a/src/Modules/ContentTypes/Managers/CustomFieldManager.php
+++ b/src/Modules/ContentTypes/Managers/CustomFieldManager.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare( strict_types=1 );
 
 /**
  * CustomField Manager
@@ -32,7 +32,7 @@ class CustomFieldManager
      *
      * @param  array  $args  Custom field configuration.
      */
-    public function registerField(array $args): void
+    public function registerField( array $args ): void
     {
         /**
          * Filters the array of registered custom fields.
@@ -45,14 +45,14 @@ class CustomFieldManager
          *
          * @return array Filtered custom fields array.
          */
-        addFilter('ap.contentTypes.registeredCustomFields', function ($fields) use ($args) {
+        addFilter( 'ap.contentTypes.registeredCustomFields', function ( $fields ) use ( $args ) {
             $key = $args['key'] ?? '';
-            if ($key) {
-                $fields[$key] = $args;
+            if ( $key ) {
+                $fields[ $key ] = $args;
             }
 
             return $fields;
-        });
+        } );
     }
 
     /**
@@ -62,10 +62,10 @@ class CustomFieldManager
      *
      * @param  string  $contentType  Content type slug.
      */
-    public function getFieldsForContentType(string $contentType): Collection
+    public function getFieldsForContentType( string $contentType ): Collection
     {
-        return CustomField::whereJsonContains('content_types', $contentType)
-            ->orderBy('order')
+        return CustomField::whereJsonContains( 'content_types', $contentType )
+            ->orderBy( 'order' )
             ->get();
     }
 
@@ -76,21 +76,21 @@ class CustomFieldManager
      *
      * @param  array  $data  Custom field data.
      */
-    public function createField(array $data): CustomField
+    public function createField( array $data ): CustomField
     {
-        $field = DB::transaction(function () use ($data) {
-            $field = CustomField::create($data);
+        $field = DB::transaction( function () use ( $data ) {
+            $field = CustomField::create( $data );
 
             // Add columns to content type tables
-            foreach ($field->content_types as $contentTypeSlug) {
-                $contentType = app(ContentTypeManager::class)->getContentType($contentTypeSlug);
-                if ($contentType) {
-                    $this->addColumnToTable($field, $contentType->table_name);
+            foreach ( $field->content_types as $contentTypeSlug ) {
+                $contentType = app( ContentTypeManager::class )->getContentType( $contentTypeSlug );
+                if ( $contentType ) {
+                    $this->addColumnToTable( $field, $contentType->table_name );
                 }
             }
 
             return $field;
-        });
+        } );
 
         /**
          * Fires after a custom field has been created.
@@ -101,7 +101,7 @@ class CustomFieldManager
          *
          * @param  CustomField  $field  The created custom field instance.
          */
-        doAction('ap.contentTypes.customFieldCreated', $field);
+        doAction( 'ap.contentTypes.customFieldCreated', $field );
 
         return $field;
     }
@@ -114,39 +114,39 @@ class CustomFieldManager
      * @param  int  $id  Custom field ID.
      * @param  array  $data  Custom field data.
      */
-    public function updateField(int $id, array $data): CustomField
+    public function updateField( int $id, array $data ): CustomField
     {
-        $field = DB::transaction(function () use ($id, $data) {
-            $field           = CustomField::findOrFail($id);
+        $field = DB::transaction( function () use ( $id, $data ) {
+            $field           = CustomField::findOrFail( $id );
             $oldContentTypes = $field->content_types;
 
-            $field->update($data);
+            $field->update( $data );
 
             // Handle content type changes
-            if (isset($data['content_types'])) {
+            if ( isset( $data['content_types'] ) ) {
                 $newContentTypes = $data['content_types'];
-                $addedTypes      = array_diff($newContentTypes, $oldContentTypes);
-                $removedTypes    = array_diff($oldContentTypes, $newContentTypes);
+                $addedTypes      = array_diff( $newContentTypes, $oldContentTypes );
+                $removedTypes    = array_diff( $oldContentTypes, $newContentTypes );
 
                 // Add columns to new content types
-                foreach ($addedTypes as $contentTypeSlug) {
-                    $contentType = app(ContentTypeManager::class)->getContentType($contentTypeSlug);
-                    if ($contentType) {
-                        $this->addColumnToTable($field, $contentType->table_name);
+                foreach ( $addedTypes as $contentTypeSlug ) {
+                    $contentType = app( ContentTypeManager::class )->getContentType( $contentTypeSlug );
+                    if ( $contentType ) {
+                        $this->addColumnToTable( $field, $contentType->table_name );
                     }
                 }
 
                 // Remove columns from removed content types
-                foreach ($removedTypes as $contentTypeSlug) {
-                    $contentType = app(ContentTypeManager::class)->getContentType($contentTypeSlug);
-                    if ($contentType) {
-                        $this->removeColumnFromTable($field, $contentType->table_name);
+                foreach ( $removedTypes as $contentTypeSlug ) {
+                    $contentType = app( ContentTypeManager::class )->getContentType( $contentTypeSlug );
+                    if ( $contentType ) {
+                        $this->removeColumnFromTable( $field, $contentType->table_name );
                     }
                 }
             }
 
             return $field;
-        });
+        } );
 
         /**
          * Fires after a custom field has been updated.
@@ -157,7 +157,7 @@ class CustomFieldManager
          *
          * @param  CustomField  $field  The updated custom field instance.
          */
-        doAction('ap.contentTypes.customFieldUpdated', $field);
+        doAction( 'ap.contentTypes.customFieldUpdated', $field );
 
         return $field;
     }
@@ -169,10 +169,10 @@ class CustomFieldManager
      *
      * @param  int  $id  Custom field ID.
      */
-    public function deleteField(int $id): bool
+    public function deleteField( int $id ): bool
     {
-        return DB::transaction(function () use ($id) {
-            $field = CustomField::findOrFail($id);
+        return DB::transaction( function () use ( $id ) {
+            $field = CustomField::findOrFail( $id );
 
             /**
              * Fires before a custom field is deleted.
@@ -183,16 +183,16 @@ class CustomFieldManager
              *
              * @param  CustomField  $field  The custom field being deleted.
              */
-            doAction('ap.contentTypes.customFieldDeleting', $field);
+            doAction( 'ap.contentTypes.customFieldDeleting', $field );
 
             $deleted = $field->delete();
 
-            if ($deleted) {
+            if ( $deleted ) {
                 // Remove columns from content type tables
-                foreach ($field->content_types as $contentTypeSlug) {
-                    $contentType = app(ContentTypeManager::class)->getContentType($contentTypeSlug);
-                    if ($contentType) {
-                        $this->removeColumnFromTable($field, $contentType->table_name);
+                foreach ( $field->content_types as $contentTypeSlug ) {
+                    $contentType = app( ContentTypeManager::class )->getContentType( $contentTypeSlug );
+                    if ( $contentType ) {
+                        $this->removeColumnFromTable( $field, $contentType->table_name );
                     }
                 }
 
@@ -205,11 +205,11 @@ class CustomFieldManager
                  *
                  * @param  string  $key  The key of the deleted custom field.
                  */
-                doAction('ap.contentTypes.customFieldDeleted', $field->key);
+                doAction( 'ap.contentTypes.customFieldDeleted', $field->key );
             }
 
             return $deleted;
-        });
+        } );
     }
 
     /**
@@ -220,27 +220,27 @@ class CustomFieldManager
      * @param  CustomField  $field  The custom field.
      * @param  string  $tableName  The table name.
      */
-    public function addColumnToTable(CustomField $field, string $tableName): void
+    public function addColumnToTable( CustomField $field, string $tableName ): void
     {
-        if (! Schema::hasTable($tableName)) {
+        if ( ! Schema::hasTable( $tableName ) ) {
             return;
         }
 
-        if (Schema::hasColumn($tableName, $field->key)) {
+        if ( Schema::hasColumn( $tableName, $field->key ) ) {
             return;
         }
 
-        Schema::table($tableName, function ($table) use ($field): void {
-            $column = $table->{$field->column_type->value}($field->key);
+        Schema::table( $tableName, function ( $table ) use ( $field ): void {
+            $column = $table->{$field->column_type->value}( $field->key );
 
-            if (! $field->required) {
+            if ( ! $field->required ) {
                 $column->nullable();
             }
 
-            if (null !== $field->default_value) {
-                $column->default($field->default_value);
+            if ( null !== $field->default_value ) {
+                $column->default( $field->default_value );
             }
-        });
+        } );
 
         /**
          * Fires after a custom field column has been added.
@@ -252,7 +252,7 @@ class CustomFieldManager
          * @param  CustomField  $field  The custom field.
          * @param  string  $tableName  The table name.
          */
-        doAction('ap.contentTypes.customFieldColumnAdded', $field, $tableName);
+        doAction( 'ap.contentTypes.customFieldColumnAdded', $field, $tableName );
     }
 
     /**
@@ -263,19 +263,19 @@ class CustomFieldManager
      * @param  CustomField  $field  The custom field.
      * @param  string  $tableName  The table name.
      */
-    public function removeColumnFromTable(CustomField $field, string $tableName): void
+    public function removeColumnFromTable( CustomField $field, string $tableName ): void
     {
-        if (! Schema::hasTable($tableName)) {
+        if ( ! Schema::hasTable( $tableName ) ) {
             return;
         }
 
-        if (! Schema::hasColumn($tableName, $field->key)) {
+        if ( ! Schema::hasColumn( $tableName, $field->key ) ) {
             return;
         }
 
-        Schema::table($tableName, function ($table) use ($field): void {
-            $table->dropColumn($field->key);
-        });
+        Schema::table( $tableName, function ( $table ) use ( $field ): void {
+            $table->dropColumn( $field->key );
+        } );
 
         /**
          * Fires after a custom field column has been removed.
@@ -287,7 +287,7 @@ class CustomFieldManager
          * @param  CustomField  $field  The custom field.
          * @param  string  $tableName  The table name.
          */
-        doAction('ap.contentTypes.customFieldColumnRemoved', $field, $tableName);
+        doAction( 'ap.contentTypes.customFieldColumnRemoved', $field, $tableName );
     }
 
     /**
@@ -300,17 +300,17 @@ class CustomFieldManager
      *
      * @return string The migration file path.
      */
-    public function generateMigration(CustomField $field, string $action): string
+    public function generateMigration( CustomField $field, string $action ): string
     {
-        $timestamp = date('Y_m_d_His');
-        $className = Str::studly("{$action}_".$field->key.'_to_content_types');
+        $timestamp = date( 'Y_m_d_His' );
+        $className = Str::studly( "{$action}_" . $field->key . '_to_content_types' );
         $fileName  = "{$timestamp}_{$action}_{$field->key}_to_content_types.php";
 
-        $migrationPath = database_path('migrations/'.$fileName);
+        $migrationPath = database_path( 'migrations/' . $fileName );
 
-        $stub = $this->getMigrationStub($field, $action, $className);
+        $stub = $this->getMigrationStub( $field, $action, $className );
 
-        file_put_contents($migrationPath, $stub);
+        file_put_contents( $migrationPath, $stub );
 
         return $migrationPath;
     }
@@ -324,12 +324,12 @@ class CustomFieldManager
      * @param  string  $action  The action (add or remove).
      * @param  string  $className  The migration class name.
      */
-    protected function getMigrationStub(CustomField $field, string $action, string $className): string
+    protected function getMigrationStub( CustomField $field, string $action, string $className ): string
     {
         $tables = [];
-        foreach ($field->content_types as $contentTypeSlug) {
-            $contentType = app(ContentTypeManager::class)->getContentType($contentTypeSlug);
-            if ($contentType) {
+        foreach ( $field->content_types as $contentTypeSlug ) {
+            $contentType = app( ContentTypeManager::class )->getContentType( $contentTypeSlug );
+            if ( $contentType ) {
                 $tables[] = $contentType->table_name;
             }
         }
@@ -337,8 +337,8 @@ class CustomFieldManager
         $upCode   = '';
         $downCode = '';
 
-        foreach ($tables as $tableName) {
-            if ('add' === $action) {
+        foreach ( $tables as $tableName ) {
+            if ( 'add' === $action ) {
                 $upCode .= "        Schema::table('{$tableName}', function (Blueprint \$table) {\n";
                 $upCode .= "            {$field->getMigrationColumnDefinition()}\n";
                 $upCode .= "        });\n\n";

--- a/src/Modules/ContentTypes/Managers/CustomFieldManager.php
+++ b/src/Modules/ContentTypes/Managers/CustomFieldManager.php
@@ -1,6 +1,6 @@
 <?php
 
-declare( strict_types = 1 );
+declare(strict_types=1);
 
 /**
  * CustomField Manager
@@ -32,7 +32,7 @@ class CustomFieldManager
      *
      * @param  array  $args  Custom field configuration.
      */
-    public function registerField( array $args ): void
+    public function registerField(array $args): void
     {
         /**
          * Filters the array of registered custom fields.
@@ -45,14 +45,14 @@ class CustomFieldManager
          *
          * @return array Filtered custom fields array.
          */
-        addFilter( 'ap.contentTypes.registeredCustomFields', function ( $fields ) use ( $args ) {
+        addFilter('ap.contentTypes.registeredCustomFields', function ($fields) use ($args) {
             $key = $args['key'] ?? '';
-            if ( $key ) {
-                $fields[ $key ] = $args;
+            if ($key) {
+                $fields[$key] = $args;
             }
 
             return $fields;
-        } );
+        });
     }
 
     /**
@@ -62,10 +62,10 @@ class CustomFieldManager
      *
      * @param  string  $contentType  Content type slug.
      */
-    public function getFieldsForContentType( string $contentType ): Collection
+    public function getFieldsForContentType(string $contentType): Collection
     {
-        return CustomField::whereJsonContains( 'content_types', $contentType )
-            ->orderBy( 'order' )
+        return CustomField::whereJsonContains('content_types', $contentType)
+            ->orderBy('order')
             ->get();
     }
 
@@ -76,21 +76,21 @@ class CustomFieldManager
      *
      * @param  array  $data  Custom field data.
      */
-    public function createField( array $data ): CustomField
+    public function createField(array $data): CustomField
     {
-        $field = DB::transaction( function () use ( $data ) {
-            $field = CustomField::create( $data );
+        $field = DB::transaction(function () use ($data) {
+            $field = CustomField::create($data);
 
             // Add columns to content type tables
-            foreach ( $field->content_types as $contentTypeSlug ) {
-                $contentType = app( ContentTypeManager::class )->getContentType( $contentTypeSlug );
-                if ( $contentType ) {
-                    $this->addColumnToTable( $field, $contentType->table_name );
+            foreach ($field->content_types as $contentTypeSlug) {
+                $contentType = app(ContentTypeManager::class)->getContentType($contentTypeSlug);
+                if ($contentType) {
+                    $this->addColumnToTable($field, $contentType->table_name);
                 }
             }
 
             return $field;
-        } );
+        });
 
         /**
          * Fires after a custom field has been created.
@@ -101,7 +101,7 @@ class CustomFieldManager
          *
          * @param  CustomField  $field  The created custom field instance.
          */
-        doAction( 'ap.contentTypes.customFieldCreated', $field );
+        doAction('ap.contentTypes.customFieldCreated', $field);
 
         return $field;
     }
@@ -114,39 +114,39 @@ class CustomFieldManager
      * @param  int  $id  Custom field ID.
      * @param  array  $data  Custom field data.
      */
-    public function updateField( int $id, array $data ): CustomField
+    public function updateField(int $id, array $data): CustomField
     {
-        $field = DB::transaction( function () use ( $id, $data ) {
-            $field           = CustomField::findOrFail( $id );
+        $field = DB::transaction(function () use ($id, $data) {
+            $field           = CustomField::findOrFail($id);
             $oldContentTypes = $field->content_types;
 
-            $field->update( $data );
+            $field->update($data);
 
             // Handle content type changes
-            if ( isset( $data['content_types'] ) ) {
+            if (isset($data['content_types'])) {
                 $newContentTypes = $data['content_types'];
-                $addedTypes      = array_diff( $newContentTypes, $oldContentTypes );
-                $removedTypes    = array_diff( $oldContentTypes, $newContentTypes );
+                $addedTypes      = array_diff($newContentTypes, $oldContentTypes);
+                $removedTypes    = array_diff($oldContentTypes, $newContentTypes);
 
                 // Add columns to new content types
-                foreach ( $addedTypes as $contentTypeSlug ) {
-                    $contentType = app( ContentTypeManager::class )->getContentType( $contentTypeSlug );
-                    if ( $contentType ) {
-                        $this->addColumnToTable( $field, $contentType->table_name );
+                foreach ($addedTypes as $contentTypeSlug) {
+                    $contentType = app(ContentTypeManager::class)->getContentType($contentTypeSlug);
+                    if ($contentType) {
+                        $this->addColumnToTable($field, $contentType->table_name);
                     }
                 }
 
                 // Remove columns from removed content types
-                foreach ( $removedTypes as $contentTypeSlug ) {
-                    $contentType = app( ContentTypeManager::class )->getContentType( $contentTypeSlug );
-                    if ( $contentType ) {
-                        $this->removeColumnFromTable( $field, $contentType->table_name );
+                foreach ($removedTypes as $contentTypeSlug) {
+                    $contentType = app(ContentTypeManager::class)->getContentType($contentTypeSlug);
+                    if ($contentType) {
+                        $this->removeColumnFromTable($field, $contentType->table_name);
                     }
                 }
             }
 
             return $field;
-        } );
+        });
 
         /**
          * Fires after a custom field has been updated.
@@ -157,7 +157,7 @@ class CustomFieldManager
          *
          * @param  CustomField  $field  The updated custom field instance.
          */
-        doAction( 'ap.contentTypes.customFieldUpdated', $field );
+        doAction('ap.contentTypes.customFieldUpdated', $field);
 
         return $field;
     }
@@ -169,10 +169,10 @@ class CustomFieldManager
      *
      * @param  int  $id  Custom field ID.
      */
-    public function deleteField( int $id ): bool
+    public function deleteField(int $id): bool
     {
-        return DB::transaction( function () use ( $id ) {
-            $field = CustomField::findOrFail( $id );
+        return DB::transaction(function () use ($id) {
+            $field = CustomField::findOrFail($id);
 
             /**
              * Fires before a custom field is deleted.
@@ -183,16 +183,16 @@ class CustomFieldManager
              *
              * @param  CustomField  $field  The custom field being deleted.
              */
-            doAction( 'ap.contentTypes.customFieldDeleting', $field );
+            doAction('ap.contentTypes.customFieldDeleting', $field);
 
             $deleted = $field->delete();
 
-            if ( $deleted ) {
+            if ($deleted) {
                 // Remove columns from content type tables
-                foreach ( $field->content_types as $contentTypeSlug ) {
-                    $contentType = app( ContentTypeManager::class )->getContentType( $contentTypeSlug );
-                    if ( $contentType ) {
-                        $this->removeColumnFromTable( $field, $contentType->table_name );
+                foreach ($field->content_types as $contentTypeSlug) {
+                    $contentType = app(ContentTypeManager::class)->getContentType($contentTypeSlug);
+                    if ($contentType) {
+                        $this->removeColumnFromTable($field, $contentType->table_name);
                     }
                 }
 
@@ -205,11 +205,11 @@ class CustomFieldManager
                  *
                  * @param  string  $key  The key of the deleted custom field.
                  */
-                doAction( 'ap.contentTypes.customFieldDeleted', $field->key );
+                doAction('ap.contentTypes.customFieldDeleted', $field->key);
             }
 
             return $deleted;
-        } );
+        });
     }
 
     /**
@@ -220,27 +220,27 @@ class CustomFieldManager
      * @param  CustomField  $field  The custom field.
      * @param  string  $tableName  The table name.
      */
-    public function addColumnToTable( CustomField $field, string $tableName ): void
+    public function addColumnToTable(CustomField $field, string $tableName): void
     {
-        if ( ! Schema::hasTable( $tableName ) ) {
+        if (! Schema::hasTable($tableName)) {
             return;
         }
 
-        if ( Schema::hasColumn( $tableName, $field->key ) ) {
+        if (Schema::hasColumn($tableName, $field->key)) {
             return;
         }
 
-        Schema::table( $tableName, function ( $table ) use ( $field ): void {
-            $column = $table->{$field->column_type}( $field->key );
+        Schema::table($tableName, function ($table) use ($field): void {
+            $column = $table->{$field->column_type->value}($field->key);
 
-            if ( ! $field->required ) {
+            if (! $field->required) {
                 $column->nullable();
             }
 
-            if ( null !== $field->default_value ) {
-                $column->default( $field->default_value );
+            if (null !== $field->default_value) {
+                $column->default($field->default_value);
             }
-        } );
+        });
 
         /**
          * Fires after a custom field column has been added.
@@ -252,7 +252,7 @@ class CustomFieldManager
          * @param  CustomField  $field  The custom field.
          * @param  string  $tableName  The table name.
          */
-        doAction( 'ap.contentTypes.customFieldColumnAdded', $field, $tableName );
+        doAction('ap.contentTypes.customFieldColumnAdded', $field, $tableName);
     }
 
     /**
@@ -263,19 +263,19 @@ class CustomFieldManager
      * @param  CustomField  $field  The custom field.
      * @param  string  $tableName  The table name.
      */
-    public function removeColumnFromTable( CustomField $field, string $tableName ): void
+    public function removeColumnFromTable(CustomField $field, string $tableName): void
     {
-        if ( ! Schema::hasTable( $tableName ) ) {
+        if (! Schema::hasTable($tableName)) {
             return;
         }
 
-        if ( ! Schema::hasColumn( $tableName, $field->key ) ) {
+        if (! Schema::hasColumn($tableName, $field->key)) {
             return;
         }
 
-        Schema::table( $tableName, function ( $table ) use ( $field ): void {
-            $table->dropColumn( $field->key );
-        } );
+        Schema::table($tableName, function ($table) use ($field): void {
+            $table->dropColumn($field->key);
+        });
 
         /**
          * Fires after a custom field column has been removed.
@@ -287,7 +287,7 @@ class CustomFieldManager
          * @param  CustomField  $field  The custom field.
          * @param  string  $tableName  The table name.
          */
-        doAction( 'ap.contentTypes.customFieldColumnRemoved', $field, $tableName );
+        doAction('ap.contentTypes.customFieldColumnRemoved', $field, $tableName);
     }
 
     /**
@@ -300,17 +300,17 @@ class CustomFieldManager
      *
      * @return string The migration file path.
      */
-    public function generateMigration( CustomField $field, string $action ): string
+    public function generateMigration(CustomField $field, string $action): string
     {
-        $timestamp = date( 'Y_m_d_His' );
-        $className = Str::studly( "{$action}_" . $field->key . '_to_content_types' );
+        $timestamp = date('Y_m_d_His');
+        $className = Str::studly("{$action}_".$field->key.'_to_content_types');
         $fileName  = "{$timestamp}_{$action}_{$field->key}_to_content_types.php";
 
-        $migrationPath = database_path( 'migrations/' . $fileName );
+        $migrationPath = database_path('migrations/'.$fileName);
 
-        $stub = $this->getMigrationStub( $field, $action, $className );
+        $stub = $this->getMigrationStub($field, $action, $className);
 
-        file_put_contents( $migrationPath, $stub );
+        file_put_contents($migrationPath, $stub);
 
         return $migrationPath;
     }
@@ -324,12 +324,12 @@ class CustomFieldManager
      * @param  string  $action  The action (add or remove).
      * @param  string  $className  The migration class name.
      */
-    protected function getMigrationStub( CustomField $field, string $action, string $className ): string
+    protected function getMigrationStub(CustomField $field, string $action, string $className): string
     {
         $tables = [];
-        foreach ( $field->content_types as $contentTypeSlug ) {
-            $contentType = app( ContentTypeManager::class )->getContentType( $contentTypeSlug );
-            if ( $contentType ) {
+        foreach ($field->content_types as $contentTypeSlug) {
+            $contentType = app(ContentTypeManager::class)->getContentType($contentTypeSlug);
+            if ($contentType) {
                 $tables[] = $contentType->table_name;
             }
         }
@@ -337,8 +337,8 @@ class CustomFieldManager
         $upCode   = '';
         $downCode = '';
 
-        foreach ( $tables as $tableName ) {
-            if ( 'add' === $action ) {
+        foreach ($tables as $tableName) {
+            if ('add' === $action) {
                 $upCode .= "        Schema::table('{$tableName}', function (Blueprint \$table) {\n";
                 $upCode .= "            {$field->getMigrationColumnDefinition()}\n";
                 $upCode .= "        });\n\n";

--- a/src/Modules/ContentTypes/Models/Concerns/HasContentStatus.php
+++ b/src/Modules/ContentTypes/Models/Concerns/HasContentStatus.php
@@ -61,6 +61,6 @@ trait HasContentStatus
     public function isPublished(): bool
     {
         return ContentStatus::Published === $this->status &&
-            ( null === $this->published_at || $this->published_at->isPast());
+            ( null === $this->published_at || $this->published_at->isPast() );
     }
 }

--- a/src/Modules/ContentTypes/Models/Concerns/HasContentStatus.php
+++ b/src/Modules/ContentTypes/Models/Concerns/HasContentStatus.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare( strict_types=1 );
 
 /**
  * HasContentStatus Trait
@@ -32,13 +32,13 @@ trait HasContentStatus
      *
      * @return Builder
      */
-    public function scopePublished(Builder $query)
+    public function scopePublished( Builder $query )
     {
-        return $query->where('status', ContentStatus::Published)
-            ->where(function ($q): void {
-                $q->whereNull('published_at')
-                    ->orWhere('published_at', '<=', now());
-            });
+        return $query->where( 'status', ContentStatus::Published )
+            ->where( function ( $q ): void {
+                $q->whereNull( 'published_at' )
+                    ->orWhere( 'published_at', '<=', now() );
+            } );
     }
 
     /**
@@ -48,9 +48,9 @@ trait HasContentStatus
      *
      * @return Builder
      */
-    public function scopeDraft(Builder $query)
+    public function scopeDraft( Builder $query )
     {
-        return $query->where('status', ContentStatus::Draft);
+        return $query->where( 'status', ContentStatus::Draft );
     }
 
     /**
@@ -61,6 +61,6 @@ trait HasContentStatus
     public function isPublished(): bool
     {
         return ContentStatus::Published === $this->status &&
-            (null === $this->published_at || $this->published_at->isPast());
+            ( null === $this->published_at || $this->published_at->isPast());
     }
 }

--- a/src/Modules/ContentTypes/Models/Concerns/HasContentStatus.php
+++ b/src/Modules/ContentTypes/Models/Concerns/HasContentStatus.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * HasContentStatus Trait
+ *
+ * Provides shared content status scopes and helper methods for content type models.
+ *
+ * @since 1.1.0
+ */
+
+namespace ArtisanPackUI\CMSFramework\Modules\ContentTypes\Models\Concerns;
+
+use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Enums\ContentStatus;
+use Illuminate\Database\Eloquent\Builder;
+
+/**
+ * Trait for adding content status scopes and helpers to models.
+ *
+ * Provides scopePublished, scopeDraft, and isPublished methods
+ * that are shared across Post, Page, and other content type models.
+ *
+ * @since 1.1.0
+ */
+trait HasContentStatus
+{
+    /**
+     * Scope a query to only include published content.
+     *
+     * @since 1.1.0
+     *
+     * @return Builder
+     */
+    public function scopePublished(Builder $query)
+    {
+        return $query->where('status', ContentStatus::Published)
+            ->where(function ($q): void {
+                $q->whereNull('published_at')
+                    ->orWhere('published_at', '<=', now());
+            });
+    }
+
+    /**
+     * Scope a query to only include draft content.
+     *
+     * @since 1.1.0
+     *
+     * @return Builder
+     */
+    public function scopeDraft(Builder $query)
+    {
+        return $query->where('status', ContentStatus::Draft);
+    }
+
+    /**
+     * Check if the content is published.
+     *
+     * @since 1.1.0
+     */
+    public function isPublished(): bool
+    {
+        return ContentStatus::Published === $this->status &&
+            (null === $this->published_at || $this->published_at->isPast());
+    }
+}

--- a/src/Modules/ContentTypes/Models/CustomField.php
+++ b/src/Modules/ContentTypes/Models/CustomField.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare( strict_types=1 );
 
 /**
  * CustomField Model
@@ -71,13 +71,13 @@ class CustomField extends Model
         $definition = "\$table->{$this->column_type->value}('{$this->key}')";
 
         // Add nullable if not required
-        if (! $this->required) {
+        if ( ! $this->required ) {
             $definition .= '->nullable()';
         }
 
         // Add default value if specified
-        if (null !== $this->default_value) {
-            $default = is_numeric($this->default_value) ? $this->default_value : "'{$this->default_value}'";
+        if ( null !== $this->default_value ) {
+            $default = is_numeric( $this->default_value ) ? $this->default_value : "'{$this->default_value}'";
             $definition .= "->default({$default})";
         }
 
@@ -93,7 +93,7 @@ class CustomField extends Model
      */
     public function getContentTypes(): Collection
     {
-        return ContentType::whereIn('slug', $this->content_types)->get();
+        return ContentType::whereIn( 'slug', $this->content_types )->get();
     }
 
     /**

--- a/src/Modules/ContentTypes/Models/CustomField.php
+++ b/src/Modules/ContentTypes/Models/CustomField.php
@@ -1,6 +1,6 @@
 <?php
 
-declare( strict_types = 1 );
+declare(strict_types=1);
 
 /**
  * CustomField Model
@@ -12,6 +12,8 @@ declare( strict_types = 1 );
 
 namespace ArtisanPackUI\CMSFramework\Modules\ContentTypes\Models;
 
+use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Enums\ColumnType;
+use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Enums\FieldType;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Collection;
@@ -22,8 +24,8 @@ use Illuminate\Support\Collection;
  * @property int $id
  * @property string $name
  * @property string $key
- * @property string $type
- * @property string $column_type
+ * @property FieldType $type
+ * @property ColumnType $column_type
  * @property string|null $description
  * @property array $content_types
  * @property array|null $options
@@ -66,16 +68,16 @@ class CustomField extends Model
      */
     public function getMigrationColumnDefinition(): string
     {
-        $definition = "\$table->{$this->column_type}('{$this->key}')";
+        $definition = "\$table->{$this->column_type->value}('{$this->key}')";
 
         // Add nullable if not required
-        if ( ! $this->required ) {
+        if (! $this->required) {
             $definition .= '->nullable()';
         }
 
         // Add default value if specified
-        if ( null !== $this->default_value ) {
-            $default = is_numeric( $this->default_value ) ? $this->default_value : "'{$this->default_value}'";
+        if (null !== $this->default_value) {
+            $default = is_numeric($this->default_value) ? $this->default_value : "'{$this->default_value}'";
             $definition .= "->default({$default})";
         }
 
@@ -91,7 +93,7 @@ class CustomField extends Model
      */
     public function getContentTypes(): Collection
     {
-        return ContentType::whereIn( 'slug', $this->content_types )->get();
+        return ContentType::whereIn('slug', $this->content_types)->get();
     }
 
     /**
@@ -104,6 +106,8 @@ class CustomField extends Model
     protected function casts(): array
     {
         return [
+            'type'          => FieldType::class,
+            'column_type'   => ColumnType::class,
             'content_types' => 'array',
             'options'       => 'array',
             'required'      => 'boolean',

--- a/src/Modules/ContentTypes/database/migrations/2025_01_10_000001_create_content_types_table.php
+++ b/src/Modules/ContentTypes/database/migrations/2025_01_10_000001_create_content_types_table.php
@@ -39,6 +39,6 @@ return new class extends Migration {
      */
     public function down(): void
     {
-        Schema::dropIfExists( 'content_types');
+        Schema::dropIfExists( 'content_types' );
     }
 };

--- a/src/Modules/ContentTypes/database/migrations/2025_01_10_000002_create_custom_fields_table.php
+++ b/src/Modules/ContentTypes/database/migrations/2025_01_10_000002_create_custom_fields_table.php
@@ -34,6 +34,6 @@ return new class extends Migration {
      */
     public function down(): void
     {
-        Schema::dropIfExists( 'custom_fields');
+        Schema::dropIfExists( 'custom_fields' );
     }
 };

--- a/src/Modules/ContentTypes/database/migrations/2025_01_11_000003_create_taxonomies_table.php
+++ b/src/Modules/ContentTypes/database/migrations/2025_01_11_000003_create_taxonomies_table.php
@@ -32,6 +32,6 @@ return new class extends Migration {
      */
     public function down(): void
     {
-        Schema::dropIfExists( 'taxonomies');
+        Schema::dropIfExists( 'taxonomies' );
     }
 };

--- a/src/Modules/Core/Managers/Concerns/HasManifestParsing.php
+++ b/src/Modules/Core/Managers/Concerns/HasManifestParsing.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare( strict_types=1 );
 
 /**
  * HasManifestParsing Trait
@@ -39,16 +39,16 @@ trait HasManifestParsing
      *
      * @return array|null Parsed manifest data, or null on error.
      */
-    protected function parseManifest(string $manifestPath): ?array
+    protected function parseManifest( string $manifestPath ): ?array
     {
-        if (! File::exists($manifestPath)) {
+        if ( ! File::exists( $manifestPath ) ) {
             return null;
         }
 
-        $content  = File::get($manifestPath);
-        $manifest = json_decode($content, true);
+        $content  = File::get( $manifestPath );
+        $manifest = json_decode( $content, true );
 
-        if (JSON_ERROR_NONE !== json_last_error()) {
+        if ( JSON_ERROR_NONE !== json_last_error() ) {
             return null;
         }
 
@@ -67,9 +67,9 @@ trait HasManifestParsing
      *
      * @return bool True if the slug is valid, false otherwise.
      */
-    protected function validateSlug(string $slug): bool
+    protected function validateSlug( string $slug ): bool
     {
-        return (bool) preg_match('/^[a-zA-Z0-9_-]+$/', $slug);
+        return (bool) preg_match( '/^[a-zA-Z0-9_-]+$/', $slug );
     }
 
     /**
@@ -85,17 +85,17 @@ trait HasManifestParsing
      *
      * @return string|null The resolved real path, or null if invalid or outside base directory.
      */
-    protected function resolveSecurePath(string $itemPath, string $basePath): ?string
+    protected function resolveSecurePath( string $itemPath, string $basePath ): ?string
     {
-        $realItemPath = realpath($itemPath);
+        $realItemPath = realpath( $itemPath );
 
-        if (false === $realItemPath) {
+        if ( false === $realItemPath ) {
             return null;
         }
 
-        $realBasePath = realpath($basePath);
+        $realBasePath = realpath( $basePath );
 
-        if (false === $realBasePath || 0 !== strpos($realItemPath, $realBasePath.DIRECTORY_SEPARATOR)) {
+        if ( false === $realBasePath || 0 !== strpos( $realItemPath, $realBasePath . DIRECTORY_SEPARATOR ) ) {
             return null;
         }
 

--- a/src/Modules/Core/Managers/Concerns/HasManifestParsing.php
+++ b/src/Modules/Core/Managers/Concerns/HasManifestParsing.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * HasManifestParsing Trait
+ *
+ * Provides shared manifest parsing, slug validation, and path traversal
+ * prevention logic for package managers (plugins, themes, etc.).
+ *
+ *
+ * @since      1.1.0
+ */
+
+namespace ArtisanPackUI\CMSFramework\Modules\Core\Managers\Concerns;
+
+use Illuminate\Support\Facades\File;
+
+/**
+ * Trait for shared manifest parsing and path validation across package managers.
+ *
+ * Extracts common logic from PluginManager and ThemeManager to ensure
+ * consistent manifest parsing, slug validation, and path traversal
+ * prevention across all discoverable package types.
+ *
+ * @since 1.1.0
+ */
+trait HasManifestParsing
+{
+    /**
+     * Parse a JSON manifest file.
+     *
+     * Reads and decodes a JSON manifest file (plugin.json, theme.json, etc.),
+     * returning null if the file doesn't exist or contains invalid JSON.
+     *
+     * @since 1.1.0
+     *
+     * @param  string  $manifestPath  Absolute path to the manifest file.
+     *
+     * @return array|null Parsed manifest data, or null on error.
+     */
+    protected function parseManifest(string $manifestPath): ?array
+    {
+        if (! File::exists($manifestPath)) {
+            return null;
+        }
+
+        $content  = File::get($manifestPath);
+        $manifest = json_decode($content, true);
+
+        if (JSON_ERROR_NONE !== json_last_error()) {
+            return null;
+        }
+
+        return $manifest;
+    }
+
+    /**
+     * Validate a slug format.
+     *
+     * Ensures the slug only contains alphanumeric characters, hyphens,
+     * and underscores to prevent path traversal and injection attacks.
+     *
+     * @since 1.1.0
+     *
+     * @param  string  $slug  The slug to validate.
+     *
+     * @return bool True if the slug is valid, false otherwise.
+     */
+    protected function validateSlug(string $slug): bool
+    {
+        return (bool) preg_match('/^[a-zA-Z0-9_-]+$/', $slug);
+    }
+
+    /**
+     * Resolve and validate a path within a base directory.
+     *
+     * Resolves the real filesystem path and verifies it is contained within
+     * the expected base directory to prevent path traversal attacks.
+     *
+     * @since 1.1.0
+     *
+     * @param  string  $itemPath  The path to validate.
+     * @param  string  $basePath  The base directory the path must be within.
+     *
+     * @return string|null The resolved real path, or null if invalid or outside base directory.
+     */
+    protected function resolveSecurePath(string $itemPath, string $basePath): ?string
+    {
+        $realItemPath = realpath($itemPath);
+
+        if (false === $realItemPath) {
+            return null;
+        }
+
+        $realBasePath = realpath($basePath);
+
+        if (false === $realBasePath || 0 !== strpos($realItemPath, $realBasePath.DIRECTORY_SEPARATOR)) {
+            return null;
+        }
+
+        return $realItemPath;
+    }
+}

--- a/src/Modules/Core/Updates/Console/CheckForUpdateCommand.php
+++ b/src/Modules/Core/Updates/Console/CheckForUpdateCommand.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare( strict_types=1 );
 
 namespace ArtisanPackUI\CMSFramework\Modules\Core\Updates\Console;
 
@@ -41,46 +41,46 @@ class CheckForUpdateCommand extends Command
      *
      * @since 1.0.0
      */
-    public function handle(ApplicationUpdateManager $manager): int
+    public function handle( ApplicationUpdateManager $manager ): int
     {
-        $this->info('Checking for updates...');
+        $this->info( 'Checking for updates...' );
 
-        if ($this->option('clear-cache')) {
+        if ( $this->option( 'clear-cache' ) ) {
             $manager->clearCache();
-            $this->line('Cache cleared.');
+            $this->line( 'Cache cleared.' );
         }
 
         try {
             $updateInfo = $manager->checkForUpdate();
 
-            if ($updateInfo->hasUpdate()) {
+            if ( $updateInfo->hasUpdate() ) {
                 $this->newLine();
-                $this->info('✓ Update available!');
-                $this->line("Current version: {$updateInfo->currentVersion}");
-                $this->line("Latest version:  {$updateInfo->latestVersion}");
+                $this->info( '✓ Update available!' );
+                $this->line( "Current version: {$updateInfo->currentVersion}" );
+                $this->line( "Latest version:  {$updateInfo->latestVersion}" );
 
-                if ($updateInfo->releaseDate) {
-                    $this->line("Release date: {$updateInfo->releaseDate}");
+                if ( $updateInfo->releaseDate ) {
+                    $this->line( "Release date: {$updateInfo->releaseDate}" );
                 }
 
-                if ($updateInfo->changelog) {
+                if ( $updateInfo->changelog ) {
                     $this->newLine();
-                    $this->line('Changelog:');
-                    $this->line($updateInfo->changelog);
+                    $this->line( 'Changelog:' );
+                    $this->line( $updateInfo->changelog );
                 }
 
                 $this->newLine();
-                $this->comment('Run "php artisan update:perform" to install the update.');
+                $this->comment( 'Run "php artisan update:perform" to install the update.' );
 
                 return self::SUCCESS;
             }
 
-            $this->info('✓ You are running the latest version.');
+            $this->info( '✓ You are running the latest version.' );
 
             return self::SUCCESS;
-        } catch (Exception $e) {
-            $this->error('✗ Failed to check for updates:');
-            $this->error($e->getMessage());
+        } catch ( Exception $e ) {
+            $this->error( '✗ Failed to check for updates:' );
+            $this->error( $e->getMessage());
 
             return self::FAILURE;
         }

--- a/src/Modules/Core/Updates/Console/CheckForUpdateCommand.php
+++ b/src/Modules/Core/Updates/Console/CheckForUpdateCommand.php
@@ -80,7 +80,7 @@ class CheckForUpdateCommand extends Command
             return self::SUCCESS;
         } catch ( Exception $e ) {
             $this->error( '✗ Failed to check for updates:' );
-            $this->error( $e->getMessage());
+            $this->error( $e->getMessage() );
 
             return self::FAILURE;
         }

--- a/src/Modules/Core/Updates/Console/CheckForUpdateCommand.php
+++ b/src/Modules/Core/Updates/Console/CheckForUpdateCommand.php
@@ -1,6 +1,6 @@
 <?php
 
-declare( strict_types = 1 );
+declare(strict_types=1);
 
 namespace ArtisanPackUI\CMSFramework\Modules\Core\Updates\Console;
 
@@ -41,46 +41,46 @@ class CheckForUpdateCommand extends Command
      *
      * @since 1.0.0
      */
-    public function handle( ApplicationUpdateManager $manager ): int
+    public function handle(ApplicationUpdateManager $manager): int
     {
-        $this->info( 'Checking for updates...' );
+        $this->info('Checking for updates...');
 
-        if ( $this->option( 'clear-cache' ) ) {
+        if ($this->option('clear-cache')) {
             $manager->clearCache();
-            $this->line( 'Cache cleared.' );
+            $this->line('Cache cleared.');
         }
 
         try {
             $updateInfo = $manager->checkForUpdate();
 
-            if ( $updateInfo->hasUpdate ) {
+            if ($updateInfo->hasUpdate()) {
                 $this->newLine();
-                $this->info( '✓ Update available!' );
-                $this->line( "Current version: {$updateInfo->currentVersion}" );
-                $this->line( "Latest version:  {$updateInfo->latestVersion}" );
+                $this->info('✓ Update available!');
+                $this->line("Current version: {$updateInfo->currentVersion}");
+                $this->line("Latest version:  {$updateInfo->latestVersion}");
 
-                if ( $updateInfo->releaseDate ) {
-                    $this->line( "Release date: {$updateInfo->releaseDate}" );
+                if ($updateInfo->releaseDate) {
+                    $this->line("Release date: {$updateInfo->releaseDate}");
                 }
 
-                if ( $updateInfo->changelog ) {
+                if ($updateInfo->changelog) {
                     $this->newLine();
-                    $this->line( 'Changelog:' );
-                    $this->line( $updateInfo->changelog );
+                    $this->line('Changelog:');
+                    $this->line($updateInfo->changelog);
                 }
 
                 $this->newLine();
-                $this->comment( 'Run "php artisan update:perform" to install the update.' );
+                $this->comment('Run "php artisan update:perform" to install the update.');
 
                 return self::SUCCESS;
             }
 
-            $this->info( '✓ You are running the latest version.' );
+            $this->info('✓ You are running the latest version.');
 
             return self::SUCCESS;
-        } catch ( Exception $e ) {
-            $this->error( '✗ Failed to check for updates:' );
-            $this->error( $e->getMessage() );
+        } catch (Exception $e) {
+            $this->error('✗ Failed to check for updates:');
+            $this->error($e->getMessage());
 
             return self::FAILURE;
         }

--- a/src/Modules/Core/Updates/Console/CheckForUpdateScheduled.php
+++ b/src/Modules/Core/Updates/Console/CheckForUpdateScheduled.php
@@ -1,6 +1,6 @@
 <?php
 
-declare( strict_types = 1 );
+declare(strict_types=1);
 
 namespace ArtisanPackUI\CMSFramework\Modules\Core\Updates\Console;
 
@@ -42,59 +42,59 @@ class CheckForUpdateScheduled extends Command
      *
      * @since 1.0.0
      */
-    public function handle( ApplicationUpdateManager $manager ): int
+    public function handle(ApplicationUpdateManager $manager): int
     {
         try {
             $updateInfo = $manager->checkForUpdate();
 
-            if ( $updateInfo->hasUpdate ) {
+            if ($updateInfo->hasUpdate()) {
                 // Store in cache for admin panel notification
-                Cache::put( 'cms.update_available', $updateInfo->toArray(), now()->addDays( 1 ) );
+                Cache::put('cms.update_available', $updateInfo->toArray(), now()->addDays(1));
 
                 // Log the available update
-                Log::info( 'Update available', [
+                Log::info('Update available', [
                     'current_version' => $updateInfo->currentVersion,
                     'latest_version'  => $updateInfo->latestVersion,
                     'release_date'    => $updateInfo->releaseDate,
-                ] );
+                ]);
 
                 // Auto-update if enabled
-                if ( config( 'cms.updates.auto_update_enabled', false ) ) {
-                    $this->info( 'Auto-update is enabled. Starting update process...' );
+                if (config('cms.updates.auto_update_enabled', false)) {
+                    $this->info('Auto-update is enabled. Starting update process...');
 
                     $success = $manager->performUpdate();
 
-                    if ( $success ) {
-                        Log::info( 'Auto-update completed successfully', [
+                    if ($success) {
+                        Log::info('Auto-update completed successfully', [
                             'version' => $updateInfo->latestVersion,
-                        ] );
+                        ]);
 
-                        $this->info( 'Auto-update completed successfully!' );
+                        $this->info('Auto-update completed successfully!');
 
                         return self::SUCCESS;
                     }
 
-                    Log::error( 'Auto-update failed' );
-                    $this->error( 'Auto-update failed' );
+                    Log::error('Auto-update failed');
+                    $this->error('Auto-update failed');
 
                     return self::FAILURE;
                 }
 
-                $this->info( "Update available: {$updateInfo->latestVersion}" );
+                $this->info("Update available: {$updateInfo->latestVersion}");
             } else {
                 // Clear cache if no update available
-                Cache::forget( 'cms.update_available' );
+                Cache::forget('cms.update_available');
 
-                $this->info( 'No updates available' );
+                $this->info('No updates available');
             }
 
             return self::SUCCESS;
-        } catch ( Exception $e ) {
-            Log::error( 'Scheduled update check failed', [
+        } catch (Exception $e) {
+            Log::error('Scheduled update check failed', [
                 'error' => $e->getMessage(),
-            ] );
+            ]);
 
-            $this->error( "Failed: {$e->getMessage()}" );
+            $this->error("Failed: {$e->getMessage()}");
 
             return self::FAILURE;
         }

--- a/src/Modules/Core/Updates/Console/CheckForUpdateScheduled.php
+++ b/src/Modules/Core/Updates/Console/CheckForUpdateScheduled.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare( strict_types=1 );
 
 namespace ArtisanPackUI\CMSFramework\Modules\Core\Updates\Console;
 
@@ -42,59 +42,59 @@ class CheckForUpdateScheduled extends Command
      *
      * @since 1.0.0
      */
-    public function handle(ApplicationUpdateManager $manager): int
+    public function handle( ApplicationUpdateManager $manager ): int
     {
         try {
             $updateInfo = $manager->checkForUpdate();
 
-            if ($updateInfo->hasUpdate()) {
+            if ( $updateInfo->hasUpdate() ) {
                 // Store in cache for admin panel notification
-                Cache::put('cms.update_available', $updateInfo, now()->addDays(1));
+                Cache::put( 'cms.update_available', $updateInfo, now()->addDays( 1 ) );
 
                 // Log the available update
-                Log::info('Update available', [
+                Log::info( 'Update available', [
                     'current_version' => $updateInfo->currentVersion,
                     'latest_version'  => $updateInfo->latestVersion,
                     'release_date'    => $updateInfo->releaseDate,
-                ]);
+                ] );
 
                 // Auto-update if enabled
-                if (config('cms.updates.auto_update_enabled', false)) {
-                    $this->info('Auto-update is enabled. Starting update process...');
+                if ( config( 'cms.updates.auto_update_enabled', false ) ) {
+                    $this->info( 'Auto-update is enabled. Starting update process...' );
 
                     $success = $manager->performUpdate();
 
-                    if ($success) {
-                        Log::info('Auto-update completed successfully', [
+                    if ( $success ) {
+                        Log::info( 'Auto-update completed successfully', [
                             'version' => $updateInfo->latestVersion,
-                        ]);
+                        ] );
 
-                        $this->info('Auto-update completed successfully!');
+                        $this->info( 'Auto-update completed successfully!' );
 
                         return self::SUCCESS;
                     }
 
-                    Log::error('Auto-update failed');
-                    $this->error('Auto-update failed');
+                    Log::error( 'Auto-update failed' );
+                    $this->error( 'Auto-update failed' );
 
                     return self::FAILURE;
                 }
 
-                $this->info("Update available: {$updateInfo->latestVersion}");
+                $this->info( "Update available: {$updateInfo->latestVersion}" );
             } else {
                 // Clear cache if no update available
-                Cache::forget('cms.update_available');
+                Cache::forget( 'cms.update_available' );
 
-                $this->info('No updates available');
+                $this->info( 'No updates available' );
             }
 
             return self::SUCCESS;
-        } catch (Exception $e) {
-            Log::error('Scheduled update check failed', [
+        } catch ( Exception $e ) {
+            Log::error( 'Scheduled update check failed', [
                 'error' => $e->getMessage(),
-            ]);
+            ] );
 
-            $this->error("Failed: {$e->getMessage()}");
+            $this->error( "Failed: {$e->getMessage()}");
 
             return self::FAILURE;
         }

--- a/src/Modules/Core/Updates/Console/CheckForUpdateScheduled.php
+++ b/src/Modules/Core/Updates/Console/CheckForUpdateScheduled.php
@@ -49,7 +49,7 @@ class CheckForUpdateScheduled extends Command
 
             if ($updateInfo->hasUpdate()) {
                 // Store in cache for admin panel notification
-                Cache::put('cms.update_available', $updateInfo->toArray(), now()->addDays(1));
+                Cache::put('cms.update_available', $updateInfo, now()->addDays(1));
 
                 // Log the available update
                 Log::info('Update available', [

--- a/src/Modules/Core/Updates/Console/CheckForUpdateScheduled.php
+++ b/src/Modules/Core/Updates/Console/CheckForUpdateScheduled.php
@@ -94,7 +94,7 @@ class CheckForUpdateScheduled extends Command
                 'error' => $e->getMessage(),
             ] );
 
-            $this->error( "Failed: {$e->getMessage()}");
+            $this->error( "Failed: {$e->getMessage()}" );
 
             return self::FAILURE;
         }

--- a/src/Modules/Core/Updates/Console/PerformUpdateCommand.php
+++ b/src/Modules/Core/Updates/Console/PerformUpdateCommand.php
@@ -1,6 +1,6 @@
 <?php
 
-declare( strict_types = 1 );
+declare(strict_types=1);
 
 namespace ArtisanPackUI\CMSFramework\Modules\Core\Updates\Console;
 
@@ -42,30 +42,30 @@ class PerformUpdateCommand extends Command
      *
      * @since 1.0.0
      */
-    public function handle( ApplicationUpdateManager $manager ): int
+    public function handle(ApplicationUpdateManager $manager): int
     {
         try {
             // Check for updates first
             $updateInfo = $manager->checkForUpdate();
 
-            if ( ! $updateInfo->hasUpdate ) {
-                $this->info( '✓ You are already running the latest version.' );
+            if (! $updateInfo->hasUpdate()) {
+                $this->info('✓ You are already running the latest version.');
 
                 return self::SUCCESS;
             }
 
-            $version = $this->option( 'version' ) ?? $updateInfo->latestVersion;
+            $version = $this->option('version') ?? $updateInfo->latestVersion;
 
             // Show update information
             $this->newLine();
-            $this->line( "Current version: {$updateInfo->currentVersion}" );
-            $this->line( "Update to:       {$version}" );
+            $this->line("Current version: {$updateInfo->currentVersion}");
+            $this->line("Update to:       {$version}");
             $this->newLine();
 
             // Confirm update
-            if ( ! $this->option( 'force' ) ) {
-                if ( ! $this->confirm( 'Do you want to proceed with the update?' ) ) {
-                    $this->info( 'Update cancelled.' );
+            if (! $this->option('force')) {
+                if (! $this->confirm('Do you want to proceed with the update?')) {
+                    $this->info('Update cancelled.');
 
                     return self::SUCCESS;
                 }
@@ -73,24 +73,24 @@ class PerformUpdateCommand extends Command
 
             // Perform update
             $this->newLine();
-            $this->warn( '⚠ Starting update process...' );
-            $this->line( 'This may take several minutes. Do not interrupt the process.' );
+            $this->warn('⚠ Starting update process...');
+            $this->line('This may take several minutes. Do not interrupt the process.');
             $this->newLine();
 
-            $manager->performUpdate( $version );
+            $manager->performUpdate($version);
 
-            $this->newLine( 2 );
-            $this->info( '✓ Update completed successfully!' );
-            $this->line( "Application updated to version {$version}" );
+            $this->newLine(2);
+            $this->info('✓ Update completed successfully!');
+            $this->line("Application updated to version {$version}");
 
             return self::SUCCESS;
-        } catch ( Exception $e ) {
+        } catch (Exception $e) {
             $this->newLine();
-            $this->error( '✗ Update failed:' );
-            $this->error( $e->getMessage() );
+            $this->error('✗ Update failed:');
+            $this->error($e->getMessage());
             $this->newLine();
-            $this->warn( 'If a backup was created, you can restore it using:' );
-            $this->comment( 'php artisan update:rollback' );
+            $this->warn('If a backup was created, you can restore it using:');
+            $this->comment('php artisan update:rollback');
 
             return self::FAILURE;
         }

--- a/src/Modules/Core/Updates/Console/PerformUpdateCommand.php
+++ b/src/Modules/Core/Updates/Console/PerformUpdateCommand.php
@@ -90,7 +90,7 @@ class PerformUpdateCommand extends Command
             $this->error( $e->getMessage() );
             $this->newLine();
             $this->warn( 'If a backup was created, you can restore it using:' );
-            $this->comment( 'php artisan update:rollback');
+            $this->comment( 'php artisan update:rollback' );
 
             return self::FAILURE;
         }

--- a/src/Modules/Core/Updates/Console/PerformUpdateCommand.php
+++ b/src/Modules/Core/Updates/Console/PerformUpdateCommand.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare( strict_types=1 );
 
 namespace ArtisanPackUI\CMSFramework\Modules\Core\Updates\Console;
 
@@ -42,30 +42,30 @@ class PerformUpdateCommand extends Command
      *
      * @since 1.0.0
      */
-    public function handle(ApplicationUpdateManager $manager): int
+    public function handle( ApplicationUpdateManager $manager ): int
     {
         try {
             // Check for updates first
             $updateInfo = $manager->checkForUpdate();
 
-            if (! $updateInfo->hasUpdate()) {
-                $this->info('✓ You are already running the latest version.');
+            if ( ! $updateInfo->hasUpdate() ) {
+                $this->info( '✓ You are already running the latest version.' );
 
                 return self::SUCCESS;
             }
 
-            $version = $this->option('version') ?? $updateInfo->latestVersion;
+            $version = $this->option( 'version' ) ?? $updateInfo->latestVersion;
 
             // Show update information
             $this->newLine();
-            $this->line("Current version: {$updateInfo->currentVersion}");
-            $this->line("Update to:       {$version}");
+            $this->line( "Current version: {$updateInfo->currentVersion}" );
+            $this->line( "Update to:       {$version}" );
             $this->newLine();
 
             // Confirm update
-            if (! $this->option('force')) {
-                if (! $this->confirm('Do you want to proceed with the update?')) {
-                    $this->info('Update cancelled.');
+            if ( ! $this->option( 'force' ) ) {
+                if ( ! $this->confirm( 'Do you want to proceed with the update?' ) ) {
+                    $this->info( 'Update cancelled.' );
 
                     return self::SUCCESS;
                 }
@@ -73,24 +73,24 @@ class PerformUpdateCommand extends Command
 
             // Perform update
             $this->newLine();
-            $this->warn('⚠ Starting update process...');
-            $this->line('This may take several minutes. Do not interrupt the process.');
+            $this->warn( '⚠ Starting update process...' );
+            $this->line( 'This may take several minutes. Do not interrupt the process.' );
             $this->newLine();
 
-            $manager->performUpdate($version);
+            $manager->performUpdate( $version );
 
-            $this->newLine(2);
-            $this->info('✓ Update completed successfully!');
-            $this->line("Application updated to version {$version}");
+            $this->newLine( 2 );
+            $this->info( '✓ Update completed successfully!' );
+            $this->line( "Application updated to version {$version}" );
 
             return self::SUCCESS;
-        } catch (Exception $e) {
+        } catch ( Exception $e ) {
             $this->newLine();
-            $this->error('✗ Update failed:');
-            $this->error($e->getMessage());
+            $this->error( '✗ Update failed:' );
+            $this->error( $e->getMessage() );
             $this->newLine();
-            $this->warn('If a backup was created, you can restore it using:');
-            $this->comment('php artisan update:rollback');
+            $this->warn( 'If a backup was created, you can restore it using:' );
+            $this->comment( 'php artisan update:rollback');
 
             return self::FAILURE;
         }

--- a/src/Modules/Core/Updates/Enums/UpdateType.php
+++ b/src/Modules/Core/Updates/Enums/UpdateType.php
@@ -9,7 +9,7 @@
  * @since 1.1.0
  */
 
-declare(strict_types=1);
+declare( strict_types=1 );
 
 namespace ArtisanPackUI\CMSFramework\Modules\Core\Updates\Enums;
 

--- a/src/Modules/Core/Updates/Enums/UpdateType.php
+++ b/src/Modules/Core/Updates/Enums/UpdateType.php
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * Update Type Enum
+ *
+ * Defines the valid update types for the update checker system.
+ *
+ *
+ * @since 1.1.0
+ */
+
+declare(strict_types=1);
+
+namespace ArtisanPackUI\CMSFramework\Modules\Core\Updates\Enums;
+
+/**
+ * Enum for update types.
+ *
+ * @since 1.1.0
+ */
+enum UpdateType: string
+{
+    case Application = 'application';
+    case Plugin      = 'plugin';
+    case Theme       = 'theme';
+}

--- a/src/Modules/Core/Updates/Managers/ApplicationUpdateManager.php
+++ b/src/Modules/Core/Updates/Managers/ApplicationUpdateManager.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare( strict_types=1 );
 
 namespace ArtisanPackUI\CMSFramework\Modules\Core\Updates\Managers;
 
@@ -67,11 +67,11 @@ class ApplicationUpdateManager
      *
      * @return bool True if update successful
      */
-    public function performUpdate(?string $version = null): bool
+    public function performUpdate( ?string $version = null ): bool
     {
         $updateInfo = $this->checkForUpdate();
 
-        if (! $updateInfo->hasUpdate()) {
+        if ( ! $updateInfo->hasUpdate() ) {
             throw UpdateException::noUpdateAvailable();
         }
 
@@ -83,20 +83,20 @@ class ApplicationUpdateManager
             $this->enableMaintenanceMode();
 
             // Step 2: Create backup
-            if (config('cms.updates.backup_enabled', true)) {
+            if ( config( 'cms.updates.backup_enabled', true ) ) {
                 $this->createBackup();
             }
 
             // Step 3: Download update
-            $zipPath = $this->getUpdateChecker()->downloadUpdate($targetVersion);
+            $zipPath = $this->getUpdateChecker()->downloadUpdate( $targetVersion );
 
             // Step 4: Verify checksum (if available)
-            if (config('cms.updates.verify_checksum', true) && $updateInfo->sha256) {
-                $this->verifyChecksum($zipPath, $updateInfo->sha256);
+            if ( config( 'cms.updates.verify_checksum', true ) && $updateInfo->sha256 ) {
+                $this->verifyChecksum( $zipPath, $updateInfo->sha256 );
             }
 
             // Step 5: Extract update
-            $this->extractUpdate($zipPath);
+            $this->extractUpdate( $zipPath );
 
             // Step 6: Run composer install
             $this->runComposerInstall();
@@ -108,15 +108,15 @@ class ApplicationUpdateManager
             $this->clearCaches();
 
             // Step 9: Clean up
-            $this->cleanup($zipPath);
+            $this->cleanup( $zipPath );
 
             // Step 10: Disable maintenance mode
             $this->disableMaintenanceMode();
 
             return true;
-        } catch (Exception $e) {
+        } catch ( Exception $e ) {
             // Rollback on failure
-            $this->handleUpdateFailure($e);
+            $this->handleUpdateFailure( $e );
 
             throw $e;
         }
@@ -129,7 +129,7 @@ class ApplicationUpdateManager
      *
      * @param  UpdateChecker  $checker  Update checker instance
      */
-    public function setUpdateChecker(UpdateChecker $checker): void
+    public function setUpdateChecker( UpdateChecker $checker ): void
     {
         $this->checker = $checker;
     }
@@ -143,19 +143,19 @@ class ApplicationUpdateManager
      *
      * @throws UpdateException
      */
-    public function rollback(string $backupPath): void
+    public function rollback( string $backupPath ): void
     {
-        if (! File::exists($backupPath)) {
-            throw UpdateException::rollbackFailed("Backup not found: {$backupPath}");
+        if ( ! File::exists( $backupPath ) ) {
+            throw UpdateException::rollbackFailed( "Backup not found: {$backupPath}" );
         }
 
         $zip = new ZipArchive;
 
-        if (true !== $zip->open($backupPath)) {
-            throw UpdateException::rollbackFailed('Could not open backup ZIP');
+        if ( true !== $zip->open( $backupPath ) ) {
+            throw UpdateException::rollbackFailed( 'Could not open backup ZIP' );
         }
 
-        $zip->extractTo(base_path());
+        $zip->extractTo( base_path() );
         $zip->close();
 
         // Restore composer dependencies
@@ -186,13 +186,13 @@ class ApplicationUpdateManager
      */
     protected function getUpdateChecker(): UpdateChecker
     {
-        if ($this->checker) {
+        if ( $this->checker ) {
             return $this->checker;
         }
 
-        $updateUrl = config('cms.updates.update_source_url');
+        $updateUrl = config( 'cms.updates.update_source_url' );
 
-        if (! $updateUrl) {
+        if ( ! $updateUrl ) {
             throw UpdateException::noUpdateUrlConfigured();
         }
 
@@ -214,32 +214,32 @@ class ApplicationUpdateManager
      */
     protected function createBackup(): void
     {
-        $backupDir  = storage_path(config('cms.updates.backup_path', 'backups/application'));
-        $backupName = 'backup-'.date('Y-m-d-His').'.zip';
+        $backupDir  = storage_path( config( 'cms.updates.backup_path', 'backups/application' ) );
+        $backupName = 'backup-' . date( 'Y-m-d-His' ) . '.zip';
         $backupPath = "{$backupDir}/{$backupName}";
 
         // Create backup directory
-        if (! File::exists($backupDir)) {
-            File::makeDirectory($backupDir, 0755, true);
+        if ( ! File::exists( $backupDir ) ) {
+            File::makeDirectory( $backupDir, 0755, true );
         }
 
         // Create backup ZIP
         $zip = new ZipArchive;
 
-        if (true !== $zip->open($backupPath, ZipArchive::CREATE | ZipArchive::OVERWRITE)) {
-            throw UpdateException::backupFailed($backupPath);
+        if ( true !== $zip->open( $backupPath, ZipArchive::CREATE | ZipArchive::OVERWRITE ) ) {
+            throw UpdateException::backupFailed( $backupPath );
         }
 
         // Add all files except excluded paths
-        $excludePaths = config('cms.updates.exclude_from_update', []);
-        $this->addDirectoryToZip($zip, base_path(), '', $excludePaths);
+        $excludePaths = config( 'cms.updates.exclude_from_update', [] );
+        $this->addDirectoryToZip( $zip, base_path(), '', $excludePaths );
 
         $zip->close();
 
         $this->backupPath = $backupPath;
 
         // Clean old backups
-        $this->cleanOldBackups($backupDir);
+        $this->cleanOldBackups( $backupDir );
     }
 
     /**
@@ -252,53 +252,53 @@ class ApplicationUpdateManager
      * @param  string  $localPath  Local path in ZIP
      * @param  array<string>  $excludePaths  Paths to exclude
      */
-    protected function addDirectoryToZip(ZipArchive $zip, string $sourcePath, string $localPath, array $excludePaths): void
+    protected function addDirectoryToZip( ZipArchive $zip, string $sourcePath, string $localPath, array $excludePaths ): void
     {
         $files = new RecursiveIteratorIterator(
-            new RecursiveDirectoryIterator($sourcePath),
+            new RecursiveDirectoryIterator( $sourcePath ),
             RecursiveIteratorIterator::LEAVES_ONLY,
         );
 
         $basePath = base_path();
 
-        foreach ($files as $file) {
-            if ($file->isDir()) {
+        foreach ( $files as $file ) {
+            if ( $file->isDir() ) {
                 continue;
             }
 
             // Get real path and validate it
             $filePath = $file->getRealPath();
 
-            if (false === $filePath) {
+            if ( false === $filePath ) {
                 // getRealPath() failed - log and skip
-                \Illuminate\Support\Facades\Log::warning('Failed to get real path for file during backup', [
+                \Illuminate\Support\Facades\Log::warning( 'Failed to get real path for file during backup', [
                     'file' => $file->getPathname(),
-                ]);
+                ] );
 
                 continue;
             }
 
             // Verify the resolved path starts with base_path() to prevent traversal issues
-            if (! str_starts_with($filePath, $basePath)) {
+            if ( ! str_starts_with( $filePath, $basePath ) ) {
                 // File is outside base path (symlink or external) - log and skip
-                \Illuminate\Support\Facades\Log::warning('Skipping file outside base path during backup', [
+                \Illuminate\Support\Facades\Log::warning( 'Skipping file outside base path during backup', [
                     'file'      => $filePath,
                     'base_path' => $basePath,
-                ]);
+                ] );
 
                 continue;
             }
 
             // Safe to compute relative path
-            $relativePath = substr($filePath, strlen($basePath) + 1);
+            $relativePath = substr( $filePath, strlen( $basePath ) + 1 );
 
             // Skip excluded paths
-            if ($this->isPathExcluded($relativePath, $excludePaths)) {
+            if ( $this->isPathExcluded( $relativePath, $excludePaths ) ) {
                 continue;
             }
 
-            $zipPath = $localPath.DIRECTORY_SEPARATOR.$relativePath;
-            $zip->addFile($filePath, $zipPath);
+            $zipPath = $localPath . DIRECTORY_SEPARATOR . $relativePath;
+            $zip->addFile( $filePath, $zipPath );
         }
     }
 
@@ -312,14 +312,14 @@ class ApplicationUpdateManager
      *
      * @return bool True if excluded
      */
-    protected function isPathExcluded(string $path, array $excludePaths): bool
+    protected function isPathExcluded( string $path, array $excludePaths ): bool
     {
-        foreach ($excludePaths as $exclude) {
-            if (str_starts_with($path, $exclude)) {
+        foreach ( $excludePaths as $exclude ) {
+            if ( str_starts_with( $path, $exclude ) ) {
                 return true;
             }
 
-            if (str_contains($exclude, '*') && fnmatch($exclude, $path)) {
+            if ( str_contains( $exclude, '*' ) && fnmatch( $exclude, $path ) ) {
                 return true;
             }
         }
@@ -334,20 +334,20 @@ class ApplicationUpdateManager
      *
      * @param  string  $backupDir  Backup directory
      */
-    protected function cleanOldBackups(string $backupDir): void
+    protected function cleanOldBackups( string $backupDir ): void
     {
-        $retentionDays = config('cms.updates.backup_retention_days', 30);
-        $cutoffTime    = time() - ($retentionDays * 86400);
+        $retentionDays = config( 'cms.updates.backup_retention_days', 30 );
+        $cutoffTime    = time() - ( $retentionDays * 86400 );
 
-        $backups = glob("{$backupDir}/backup-*.zip");
+        $backups = glob( "{$backupDir}/backup-*.zip" );
 
-        if (false === $backups) {
+        if ( false === $backups ) {
             return;
         }
 
-        foreach ($backups as $backup) {
-            if (filemtime($backup) < $cutoffTime) {
-                File::delete($backup);
+        foreach ( $backups as $backup ) {
+            if ( filemtime( $backup ) < $cutoffTime ) {
+                File::delete( $backup );
             }
         }
     }
@@ -362,12 +362,12 @@ class ApplicationUpdateManager
      *
      * @throws UpdateException
      */
-    protected function verifyChecksum(string $zipPath, string $expectedHash): void
+    protected function verifyChecksum( string $zipPath, string $expectedHash ): void
     {
-        $actualHash = hash_file('sha256', $zipPath);
+        $actualHash = hash_file( 'sha256', $zipPath );
 
-        if ($actualHash !== $expectedHash) {
-            throw UpdateException::checksumMismatch($expectedHash, $actualHash);
+        if ( $actualHash !== $expectedHash ) {
+            throw UpdateException::checksumMismatch( $expectedHash, $actualHash );
         }
     }
 
@@ -380,73 +380,73 @@ class ApplicationUpdateManager
      *
      * @throws UpdateException
      */
-    protected function extractUpdate(string $zipPath): void
+    protected function extractUpdate( string $zipPath ): void
     {
         $zip = new ZipArchive;
 
-        if (true !== $zip->open($zipPath)) {
-            throw UpdateException::extractionFailed($zipPath);
+        if ( true !== $zip->open( $zipPath ) ) {
+            throw UpdateException::extractionFailed( $zipPath );
         }
 
         $extractPath  = base_path();
-        $excludePaths = config('cms.updates.exclude_from_update', []);
+        $excludePaths = config( 'cms.updates.exclude_from_update', [] );
 
         // Detect common root prefix by scanning all entry names
-        $commonPrefix = $this->detectCommonRootPrefix($zip, $excludePaths);
+        $commonPrefix = $this->detectCommonRootPrefix( $zip, $excludePaths );
 
         // Extract files (except excluded paths), stripping common prefix
-        for ($i = 0; $i < $zip->numFiles; $i++) {
-            $filename = $zip->getNameIndex($i);
+        for ( $i = 0; $i < $zip->numFiles; $i++ ) {
+            $filename = $zip->getNameIndex( $i );
 
             // Strip common prefix if detected
-            $targetPath = $commonPrefix ? substr($filename, strlen($commonPrefix)) : $filename;
+            $targetPath = $commonPrefix ? substr( $filename, strlen( $commonPrefix ) ) : $filename;
 
             // Skip excluded paths (check both original and stripped paths)
-            if ($this->isPathExcluded($filename, $excludePaths) || $this->isPathExcluded($targetPath, $excludePaths)) {
+            if ( $this->isPathExcluded( $filename, $excludePaths ) || $this->isPathExcluded( $targetPath, $excludePaths ) ) {
                 continue;
             }
 
             // Skip empty paths (directories become empty after prefix stripping)
-            if (empty($targetPath)) {
+            if ( empty( $targetPath ) ) {
                 continue;
             }
 
             // Get file info
-            $stat = $zip->statIndex($i);
-            if (false === $stat) {
+            $stat = $zip->statIndex( $i );
+            if ( false === $stat ) {
                 continue;
             }
 
-            $fullTargetPath = $extractPath.DIRECTORY_SEPARATOR.$targetPath;
+            $fullTargetPath = $extractPath . DIRECTORY_SEPARATOR . $targetPath;
 
             // Handle directories
-            if (str_ends_with($filename, '/')) {
-                if (! File::exists($fullTargetPath)) {
-                    File::makeDirectory($fullTargetPath, 0755, true);
+            if ( str_ends_with( $filename, '/' ) ) {
+                if ( ! File::exists( $fullTargetPath ) ) {
+                    File::makeDirectory( $fullTargetPath, 0755, true );
                 }
 
                 continue;
             }
 
             // Handle files - ensure parent directory exists
-            $targetDir = dirname($fullTargetPath);
-            if (! File::exists($targetDir)) {
-                File::makeDirectory($targetDir, 0755, true);
+            $targetDir = dirname( $fullTargetPath );
+            if ( ! File::exists( $targetDir ) ) {
+                File::makeDirectory( $targetDir, 0755, true );
             }
 
             // Extract file
-            $fileContent = $zip->getFromIndex($i);
-            if (false === $fileContent) {
+            $fileContent = $zip->getFromIndex( $i );
+            if ( false === $fileContent ) {
                 continue;
             }
 
-            File::put($fullTargetPath, $fileContent);
+            File::put( $fullTargetPath, $fileContent );
 
             // Preserve file permissions if available
-            if (isset($stat['external_attributes'])) {
-                $permissions = ($stat['external_attributes'] >> 16) & 0777;
-                if ($permissions > 0) {
-                    @chmod($fullTargetPath, $permissions);
+            if ( isset( $stat['external_attributes'] ) ) {
+                $permissions = ( $stat['external_attributes'] >> 16 ) & 0777;
+                if ( $permissions > 0 ) {
+                    @chmod( $fullTargetPath, $permissions );
                 }
             }
         }
@@ -464,34 +464,34 @@ class ApplicationUpdateManager
      *
      * @return string|null Common root prefix, or null if none detected
      */
-    protected function detectCommonRootPrefix(ZipArchive $zip, array $excludePaths): ?string
+    protected function detectCommonRootPrefix( ZipArchive $zip, array $excludePaths ): ?string
     {
         $firstSegments = [];
 
         // Scan all non-excluded entries to find first path segment
-        for ($i = 0; $i < $zip->numFiles; $i++) {
-            $filename = $zip->getNameIndex($i);
+        for ( $i = 0; $i < $zip->numFiles; $i++ ) {
+            $filename = $zip->getNameIndex( $i );
 
             // Skip excluded paths
-            if ($this->isPathExcluded($filename, $excludePaths)) {
+            if ( $this->isPathExcluded( $filename, $excludePaths ) ) {
                 continue;
             }
 
             // Get first path segment
-            $parts = explode('/', $filename);
-            if (! empty($parts[0])) {
+            $parts = explode( '/', $filename );
+            if ( ! empty( $parts[0] ) ) {
                 $firstSegments[] = $parts[0];
             }
         }
 
         // If all entries share the same first segment, that's our common prefix
-        if (empty($firstSegments)) {
+        if ( empty( $firstSegments ) ) {
             return null;
         }
 
-        $uniqueSegments = array_unique($firstSegments);
-        if (1 === count($uniqueSegments)) {
-            return reset($uniqueSegments).'/';
+        $uniqueSegments = array_unique( $firstSegments );
+        if ( 1 === count( $uniqueSegments ) ) {
+            return reset( $uniqueSegments ) . '/';
         }
 
         return null;
@@ -506,15 +506,15 @@ class ApplicationUpdateManager
      */
     protected function runComposerInstall(): void
     {
-        $command = config('cms.updates.composer_install_command');
-        $timeout = config('cms.updates.composer_timeout', 600);
+        $command = config( 'cms.updates.composer_install_command' );
+        $timeout = config( 'cms.updates.composer_timeout', 600 );
 
-        $result = Process::timeout($timeout)
-            ->path(base_path())
-            ->run($command);
+        $result = Process::timeout( $timeout )
+            ->path( base_path() )
+            ->run( $command );
 
-        if (! $result->successful()) {
-            throw UpdateException::composerInstallFailed($result->errorOutput());
+        if ( ! $result->successful() ) {
+            throw UpdateException::composerInstallFailed( $result->errorOutput() );
         }
     }
 
@@ -528,9 +528,9 @@ class ApplicationUpdateManager
     protected function runMigrations(): void
     {
         try {
-            Artisan::call('migrate', ['--force' => true]);
-        } catch (Exception $e) {
-            throw UpdateException::migrationFailed($e->getMessage());
+            Artisan::call( 'migrate', ['--force' => true] );
+        } catch ( Exception $e ) {
+            throw UpdateException::migrationFailed( $e->getMessage() );
         }
     }
 
@@ -541,10 +541,10 @@ class ApplicationUpdateManager
      */
     protected function clearCaches(): void
     {
-        Artisan::call('config:clear');
-        Artisan::call('cache:clear');
-        Artisan::call('route:clear');
-        Artisan::call('view:clear');
+        Artisan::call( 'config:clear' );
+        Artisan::call( 'cache:clear' );
+        Artisan::call( 'route:clear' );
+        Artisan::call( 'view:clear' );
     }
 
     /**
@@ -554,10 +554,10 @@ class ApplicationUpdateManager
      *
      * @param  string  $zipPath  Path to ZIP file
      */
-    protected function cleanup(string $zipPath): void
+    protected function cleanup( string $zipPath ): void
     {
-        if (File::exists($zipPath)) {
-            File::delete($zipPath);
+        if ( File::exists( $zipPath ) ) {
+            File::delete( $zipPath );
         }
     }
 
@@ -571,9 +571,9 @@ class ApplicationUpdateManager
     protected function enableMaintenanceMode(): void
     {
         try {
-            Artisan::call('down', ['--render' => 'errors::503']);
-        } catch (Exception $e) {
-            throw UpdateException::maintenanceModeFailure('enable');
+            Artisan::call( 'down', ['--render' => 'errors::503'] );
+        } catch ( Exception $e ) {
+            throw UpdateException::maintenanceModeFailure( 'enable' );
         }
     }
 
@@ -587,9 +587,9 @@ class ApplicationUpdateManager
     protected function disableMaintenanceMode(): void
     {
         try {
-            Artisan::call('up');
-        } catch (Exception $e) {
-            throw UpdateException::maintenanceModeFailure('disable');
+            Artisan::call( 'up' );
+        } catch ( Exception $e ) {
+            throw UpdateException::maintenanceModeFailure( 'disable' );
         }
     }
 
@@ -600,10 +600,10 @@ class ApplicationUpdateManager
      *
      * @param  Exception  $exception  The exception that caused failure
      */
-    protected function handleUpdateFailure(Exception $exception): void
+    protected function handleUpdateFailure( Exception $exception ): void
     {
         // Log the original exception for debugging
-        \Illuminate\Support\Facades\Log::error('Update failed, beginning rollback', [
+        \Illuminate\Support\Facades\Log::error( 'Update failed, beginning rollback', [
             'exception' => $exception->getMessage(),
             'trace'     => $exception->getTraceAsString(),
             'file'      => $exception->getFile(),
@@ -613,17 +613,17 @@ class ApplicationUpdateManager
         // Attempt to disable maintenance mode
         try {
             $this->disableMaintenanceMode();
-        } catch (Exception $e) {
+        } catch ( Exception $e) {
             // Maintenance mode failure is not critical during rollback
         }
 
         // If we have a backup, attempt rollback
-        if ($this->backupPath && File::exists($this->backupPath)) {
+        if ( $this->backupPath && File::exists( $this->backupPath)) {
             try {
-                $this->rollback($this->backupPath);
-            } catch (Exception $e) {
+                $this->rollback( $this->backupPath);
+            } catch ( Exception $e) {
                 // Rollback failed - this is critical
-                throw UpdateException::rollbackFailed($e->getMessage());
+                throw UpdateException::rollbackFailed( $e->getMessage());
             }
         }
     }

--- a/src/Modules/Core/Updates/Managers/ApplicationUpdateManager.php
+++ b/src/Modules/Core/Updates/Managers/ApplicationUpdateManager.php
@@ -71,7 +71,7 @@ class ApplicationUpdateManager
     {
         $updateInfo = $this->checkForUpdate();
 
-        if (! $updateInfo->hasUpdate) {
+        if (! $updateInfo->hasUpdate()) {
             throw UpdateException::noUpdateAvailable();
         }
 

--- a/src/Modules/Core/Updates/Managers/ApplicationUpdateManager.php
+++ b/src/Modules/Core/Updates/Managers/ApplicationUpdateManager.php
@@ -1,9 +1,10 @@
 <?php
 
-declare( strict_types = 1 );
+declare(strict_types=1);
 
 namespace ArtisanPackUI\CMSFramework\Modules\Core\Updates\Managers;
 
+use ArtisanPackUI\CMSFramework\Modules\Core\Updates\Enums\UpdateType;
 use ArtisanPackUI\CMSFramework\Modules\Core\Updates\Exceptions\UpdateException;
 use ArtisanPackUI\CMSFramework\Modules\Core\Updates\UpdateChecker;
 use ArtisanPackUI\CMSFramework\Modules\Core\Updates\UpdateCheckerFactory;
@@ -66,11 +67,11 @@ class ApplicationUpdateManager
      *
      * @return bool True if update successful
      */
-    public function performUpdate( ?string $version = null ): bool
+    public function performUpdate(?string $version = null): bool
     {
         $updateInfo = $this->checkForUpdate();
 
-        if ( ! $updateInfo->hasUpdate ) {
+        if (! $updateInfo->hasUpdate) {
             throw UpdateException::noUpdateAvailable();
         }
 
@@ -82,20 +83,20 @@ class ApplicationUpdateManager
             $this->enableMaintenanceMode();
 
             // Step 2: Create backup
-            if ( config( 'cms.updates.backup_enabled', true ) ) {
+            if (config('cms.updates.backup_enabled', true)) {
                 $this->createBackup();
             }
 
             // Step 3: Download update
-            $zipPath = $this->getUpdateChecker()->downloadUpdate( $targetVersion );
+            $zipPath = $this->getUpdateChecker()->downloadUpdate($targetVersion);
 
             // Step 4: Verify checksum (if available)
-            if ( config( 'cms.updates.verify_checksum', true ) && $updateInfo->sha256 ) {
-                $this->verifyChecksum( $zipPath, $updateInfo->sha256 );
+            if (config('cms.updates.verify_checksum', true) && $updateInfo->sha256) {
+                $this->verifyChecksum($zipPath, $updateInfo->sha256);
             }
 
             // Step 5: Extract update
-            $this->extractUpdate( $zipPath );
+            $this->extractUpdate($zipPath);
 
             // Step 6: Run composer install
             $this->runComposerInstall();
@@ -107,15 +108,15 @@ class ApplicationUpdateManager
             $this->clearCaches();
 
             // Step 9: Clean up
-            $this->cleanup( $zipPath );
+            $this->cleanup($zipPath);
 
             // Step 10: Disable maintenance mode
             $this->disableMaintenanceMode();
 
             return true;
-        } catch ( Exception $e ) {
+        } catch (Exception $e) {
             // Rollback on failure
-            $this->handleUpdateFailure( $e );
+            $this->handleUpdateFailure($e);
 
             throw $e;
         }
@@ -128,7 +129,7 @@ class ApplicationUpdateManager
      *
      * @param  UpdateChecker  $checker  Update checker instance
      */
-    public function setUpdateChecker( UpdateChecker $checker ): void
+    public function setUpdateChecker(UpdateChecker $checker): void
     {
         $this->checker = $checker;
     }
@@ -142,19 +143,19 @@ class ApplicationUpdateManager
      *
      * @throws UpdateException
      */
-    public function rollback( string $backupPath ): void
+    public function rollback(string $backupPath): void
     {
-        if ( ! File::exists( $backupPath ) ) {
-            throw UpdateException::rollbackFailed( "Backup not found: {$backupPath}" );
+        if (! File::exists($backupPath)) {
+            throw UpdateException::rollbackFailed("Backup not found: {$backupPath}");
         }
 
         $zip = new ZipArchive;
 
-        if ( true !== $zip->open( $backupPath ) ) {
-            throw UpdateException::rollbackFailed( 'Could not open backup ZIP' );
+        if (true !== $zip->open($backupPath)) {
+            throw UpdateException::rollbackFailed('Could not open backup ZIP');
         }
 
-        $zip->extractTo( base_path() );
+        $zip->extractTo(base_path());
         $zip->close();
 
         // Restore composer dependencies
@@ -185,19 +186,19 @@ class ApplicationUpdateManager
      */
     protected function getUpdateChecker(): UpdateChecker
     {
-        if ( $this->checker ) {
+        if ($this->checker) {
             return $this->checker;
         }
 
-        $updateUrl = config( 'cms.updates.update_source_url' );
+        $updateUrl = config('cms.updates.update_source_url');
 
-        if ( ! $updateUrl ) {
+        if (! $updateUrl) {
             throw UpdateException::noUpdateUrlConfigured();
         }
 
         $this->checker = UpdateCheckerFactory::buildUpdateChecker(
             url: $updateUrl,
-            type: 'application',
+            type: UpdateType::Application,
             slug: 'digital-shopfront-cms',
         );
 
@@ -213,32 +214,32 @@ class ApplicationUpdateManager
      */
     protected function createBackup(): void
     {
-        $backupDir  = storage_path( config( 'cms.updates.backup_path', 'backups/application' ) );
-        $backupName = 'backup-' . date( 'Y-m-d-His' ) . '.zip';
+        $backupDir  = storage_path(config('cms.updates.backup_path', 'backups/application'));
+        $backupName = 'backup-'.date('Y-m-d-His').'.zip';
         $backupPath = "{$backupDir}/{$backupName}";
 
         // Create backup directory
-        if ( ! File::exists( $backupDir ) ) {
-            File::makeDirectory( $backupDir, 0755, true );
+        if (! File::exists($backupDir)) {
+            File::makeDirectory($backupDir, 0755, true);
         }
 
         // Create backup ZIP
         $zip = new ZipArchive;
 
-        if ( true !== $zip->open( $backupPath, ZipArchive::CREATE | ZipArchive::OVERWRITE ) ) {
-            throw UpdateException::backupFailed( $backupPath );
+        if (true !== $zip->open($backupPath, ZipArchive::CREATE | ZipArchive::OVERWRITE)) {
+            throw UpdateException::backupFailed($backupPath);
         }
 
         // Add all files except excluded paths
-        $excludePaths = config( 'cms.updates.exclude_from_update', [] );
-        $this->addDirectoryToZip( $zip, base_path(), '', $excludePaths );
+        $excludePaths = config('cms.updates.exclude_from_update', []);
+        $this->addDirectoryToZip($zip, base_path(), '', $excludePaths);
 
         $zip->close();
 
         $this->backupPath = $backupPath;
 
         // Clean old backups
-        $this->cleanOldBackups( $backupDir );
+        $this->cleanOldBackups($backupDir);
     }
 
     /**
@@ -251,53 +252,53 @@ class ApplicationUpdateManager
      * @param  string  $localPath  Local path in ZIP
      * @param  array<string>  $excludePaths  Paths to exclude
      */
-    protected function addDirectoryToZip( ZipArchive $zip, string $sourcePath, string $localPath, array $excludePaths ): void
+    protected function addDirectoryToZip(ZipArchive $zip, string $sourcePath, string $localPath, array $excludePaths): void
     {
         $files = new RecursiveIteratorIterator(
-            new RecursiveDirectoryIterator( $sourcePath ),
+            new RecursiveDirectoryIterator($sourcePath),
             RecursiveIteratorIterator::LEAVES_ONLY,
         );
 
         $basePath = base_path();
 
-        foreach ( $files as $file ) {
-            if ( $file->isDir() ) {
+        foreach ($files as $file) {
+            if ($file->isDir()) {
                 continue;
             }
 
             // Get real path and validate it
             $filePath = $file->getRealPath();
 
-            if ( false === $filePath ) {
+            if (false === $filePath) {
                 // getRealPath() failed - log and skip
-                \Illuminate\Support\Facades\Log::warning( 'Failed to get real path for file during backup', [
+                \Illuminate\Support\Facades\Log::warning('Failed to get real path for file during backup', [
                     'file' => $file->getPathname(),
-                ] );
+                ]);
 
                 continue;
             }
 
             // Verify the resolved path starts with base_path() to prevent traversal issues
-            if ( ! str_starts_with( $filePath, $basePath ) ) {
+            if (! str_starts_with($filePath, $basePath)) {
                 // File is outside base path (symlink or external) - log and skip
-                \Illuminate\Support\Facades\Log::warning( 'Skipping file outside base path during backup', [
+                \Illuminate\Support\Facades\Log::warning('Skipping file outside base path during backup', [
                     'file'      => $filePath,
                     'base_path' => $basePath,
-                ] );
+                ]);
 
                 continue;
             }
 
             // Safe to compute relative path
-            $relativePath = substr( $filePath, strlen( $basePath ) + 1 );
+            $relativePath = substr($filePath, strlen($basePath) + 1);
 
             // Skip excluded paths
-            if ( $this->isPathExcluded( $relativePath, $excludePaths ) ) {
+            if ($this->isPathExcluded($relativePath, $excludePaths)) {
                 continue;
             }
 
-            $zipPath = $localPath . DIRECTORY_SEPARATOR . $relativePath;
-            $zip->addFile( $filePath, $zipPath );
+            $zipPath = $localPath.DIRECTORY_SEPARATOR.$relativePath;
+            $zip->addFile($filePath, $zipPath);
         }
     }
 
@@ -311,14 +312,14 @@ class ApplicationUpdateManager
      *
      * @return bool True if excluded
      */
-    protected function isPathExcluded( string $path, array $excludePaths ): bool
+    protected function isPathExcluded(string $path, array $excludePaths): bool
     {
-        foreach ( $excludePaths as $exclude ) {
-            if ( str_starts_with( $path, $exclude ) ) {
+        foreach ($excludePaths as $exclude) {
+            if (str_starts_with($path, $exclude)) {
                 return true;
             }
 
-            if ( str_contains( $exclude, '*' ) && fnmatch( $exclude, $path ) ) {
+            if (str_contains($exclude, '*') && fnmatch($exclude, $path)) {
                 return true;
             }
         }
@@ -333,20 +334,20 @@ class ApplicationUpdateManager
      *
      * @param  string  $backupDir  Backup directory
      */
-    protected function cleanOldBackups( string $backupDir ): void
+    protected function cleanOldBackups(string $backupDir): void
     {
-        $retentionDays = config( 'cms.updates.backup_retention_days', 30 );
-        $cutoffTime    = time() - ( $retentionDays * 86400 );
+        $retentionDays = config('cms.updates.backup_retention_days', 30);
+        $cutoffTime    = time() - ($retentionDays * 86400);
 
-        $backups = glob( "{$backupDir}/backup-*.zip" );
+        $backups = glob("{$backupDir}/backup-*.zip");
 
-        if ( false === $backups ) {
+        if (false === $backups) {
             return;
         }
 
-        foreach ( $backups as $backup ) {
-            if ( filemtime( $backup ) < $cutoffTime ) {
-                File::delete( $backup );
+        foreach ($backups as $backup) {
+            if (filemtime($backup) < $cutoffTime) {
+                File::delete($backup);
             }
         }
     }
@@ -361,12 +362,12 @@ class ApplicationUpdateManager
      *
      * @throws UpdateException
      */
-    protected function verifyChecksum( string $zipPath, string $expectedHash ): void
+    protected function verifyChecksum(string $zipPath, string $expectedHash): void
     {
-        $actualHash = hash_file( 'sha256', $zipPath );
+        $actualHash = hash_file('sha256', $zipPath);
 
-        if ( $actualHash !== $expectedHash ) {
-            throw UpdateException::checksumMismatch( $expectedHash, $actualHash );
+        if ($actualHash !== $expectedHash) {
+            throw UpdateException::checksumMismatch($expectedHash, $actualHash);
         }
     }
 
@@ -379,73 +380,73 @@ class ApplicationUpdateManager
      *
      * @throws UpdateException
      */
-    protected function extractUpdate( string $zipPath ): void
+    protected function extractUpdate(string $zipPath): void
     {
         $zip = new ZipArchive;
 
-        if ( true !== $zip->open( $zipPath ) ) {
-            throw UpdateException::extractionFailed( $zipPath );
+        if (true !== $zip->open($zipPath)) {
+            throw UpdateException::extractionFailed($zipPath);
         }
 
         $extractPath  = base_path();
-        $excludePaths = config( 'cms.updates.exclude_from_update', [] );
+        $excludePaths = config('cms.updates.exclude_from_update', []);
 
         // Detect common root prefix by scanning all entry names
-        $commonPrefix = $this->detectCommonRootPrefix( $zip, $excludePaths );
+        $commonPrefix = $this->detectCommonRootPrefix($zip, $excludePaths);
 
         // Extract files (except excluded paths), stripping common prefix
-        for ( $i = 0; $i < $zip->numFiles; $i++ ) {
-            $filename = $zip->getNameIndex( $i );
+        for ($i = 0; $i < $zip->numFiles; $i++) {
+            $filename = $zip->getNameIndex($i);
 
             // Strip common prefix if detected
-            $targetPath = $commonPrefix ? substr( $filename, strlen( $commonPrefix ) ) : $filename;
+            $targetPath = $commonPrefix ? substr($filename, strlen($commonPrefix)) : $filename;
 
             // Skip excluded paths (check both original and stripped paths)
-            if ( $this->isPathExcluded( $filename, $excludePaths ) || $this->isPathExcluded( $targetPath, $excludePaths ) ) {
+            if ($this->isPathExcluded($filename, $excludePaths) || $this->isPathExcluded($targetPath, $excludePaths)) {
                 continue;
             }
 
             // Skip empty paths (directories become empty after prefix stripping)
-            if ( empty( $targetPath ) ) {
+            if (empty($targetPath)) {
                 continue;
             }
 
             // Get file info
-            $stat = $zip->statIndex( $i );
-            if ( false === $stat ) {
+            $stat = $zip->statIndex($i);
+            if (false === $stat) {
                 continue;
             }
 
-            $fullTargetPath = $extractPath . DIRECTORY_SEPARATOR . $targetPath;
+            $fullTargetPath = $extractPath.DIRECTORY_SEPARATOR.$targetPath;
 
             // Handle directories
-            if ( str_ends_with( $filename, '/' ) ) {
-                if ( ! File::exists( $fullTargetPath ) ) {
-                    File::makeDirectory( $fullTargetPath, 0755, true );
+            if (str_ends_with($filename, '/')) {
+                if (! File::exists($fullTargetPath)) {
+                    File::makeDirectory($fullTargetPath, 0755, true);
                 }
 
                 continue;
             }
 
             // Handle files - ensure parent directory exists
-            $targetDir = dirname( $fullTargetPath );
-            if ( ! File::exists( $targetDir ) ) {
-                File::makeDirectory( $targetDir, 0755, true );
+            $targetDir = dirname($fullTargetPath);
+            if (! File::exists($targetDir)) {
+                File::makeDirectory($targetDir, 0755, true);
             }
 
             // Extract file
-            $fileContent = $zip->getFromIndex( $i );
-            if ( false === $fileContent ) {
+            $fileContent = $zip->getFromIndex($i);
+            if (false === $fileContent) {
                 continue;
             }
 
-            File::put( $fullTargetPath, $fileContent );
+            File::put($fullTargetPath, $fileContent);
 
             // Preserve file permissions if available
-            if ( isset( $stat['external_attributes'] ) ) {
-                $permissions = ( $stat['external_attributes'] >> 16 ) & 0777;
-                if ( $permissions > 0 ) {
-                    @chmod( $fullTargetPath, $permissions );
+            if (isset($stat['external_attributes'])) {
+                $permissions = ($stat['external_attributes'] >> 16) & 0777;
+                if ($permissions > 0) {
+                    @chmod($fullTargetPath, $permissions);
                 }
             }
         }
@@ -463,34 +464,34 @@ class ApplicationUpdateManager
      *
      * @return string|null Common root prefix, or null if none detected
      */
-    protected function detectCommonRootPrefix( ZipArchive $zip, array $excludePaths ): ?string
+    protected function detectCommonRootPrefix(ZipArchive $zip, array $excludePaths): ?string
     {
         $firstSegments = [];
 
         // Scan all non-excluded entries to find first path segment
-        for ( $i = 0; $i < $zip->numFiles; $i++ ) {
-            $filename = $zip->getNameIndex( $i );
+        for ($i = 0; $i < $zip->numFiles; $i++) {
+            $filename = $zip->getNameIndex($i);
 
             // Skip excluded paths
-            if ( $this->isPathExcluded( $filename, $excludePaths ) ) {
+            if ($this->isPathExcluded($filename, $excludePaths)) {
                 continue;
             }
 
             // Get first path segment
-            $parts = explode( '/', $filename );
-            if ( ! empty( $parts[0] ) ) {
+            $parts = explode('/', $filename);
+            if (! empty($parts[0])) {
                 $firstSegments[] = $parts[0];
             }
         }
 
         // If all entries share the same first segment, that's our common prefix
-        if ( empty( $firstSegments ) ) {
+        if (empty($firstSegments)) {
             return null;
         }
 
-        $uniqueSegments = array_unique( $firstSegments );
-        if ( 1 === count( $uniqueSegments ) ) {
-            return reset( $uniqueSegments ) . '/';
+        $uniqueSegments = array_unique($firstSegments);
+        if (1 === count($uniqueSegments)) {
+            return reset($uniqueSegments).'/';
         }
 
         return null;
@@ -505,15 +506,15 @@ class ApplicationUpdateManager
      */
     protected function runComposerInstall(): void
     {
-        $command = config( 'cms.updates.composer_install_command' );
-        $timeout = config( 'cms.updates.composer_timeout', 600 );
+        $command = config('cms.updates.composer_install_command');
+        $timeout = config('cms.updates.composer_timeout', 600);
 
-        $result = Process::timeout( $timeout )
-            ->path( base_path() )
-            ->run( $command );
+        $result = Process::timeout($timeout)
+            ->path(base_path())
+            ->run($command);
 
-        if ( ! $result->successful() ) {
-            throw UpdateException::composerInstallFailed( $result->errorOutput() );
+        if (! $result->successful()) {
+            throw UpdateException::composerInstallFailed($result->errorOutput());
         }
     }
 
@@ -527,9 +528,9 @@ class ApplicationUpdateManager
     protected function runMigrations(): void
     {
         try {
-            Artisan::call( 'migrate', ['--force' => true] );
-        } catch ( Exception $e ) {
-            throw UpdateException::migrationFailed( $e->getMessage() );
+            Artisan::call('migrate', ['--force' => true]);
+        } catch (Exception $e) {
+            throw UpdateException::migrationFailed($e->getMessage());
         }
     }
 
@@ -540,10 +541,10 @@ class ApplicationUpdateManager
      */
     protected function clearCaches(): void
     {
-        Artisan::call( 'config:clear' );
-        Artisan::call( 'cache:clear' );
-        Artisan::call( 'route:clear' );
-        Artisan::call( 'view:clear' );
+        Artisan::call('config:clear');
+        Artisan::call('cache:clear');
+        Artisan::call('route:clear');
+        Artisan::call('view:clear');
     }
 
     /**
@@ -553,10 +554,10 @@ class ApplicationUpdateManager
      *
      * @param  string  $zipPath  Path to ZIP file
      */
-    protected function cleanup( string $zipPath ): void
+    protected function cleanup(string $zipPath): void
     {
-        if ( File::exists( $zipPath ) ) {
-            File::delete( $zipPath );
+        if (File::exists($zipPath)) {
+            File::delete($zipPath);
         }
     }
 
@@ -570,9 +571,9 @@ class ApplicationUpdateManager
     protected function enableMaintenanceMode(): void
     {
         try {
-            Artisan::call( 'down', ['--render' => 'errors::503'] );
-        } catch ( Exception $e ) {
-            throw UpdateException::maintenanceModeFailure( 'enable' );
+            Artisan::call('down', ['--render' => 'errors::503']);
+        } catch (Exception $e) {
+            throw UpdateException::maintenanceModeFailure('enable');
         }
     }
 
@@ -586,9 +587,9 @@ class ApplicationUpdateManager
     protected function disableMaintenanceMode(): void
     {
         try {
-            Artisan::call( 'up' );
-        } catch ( Exception $e ) {
-            throw UpdateException::maintenanceModeFailure( 'disable' );
+            Artisan::call('up');
+        } catch (Exception $e) {
+            throw UpdateException::maintenanceModeFailure('disable');
         }
     }
 
@@ -599,30 +600,30 @@ class ApplicationUpdateManager
      *
      * @param  Exception  $exception  The exception that caused failure
      */
-    protected function handleUpdateFailure( Exception $exception ): void
+    protected function handleUpdateFailure(Exception $exception): void
     {
         // Log the original exception for debugging
-        \Illuminate\Support\Facades\Log::error( 'Update failed, beginning rollback', [
+        \Illuminate\Support\Facades\Log::error('Update failed, beginning rollback', [
             'exception' => $exception->getMessage(),
             'trace'     => $exception->getTraceAsString(),
             'file'      => $exception->getFile(),
             'line'      => $exception->getLine(),
-        ] );
+        ]);
 
         // Attempt to disable maintenance mode
         try {
             $this->disableMaintenanceMode();
-        } catch ( Exception $e ) {
+        } catch (Exception $e) {
             // Maintenance mode failure is not critical during rollback
         }
 
         // If we have a backup, attempt rollback
-        if ( $this->backupPath && File::exists( $this->backupPath ) ) {
+        if ($this->backupPath && File::exists($this->backupPath)) {
             try {
-                $this->rollback( $this->backupPath );
-            } catch ( Exception $e ) {
+                $this->rollback($this->backupPath);
+            } catch (Exception $e) {
                 // Rollback failed - this is critical
-                throw UpdateException::rollbackFailed( $e->getMessage());
+                throw UpdateException::rollbackFailed($e->getMessage());
             }
         }
     }

--- a/src/Modules/Core/Updates/Managers/ApplicationUpdateManager.php
+++ b/src/Modules/Core/Updates/Managers/ApplicationUpdateManager.php
@@ -608,20 +608,20 @@ class ApplicationUpdateManager
             'trace'     => $exception->getTraceAsString(),
             'file'      => $exception->getFile(),
             'line'      => $exception->getLine(),
-        ]);
+        ] );
 
         // Attempt to disable maintenance mode
         try {
             $this->disableMaintenanceMode();
-        } catch ( Exception $e) {
+        } catch ( Exception $e ) {
             // Maintenance mode failure is not critical during rollback
         }
 
         // If we have a backup, attempt rollback
-        if ( $this->backupPath && File::exists( $this->backupPath)) {
+        if ( $this->backupPath && File::exists( $this->backupPath ) ) {
             try {
-                $this->rollback( $this->backupPath);
-            } catch ( Exception $e) {
+                $this->rollback( $this->backupPath );
+            } catch ( Exception $e ) {
                 // Rollback failed - this is critical
                 throw UpdateException::rollbackFailed( $e->getMessage());
             }

--- a/src/Modules/Core/Updates/Sources/GitHubUpdateSource.php
+++ b/src/Modules/Core/Updates/Sources/GitHubUpdateSource.php
@@ -147,7 +147,7 @@ class GitHubUpdateSource implements UpdateSourceInterface
             $downloadUrl = $this->extractDownloadUrl($release);
         }
 
-        $tempPath = storage_path('app/temp/update-'.time().'.zip');
+        $tempPath = storage_path('app/temp/update-'.bin2hex(random_bytes(16)).'.zip');
 
         // Ensure temp directory exists
         if (! File::exists(dirname($tempPath))) {

--- a/src/Modules/Core/Updates/Sources/GitHubUpdateSource.php
+++ b/src/Modules/Core/Updates/Sources/GitHubUpdateSource.php
@@ -304,9 +304,9 @@ class GitHubUpdateSource implements UpdateSourceInterface
     {
         // Find ZIP asset
         $zipAsset = collect( $release['assets'] ?? [] )
-            ->first( fn ( $asset) => Str::endsWith( $asset['name'], '.zip'));
+            ->first( fn ( $asset ) => Str::endsWith( $asset['name'], '.zip' ) );
 
-        if ( $zipAsset) {
+        if ( $zipAsset ) {
             return $zipAsset['browser_download_url'];
         }
 

--- a/src/Modules/Core/Updates/Sources/GitHubUpdateSource.php
+++ b/src/Modules/Core/Updates/Sources/GitHubUpdateSource.php
@@ -1,6 +1,6 @@
 <?php
 
-declare( strict_types = 1 );
+declare(strict_types=1);
 
 namespace ArtisanPackUI\CMSFramework\Modules\Core\Updates\Sources;
 
@@ -54,7 +54,7 @@ class GitHubUpdateSource implements UpdateSourceInterface
         protected string $url,
         protected string $currentVersion,
     ) {
-        $this->parseUrl( $url );
+        $this->parseUrl($url);
     }
 
     /**
@@ -66,9 +66,9 @@ class GitHubUpdateSource implements UpdateSourceInterface
      *
      * @return bool True if URL is a GitHub repository
      */
-    public function supports( string $url ): bool
+    public function supports(string $url): bool
     {
-        return Str::contains( $url, 'github.com' );
+        return Str::contains($url, 'github.com');
     }
 
     /**
@@ -84,24 +84,24 @@ class GitHubUpdateSource implements UpdateSourceInterface
     {
         $releases = $this->fetchReleases();
 
-        if ( empty( $releases ) ) {
-            throw UpdateException::versionCheckFailed( 'No releases found on GitHub' );
+        if (empty($releases)) {
+            throw UpdateException::versionCheckFailed('No releases found on GitHub');
         }
 
         // Get latest non-prerelease version
-        $latest = collect( $releases )
-            ->filter( fn ( $release ) => ! $release['prerelease'] )
+        $latest = collect($releases)
+            ->filter(fn ($release) => ! $release['prerelease'])
             ->first();
 
-        if ( ! $latest ) {
-            throw UpdateException::versionCheckFailed( 'No stable releases found' );
+        if (! $latest) {
+            throw UpdateException::versionCheckFailed('No stable releases found');
         }
 
         // Find ZIP asset
-        $zipAsset = collect( $latest['assets'] )
-            ->first( fn ( $asset ) => Str::endsWith( $asset['name'], '.zip' ) );
+        $zipAsset = collect($latest['assets'])
+            ->first(fn ($asset) => Str::endsWith($asset['name'], '.zip'));
 
-        if ( ! $zipAsset ) {
+        if (! $zipAsset) {
             // Fallback to source code ZIP
             $zipAsset = [
                 'browser_download_url' => $latest['zipball_url'],
@@ -110,8 +110,7 @@ class GitHubUpdateSource implements UpdateSourceInterface
 
         return new UpdateInfo(
             currentVersion: $this->currentVersion,
-            latestVersion: ltrim( $latest['tag_name'], 'v' ),
-            hasUpdate: version_compare( ltrim( $latest['tag_name'], 'v' ), $this->currentVersion, '>' ),
+            latestVersion: ltrim($latest['tag_name'], 'v'),
             downloadUrl: $zipAsset['browser_download_url'],
             changelog: $latest['body'] ?? null,
             releaseDate: $latest['published_at'] ?? null,
@@ -135,38 +134,38 @@ class GitHubUpdateSource implements UpdateSourceInterface
      *
      * @return string Path to downloaded ZIP file
      */
-    public function downloadUpdate( string $version ): string
+    public function downloadUpdate(string $version): string
     {
         // Get release info for the specified version
-        if ( 'latest' === $version || empty( $version ) ) {
+        if ('latest' === $version || empty($version)) {
             $updateInfo  = $this->checkForUpdate();
             $downloadUrl = $updateInfo->downloadUrl;
         } else {
-            $release     = $this->getReleaseByVersion( $version );
-            $downloadUrl = $this->extractDownloadUrl( $release );
+            $release     = $this->getReleaseByVersion($version);
+            $downloadUrl = $this->extractDownloadUrl($release);
         }
 
-        $tempPath = storage_path( 'app/temp/update-' . time() . '.zip' );
+        $tempPath = storage_path('app/temp/update-'.time().'.zip');
 
         // Ensure temp directory exists
-        if ( ! File::exists( dirname( $tempPath ) ) ) {
-            File::makeDirectory( dirname( $tempPath ), 0755, true );
+        if (! File::exists(dirname($tempPath))) {
+            File::makeDirectory(dirname($tempPath), 0755, true);
         }
 
         $headers = [];
-        if ( $this->accessToken ) {
+        if ($this->accessToken) {
             $headers['Authorization'] = "token {$this->accessToken}";
         }
 
-        $response = Http::withHeaders( $headers )
-            ->timeout( config( 'cms.updates.download_timeout', 300 ) )
-            ->get( $downloadUrl );
+        $response = Http::withHeaders($headers)
+            ->timeout(config('cms.updates.download_timeout', 300))
+            ->get($downloadUrl);
 
-        if ( ! $response->successful() ) {
-            throw UpdateException::downloadFailed( $downloadUrl );
+        if (! $response->successful()) {
+            throw UpdateException::downloadFailed($downloadUrl);
         }
 
-        File::put( $tempPath, $response->body() );
+        File::put($tempPath, $response->body());
 
         return $tempPath;
     }
@@ -178,9 +177,9 @@ class GitHubUpdateSource implements UpdateSourceInterface
      *
      * @param  array|string  $credentials  GitHub token or credentials array
      */
-    public function setAuthentication( string|array $credentials ): void
+    public function setAuthentication(string|array $credentials): void
     {
-        $this->accessToken = is_string( $credentials ) ? $credentials : $credentials['token'] ?? null;
+        $this->accessToken = is_string($credentials) ? $credentials : $credentials['token'] ?? null;
     }
 
     /**
@@ -204,15 +203,15 @@ class GitHubUpdateSource implements UpdateSourceInterface
      *
      * @throws InvalidArgumentException If URL is invalid
      */
-    protected function parseUrl( string $url ): void
+    protected function parseUrl(string $url): void
     {
         // Extract owner and repo from URL
         // Supports: https://github.com/owner/repo
-        if ( preg_match( '#github\.com/([^/]+)/([^/]+)#', $url, $matches ) ) {
+        if (preg_match('#github\.com/([^/]+)/([^/]+)#', $url, $matches)) {
             $this->owner = $matches[1];
-            $this->repo  = rtrim( $matches[2], '.git' );
+            $this->repo  = rtrim($matches[2], '.git');
         } else {
-            throw new InvalidArgumentException( 'Invalid GitHub URL' );
+            throw new InvalidArgumentException('Invalid GitHub URL');
         }
     }
 
@@ -230,16 +229,16 @@ class GitHubUpdateSource implements UpdateSourceInterface
         $apiUrl = "https://api.github.com/repos/{$this->owner}/{$this->repo}/releases";
 
         $headers = ['Accept' => 'application/vnd.github.v3+json'];
-        if ( $this->accessToken ) {
+        if ($this->accessToken) {
             $headers['Authorization'] = "token {$this->accessToken}";
         }
 
-        $response = Http::withHeaders( $headers )
-            ->timeout( config( 'cms.updates.http_timeout', 15 ) )
-            ->get( $apiUrl );
+        $response = Http::withHeaders($headers)
+            ->timeout(config('cms.updates.http_timeout', 15))
+            ->get($apiUrl);
 
-        if ( ! $response->successful() ) {
-            throw UpdateException::versionCheckFailed( "GitHub API error: {$response->status()}" );
+        if (! $response->successful()) {
+            throw UpdateException::versionCheckFailed("GitHub API error: {$response->status()}");
         }
 
         return $response->json();
@@ -256,33 +255,33 @@ class GitHubUpdateSource implements UpdateSourceInterface
      *
      * @return array Release data
      */
-    protected function getReleaseByVersion( string $version ): array
+    protected function getReleaseByVersion(string $version): array
     {
         // Try with 'v' prefix first (common convention)
-        $tag = str_starts_with( $version, 'v' ) ? $version : "v{$version}";
+        $tag = str_starts_with($version, 'v') ? $version : "v{$version}";
 
         $apiUrl = "https://api.github.com/repos/{$this->owner}/{$this->repo}/releases/tags/{$tag}";
 
         $headers = ['Accept' => 'application/vnd.github.v3+json'];
-        if ( $this->accessToken ) {
+        if ($this->accessToken) {
             $headers['Authorization'] = "token {$this->accessToken}";
         }
 
-        $response = Http::withHeaders( $headers )
-            ->timeout( config( 'cms.updates.http_timeout', 15 ) )
-            ->get( $apiUrl );
+        $response = Http::withHeaders($headers)
+            ->timeout(config('cms.updates.http_timeout', 15))
+            ->get($apiUrl);
 
-        if ( ! $response->successful() ) {
+        if (! $response->successful()) {
             // Try without 'v' prefix
-            $tag    = ltrim( $version, 'v' );
+            $tag    = ltrim($version, 'v');
             $apiUrl = "https://api.github.com/repos/{$this->owner}/{$this->repo}/releases/tags/{$tag}";
 
-            $response = Http::withHeaders( $headers )
-                ->timeout( config( 'cms.updates.http_timeout', 15 ) )
-                ->get( $apiUrl );
+            $response = Http::withHeaders($headers)
+                ->timeout(config('cms.updates.http_timeout', 15))
+                ->get($apiUrl);
 
-            if ( ! $response->successful() ) {
-                throw UpdateException::downloadFailed( "Release not found for version: {$version}" );
+            if (! $response->successful()) {
+                throw UpdateException::downloadFailed("Release not found for version: {$version}");
             }
         }
 
@@ -298,17 +297,17 @@ class GitHubUpdateSource implements UpdateSourceInterface
      *
      * @return string Download URL
      */
-    protected function extractDownloadUrl( array $release ): string
+    protected function extractDownloadUrl(array $release): string
     {
         // Find ZIP asset
-        $zipAsset = collect( $release['assets'] ?? [] )
-            ->first( fn ( $asset ) => Str::endsWith( $asset['name'], '.zip' ) );
+        $zipAsset = collect($release['assets'] ?? [])
+            ->first(fn ($asset) => Str::endsWith($asset['name'], '.zip'));
 
-        if ( $zipAsset ) {
+        if ($zipAsset) {
             return $zipAsset['browser_download_url'];
         }
 
         // Fallback to source code ZIP
-        return $release['zipball_url'] ?? throw UpdateException::downloadFailed( 'No download URL found in release');
+        return $release['zipball_url'] ?? throw UpdateException::downloadFailed('No download URL found in release');
     }
 }

--- a/src/Modules/Core/Updates/Sources/GitHubUpdateSource.php
+++ b/src/Modules/Core/Updates/Sources/GitHubUpdateSource.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare( strict_types=1 );
 
 namespace ArtisanPackUI\CMSFramework\Modules\Core\Updates\Sources;
 
@@ -54,7 +54,7 @@ class GitHubUpdateSource implements UpdateSourceInterface
         protected string $url,
         protected string $currentVersion,
     ) {
-        $this->parseUrl($url);
+        $this->parseUrl( $url );
     }
 
     /**
@@ -66,11 +66,11 @@ class GitHubUpdateSource implements UpdateSourceInterface
      *
      * @return bool True if URL is a GitHub repository
      */
-    public function supports(string $url): bool
+    public function supports( string $url ): bool
     {
-        $host = parse_url($url, PHP_URL_HOST);
+        $host = parse_url( $url, PHP_URL_HOST );
 
-        return 'github.com' === $host || str_ends_with((string) $host, '.github.com');
+        return 'github.com' === $host || str_ends_with( (string) $host, '.github.com' );
     }
 
     /**
@@ -86,24 +86,24 @@ class GitHubUpdateSource implements UpdateSourceInterface
     {
         $releases = $this->fetchReleases();
 
-        if (empty($releases)) {
-            throw UpdateException::versionCheckFailed('No releases found on GitHub');
+        if ( empty( $releases ) ) {
+            throw UpdateException::versionCheckFailed( 'No releases found on GitHub' );
         }
 
         // Get latest non-prerelease version
-        $latest = collect($releases)
-            ->filter(fn ($release) => ! $release['prerelease'])
+        $latest = collect( $releases )
+            ->filter( fn ( $release ) => ! $release['prerelease'] )
             ->first();
 
-        if (! $latest) {
-            throw UpdateException::versionCheckFailed('No stable releases found');
+        if ( ! $latest ) {
+            throw UpdateException::versionCheckFailed( 'No stable releases found' );
         }
 
         // Find ZIP asset
-        $zipAsset = collect($latest['assets'])
-            ->first(fn ($asset) => Str::endsWith($asset['name'], '.zip'));
+        $zipAsset = collect( $latest['assets'] )
+            ->first( fn ( $asset ) => Str::endsWith( $asset['name'], '.zip' ) );
 
-        if (! $zipAsset) {
+        if ( ! $zipAsset ) {
             // Fallback to source code ZIP
             $zipAsset = [
                 'browser_download_url' => $latest['zipball_url'],
@@ -112,7 +112,7 @@ class GitHubUpdateSource implements UpdateSourceInterface
 
         return new UpdateInfo(
             currentVersion: $this->currentVersion,
-            latestVersion: ltrim($latest['tag_name'], 'v'),
+            latestVersion: ltrim( $latest['tag_name'], 'v' ),
             downloadUrl: $zipAsset['browser_download_url'],
             changelog: $latest['body'] ?? null,
             releaseDate: $latest['published_at'] ?? null,
@@ -136,38 +136,38 @@ class GitHubUpdateSource implements UpdateSourceInterface
      *
      * @return string Path to downloaded ZIP file
      */
-    public function downloadUpdate(string $version): string
+    public function downloadUpdate( string $version ): string
     {
         // Get release info for the specified version
-        if ('latest' === $version || empty($version)) {
+        if ( 'latest' === $version || empty( $version ) ) {
             $updateInfo  = $this->checkForUpdate();
             $downloadUrl = $updateInfo->downloadUrl;
         } else {
-            $release     = $this->getReleaseByVersion($version);
-            $downloadUrl = $this->extractDownloadUrl($release);
+            $release     = $this->getReleaseByVersion( $version );
+            $downloadUrl = $this->extractDownloadUrl( $release );
         }
 
-        $tempPath = storage_path('app/temp/update-'.bin2hex(random_bytes(16)).'.zip');
+        $tempPath = storage_path( 'app/temp/update-' . bin2hex( random_bytes( 16 ) ) . '.zip' );
 
         // Ensure temp directory exists
-        if (! File::exists(dirname($tempPath))) {
-            File::makeDirectory(dirname($tempPath), 0755, true);
+        if ( ! File::exists( dirname( $tempPath ) ) ) {
+            File::makeDirectory( dirname( $tempPath ), 0755, true );
         }
 
         $headers = [];
-        if ($this->accessToken) {
+        if ( $this->accessToken ) {
             $headers['Authorization'] = "token {$this->accessToken}";
         }
 
-        $response = Http::withHeaders($headers)
-            ->timeout(config('cms.updates.download_timeout', 300))
-            ->get($downloadUrl);
+        $response = Http::withHeaders( $headers )
+            ->timeout( config( 'cms.updates.download_timeout', 300 ) )
+            ->get( $downloadUrl );
 
-        if (! $response->successful()) {
-            throw UpdateException::downloadFailed($downloadUrl);
+        if ( ! $response->successful() ) {
+            throw UpdateException::downloadFailed( $downloadUrl );
         }
 
-        File::put($tempPath, $response->body());
+        File::put( $tempPath, $response->body() );
 
         return $tempPath;
     }
@@ -179,9 +179,9 @@ class GitHubUpdateSource implements UpdateSourceInterface
      *
      * @param  array|string  $credentials  GitHub token or credentials array
      */
-    public function setAuthentication(string|array $credentials): void
+    public function setAuthentication( string|array $credentials ): void
     {
-        $this->accessToken = is_string($credentials) ? $credentials : $credentials['token'] ?? null;
+        $this->accessToken = is_string( $credentials ) ? $credentials : $credentials['token'] ?? null;
     }
 
     /**
@@ -205,16 +205,16 @@ class GitHubUpdateSource implements UpdateSourceInterface
      *
      * @throws InvalidArgumentException If URL is invalid
      */
-    protected function parseUrl(string $url): void
+    protected function parseUrl( string $url ): void
     {
         // Extract owner and repo from URL
         // Supports: https://github.com/owner/repo
-        if (preg_match('#github\.com/([^/]+)/([^/]+)#', $url, $matches)) {
+        if ( preg_match( '#github\.com/([^/]+)/([^/]+)#', $url, $matches ) ) {
             $this->owner = $matches[1];
             $repo        = $matches[2];
-            $this->repo  = str_ends_with($repo, '.git') ? substr($repo, 0, -4) : $repo;
+            $this->repo  = str_ends_with( $repo, '.git' ) ? substr( $repo, 0, -4 ) : $repo;
         } else {
-            throw new InvalidArgumentException('Invalid GitHub URL');
+            throw new InvalidArgumentException( 'Invalid GitHub URL' );
         }
     }
 
@@ -232,16 +232,16 @@ class GitHubUpdateSource implements UpdateSourceInterface
         $apiUrl = "https://api.github.com/repos/{$this->owner}/{$this->repo}/releases";
 
         $headers = ['Accept' => 'application/vnd.github.v3+json'];
-        if ($this->accessToken) {
+        if ( $this->accessToken ) {
             $headers['Authorization'] = "token {$this->accessToken}";
         }
 
-        $response = Http::withHeaders($headers)
-            ->timeout(config('cms.updates.http_timeout', 15))
-            ->get($apiUrl);
+        $response = Http::withHeaders( $headers )
+            ->timeout( config( 'cms.updates.http_timeout', 15 ) )
+            ->get( $apiUrl );
 
-        if (! $response->successful()) {
-            throw UpdateException::versionCheckFailed("GitHub API error: {$response->status()}");
+        if ( ! $response->successful() ) {
+            throw UpdateException::versionCheckFailed( "GitHub API error: {$response->status()}" );
         }
 
         return $response->json();
@@ -258,33 +258,33 @@ class GitHubUpdateSource implements UpdateSourceInterface
      *
      * @return array Release data
      */
-    protected function getReleaseByVersion(string $version): array
+    protected function getReleaseByVersion( string $version ): array
     {
         // Try with 'v' prefix first (common convention)
-        $tag = str_starts_with($version, 'v') ? $version : "v{$version}";
+        $tag = str_starts_with( $version, 'v' ) ? $version : "v{$version}";
 
         $apiUrl = "https://api.github.com/repos/{$this->owner}/{$this->repo}/releases/tags/{$tag}";
 
         $headers = ['Accept' => 'application/vnd.github.v3+json'];
-        if ($this->accessToken) {
+        if ( $this->accessToken ) {
             $headers['Authorization'] = "token {$this->accessToken}";
         }
 
-        $response = Http::withHeaders($headers)
-            ->timeout(config('cms.updates.http_timeout', 15))
-            ->get($apiUrl);
+        $response = Http::withHeaders( $headers )
+            ->timeout( config( 'cms.updates.http_timeout', 15 ) )
+            ->get( $apiUrl );
 
-        if (! $response->successful()) {
+        if ( ! $response->successful() ) {
             // Try without 'v' prefix
-            $tag    = ltrim($version, 'v');
+            $tag    = ltrim( $version, 'v' );
             $apiUrl = "https://api.github.com/repos/{$this->owner}/{$this->repo}/releases/tags/{$tag}";
 
-            $response = Http::withHeaders($headers)
-                ->timeout(config('cms.updates.http_timeout', 15))
-                ->get($apiUrl);
+            $response = Http::withHeaders( $headers )
+                ->timeout( config( 'cms.updates.http_timeout', 15 ) )
+                ->get( $apiUrl );
 
-            if (! $response->successful()) {
-                throw UpdateException::downloadFailed("Release not found for version: {$version}");
+            if ( ! $response->successful() ) {
+                throw UpdateException::downloadFailed( "Release not found for version: {$version}" );
             }
         }
 
@@ -300,17 +300,17 @@ class GitHubUpdateSource implements UpdateSourceInterface
      *
      * @return string Download URL
      */
-    protected function extractDownloadUrl(array $release): string
+    protected function extractDownloadUrl( array $release ): string
     {
         // Find ZIP asset
-        $zipAsset = collect($release['assets'] ?? [])
-            ->first(fn ($asset) => Str::endsWith($asset['name'], '.zip'));
+        $zipAsset = collect( $release['assets'] ?? [] )
+            ->first( fn ( $asset) => Str::endsWith( $asset['name'], '.zip'));
 
-        if ($zipAsset) {
+        if ( $zipAsset) {
             return $zipAsset['browser_download_url'];
         }
 
         // Fallback to source code ZIP
-        return $release['zipball_url'] ?? throw UpdateException::downloadFailed('No download URL found in release');
+        return $release['zipball_url'] ?? throw UpdateException::downloadFailed( 'No download URL found in release');
     }
 }

--- a/src/Modules/Core/Updates/Sources/GitHubUpdateSource.php
+++ b/src/Modules/Core/Updates/Sources/GitHubUpdateSource.php
@@ -68,7 +68,9 @@ class GitHubUpdateSource implements UpdateSourceInterface
      */
     public function supports(string $url): bool
     {
-        return Str::contains($url, 'github.com');
+        $host = parse_url($url, PHP_URL_HOST);
+
+        return 'github.com' === $host || str_ends_with((string) $host, '.github.com');
     }
 
     /**
@@ -209,7 +211,8 @@ class GitHubUpdateSource implements UpdateSourceInterface
         // Supports: https://github.com/owner/repo
         if (preg_match('#github\.com/([^/]+)/([^/]+)#', $url, $matches)) {
             $this->owner = $matches[1];
-            $this->repo  = rtrim($matches[2], '.git');
+            $repo        = $matches[2];
+            $this->repo  = str_ends_with($repo, '.git') ? substr($repo, 0, -4) : $repo;
         } else {
             throw new InvalidArgumentException('Invalid GitHub URL');
         }

--- a/src/Modules/Core/Updates/Sources/GitLabUpdateSource.php
+++ b/src/Modules/Core/Updates/Sources/GitLabUpdateSource.php
@@ -9,7 +9,6 @@ use ArtisanPackUI\CMSFramework\Modules\Core\Updates\Exceptions\UpdateException;
 use ArtisanPackUI\CMSFramework\Modules\Core\Updates\ValueObjects\UpdateInfo;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Http;
-use Illuminate\Support\Str;
 use InvalidArgumentException;
 
 /**
@@ -61,7 +60,9 @@ class GitLabUpdateSource implements UpdateSourceInterface
      */
     public function supports(string $url): bool
     {
-        return Str::contains($url, 'gitlab.com');
+        $host = parse_url($url, PHP_URL_HOST);
+
+        return 'gitlab.com' === $host;
     }
 
     /**
@@ -187,14 +188,20 @@ class GitLabUpdateSource implements UpdateSourceInterface
      */
     protected function parseUrl(string $url): void
     {
-        // Extract project path and convert to project ID
-        // Supports: https://gitlab.com/group/subgroup/project
-        if (preg_match('#gitlab\.com/(.+)$#', $url, $matches)) {
-            // URL-encode the project path for API
-            $this->projectId = urlencode(trim($matches[1], '/'));
-        } else {
+        $host = parse_url($url, PHP_URL_HOST);
+
+        if ('gitlab.com' !== $host) {
             throw new InvalidArgumentException('Invalid GitLab URL');
         }
+
+        $path = parse_url($url, PHP_URL_PATH);
+
+        if (! $path || '/' === trim($path, '/')) {
+            throw new InvalidArgumentException('Invalid GitLab URL');
+        }
+
+        // URL-encode the project path for API
+        $this->projectId = urlencode(trim($path, '/'));
     }
 
     /**

--- a/src/Modules/Core/Updates/Sources/GitLabUpdateSource.php
+++ b/src/Modules/Core/Updates/Sources/GitLabUpdateSource.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare( strict_types=1 );
 
 namespace ArtisanPackUI\CMSFramework\Modules\Core\Updates\Sources;
 
@@ -46,7 +46,7 @@ class GitLabUpdateSource implements UpdateSourceInterface
         protected string $url,
         protected string $currentVersion,
     ) {
-        $this->parseUrl($url);
+        $this->parseUrl( $url );
     }
 
     /**
@@ -58,9 +58,9 @@ class GitLabUpdateSource implements UpdateSourceInterface
      *
      * @return bool True if URL is a GitLab repository
      */
-    public function supports(string $url): bool
+    public function supports( string $url ): bool
     {
-        $host = parse_url($url, PHP_URL_HOST);
+        $host = parse_url( $url, PHP_URL_HOST );
 
         return 'gitlab.com' === $host;
     }
@@ -78,17 +78,17 @@ class GitLabUpdateSource implements UpdateSourceInterface
     {
         $releases = $this->fetchReleases();
 
-        if (empty($releases)) {
-            throw UpdateException::versionCheckFailed('No releases found on GitLab');
+        if ( empty( $releases ) ) {
+            throw UpdateException::versionCheckFailed( 'No releases found on GitLab' );
         }
 
         // Filter out prereleases and get latest stable
-        $latest = collect($releases)
-            ->filter(fn ($release) => empty($release['upcoming_release']))
+        $latest = collect( $releases )
+            ->filter( fn ( $release ) => empty( $release['upcoming_release'] ) )
             ->first();
 
-        if (! $latest) {
-            throw UpdateException::versionCheckFailed('No stable releases found');
+        if ( ! $latest ) {
+            throw UpdateException::versionCheckFailed( 'No stable releases found' );
         }
 
         // Get download link for source code
@@ -96,7 +96,7 @@ class GitLabUpdateSource implements UpdateSourceInterface
 
         return new UpdateInfo(
             currentVersion: $this->currentVersion,
-            latestVersion: ltrim($latest['tag_name'], 'v'),
+            latestVersion: ltrim( $latest['tag_name'], 'v' ),
             downloadUrl: $downloadUrl,
             changelog: $latest['description'] ?? null,
             releaseDate: $latest['created_at'] ?? null,
@@ -118,37 +118,37 @@ class GitLabUpdateSource implements UpdateSourceInterface
      *
      * @return string Path to downloaded ZIP file
      */
-    public function downloadUpdate(string $version): string
+    public function downloadUpdate( string $version ): string
     {
         // Get release info for the specified version
-        if ('latest' === $version || empty($version)) {
+        if ( 'latest' === $version || empty( $version ) ) {
             $updateInfo  = $this->checkForUpdate();
             $downloadUrl = $updateInfo->downloadUrl;
         } else {
-            $release     = $this->getReleaseByVersion($version);
-            $downloadUrl = $this->extractDownloadUrl($release);
+            $release     = $this->getReleaseByVersion( $version );
+            $downloadUrl = $this->extractDownloadUrl( $release );
         }
 
-        $tempPath = storage_path('app/temp/update-'.bin2hex(random_bytes(16)).'.zip');
+        $tempPath = storage_path( 'app/temp/update-' . bin2hex( random_bytes( 16 ) ) . '.zip' );
 
-        if (! File::exists(dirname($tempPath))) {
-            File::makeDirectory(dirname($tempPath), 0755, true);
+        if ( ! File::exists( dirname( $tempPath ) ) ) {
+            File::makeDirectory( dirname( $tempPath ), 0755, true );
         }
 
         $headers = [];
-        if ($this->accessToken) {
+        if ( $this->accessToken ) {
             $headers['PRIVATE-TOKEN'] = $this->accessToken;
         }
 
-        $response = Http::withHeaders($headers)
-            ->timeout(config('cms.updates.download_timeout', 300))
-            ->get($downloadUrl);
+        $response = Http::withHeaders( $headers )
+            ->timeout( config( 'cms.updates.download_timeout', 300 ) )
+            ->get( $downloadUrl );
 
-        if (! $response->successful()) {
-            throw UpdateException::downloadFailed($downloadUrl);
+        if ( ! $response->successful() ) {
+            throw UpdateException::downloadFailed( $downloadUrl );
         }
 
-        File::put($tempPath, $response->body());
+        File::put( $tempPath, $response->body() );
 
         return $tempPath;
     }
@@ -160,9 +160,9 @@ class GitLabUpdateSource implements UpdateSourceInterface
      *
      * @param  array|string  $credentials  GitLab token or credentials array
      */
-    public function setAuthentication(string|array $credentials): void
+    public function setAuthentication( string|array $credentials ): void
     {
-        $this->accessToken = is_string($credentials) ? $credentials : $credentials['token'] ?? null;
+        $this->accessToken = is_string( $credentials ) ? $credentials : $credentials['token'] ?? null;
     }
 
     /**
@@ -186,22 +186,22 @@ class GitLabUpdateSource implements UpdateSourceInterface
      *
      * @throws InvalidArgumentException If URL is invalid
      */
-    protected function parseUrl(string $url): void
+    protected function parseUrl( string $url ): void
     {
-        $host = parse_url($url, PHP_URL_HOST);
+        $host = parse_url( $url, PHP_URL_HOST );
 
-        if ('gitlab.com' !== $host) {
-            throw new InvalidArgumentException('Invalid GitLab URL');
+        if ( 'gitlab.com' !== $host ) {
+            throw new InvalidArgumentException( 'Invalid GitLab URL' );
         }
 
-        $path = parse_url($url, PHP_URL_PATH);
+        $path = parse_url( $url, PHP_URL_PATH );
 
-        if (! $path || '' === trim($path, '/')) {
-            throw new InvalidArgumentException('Invalid GitLab URL');
+        if ( ! $path || '' === trim( $path, '/' ) ) {
+            throw new InvalidArgumentException( 'Invalid GitLab URL' );
         }
 
         // URL-encode the project path for API
-        $this->projectId = urlencode(trim($path, '/'));
+        $this->projectId = urlencode( trim( $path, '/' ) );
     }
 
     /**
@@ -218,16 +218,16 @@ class GitLabUpdateSource implements UpdateSourceInterface
         $apiUrl = "https://gitlab.com/api/v4/projects/{$this->projectId}/releases";
 
         $headers = [];
-        if ($this->accessToken) {
+        if ( $this->accessToken ) {
             $headers['PRIVATE-TOKEN'] = $this->accessToken;
         }
 
-        $response = Http::withHeaders($headers)
-            ->timeout(config('cms.updates.http_timeout', 15))
-            ->get($apiUrl);
+        $response = Http::withHeaders( $headers )
+            ->timeout( config( 'cms.updates.http_timeout', 15 ) )
+            ->get( $apiUrl );
 
-        if (! $response->successful()) {
-            throw UpdateException::versionCheckFailed("GitLab API error: {$response->status()}");
+        if ( ! $response->successful() ) {
+            throw UpdateException::versionCheckFailed( "GitLab API error: {$response->status()}" );
         }
 
         return $response->json();
@@ -244,33 +244,33 @@ class GitLabUpdateSource implements UpdateSourceInterface
      *
      * @return array Release data
      */
-    protected function getReleaseByVersion(string $version): array
+    protected function getReleaseByVersion( string $version ): array
     {
         // Try with 'v' prefix first (common convention)
-        $tag = str_starts_with($version, 'v') ? $version : "v{$version}";
+        $tag = str_starts_with( $version, 'v' ) ? $version : "v{$version}";
 
         $apiUrl = "https://gitlab.com/api/v4/projects/{$this->projectId}/releases/{$tag}";
 
         $headers = [];
-        if ($this->accessToken) {
+        if ( $this->accessToken ) {
             $headers['PRIVATE-TOKEN'] = $this->accessToken;
         }
 
-        $response = Http::withHeaders($headers)
-            ->timeout(config('cms.updates.http_timeout', 15))
-            ->get($apiUrl);
+        $response = Http::withHeaders( $headers )
+            ->timeout( config( 'cms.updates.http_timeout', 15 ) )
+            ->get( $apiUrl );
 
-        if (! $response->successful()) {
+        if ( ! $response->successful() ) {
             // Try without 'v' prefix
-            $tag    = ltrim($version, 'v');
+            $tag    = ltrim( $version, 'v' );
             $apiUrl = "https://gitlab.com/api/v4/projects/{$this->projectId}/releases/{$tag}";
 
-            $response = Http::withHeaders($headers)
-                ->timeout(config('cms.updates.http_timeout', 15))
-                ->get($apiUrl);
+            $response = Http::withHeaders( $headers )
+                ->timeout( config( 'cms.updates.http_timeout', 15 ) )
+                ->get( $apiUrl );
 
-            if (! $response->successful()) {
-                throw UpdateException::downloadFailed("Release not found for version: {$version}");
+            if ( ! $response->successful() ) {
+                throw UpdateException::downloadFailed( "Release not found for version: {$version}" );
             }
         }
 
@@ -286,11 +286,11 @@ class GitLabUpdateSource implements UpdateSourceInterface
      *
      * @return string Download URL
      */
-    protected function extractDownloadUrl(array $release): string
+    protected function extractDownloadUrl( array $release): string
     {
         // Get download link for source code
-        if (! isset($release['tag_name'])) {
-            throw UpdateException::downloadFailed('No tag_name found in release');
+        if ( ! isset( $release['tag_name'])) {
+            throw UpdateException::downloadFailed( 'No tag_name found in release');
         }
 
         return "https://gitlab.com/api/v4/projects/{$this->projectId}/repository/archive.zip?sha={$release['tag_name']}";

--- a/src/Modules/Core/Updates/Sources/GitLabUpdateSource.php
+++ b/src/Modules/Core/Updates/Sources/GitLabUpdateSource.php
@@ -1,6 +1,6 @@
 <?php
 
-declare( strict_types = 1 );
+declare(strict_types=1);
 
 namespace ArtisanPackUI\CMSFramework\Modules\Core\Updates\Sources;
 
@@ -47,7 +47,7 @@ class GitLabUpdateSource implements UpdateSourceInterface
         protected string $url,
         protected string $currentVersion,
     ) {
-        $this->parseUrl( $url );
+        $this->parseUrl($url);
     }
 
     /**
@@ -59,9 +59,9 @@ class GitLabUpdateSource implements UpdateSourceInterface
      *
      * @return bool True if URL is a GitLab repository
      */
-    public function supports( string $url ): bool
+    public function supports(string $url): bool
     {
-        return Str::contains( $url, 'gitlab.com' );
+        return Str::contains($url, 'gitlab.com');
     }
 
     /**
@@ -77,17 +77,17 @@ class GitLabUpdateSource implements UpdateSourceInterface
     {
         $releases = $this->fetchReleases();
 
-        if ( empty( $releases ) ) {
-            throw UpdateException::versionCheckFailed( 'No releases found on GitLab' );
+        if (empty($releases)) {
+            throw UpdateException::versionCheckFailed('No releases found on GitLab');
         }
 
         // Filter out prereleases and get latest stable
-        $latest = collect( $releases )
-            ->filter( fn ( $release ) => empty( $release['upcoming_release'] ) )
+        $latest = collect($releases)
+            ->filter(fn ($release) => empty($release['upcoming_release']))
             ->first();
 
-        if ( ! $latest ) {
-            throw UpdateException::versionCheckFailed( 'No stable releases found' );
+        if (! $latest) {
+            throw UpdateException::versionCheckFailed('No stable releases found');
         }
 
         // Get download link for source code
@@ -95,8 +95,7 @@ class GitLabUpdateSource implements UpdateSourceInterface
 
         return new UpdateInfo(
             currentVersion: $this->currentVersion,
-            latestVersion: ltrim( $latest['tag_name'], 'v' ),
-            hasUpdate: version_compare( ltrim( $latest['tag_name'], 'v' ), $this->currentVersion, '>' ),
+            latestVersion: ltrim($latest['tag_name'], 'v'),
             downloadUrl: $downloadUrl,
             changelog: $latest['description'] ?? null,
             releaseDate: $latest['created_at'] ?? null,
@@ -118,37 +117,37 @@ class GitLabUpdateSource implements UpdateSourceInterface
      *
      * @return string Path to downloaded ZIP file
      */
-    public function downloadUpdate( string $version ): string
+    public function downloadUpdate(string $version): string
     {
         // Get release info for the specified version
-        if ( 'latest' === $version || empty( $version ) ) {
+        if ('latest' === $version || empty($version)) {
             $updateInfo  = $this->checkForUpdate();
             $downloadUrl = $updateInfo->downloadUrl;
         } else {
-            $release     = $this->getReleaseByVersion( $version );
-            $downloadUrl = $this->extractDownloadUrl( $release );
+            $release     = $this->getReleaseByVersion($version);
+            $downloadUrl = $this->extractDownloadUrl($release);
         }
 
-        $tempPath = storage_path( 'app/temp/update-' . time() . '.zip' );
+        $tempPath = storage_path('app/temp/update-'.time().'.zip');
 
-        if ( ! File::exists( dirname( $tempPath ) ) ) {
-            File::makeDirectory( dirname( $tempPath ), 0755, true );
+        if (! File::exists(dirname($tempPath))) {
+            File::makeDirectory(dirname($tempPath), 0755, true);
         }
 
         $headers = [];
-        if ( $this->accessToken ) {
+        if ($this->accessToken) {
             $headers['PRIVATE-TOKEN'] = $this->accessToken;
         }
 
-        $response = Http::withHeaders( $headers )
-            ->timeout( config( 'cms.updates.download_timeout', 300 ) )
-            ->get( $downloadUrl );
+        $response = Http::withHeaders($headers)
+            ->timeout(config('cms.updates.download_timeout', 300))
+            ->get($downloadUrl);
 
-        if ( ! $response->successful() ) {
-            throw UpdateException::downloadFailed( $downloadUrl );
+        if (! $response->successful()) {
+            throw UpdateException::downloadFailed($downloadUrl);
         }
 
-        File::put( $tempPath, $response->body() );
+        File::put($tempPath, $response->body());
 
         return $tempPath;
     }
@@ -160,9 +159,9 @@ class GitLabUpdateSource implements UpdateSourceInterface
      *
      * @param  array|string  $credentials  GitLab token or credentials array
      */
-    public function setAuthentication( string|array $credentials ): void
+    public function setAuthentication(string|array $credentials): void
     {
-        $this->accessToken = is_string( $credentials ) ? $credentials : $credentials['token'] ?? null;
+        $this->accessToken = is_string($credentials) ? $credentials : $credentials['token'] ?? null;
     }
 
     /**
@@ -186,15 +185,15 @@ class GitLabUpdateSource implements UpdateSourceInterface
      *
      * @throws InvalidArgumentException If URL is invalid
      */
-    protected function parseUrl( string $url ): void
+    protected function parseUrl(string $url): void
     {
         // Extract project path and convert to project ID
         // Supports: https://gitlab.com/group/subgroup/project
-        if ( preg_match( '#gitlab\.com/(.+)$#', $url, $matches ) ) {
+        if (preg_match('#gitlab\.com/(.+)$#', $url, $matches)) {
             // URL-encode the project path for API
-            $this->projectId = urlencode( trim( $matches[1], '/' ) );
+            $this->projectId = urlencode(trim($matches[1], '/'));
         } else {
-            throw new InvalidArgumentException( 'Invalid GitLab URL' );
+            throw new InvalidArgumentException('Invalid GitLab URL');
         }
     }
 
@@ -212,16 +211,16 @@ class GitLabUpdateSource implements UpdateSourceInterface
         $apiUrl = "https://gitlab.com/api/v4/projects/{$this->projectId}/releases";
 
         $headers = [];
-        if ( $this->accessToken ) {
+        if ($this->accessToken) {
             $headers['PRIVATE-TOKEN'] = $this->accessToken;
         }
 
-        $response = Http::withHeaders( $headers )
-            ->timeout( config( 'cms.updates.http_timeout', 15 ) )
-            ->get( $apiUrl );
+        $response = Http::withHeaders($headers)
+            ->timeout(config('cms.updates.http_timeout', 15))
+            ->get($apiUrl);
 
-        if ( ! $response->successful() ) {
-            throw UpdateException::versionCheckFailed( "GitLab API error: {$response->status()}" );
+        if (! $response->successful()) {
+            throw UpdateException::versionCheckFailed("GitLab API error: {$response->status()}");
         }
 
         return $response->json();
@@ -238,33 +237,33 @@ class GitLabUpdateSource implements UpdateSourceInterface
      *
      * @return array Release data
      */
-    protected function getReleaseByVersion( string $version ): array
+    protected function getReleaseByVersion(string $version): array
     {
         // Try with 'v' prefix first (common convention)
-        $tag = str_starts_with( $version, 'v' ) ? $version : "v{$version}";
+        $tag = str_starts_with($version, 'v') ? $version : "v{$version}";
 
         $apiUrl = "https://gitlab.com/api/v4/projects/{$this->projectId}/releases/{$tag}";
 
         $headers = [];
-        if ( $this->accessToken ) {
+        if ($this->accessToken) {
             $headers['PRIVATE-TOKEN'] = $this->accessToken;
         }
 
-        $response = Http::withHeaders( $headers )
-            ->timeout( config( 'cms.updates.http_timeout', 15 ) )
-            ->get( $apiUrl );
+        $response = Http::withHeaders($headers)
+            ->timeout(config('cms.updates.http_timeout', 15))
+            ->get($apiUrl);
 
-        if ( ! $response->successful() ) {
+        if (! $response->successful()) {
             // Try without 'v' prefix
-            $tag    = ltrim( $version, 'v' );
+            $tag    = ltrim($version, 'v');
             $apiUrl = "https://gitlab.com/api/v4/projects/{$this->projectId}/releases/{$tag}";
 
-            $response = Http::withHeaders( $headers )
-                ->timeout( config( 'cms.updates.http_timeout', 15 ) )
-                ->get( $apiUrl );
+            $response = Http::withHeaders($headers)
+                ->timeout(config('cms.updates.http_timeout', 15))
+                ->get($apiUrl);
 
-            if ( ! $response->successful() ) {
-                throw UpdateException::downloadFailed( "Release not found for version: {$version}" );
+            if (! $response->successful()) {
+                throw UpdateException::downloadFailed("Release not found for version: {$version}");
             }
         }
 
@@ -280,11 +279,11 @@ class GitLabUpdateSource implements UpdateSourceInterface
      *
      * @return string Download URL
      */
-    protected function extractDownloadUrl( array $release ): string
+    protected function extractDownloadUrl(array $release): string
     {
         // Get download link for source code
-        if ( ! isset( $release['tag_name'] ) ) {
-            throw UpdateException::downloadFailed( 'No tag_name found in release' );
+        if (! isset($release['tag_name'])) {
+            throw UpdateException::downloadFailed('No tag_name found in release');
         }
 
         return "https://gitlab.com/api/v4/projects/{$this->projectId}/repository/archive.zip?sha={$release['tag_name']}";

--- a/src/Modules/Core/Updates/Sources/GitLabUpdateSource.php
+++ b/src/Modules/Core/Updates/Sources/GitLabUpdateSource.php
@@ -286,11 +286,11 @@ class GitLabUpdateSource implements UpdateSourceInterface
      *
      * @return string Download URL
      */
-    protected function extractDownloadUrl( array $release): string
+    protected function extractDownloadUrl( array $release ): string
     {
         // Get download link for source code
-        if ( ! isset( $release['tag_name'])) {
-            throw UpdateException::downloadFailed( 'No tag_name found in release');
+        if ( ! isset( $release['tag_name'] ) ) {
+            throw UpdateException::downloadFailed( 'No tag_name found in release' );
         }
 
         return "https://gitlab.com/api/v4/projects/{$this->projectId}/repository/archive.zip?sha={$release['tag_name']}";

--- a/src/Modules/Core/Updates/Sources/GitLabUpdateSource.php
+++ b/src/Modules/Core/Updates/Sources/GitLabUpdateSource.php
@@ -129,7 +129,7 @@ class GitLabUpdateSource implements UpdateSourceInterface
             $downloadUrl = $this->extractDownloadUrl($release);
         }
 
-        $tempPath = storage_path('app/temp/update-'.time().'.zip');
+        $tempPath = storage_path('app/temp/update-'.bin2hex(random_bytes(16)).'.zip');
 
         if (! File::exists(dirname($tempPath))) {
             File::makeDirectory(dirname($tempPath), 0755, true);
@@ -196,7 +196,7 @@ class GitLabUpdateSource implements UpdateSourceInterface
 
         $path = parse_url($url, PHP_URL_PATH);
 
-        if (! $path || '/' === trim($path, '/')) {
+        if (! $path || '' === trim($path, '/')) {
             throw new InvalidArgumentException('Invalid GitLab URL');
         }
 

--- a/src/Modules/Core/Updates/UpdateChecker.php
+++ b/src/Modules/Core/Updates/UpdateChecker.php
@@ -1,10 +1,11 @@
 <?php
 
-declare( strict_types = 1 );
+declare(strict_types=1);
 
 namespace ArtisanPackUI\CMSFramework\Modules\Core\Updates;
 
 use ArtisanPackUI\CMSFramework\Modules\Core\Updates\Contracts\UpdateSourceInterface;
+use ArtisanPackUI\CMSFramework\Modules\Core\Updates\Enums\UpdateType;
 use ArtisanPackUI\CMSFramework\Modules\Core\Updates\ValueObjects\UpdateInfo;
 use Illuminate\Support\Facades\Cache;
 
@@ -23,15 +24,14 @@ class UpdateChecker
      * @since 1.0.0
      *
      * @param  UpdateSourceInterface  $source  The update source
-     * @param  string  $type  Update type (application, plugin, theme)
+     * @param  UpdateType  $type  Update type (application, plugin, theme)
      * @param  string  $slug  Unique identifier
      */
     public function __construct(
         protected UpdateSourceInterface $source,
-        protected string $type,
+        protected UpdateType $type,
         protected string $slug,
-    ) {
-    }
+    ) {}
 
     /**
      * Check for available updates (with caching).
@@ -42,20 +42,20 @@ class UpdateChecker
      */
     public function checkForUpdate(): UpdateInfo
     {
-        $cacheKey = "cms.{$this->type}.{$this->slug}.update_check";
-        $cacheTtl = config( 'cms.updates.cache_ttl', 43200 );
+        $cacheKey = "cms.{$this->type->value}.{$this->slug}.update_check";
+        $cacheTtl = config('cms.updates.cache_ttl', 43200);
 
-        if ( config( 'cms.updates.cache_enabled', true ) ) {
-            $cached = Cache::get( $cacheKey );
-            if ( $cached instanceof UpdateInfo ) {
+        if (config('cms.updates.cache_enabled', true)) {
+            $cached = Cache::get($cacheKey);
+            if ($cached instanceof UpdateInfo) {
                 return $cached;
             }
         }
 
         $updateInfo = $this->source->checkForUpdate();
 
-        if ( config( 'cms.updates.cache_enabled', true ) ) {
-            Cache::put( $cacheKey, $updateInfo, $cacheTtl );
+        if (config('cms.updates.cache_enabled', true)) {
+            Cache::put($cacheKey, $updateInfo, $cacheTtl);
         }
 
         return $updateInfo;
@@ -70,9 +70,9 @@ class UpdateChecker
      *
      * @return string Path to downloaded ZIP file
      */
-    public function downloadUpdate( string $version ): string
+    public function downloadUpdate(string $version): string
     {
-        return $this->source->downloadUpdate( $version );
+        return $this->source->downloadUpdate($version);
     }
 
     /**
@@ -84,9 +84,9 @@ class UpdateChecker
      *
      * @return $this
      */
-    public function setAuthentication( string|array $credentials ): self
+    public function setAuthentication(string|array $credentials): self
     {
-        $this->source->setAuthentication( $credentials );
+        $this->source->setAuthentication($credentials);
 
         return $this;
     }
@@ -110,8 +110,8 @@ class UpdateChecker
      */
     public function clearCache(): void
     {
-        $cacheKey = "cms.{$this->type}.{$this->slug}.update_check";
-        Cache::forget( $cacheKey );
+        $cacheKey = "cms.{$this->type->value}.{$this->slug}.update_check";
+        Cache::forget($cacheKey);
     }
 
     /**
@@ -119,9 +119,9 @@ class UpdateChecker
      *
      * @since 1.0.0
      *
-     * @return string Update type
+     * @return UpdateType Update type
      */
-    public function getType(): string
+    public function getType(): UpdateType
     {
         return $this->type;
     }

--- a/src/Modules/Core/Updates/UpdateChecker.php
+++ b/src/Modules/Core/Updates/UpdateChecker.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare( strict_types=1 );
 
 namespace ArtisanPackUI\CMSFramework\Modules\Core\Updates;
 
@@ -31,7 +31,8 @@ class UpdateChecker
         protected UpdateSourceInterface $source,
         protected UpdateType $type,
         protected string $slug,
-    ) {}
+    ) {
+    }
 
     /**
      * Check for available updates (with caching).
@@ -43,19 +44,19 @@ class UpdateChecker
     public function checkForUpdate(): UpdateInfo
     {
         $cacheKey = "cms.{$this->type->value}.{$this->slug}.update_check";
-        $cacheTtl = config('cms.updates.cache_ttl', 43200);
+        $cacheTtl = config( 'cms.updates.cache_ttl', 43200 );
 
-        if (config('cms.updates.cache_enabled', true)) {
-            $cached = Cache::get($cacheKey);
-            if ($cached instanceof UpdateInfo) {
+        if ( config( 'cms.updates.cache_enabled', true ) ) {
+            $cached = Cache::get( $cacheKey );
+            if ( $cached instanceof UpdateInfo ) {
                 return $cached;
             }
         }
 
         $updateInfo = $this->source->checkForUpdate();
 
-        if (config('cms.updates.cache_enabled', true)) {
-            Cache::put($cacheKey, $updateInfo, $cacheTtl);
+        if ( config( 'cms.updates.cache_enabled', true ) ) {
+            Cache::put( $cacheKey, $updateInfo, $cacheTtl );
         }
 
         return $updateInfo;
@@ -70,9 +71,9 @@ class UpdateChecker
      *
      * @return string Path to downloaded ZIP file
      */
-    public function downloadUpdate(string $version): string
+    public function downloadUpdate( string $version ): string
     {
-        return $this->source->downloadUpdate($version);
+        return $this->source->downloadUpdate( $version );
     }
 
     /**
@@ -84,9 +85,9 @@ class UpdateChecker
      *
      * @return $this
      */
-    public function setAuthentication(string|array $credentials): self
+    public function setAuthentication( string|array $credentials ): self
     {
-        $this->source->setAuthentication($credentials);
+        $this->source->setAuthentication( $credentials );
 
         return $this;
     }
@@ -111,7 +112,7 @@ class UpdateChecker
     public function clearCache(): void
     {
         $cacheKey = "cms.{$this->type->value}.{$this->slug}.update_check";
-        Cache::forget($cacheKey);
+        Cache::forget( $cacheKey );
     }
 
     /**

--- a/src/Modules/Core/Updates/UpdateCheckerFactory.php
+++ b/src/Modules/Core/Updates/UpdateCheckerFactory.php
@@ -1,10 +1,11 @@
 <?php
 
-declare( strict_types = 1 );
+declare(strict_types=1);
 
 namespace ArtisanPackUI\CMSFramework\Modules\Core\Updates;
 
 use ArtisanPackUI\CMSFramework\Modules\Core\Updates\Contracts\UpdateSourceInterface;
+use ArtisanPackUI\CMSFramework\Modules\Core\Updates\Enums\UpdateType;
 use ArtisanPackUI\CMSFramework\Modules\Core\Updates\Sources\CustomJsonUpdateSource;
 use ArtisanPackUI\CMSFramework\Modules\Core\Updates\Sources\GitHubUpdateSource;
 use ArtisanPackUI\CMSFramework\Modules\Core\Updates\Sources\GitLabUpdateSource;
@@ -40,26 +41,26 @@ class UpdateCheckerFactory
      * @since 1.0.0
      *
      * @param  string  $url  Update source URL (GitHub, GitLab, custom JSON, etc.)
-     * @param  string  $type  Update type: 'application', 'plugin', 'theme'
+     * @param  UpdateType  $type  Update type
      * @param  string  $slug  Unique identifier (e.g., 'digital-shopfront-cms')
      * @param  string|null  $currentVersion  Current version (auto-detected if null)
      */
     public static function buildUpdateChecker(
         string $url,
-        string $type,
+        UpdateType $type,
         string $slug,
         ?string $currentVersion = null,
     ): UpdateChecker {
         // Detect current version if not provided
-        if ( ! $currentVersion ) {
-            $currentVersion = static::detectCurrentVersion( $type, $slug );
+        if (! $currentVersion) {
+            $currentVersion = static::detectCurrentVersion($type, $slug);
         }
 
         // Detect and instantiate appropriate source
-        $source = static::detectSource( $url, $currentVersion );
+        $source = static::detectSource($url, $currentVersion);
 
         // Create and return UpdateChecker
-        return new UpdateChecker( $source, $type, $slug );
+        return new UpdateChecker($source, $type, $slug);
     }
 
     /**
@@ -72,10 +73,10 @@ class UpdateCheckerFactory
      *
      * @param  class-string<UpdateSourceInterface>  $sourceClass  Source class name
      */
-    public static function registerSource( string $sourceClass ): void
+    public static function registerSource(string $sourceClass): void
     {
-        if ( ! in_array( $sourceClass, static::$sources ) ) {
-            array_unshift( static::$sources, $sourceClass );
+        if (! in_array($sourceClass, static::$sources)) {
+            array_unshift(static::$sources, $sourceClass);
         }
     }
 
@@ -87,24 +88,24 @@ class UpdateCheckerFactory
      * @param  string  $url  Update source URL
      * @param  string  $currentVersion  Current version
      */
-    protected static function detectSource( string $url, string $currentVersion ): UpdateSourceInterface
+    protected static function detectSource(string $url, string $currentVersion): UpdateSourceInterface
     {
-        foreach ( static::$sources as $sourceClass ) {
+        foreach (static::$sources as $sourceClass) {
             try {
                 /** @var UpdateSourceInterface $source */
-                $source = new $sourceClass( $url, $currentVersion );
+                $source = new $sourceClass($url, $currentVersion);
 
-                if ( $source->supports( $url ) ) {
+                if ($source->supports($url)) {
                     return $source;
                 }
-            } catch ( InvalidArgumentException $e ) {
+            } catch (InvalidArgumentException $e) {
                 // Skip sources that can't parse this URL
                 continue;
             }
         }
 
         // Fallback to custom JSON (always supports)
-        return new CustomJsonUpdateSource( $url, $currentVersion );
+        return new CustomJsonUpdateSource($url, $currentVersion);
     }
 
     /**
@@ -112,18 +113,17 @@ class UpdateCheckerFactory
      *
      * @since 1.0.0
      *
-     * @param  string  $type  Update type
+     * @param  UpdateType  $type  Update type
      * @param  string  $slug  Item slug
      *
      * @return string Current version
      */
-    protected static function detectCurrentVersion( string $type, string $slug ): string
+    protected static function detectCurrentVersion(UpdateType $type, string $slug): string
     {
-        return match ( $type ) {
-            'application' => config( 'app.version', '0.0.0' ),
-            'plugin'      => static::getPluginVersion( $slug ),
-            'theme'       => static::getThemeVersion( $slug ),
-            default       => '0.0.0',
+        return match ($type) {
+            UpdateType::Application => config('app.version', '0.0.0'),
+            UpdateType::Plugin      => static::getPluginVersion($slug),
+            UpdateType::Theme       => static::getThemeVersion($slug),
         };
     }
 
@@ -136,19 +136,19 @@ class UpdateCheckerFactory
      *
      * @return string Plugin version
      */
-    protected static function getPluginVersion( string $slug ): string
+    protected static function getPluginVersion(string $slug): string
     {
         try {
             $pluginModel = \ArtisanPackUI\CMSFramework\Modules\Plugins\Models\Plugin::class;
 
-            if ( ! class_exists( $pluginModel ) ) {
+            if (! class_exists($pluginModel)) {
                 return '0.0.0';
             }
 
-            $plugin = $pluginModel::where( 'slug', sanitizeText( $slug ) )->first();
+            $plugin = $pluginModel::where('slug', sanitizeText($slug))->first();
 
             return $plugin?->version ?? '0.0.0';
-        } catch ( Exception $e ) {
+        } catch (Exception $e) {
             return '0.0.0';
         }
     }
@@ -162,33 +162,33 @@ class UpdateCheckerFactory
      *
      * @return string Theme version
      */
-    protected static function getThemeVersion( string $slug ): string
+    protected static function getThemeVersion(string $slug): string
     {
-        $themePath = base_path( "themes/{$slug}/theme.json" );
+        $themePath = base_path("themes/{$slug}/theme.json");
 
-        if ( ! File::exists( $themePath ) ) {
+        if (! File::exists($themePath)) {
             return '0.0.0';
         }
 
         try {
-            $contents = File::get( $themePath );
-            $manifest = json_decode( $contents, true );
+            $contents = File::get($themePath);
+            $manifest = json_decode($contents, true);
 
             // Check if json_decode failed or didn't return an array
-            if ( null === $manifest || ! is_array( $manifest ) ) {
+            if (null === $manifest || ! is_array($manifest)) {
                 // Log the JSON error for debugging
                 $jsonError = json_last_error_msg();
-                \Illuminate\Support\Facades\Log::warning( 'Invalid JSON in theme manifest', [
+                \Illuminate\Support\Facades\Log::warning('Invalid JSON in theme manifest', [
                     'theme'      => $slug,
                     'path'       => $themePath,
                     'json_error' => $jsonError,
-                ] );
+                ]);
 
                 return '0.0.0';
             }
 
             return $manifest['version'] ?? '0.0.0';
-        } catch ( Exception $e ) {
+        } catch (Exception $e) {
             return '0.0.0';
         }
     }

--- a/src/Modules/Core/Updates/UpdateCheckerFactory.php
+++ b/src/Modules/Core/Updates/UpdateCheckerFactory.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare( strict_types=1 );
 
 namespace ArtisanPackUI\CMSFramework\Modules\Core\Updates;
 
@@ -52,15 +52,15 @@ class UpdateCheckerFactory
         ?string $currentVersion = null,
     ): UpdateChecker {
         // Detect current version if not provided
-        if (! $currentVersion) {
-            $currentVersion = static::detectCurrentVersion($type, $slug);
+        if ( ! $currentVersion ) {
+            $currentVersion = static::detectCurrentVersion( $type, $slug );
         }
 
         // Detect and instantiate appropriate source
-        $source = static::detectSource($url, $currentVersion);
+        $source = static::detectSource( $url, $currentVersion );
 
         // Create and return UpdateChecker
-        return new UpdateChecker($source, $type, $slug);
+        return new UpdateChecker( $source, $type, $slug );
     }
 
     /**
@@ -73,10 +73,10 @@ class UpdateCheckerFactory
      *
      * @param  class-string<UpdateSourceInterface>  $sourceClass  Source class name
      */
-    public static function registerSource(string $sourceClass): void
+    public static function registerSource( string $sourceClass ): void
     {
-        if (! in_array($sourceClass, static::$sources)) {
-            array_unshift(static::$sources, $sourceClass);
+        if ( ! in_array( $sourceClass, static::$sources ) ) {
+            array_unshift( static::$sources, $sourceClass );
         }
     }
 
@@ -88,24 +88,24 @@ class UpdateCheckerFactory
      * @param  string  $url  Update source URL
      * @param  string  $currentVersion  Current version
      */
-    protected static function detectSource(string $url, string $currentVersion): UpdateSourceInterface
+    protected static function detectSource( string $url, string $currentVersion ): UpdateSourceInterface
     {
-        foreach (static::$sources as $sourceClass) {
+        foreach ( static::$sources as $sourceClass ) {
             try {
                 /** @var UpdateSourceInterface $source */
-                $source = new $sourceClass($url, $currentVersion);
+                $source = new $sourceClass( $url, $currentVersion );
 
-                if ($source->supports($url)) {
+                if ( $source->supports( $url ) ) {
                     return $source;
                 }
-            } catch (InvalidArgumentException $e) {
+            } catch ( InvalidArgumentException $e ) {
                 // Skip sources that can't parse this URL
                 continue;
             }
         }
 
         // Fallback to custom JSON (always supports)
-        return new CustomJsonUpdateSource($url, $currentVersion);
+        return new CustomJsonUpdateSource( $url, $currentVersion );
     }
 
     /**
@@ -118,12 +118,12 @@ class UpdateCheckerFactory
      *
      * @return string Current version
      */
-    protected static function detectCurrentVersion(UpdateType $type, string $slug): string
+    protected static function detectCurrentVersion( UpdateType $type, string $slug ): string
     {
-        return match ($type) {
-            UpdateType::Application => config('app.version', '0.0.0'),
-            UpdateType::Plugin      => static::getPluginVersion($slug),
-            UpdateType::Theme       => static::getThemeVersion($slug),
+        return match ( $type ) {
+            UpdateType::Application => config( 'app.version', '0.0.0' ),
+            UpdateType::Plugin      => static::getPluginVersion( $slug ),
+            UpdateType::Theme       => static::getThemeVersion( $slug ),
         };
     }
 
@@ -136,19 +136,19 @@ class UpdateCheckerFactory
      *
      * @return string Plugin version
      */
-    protected static function getPluginVersion(string $slug): string
+    protected static function getPluginVersion( string $slug ): string
     {
         try {
             $pluginModel = \ArtisanPackUI\CMSFramework\Modules\Plugins\Models\Plugin::class;
 
-            if (! class_exists($pluginModel)) {
+            if ( ! class_exists( $pluginModel ) ) {
                 return '0.0.0';
             }
 
-            $plugin = $pluginModel::where('slug', sanitizeText($slug))->first();
+            $plugin = $pluginModel::where( 'slug', sanitizeText( $slug ) )->first();
 
             return $plugin?->version ?? '0.0.0';
-        } catch (Exception $e) {
+        } catch ( Exception $e ) {
             return '0.0.0';
         }
     }
@@ -162,33 +162,33 @@ class UpdateCheckerFactory
      *
      * @return string Theme version
      */
-    protected static function getThemeVersion(string $slug): string
+    protected static function getThemeVersion( string $slug ): string
     {
-        $themePath = base_path("themes/{$slug}/theme.json");
+        $themePath = base_path( "themes/{$slug}/theme.json" );
 
-        if (! File::exists($themePath)) {
+        if ( ! File::exists( $themePath ) ) {
             return '0.0.0';
         }
 
         try {
-            $contents = File::get($themePath);
-            $manifest = json_decode($contents, true);
+            $contents = File::get( $themePath );
+            $manifest = json_decode( $contents, true );
 
             // Check if json_decode failed or didn't return an array
-            if (null === $manifest || ! is_array($manifest)) {
+            if ( null === $manifest || ! is_array( $manifest ) ) {
                 // Log the JSON error for debugging
                 $jsonError = json_last_error_msg();
-                \Illuminate\Support\Facades\Log::warning('Invalid JSON in theme manifest', [
+                \Illuminate\Support\Facades\Log::warning( 'Invalid JSON in theme manifest', [
                     'theme'      => $slug,
                     'path'       => $themePath,
                     'json_error' => $jsonError,
-                ]);
+                ] );
 
                 return '0.0.0';
             }
 
             return $manifest['version'] ?? '0.0.0';
-        } catch (Exception $e) {
+        } catch ( Exception $e) {
             return '0.0.0';
         }
     }

--- a/src/Modules/Core/Updates/UpdateCheckerFactory.php
+++ b/src/Modules/Core/Updates/UpdateCheckerFactory.php
@@ -188,7 +188,7 @@ class UpdateCheckerFactory
             }
 
             return $manifest['version'] ?? '0.0.0';
-        } catch ( Exception $e) {
+        } catch ( Exception $e ) {
             return '0.0.0';
         }
     }

--- a/src/Modules/Core/Updates/ValueObjects/UpdateInfo.php
+++ b/src/Modules/Core/Updates/ValueObjects/UpdateInfo.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare( strict_types=1 );
 
 namespace ArtisanPackUI\CMSFramework\Modules\Core\Updates\ValueObjects;
 
@@ -42,7 +42,8 @@ class UpdateInfo
         public readonly ?string $sha256 = null,
         public readonly ?int $fileSize = null,
         public readonly array $metadata = [],
-    ) {}
+    ) {
+    }
 
     /**
      * Whether an update is available.
@@ -54,7 +55,7 @@ class UpdateInfo
      */
     public function hasUpdate(): bool
     {
-        return version_compare($this->latestVersion, $this->currentVersion, '>');
+        return version_compare( $this->latestVersion, $this->currentVersion, '>' );
     }
 
     /**
@@ -65,10 +66,10 @@ class UpdateInfo
      * @param  array  $data  Update data array
      * @param  string  $currentVersion  Current version
      */
-    public static function fromArray(array $data, string $currentVersion): self
+    public static function fromArray( array $data, string $currentVersion ): self
     {
-        if (! isset($data['version'], $data['download_url'])) {
-            throw new InvalidArgumentException('Missing required keys: version, download_url');
+        if ( ! isset( $data['version'], $data['download_url'] ) ) {
+            throw new InvalidArgumentException( 'Missing required keys: version, download_url' );
         }
 
         return new self(

--- a/src/Modules/Core/Updates/ValueObjects/UpdateInfo.php
+++ b/src/Modules/Core/Updates/ValueObjects/UpdateInfo.php
@@ -1,6 +1,6 @@
 <?php
 
-declare( strict_types = 1 );
+declare(strict_types=1);
 
 namespace ArtisanPackUI\CMSFramework\Modules\Core\Updates\ValueObjects;
 
@@ -22,7 +22,6 @@ class UpdateInfo
      *
      * @param  string  $currentVersion  Current installed version
      * @param  string  $latestVersion  Latest available version
-     * @param  bool  $hasUpdate  Whether an update is available
      * @param  string  $downloadUrl  URL to download the update
      * @param  string|null  $changelog  Release notes/changelog
      * @param  string|null  $releaseDate  ISO 8601 release date
@@ -35,7 +34,6 @@ class UpdateInfo
     public function __construct(
         public readonly string $currentVersion,
         public readonly string $latestVersion,
-        public readonly bool $hasUpdate,
         public readonly string $downloadUrl,
         public readonly ?string $changelog = null,
         public readonly ?string $releaseDate = null,
@@ -44,7 +42,19 @@ class UpdateInfo
         public readonly ?string $sha256 = null,
         public readonly ?int $fileSize = null,
         public readonly array $metadata = [],
-    ) {
+    ) {}
+
+    /**
+     * Whether an update is available.
+     *
+     * Computed from version comparison rather than stored state
+     * to prevent inconsistency.
+     *
+     * @since 1.1.0
+     */
+    public function hasUpdate(): bool
+    {
+        return version_compare($this->latestVersion, $this->currentVersion, '>');
     }
 
     /**
@@ -55,16 +65,15 @@ class UpdateInfo
      * @param  array  $data  Update data array
      * @param  string  $currentVersion  Current version
      */
-    public static function fromArray( array $data, string $currentVersion ): self
+    public static function fromArray(array $data, string $currentVersion): self
     {
-        if ( ! isset( $data['version'], $data['download_url'] ) ) {
-            throw new InvalidArgumentException( 'Missing required keys: version, download_url' );
+        if (! isset($data['version'], $data['download_url'])) {
+            throw new InvalidArgumentException('Missing required keys: version, download_url');
         }
 
         return new self(
             currentVersion: $currentVersion,
             latestVersion: $data['version'],
-            hasUpdate: version_compare( $data['version'], $currentVersion, '>' ),
             downloadUrl: $data['download_url'],
             changelog: $data['changelog'] ?? null,
             releaseDate: $data['release_date'] ?? null,
@@ -86,7 +95,7 @@ class UpdateInfo
         return [
             'current'               => $this->currentVersion,
             'latest'                => $this->latestVersion,
-            'hasUpdate'             => $this->hasUpdate,
+            'hasUpdate'             => $this->hasUpdate(),
             'download_url'          => $this->downloadUrl,
             'changelog'             => $this->changelog,
             'release_date'          => $this->releaseDate,

--- a/src/Modules/Notifications/Http/Controllers/NotificationController.php
+++ b/src/Modules/Notifications/Http/Controllers/NotificationController.php
@@ -1,6 +1,6 @@
 <?php
 
-declare( strict_types = 1 );
+declare(strict_types=1);
 
 /**
  * Notification API Controller
@@ -15,6 +15,7 @@ namespace ArtisanPackUI\CMSFramework\Modules\Notifications\Http\Controllers;
 use ArtisanPackUI\CMSFramework\Modules\Notifications\Http\Resources\NotificationResource;
 use ArtisanPackUI\CMSFramework\Modules\Notifications\Managers\NotificationManager;
 use ArtisanPackUI\CMSFramework\Modules\Notifications\Models\Notification;
+use Dedoc\Scramble\Attributes\Group;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
@@ -25,6 +26,7 @@ use Illuminate\Routing\Controller;
  *
  * @since 1.0.0
  */
+#[Group('Notifications', weight: 14)]
 class NotificationController extends Controller
 {
     /**
@@ -39,7 +41,7 @@ class NotificationController extends Controller
      *
      * @since 1.0.0
      */
-    public function __construct( NotificationManager $notificationManager )
+    public function __construct(NotificationManager $notificationManager)
     {
         $this->notificationManager = $notificationManager;
     }
@@ -49,16 +51,16 @@ class NotificationController extends Controller
      *
      * @since 1.0.0
      */
-    public function index( Request $request ): AnonymousResourceCollection
+    public function index(Request $request): AnonymousResourceCollection
     {
-        $request->validate( [
+        $request->validate([
             'limit'       => 'sometimes|integer|min:1|max:100',
             'unread_only' => 'sometimes|boolean',
-        ] );
+        ]);
 
         // phpcs:ignore ArtisanPackUIStandard.Security.ValidatedSanitizedInput.InputNotValidated -- Validated above
-        $limit      = $request->input( 'limit', 10 );
-        $unreadOnly = $request->boolean( 'unread_only', false );
+        $limit      = $request->input('limit', 10);
+        $unreadOnly = $request->boolean('unread_only', false);
 
         $notifications = $this->notificationManager->getUserNotifications(
             $request->user()->id,
@@ -66,7 +68,7 @@ class NotificationController extends Controller
             $unreadOnly,
         );
 
-        return NotificationResource::collection( $notifications );
+        return NotificationResource::collection($notifications);
     }
 
     /**
@@ -74,23 +76,23 @@ class NotificationController extends Controller
      *
      * @since 1.0.0
      */
-    public function show( Request $request, int $id ): NotificationResource|JsonResponse
+    public function show(Request $request, int $id): NotificationResource|JsonResponse
     {
         // phpcs:ignore ArtisanPackUIStandard.Security.ValidatedSanitizedInput.MissingUnslash -- Authenticated user ID is type-safe
-        $notification = Notification::with( ['users' => function ( $q ) use ( $request ): void {
-            $q->where( 'user_id', $request->user()->id );
-        }] )->find( $id );
+        $notification = Notification::with(['users' => function ($q) use ($request): void {
+            $q->where('user_id', $request->user()->id);
+        }])->find($id);
 
-        if ( ! $notification ) {
-            return response()->json( ['message' => 'Notification not found'], 404 );
+        if (! $notification) {
+            return response()->json(['message' => 'Notification not found'], 404);
         }
 
         // Check if user has access to this notification
-        if ( ! $notification->users->contains( 'id', $request->user()->id ) ) {
-            return response()->json( ['message' => 'Unauthorized'], 403 );
+        if (! $notification->users->contains('id', $request->user()->id)) {
+            return response()->json(['message' => 'Unauthorized'], 403);
         }
 
-        return new NotificationResource( $notification );
+        return new NotificationResource($notification);
     }
 
     /**
@@ -98,15 +100,15 @@ class NotificationController extends Controller
      *
      * @since 1.0.0
      */
-    public function markAsRead( Request $request, int $id ): JsonResponse
+    public function markAsRead(Request $request, int $id): JsonResponse
     {
-        $success = $this->notificationManager->markAsRead( $id, $request->user()->id );
+        $success = $this->notificationManager->markAsRead($id, $request->user()->id);
 
-        if ( ! $success ) {
-            return response()->json( ['message' => 'Failed to mark notification as read'], 400 );
+        if (! $success) {
+            return response()->json(['message' => 'Failed to mark notification as read'], 400);
         }
 
-        return response()->json( ['message' => 'Notification marked as read'], 200 );
+        return response()->json(['message' => 'Notification marked as read'], 200);
     }
 
     /**
@@ -114,15 +116,15 @@ class NotificationController extends Controller
      *
      * @since 1.0.0
      */
-    public function dismiss( Request $request, int $id ): JsonResponse
+    public function dismiss(Request $request, int $id): JsonResponse
     {
-        $success = $this->notificationManager->dismissNotification( $id, $request->user()->id );
+        $success = $this->notificationManager->dismissNotification($id, $request->user()->id);
 
-        if ( ! $success ) {
-            return response()->json( ['message' => 'Failed to dismiss notification'], 400 );
+        if (! $success) {
+            return response()->json(['message' => 'Failed to dismiss notification'], 400);
         }
 
-        return response()->json( ['message' => 'Notification dismissed'], 200 );
+        return response()->json(['message' => 'Notification dismissed'], 200);
     }
 
     /**
@@ -130,14 +132,14 @@ class NotificationController extends Controller
      *
      * @since 1.0.0
      */
-    public function markAllAsRead( Request $request ): JsonResponse
+    public function markAllAsRead(Request $request): JsonResponse
     {
-        $count = $this->notificationManager->markAllAsRead( $request->user()->id );
+        $count = $this->notificationManager->markAllAsRead($request->user()->id);
 
-        return response()->json( [
+        return response()->json([
             'message' => "Marked {$count} notifications as read",
             'count'   => $count,
-        ], 200 );
+        ], 200);
     }
 
     /**
@@ -145,14 +147,14 @@ class NotificationController extends Controller
      *
      * @since 1.0.0
      */
-    public function dismissAll( Request $request ): JsonResponse
+    public function dismissAll(Request $request): JsonResponse
     {
-        $count = $this->notificationManager->dismissAll( $request->user()->id );
+        $count = $this->notificationManager->dismissAll($request->user()->id);
 
-        return response()->json( [
+        return response()->json([
             'message' => "Dismissed {$count} notifications",
             'count'   => $count,
-        ], 200 );
+        ], 200);
     }
 
     /**
@@ -160,11 +162,11 @@ class NotificationController extends Controller
      *
      * @since 1.0.0
      */
-    public function unreadCount( Request $request ): JsonResponse
+    public function unreadCount(Request $request): JsonResponse
     {
-        $count = $this->notificationManager->getUnreadCount( $request->user()->id );
+        $count = $this->notificationManager->getUnreadCount($request->user()->id);
 
-        return response()->json( [
+        return response()->json([
             'count' => $count,
         ], 200);
     }

--- a/src/Modules/Notifications/Http/Controllers/NotificationController.php
+++ b/src/Modules/Notifications/Http/Controllers/NotificationController.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare( strict_types=1 );
 
 /**
  * Notification API Controller
@@ -26,7 +26,7 @@ use Illuminate\Routing\Controller;
  *
  * @since 1.0.0
  */
-#[Group('Notifications', weight: 14)]
+#[Group( 'Notifications', weight: 14 )]
 class NotificationController extends Controller
 {
     /**
@@ -41,7 +41,7 @@ class NotificationController extends Controller
      *
      * @since 1.0.0
      */
-    public function __construct(NotificationManager $notificationManager)
+    public function __construct( NotificationManager $notificationManager )
     {
         $this->notificationManager = $notificationManager;
     }
@@ -51,16 +51,16 @@ class NotificationController extends Controller
      *
      * @since 1.0.0
      */
-    public function index(Request $request): AnonymousResourceCollection
+    public function index( Request $request ): AnonymousResourceCollection
     {
-        $request->validate([
+        $request->validate( [
             'limit'       => 'sometimes|integer|min:1|max:100',
             'unread_only' => 'sometimes|boolean',
-        ]);
+        ] );
 
         // phpcs:ignore ArtisanPackUIStandard.Security.ValidatedSanitizedInput.InputNotValidated -- Validated above
-        $limit      = $request->input('limit', 10);
-        $unreadOnly = $request->boolean('unread_only', false);
+        $limit      = $request->input( 'limit', 10 );
+        $unreadOnly = $request->boolean( 'unread_only', false );
 
         $notifications = $this->notificationManager->getUserNotifications(
             $request->user()->id,
@@ -68,7 +68,7 @@ class NotificationController extends Controller
             $unreadOnly,
         );
 
-        return NotificationResource::collection($notifications);
+        return NotificationResource::collection( $notifications );
     }
 
     /**
@@ -76,23 +76,23 @@ class NotificationController extends Controller
      *
      * @since 1.0.0
      */
-    public function show(Request $request, int $id): NotificationResource|JsonResponse
+    public function show( Request $request, int $id ): NotificationResource|JsonResponse
     {
         // phpcs:ignore ArtisanPackUIStandard.Security.ValidatedSanitizedInput.MissingUnslash -- Authenticated user ID is type-safe
-        $notification = Notification::with(['users' => function ($q) use ($request): void {
-            $q->where('user_id', $request->user()->id);
-        }])->find($id);
+        $notification = Notification::with( ['users' => function ( $q ) use ( $request ): void {
+            $q->where( 'user_id', $request->user()->id );
+        }] )->find( $id );
 
-        if (! $notification) {
-            return response()->json(['message' => 'Notification not found'], 404);
+        if ( ! $notification ) {
+            return response()->json( ['message' => 'Notification not found'], 404 );
         }
 
         // Check if user has access to this notification
-        if (! $notification->users->contains('id', $request->user()->id)) {
-            return response()->json(['message' => 'Unauthorized'], 403);
+        if ( ! $notification->users->contains( 'id', $request->user()->id ) ) {
+            return response()->json( ['message' => 'Unauthorized'], 403 );
         }
 
-        return new NotificationResource($notification);
+        return new NotificationResource( $notification );
     }
 
     /**
@@ -100,15 +100,15 @@ class NotificationController extends Controller
      *
      * @since 1.0.0
      */
-    public function markAsRead(Request $request, int $id): JsonResponse
+    public function markAsRead( Request $request, int $id ): JsonResponse
     {
-        $success = $this->notificationManager->markAsRead($id, $request->user()->id);
+        $success = $this->notificationManager->markAsRead( $id, $request->user()->id );
 
-        if (! $success) {
-            return response()->json(['message' => 'Failed to mark notification as read'], 400);
+        if ( ! $success ) {
+            return response()->json( ['message' => 'Failed to mark notification as read'], 400 );
         }
 
-        return response()->json(['message' => 'Notification marked as read'], 200);
+        return response()->json( ['message' => 'Notification marked as read'], 200 );
     }
 
     /**
@@ -116,15 +116,15 @@ class NotificationController extends Controller
      *
      * @since 1.0.0
      */
-    public function dismiss(Request $request, int $id): JsonResponse
+    public function dismiss( Request $request, int $id ): JsonResponse
     {
-        $success = $this->notificationManager->dismissNotification($id, $request->user()->id);
+        $success = $this->notificationManager->dismissNotification( $id, $request->user()->id );
 
-        if (! $success) {
-            return response()->json(['message' => 'Failed to dismiss notification'], 400);
+        if ( ! $success ) {
+            return response()->json( ['message' => 'Failed to dismiss notification'], 400 );
         }
 
-        return response()->json(['message' => 'Notification dismissed'], 200);
+        return response()->json( ['message' => 'Notification dismissed'], 200 );
     }
 
     /**
@@ -132,14 +132,14 @@ class NotificationController extends Controller
      *
      * @since 1.0.0
      */
-    public function markAllAsRead(Request $request): JsonResponse
+    public function markAllAsRead( Request $request ): JsonResponse
     {
-        $count = $this->notificationManager->markAllAsRead($request->user()->id);
+        $count = $this->notificationManager->markAllAsRead( $request->user()->id );
 
-        return response()->json([
+        return response()->json( [
             'message' => "Marked {$count} notifications as read",
             'count'   => $count,
-        ], 200);
+        ], 200 );
     }
 
     /**
@@ -147,14 +147,14 @@ class NotificationController extends Controller
      *
      * @since 1.0.0
      */
-    public function dismissAll(Request $request): JsonResponse
+    public function dismissAll( Request $request ): JsonResponse
     {
-        $count = $this->notificationManager->dismissAll($request->user()->id);
+        $count = $this->notificationManager->dismissAll( $request->user()->id );
 
-        return response()->json([
+        return response()->json( [
             'message' => "Dismissed {$count} notifications",
             'count'   => $count,
-        ], 200);
+        ], 200 );
     }
 
     /**
@@ -162,11 +162,11 @@ class NotificationController extends Controller
      *
      * @since 1.0.0
      */
-    public function unreadCount(Request $request): JsonResponse
+    public function unreadCount( Request $request ): JsonResponse
     {
-        $count = $this->notificationManager->getUnreadCount($request->user()->id);
+        $count = $this->notificationManager->getUnreadCount( $request->user()->id);
 
-        return response()->json([
+        return response()->json( [
             'count' => $count,
         ], 200);
     }

--- a/src/Modules/Notifications/Http/Controllers/NotificationController.php
+++ b/src/Modules/Notifications/Http/Controllers/NotificationController.php
@@ -164,7 +164,7 @@ class NotificationController extends Controller
      */
     public function unreadCount( Request $request ): JsonResponse
     {
-        $count = $this->notificationManager->getUnreadCount( $request->user()->id);
+        $count = $this->notificationManager->getUnreadCount( $request->user()->id );
 
         return response()->json( [
             'count' => $count,

--- a/src/Modules/Notifications/Managers/NotificationManager.php
+++ b/src/Modules/Notifications/Managers/NotificationManager.php
@@ -384,7 +384,7 @@ class NotificationManager
 
         return $userModel::whereIn( 'id', $userIds )
             ->whereDoesntHave( 'notificationPreferences', function ( $query ) use ( $notificationKey ): void {
-                $query->where( 'notification_type', sanitizeText( $notificationKey))
+                $query->where( 'notification_type', sanitizeText( $notificationKey ))
                     ->where( 'email_enabled', false);
             })
             ->pluck( 'id')

--- a/src/Modules/Notifications/Models/Notification.php
+++ b/src/Modules/Notifications/Models/Notification.php
@@ -90,9 +90,9 @@ class Notification extends Model
      *
      * @since 1.0.0
      *
-     * @param  \Illuminate\Database\Eloquent\Builder  $query
+     * @param  Builder  $query
      *
-     * @return \Illuminate\Database\Eloquent\Builder
+     * @return Builder
      */
     public function scopeUnreadForUser( Builder $query, int $userId )
     {
@@ -108,9 +108,9 @@ class Notification extends Model
      *
      * @since 1.0.0
      *
-     * @param  \Illuminate\Database\Eloquent\Builder  $query
+     * @param  Builder  $query
      *
-     * @return \Illuminate\Database\Eloquent\Builder
+     * @return Builder
      */
     public function scopeReadForUser( Builder $query, int $userId )
     {
@@ -126,9 +126,9 @@ class Notification extends Model
      *
      * @since 1.0.0
      *
-     * @param  \Illuminate\Database\Eloquent\Builder  $query
+     * @param  Builder  $query
      *
-     * @return \Illuminate\Database\Eloquent\Builder
+     * @return Builder
      */
     public function scopeNotDismissedForUser( Builder $query, int $userId )
     {
@@ -143,9 +143,9 @@ class Notification extends Model
      *
      * @since 1.0.0
      *
-     * @param  \Illuminate\Database\Eloquent\Builder  $query
+     * @param  Builder  $query
      *
-     * @return \Illuminate\Database\Eloquent\Builder
+     * @return Builder
      */
     public function scopeOfType( Builder $query, NotificationType $type )
     {

--- a/src/Modules/Notifications/database/migrations/2025_10_25_170424_create_notifications_table.php
+++ b/src/Modules/Notifications/database/migrations/2025_10_25_170424_create_notifications_table.php
@@ -29,6 +29,6 @@ return new class extends Migration {
      */
     public function down(): void
     {
-        Schema::dropIfExists( 'notifications');
+        Schema::dropIfExists( 'notifications' );
     }
 };

--- a/src/Modules/Notifications/database/migrations/2025_10_25_170429_create_notification_user_table.php
+++ b/src/Modules/Notifications/database/migrations/2025_10_25_170429_create_notification_user_table.php
@@ -31,6 +31,6 @@ return new class extends Migration {
      */
     public function down(): void
     {
-        Schema::dropIfExists( 'notification_user');
+        Schema::dropIfExists( 'notification_user' );
     }
 };

--- a/src/Modules/Notifications/database/migrations/2025_10_25_170433_create_notification_preferences_table.php
+++ b/src/Modules/Notifications/database/migrations/2025_10_25_170433_create_notification_preferences_table.php
@@ -28,6 +28,6 @@ return new class extends Migration {
      */
     public function down(): void
     {
-        Schema::dropIfExists( 'notification_preferences');
+        Schema::dropIfExists( 'notification_preferences' );
     }
 };

--- a/src/Modules/Notifications/helpers.php
+++ b/src/Modules/Notifications/helpers.php
@@ -197,6 +197,6 @@ if ( ! function_exists( 'apGetRegisteredNotifications' ) ) {
      */
     function apGetRegisteredNotifications(): array
     {
-        return app( NotificationManager::class)->getRegisteredNotifications();
+        return app( NotificationManager::class )->getRegisteredNotifications();
     }
 }

--- a/src/Modules/OpenApi/Console/Commands/ExportOpenApiSpecCommand.php
+++ b/src/Modules/OpenApi/Console/Commands/ExportOpenApiSpecCommand.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare( strict_types=1 );
 
 /**
  * Artisan command to export the CMS Framework OpenAPI specification.
@@ -53,42 +53,42 @@ class ExportOpenApiSpecCommand extends Command
      */
     public function handle(): int
     {
-        $path  = $this->argument('path') ?? base_path('cms-openapi.json');
+        $path  = $this->argument( 'path' ) ?? base_path( 'cms-openapi.json' );
         $flags = JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE;
 
-        if ($this->option('pretty')) {
+        if ( $this->option( 'pretty' ) ) {
             $flags |= JSON_PRETTY_PRINT;
         }
 
-        $this->info('Generating CMS Framework OpenAPI specification...');
+        $this->info( 'Generating CMS Framework OpenAPI specification...' );
 
-        $config    = Scramble::getGeneratorConfig('cms');
-        $generator = app(Generator::class);
-        $spec      = $generator($config);
-        $json      = json_encode($spec, $flags);
+        $config    = Scramble::getGeneratorConfig( 'cms' );
+        $generator = app( Generator::class );
+        $spec      = $generator( $config );
+        $json      = json_encode( $spec, $flags );
 
-        if (false === $json) {
-            $this->error('Failed to encode OpenAPI specification to JSON.');
+        if ( false === $json ) {
+            $this->error( 'Failed to encode OpenAPI specification to JSON.' );
 
             return self::FAILURE;
         }
 
-        $directory = dirname($path);
-        if (! is_dir($directory) && ! mkdir($directory, 0755, true)) {
+        $directory = dirname( $path );
+        if ( ! is_dir( $directory ) && ! mkdir( $directory, 0755, true ) ) {
             $error = error_get_last();
-            $this->error("Failed to create directory: {$directory} — ".($error['message'] ?? 'unknown error'));
+            $this->error( "Failed to create directory: {$directory} — " . ( $error['message'] ?? 'unknown error' ) );
 
             return self::FAILURE;
         }
 
-        if (false === file_put_contents($path, $json."\n")) {
+        if ( false === file_put_contents( $path, $json . "\n" ) ) {
             $error = error_get_last();
-            $this->error("Failed to write file: {$path} — ".($error['message'] ?? 'unknown error'));
+            $this->error( "Failed to write file: {$path} — " . ( $error['message'] ?? 'unknown error' ) );
 
             return self::FAILURE;
         }
 
-        $this->info("OpenAPI specification exported to: {$path}");
+        $this->info( "OpenAPI specification exported to: {$path}");
 
         return self::SUCCESS;
     }

--- a/src/Modules/OpenApi/Console/Commands/ExportOpenApiSpecCommand.php
+++ b/src/Modules/OpenApi/Console/Commands/ExportOpenApiSpecCommand.php
@@ -88,7 +88,7 @@ class ExportOpenApiSpecCommand extends Command
             return self::FAILURE;
         }
 
-        $this->info( "OpenAPI specification exported to: {$path}");
+        $this->info( "OpenAPI specification exported to: {$path}" );
 
         return self::SUCCESS;
     }

--- a/src/Modules/OpenApi/Console/Commands/ExportOpenApiSpecCommand.php
+++ b/src/Modules/OpenApi/Console/Commands/ExportOpenApiSpecCommand.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Artisan command to export the CMS Framework OpenAPI specification.
+ *
+ * Generates the OpenAPI 3.x specification as a static JSON file that can
+ * be published, committed to version control, or used for SDK generation.
+ *
+ * @since 1.1.0
+ */
+
+namespace ArtisanPackUI\CMSFramework\Modules\OpenApi\Console\Commands;
+
+use Dedoc\Scramble\Generator;
+use Dedoc\Scramble\Scramble;
+use Illuminate\Console\Command;
+
+/**
+ * Exports the CMS Framework OpenAPI specification to a static file.
+ *
+ * @since 1.1.0
+ */
+class ExportOpenApiSpecCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @since 1.1.0
+     *
+     * @var string
+     */
+    protected $signature = 'cms:openapi:export
+		{path? : The output file path (default: cms-openapi.json in project root)}
+		{--pretty : Pretty-print the JSON output}';
+
+    /**
+     * The console command description.
+     *
+     * @since 1.1.0
+     *
+     * @var string
+     */
+    protected $description = 'Export the CMS Framework OpenAPI specification to a static JSON file';
+
+    /**
+     * Execute the console command.
+     *
+     * @since 1.1.0
+     *
+     * @return int The exit code.
+     */
+    public function handle(): int
+    {
+        $path  = $this->argument('path') ?? base_path('cms-openapi.json');
+        $flags = JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE;
+
+        if ($this->option('pretty')) {
+            $flags |= JSON_PRETTY_PRINT;
+        }
+
+        $this->info('Generating CMS Framework OpenAPI specification...');
+
+        $config    = Scramble::getGeneratorConfig('cms');
+        $generator = app(Generator::class);
+        $spec      = $generator($config);
+        $json      = json_encode($spec, $flags);
+
+        if (false === $json) {
+            $this->error('Failed to encode OpenAPI specification to JSON.');
+
+            return self::FAILURE;
+        }
+
+        $directory = dirname($path);
+        if (! is_dir($directory)) {
+            mkdir($directory, 0755, true);
+        }
+
+        file_put_contents($path, $json."\n");
+
+        $this->info("OpenAPI specification exported to: {$path}");
+
+        return self::SUCCESS;
+    }
+}

--- a/src/Modules/OpenApi/Console/Commands/ExportOpenApiSpecCommand.php
+++ b/src/Modules/OpenApi/Console/Commands/ExportOpenApiSpecCommand.php
@@ -74,11 +74,19 @@ class ExportOpenApiSpecCommand extends Command
         }
 
         $directory = dirname($path);
-        if (! is_dir($directory)) {
-            mkdir($directory, 0755, true);
+        if (! is_dir($directory) && ! mkdir($directory, 0755, true)) {
+            $error = error_get_last();
+            $this->error("Failed to create directory: {$directory} — ".($error['message'] ?? 'unknown error'));
+
+            return self::FAILURE;
         }
 
-        file_put_contents($path, $json."\n");
+        if (false === file_put_contents($path, $json."\n")) {
+            $error = error_get_last();
+            $this->error("Failed to write file: {$path} — ".($error['message'] ?? 'unknown error'));
+
+            return self::FAILURE;
+        }
 
         $this->info("OpenAPI specification exported to: {$path}");
 

--- a/src/Modules/OpenApi/Providers/OpenApiServiceProvider.php
+++ b/src/Modules/OpenApi/Providers/OpenApiServiceProvider.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare( strict_types=1 );
 
 /**
  * OpenAPI Service Provider for the CMS Framework.
@@ -45,13 +45,13 @@ class OpenApiServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-        if ($this->app->runningInConsole()) {
-            $this->commands([
+        if ( $this->app->runningInConsole() ) {
+            $this->commands( [
                 ExportOpenApiSpecCommand::class,
-            ]);
+            ] );
         }
 
-        if (! $this->isEnabled()) {
+        if ( ! $this->isEnabled() ) {
             return;
         }
 
@@ -67,7 +67,7 @@ class OpenApiServiceProvider extends ServiceProvider
      */
     protected function isEnabled(): bool
     {
-        return (bool) config('artisanpack.cms-framework.openapi.enabled', true);
+        return (bool) config( 'artisanpack.cms-framework.openapi.enabled', true );
     }
 
     /**
@@ -77,22 +77,22 @@ class OpenApiServiceProvider extends ServiceProvider
      */
     protected function registerCmsApi(): void
     {
-        $config = config('artisanpack.cms-framework.openapi', []);
+        $config = config( 'artisanpack.cms-framework.openapi', [] );
 
         $uiPath       = $config['ui_path'] ?? '/docs/api/cms';
         $documentPath = $config['document_path'] ?? '/docs/api/cms.json';
 
-        Scramble::registerApi('cms', $this->buildScrambleConfig($config))
-            ->routes(function (Route $route) {
-                return $this->isCmsFrameworkRoute($route);
-            })
+        Scramble::registerApi( 'cms', $this->buildScrambleConfig( $config ) )
+            ->routes( function ( Route $route ) {
+                return $this->isCmsFrameworkRoute( $route );
+            } )
             ->expose(
                 ui: $uiPath,
                 document: $documentPath,
             )
-            ->afterOpenApiGenerated(function (OpenApi $openApi): void {
-                $this->addSecuritySchemes($openApi);
-            });
+            ->afterOpenApiGenerated( function ( OpenApi $openApi ): void {
+                $this->addSecuritySchemes( $openApi );
+            } );
     }
 
     /**
@@ -104,7 +104,7 @@ class OpenApiServiceProvider extends ServiceProvider
      *
      * @return array<string, mixed> The Scramble-compatible configuration.
      */
-    protected function buildScrambleConfig(array $config): array
+    protected function buildScrambleConfig( array $config ): array
     {
         $info = $config['info'] ?? [];
 
@@ -131,19 +131,19 @@ class OpenApiServiceProvider extends ServiceProvider
      *
      * @return bool True if the route belongs to the CMS Framework.
      */
-    protected function isCmsFrameworkRoute(Route $route): bool
+    protected function isCmsFrameworkRoute( Route $route ): bool
     {
-        if (! Str::startsWith($route->uri, 'api/v1') && ! Str::startsWith($route->uri, 'v1')) {
+        if ( ! Str::startsWith( $route->uri, 'api/v1' ) && ! Str::startsWith( $route->uri, 'v1' ) ) {
             return false;
         }
 
-        $action = $route->getAction('controller');
+        $action = $route->getAction( 'controller' );
 
-        if (null === $action || ! is_string($action)) {
+        if ( null === $action || ! is_string( $action ) ) {
             return false;
         }
 
-        return Str::startsWith($action, 'ArtisanPackUI\\CMSFramework\\');
+        return Str::startsWith( $action, 'ArtisanPackUI\\CMSFramework\\' );
     }
 
     /**
@@ -153,10 +153,10 @@ class OpenApiServiceProvider extends ServiceProvider
      *
      * @param  OpenApi  $openApi  The OpenAPI specification instance.
      */
-    protected function addSecuritySchemes(OpenApi $openApi): void
+    protected function addSecuritySchemes( OpenApi $openApi ): void
     {
         $openApi->secure(
-            SecurityScheme::http('bearer', 'JWT'),
+            SecurityScheme::http( 'bearer', 'JWT'),
         );
     }
 }

--- a/src/Modules/OpenApi/Providers/OpenApiServiceProvider.php
+++ b/src/Modules/OpenApi/Providers/OpenApiServiceProvider.php
@@ -156,7 +156,7 @@ class OpenApiServiceProvider extends ServiceProvider
     protected function addSecuritySchemes( OpenApi $openApi ): void
     {
         $openApi->secure(
-            SecurityScheme::http( 'bearer', 'JWT'),
+            SecurityScheme::http( 'bearer', 'JWT' ),
         );
     }
 }

--- a/src/Modules/OpenApi/Providers/OpenApiServiceProvider.php
+++ b/src/Modules/OpenApi/Providers/OpenApiServiceProvider.php
@@ -1,0 +1,162 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * OpenAPI Service Provider for the CMS Framework.
+ *
+ * Registers the CMS Framework API documentation with Scramble,
+ * providing auto-generated OpenAPI 3.x specification for all endpoints.
+ *
+ * @since 1.1.0
+ */
+
+namespace ArtisanPackUI\CMSFramework\Modules\OpenApi\Providers;
+
+use ArtisanPackUI\CMSFramework\Modules\OpenApi\Console\Commands\ExportOpenApiSpecCommand;
+use Dedoc\Scramble\Scramble;
+use Dedoc\Scramble\Support\Generator\OpenApi;
+use Dedoc\Scramble\Support\Generator\SecurityScheme;
+use Illuminate\Routing\Route;
+use Illuminate\Support\ServiceProvider;
+use Illuminate\Support\Str;
+
+/**
+ * Registers the CMS Framework API with Scramble for OpenAPI documentation.
+ *
+ * @since 1.1.0
+ */
+class OpenApiServiceProvider extends ServiceProvider
+{
+    /**
+     * Register any application services.
+     *
+     * @since 1.1.0
+     */
+    public function register(): void
+    {
+        Scramble::ignoreDefaultRoutes();
+    }
+
+    /**
+     * Bootstrap any application services.
+     *
+     * @since 1.1.0
+     */
+    public function boot(): void
+    {
+        if ($this->app->runningInConsole()) {
+            $this->commands([
+                ExportOpenApiSpecCommand::class,
+            ]);
+        }
+
+        if (! $this->isEnabled()) {
+            return;
+        }
+
+        $this->registerCmsApi();
+    }
+
+    /**
+     * Check if the OpenAPI documentation is enabled.
+     *
+     * @since 1.1.0
+     *
+     * @return bool True if the OpenAPI documentation is enabled.
+     */
+    protected function isEnabled(): bool
+    {
+        return (bool) config('artisanpack.cms-framework.openapi.enabled', true);
+    }
+
+    /**
+     * Register the CMS Framework API with Scramble.
+     *
+     * @since 1.1.0
+     */
+    protected function registerCmsApi(): void
+    {
+        $config = config('artisanpack.cms-framework.openapi', []);
+
+        $uiPath       = $config['ui_path'] ?? '/docs/api/cms';
+        $documentPath = $config['document_path'] ?? '/docs/api/cms.json';
+
+        Scramble::registerApi('cms', $this->buildScrambleConfig($config))
+            ->routes(function (Route $route) {
+                return $this->isCmsFrameworkRoute($route);
+            })
+            ->expose(
+                ui: $uiPath,
+                document: $documentPath,
+            )
+            ->afterOpenApiGenerated(function (OpenApi $openApi): void {
+                $this->addSecuritySchemes($openApi);
+            });
+    }
+
+    /**
+     * Build the Scramble configuration array from the package config.
+     *
+     * @since 1.1.0
+     *
+     * @param  array<string, mixed>  $config  The OpenAPI configuration array.
+     *
+     * @return array<string, mixed> The Scramble-compatible configuration.
+     */
+    protected function buildScrambleConfig(array $config): array
+    {
+        $info = $config['info'] ?? [];
+
+        $scrambleConfig             = [];
+        $scrambleConfig['api_path'] = 'api/v1';
+        $scrambleConfig['ui']       = ['title' => $info['title'] ?? 'ArtisanPack CMS Framework API'];
+
+        $scrambleConfig['info'] = [
+            'version'     => $info['version'] ?? '1.1.0',
+            'description' => $info['description'] ?? '',
+        ];
+
+        return $scrambleConfig;
+    }
+
+    /**
+     * Determine if a route belongs to the CMS Framework.
+     *
+     * Checks whether the route's controller resides within the CMS Framework namespace.
+     *
+     * @since 1.1.0
+     *
+     * @param  Route  $route  The route to check.
+     *
+     * @return bool True if the route belongs to the CMS Framework.
+     */
+    protected function isCmsFrameworkRoute(Route $route): bool
+    {
+        if (! Str::startsWith($route->uri, 'api/v1') && ! Str::startsWith($route->uri, 'v1')) {
+            return false;
+        }
+
+        $action = $route->getAction('controller');
+
+        if (null === $action || ! is_string($action)) {
+            return false;
+        }
+
+        return Str::startsWith($action, 'ArtisanPackUI\\CMSFramework\\');
+    }
+
+    /**
+     * Add security schemes to the OpenAPI specification.
+     *
+     * @since 1.1.0
+     *
+     * @param  OpenApi  $openApi  The OpenAPI specification instance.
+     */
+    protected function addSecuritySchemes(OpenApi $openApi): void
+    {
+        $openApi->secure(
+            SecurityScheme::http('bearer', 'JWT'),
+        );
+    }
+}

--- a/src/Modules/Pages/Http/Controllers/PageCategoryController.php
+++ b/src/Modules/Pages/Http/Controllers/PageCategoryController.php
@@ -109,8 +109,10 @@ class PageCategoryController extends Controller
      */
     public function show(Request $request, int $id): PageCategoryResource
     {
-        $category = PageCategory::with($this->getRequestedIncludes($request))->findOrFail($id);
+        $category = PageCategory::findOrFail($id);
         $this->authorize('view', $category);
+
+        $category->load($this->getRequestedIncludes($request));
 
         return new PageCategoryResource($category);
     }

--- a/src/Modules/Pages/Http/Controllers/PageCategoryController.php
+++ b/src/Modules/Pages/Http/Controllers/PageCategoryController.php
@@ -17,6 +17,7 @@ use ArtisanPackUI\CMSFramework\Http\Controllers\Concerns\HasIncludableRelationsh
 use ArtisanPackUI\CMSFramework\Modules\Pages\Http\Requests\PageCategoryRequest;
 use ArtisanPackUI\CMSFramework\Modules\Pages\Http\Resources\PageCategoryResource;
 use ArtisanPackUI\CMSFramework\Modules\Pages\Models\PageCategory;
+use Dedoc\Scramble\Attributes\Group;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
@@ -32,6 +33,7 @@ use Illuminate\Routing\Controller;
  *
  * @since 1.0.0
  */
+#[Group('Page Categories', weight: 5)]
 class PageCategoryController extends Controller
 {
     use AuthorizesRequests;

--- a/src/Modules/Pages/Http/Controllers/PageCategoryController.php
+++ b/src/Modules/Pages/Http/Controllers/PageCategoryController.php
@@ -159,7 +159,7 @@ class PageCategoryController extends Controller
     public function destroy( int $id ): Response
     {
         $category = PageCategory::findOrFail( $id );
-        $this->authorize( 'delete', $category);
+        $this->authorize( 'delete', $category );
 
         $category->delete();
 

--- a/src/Modules/Pages/Http/Controllers/PageCategoryController.php
+++ b/src/Modules/Pages/Http/Controllers/PageCategoryController.php
@@ -1,6 +1,6 @@
 <?php
 
-declare( strict_types = 1 );
+declare(strict_types=1);
 
 /**
  * PageCategory Controller for the CMS Framework Pages Module.
@@ -13,11 +13,13 @@ declare( strict_types = 1 );
 
 namespace ArtisanPackUI\CMSFramework\Modules\Pages\Http\Controllers;
 
+use ArtisanPackUI\CMSFramework\Http\Controllers\Concerns\HasIncludableRelationships;
 use ArtisanPackUI\CMSFramework\Modules\Pages\Http\Requests\PageCategoryRequest;
 use ArtisanPackUI\CMSFramework\Modules\Pages\Http\Resources\PageCategoryResource;
 use ArtisanPackUI\CMSFramework\Modules\Pages\Models\PageCategory;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
 use Illuminate\Http\Response;
 use Illuminate\Routing\Controller;
@@ -33,6 +35,25 @@ use Illuminate\Routing\Controller;
 class PageCategoryController extends Controller
 {
     use AuthorizesRequests;
+    use HasIncludableRelationships;
+
+    /**
+     * The relationships that can be included via the include query parameter.
+     *
+     * @since 1.1.0
+     *
+     * @var array<int, string>
+     */
+    protected array $includableRelationships = ['parent', 'children'];
+
+    /**
+     * The default relationships to load when no include parameter is provided.
+     *
+     * @since 1.1.0
+     *
+     * @var array<int, string>
+     */
+    protected array $defaultIncludes = ['parent', 'children'];
 
     /**
      * Display a listing of page categories.
@@ -43,13 +64,13 @@ class PageCategoryController extends Controller
      *
      * @return AnonymousResourceCollection The paginated collection of category resources.
      */
-    public function index(): AnonymousResourceCollection
+    public function index(Request $request): AnonymousResourceCollection
     {
-        $this->authorize( 'viewAny', PageCategory::class );
+        $this->authorize('viewAny', PageCategory::class);
 
-        $categories = PageCategory::with( ['parent', 'children'] )->orderBy( 'order' )->paginate( 15 );
+        $categories = PageCategory::with($this->getRequestedIncludes($request))->orderBy('order')->paginate(15);
 
-        return PageCategoryResource::collection( $categories );
+        return PageCategoryResource::collection($categories);
     }
 
     /**
@@ -64,15 +85,15 @@ class PageCategoryController extends Controller
      *
      * @return JsonResponse The JSON response containing the created category resource.
      */
-    public function store( PageCategoryRequest $request ): JsonResponse
+    public function store(PageCategoryRequest $request): JsonResponse
     {
-        $this->authorize( 'create', PageCategory::class );
+        $this->authorize('create', PageCategory::class);
 
         $validated = $request->validated();
-        $category  = PageCategory::create( $validated );
-        $category->load( ['parent', 'children'] );
+        $category  = PageCategory::create($validated);
+        $category->load($this->getRequestedIncludes($request));
 
-        return response()->json( new PageCategoryResource( $category ), 201 );
+        return response()->json(new PageCategoryResource($category), 201);
     }
 
     /**
@@ -86,13 +107,12 @@ class PageCategoryController extends Controller
      *
      * @return PageCategoryResource The category resource.
      */
-    public function show( int $id ): PageCategoryResource
+    public function show(Request $request, int $id): PageCategoryResource
     {
-        $this->authorize( 'view', PageCategory::class );
+        $category = PageCategory::with($this->getRequestedIncludes($request))->findOrFail($id);
+        $this->authorize('view', $category);
 
-        $category = PageCategory::with( ['parent', 'children'] )->findOrFail( $id );
-
-        return new PageCategoryResource( $category );
+        return new PageCategoryResource($category);
     }
 
     /**
@@ -108,16 +128,16 @@ class PageCategoryController extends Controller
      *
      * @return PageCategoryResource The updated category resource.
      */
-    public function update( PageCategoryRequest $request, int $id ): PageCategoryResource
+    public function update(PageCategoryRequest $request, int $id): PageCategoryResource
     {
-        $category = PageCategory::findOrFail( $id );
-        $this->authorize( 'update', $category );
+        $category = PageCategory::findOrFail($id);
+        $this->authorize('update', $category);
 
         $validated = $request->validated();
-        $category->update( $validated );
-        $category->load( ['parent', 'children'] );
+        $category->update($validated);
+        $category->load($this->getRequestedIncludes($request));
 
-        return new PageCategoryResource( $category );
+        return new PageCategoryResource($category);
     }
 
     /**
@@ -132,10 +152,10 @@ class PageCategoryController extends Controller
      *
      * @return Response A response with 204 status code.
      */
-    public function destroy( int $id ): Response
+    public function destroy(int $id): Response
     {
-        $category = PageCategory::findOrFail( $id );
-        $this->authorize( 'delete', $category );
+        $category = PageCategory::findOrFail($id);
+        $this->authorize('delete', $category);
 
         $category->delete();
 

--- a/src/Modules/Pages/Http/Controllers/PageCategoryController.php
+++ b/src/Modules/Pages/Http/Controllers/PageCategoryController.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare( strict_types=1 );
 
 /**
  * PageCategory Controller for the CMS Framework Pages Module.
@@ -33,7 +33,7 @@ use Illuminate\Routing\Controller;
  *
  * @since 1.0.0
  */
-#[Group('Page Categories', weight: 5)]
+#[Group( 'Page Categories', weight: 5 )]
 class PageCategoryController extends Controller
 {
     use AuthorizesRequests;
@@ -66,13 +66,13 @@ class PageCategoryController extends Controller
      *
      * @return AnonymousResourceCollection The paginated collection of category resources.
      */
-    public function index(Request $request): AnonymousResourceCollection
+    public function index( Request $request ): AnonymousResourceCollection
     {
-        $this->authorize('viewAny', PageCategory::class);
+        $this->authorize( 'viewAny', PageCategory::class );
 
-        $categories = PageCategory::with($this->getRequestedIncludes($request))->orderBy('order')->paginate(15);
+        $categories = PageCategory::with( $this->getRequestedIncludes( $request ) )->orderBy( 'order' )->paginate( 15 );
 
-        return PageCategoryResource::collection($categories);
+        return PageCategoryResource::collection( $categories );
     }
 
     /**
@@ -87,15 +87,15 @@ class PageCategoryController extends Controller
      *
      * @return JsonResponse The JSON response containing the created category resource.
      */
-    public function store(PageCategoryRequest $request): JsonResponse
+    public function store( PageCategoryRequest $request ): JsonResponse
     {
-        $this->authorize('create', PageCategory::class);
+        $this->authorize( 'create', PageCategory::class );
 
         $validated = $request->validated();
-        $category  = PageCategory::create($validated);
-        $category->load($this->getRequestedIncludes($request));
+        $category  = PageCategory::create( $validated );
+        $category->load( $this->getRequestedIncludes( $request ) );
 
-        return response()->json(new PageCategoryResource($category), 201);
+        return response()->json( new PageCategoryResource( $category ), 201 );
     }
 
     /**
@@ -109,14 +109,14 @@ class PageCategoryController extends Controller
      *
      * @return PageCategoryResource The category resource.
      */
-    public function show(Request $request, int $id): PageCategoryResource
+    public function show( Request $request, int $id ): PageCategoryResource
     {
-        $category = PageCategory::findOrFail($id);
-        $this->authorize('view', $category);
+        $category = PageCategory::findOrFail( $id );
+        $this->authorize( 'view', $category );
 
-        $category->load($this->getRequestedIncludes($request));
+        $category->load( $this->getRequestedIncludes( $request ) );
 
-        return new PageCategoryResource($category);
+        return new PageCategoryResource( $category );
     }
 
     /**
@@ -132,16 +132,16 @@ class PageCategoryController extends Controller
      *
      * @return PageCategoryResource The updated category resource.
      */
-    public function update(PageCategoryRequest $request, int $id): PageCategoryResource
+    public function update( PageCategoryRequest $request, int $id ): PageCategoryResource
     {
-        $category = PageCategory::findOrFail($id);
-        $this->authorize('update', $category);
+        $category = PageCategory::findOrFail( $id );
+        $this->authorize( 'update', $category );
 
         $validated = $request->validated();
-        $category->update($validated);
-        $category->load($this->getRequestedIncludes($request));
+        $category->update( $validated );
+        $category->load( $this->getRequestedIncludes( $request ) );
 
-        return new PageCategoryResource($category);
+        return new PageCategoryResource( $category );
     }
 
     /**
@@ -156,10 +156,10 @@ class PageCategoryController extends Controller
      *
      * @return Response A response with 204 status code.
      */
-    public function destroy(int $id): Response
+    public function destroy( int $id ): Response
     {
-        $category = PageCategory::findOrFail($id);
-        $this->authorize('delete', $category);
+        $category = PageCategory::findOrFail( $id );
+        $this->authorize( 'delete', $category);
 
         $category->delete();
 

--- a/src/Modules/Pages/Http/Controllers/PageController.php
+++ b/src/Modules/Pages/Http/Controllers/PageController.php
@@ -363,6 +363,7 @@ class PageController extends Controller
             'delete'  => 'delete',
             'publish' => 'publish',
             'draft'   => 'update',
+            default   => throw new InvalidArgumentException(__('Unsupported bulk action: :action', ['action' => $action])),
         };
     }
 
@@ -386,6 +387,7 @@ class PageController extends Controller
                 'status'       => ContentStatus::Draft->value,
                 'published_at' => null,
             ]),
+            default   => throw new InvalidArgumentException(__('Unsupported bulk action: :action', ['action' => $action])),
         };
     }
 }

--- a/src/Modules/Pages/Http/Controllers/PageController.php
+++ b/src/Modules/Pages/Http/Controllers/PageController.php
@@ -15,6 +15,8 @@ declare(strict_types=1);
 namespace ArtisanPackUI\CMSFramework\Modules\Pages\Http\Controllers;
 
 use ArtisanPackUI\CMSFramework\Http\Controllers\Concerns\HasIncludableRelationships;
+use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Enums\ContentStatus;
+use ArtisanPackUI\CMSFramework\Modules\Pages\Http\Requests\BulkPageRequest;
 use ArtisanPackUI\CMSFramework\Modules\Pages\Http\Requests\PageRequest;
 use ArtisanPackUI\CMSFramework\Modules\Pages\Http\Resources\PageResource;
 use ArtisanPackUI\CMSFramework\Modules\Pages\Managers\PageManager;
@@ -27,6 +29,7 @@ use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
 use Illuminate\Http\Response;
 use Illuminate\Routing\Controller;
 use InvalidArgumentException;
+use Throwable;
 
 /**
  * API controller for managing pages.
@@ -290,5 +293,99 @@ class PageController extends Controller
         $page->delete();
 
         return response()->noContent();
+    }
+
+    /**
+     * Perform a bulk action on multiple pages.
+     *
+     * Processes the requested action on each page individually, respecting
+     * authorization policies. Returns a summary of successes and failures.
+     *
+     * @since 1.1.0
+     *
+     * @param  BulkPageRequest  $request  The validated bulk action request.
+     *
+     * @return JsonResponse Summary with processed count, failed count, and error details.
+     */
+    public function bulk(BulkPageRequest $request): JsonResponse
+    {
+        $action    = $request->validated('action');
+        $ids       = $request->validated('ids');
+        $processed = 0;
+        $errors    = [];
+
+        $pages = Page::whereIn('id', $ids)->get()->keyBy('id');
+
+        foreach ($ids as $id) {
+            $page = $pages->get($id);
+
+            if (null === $page) {
+                $errors[$id] = __('Page not found.');
+
+                continue;
+            }
+
+            $policyMethod = $this->getBulkPolicyMethod($action);
+
+            if (! $request->user()->can($policyMethod, $page)) {
+                $errors[$id] = __('You do not have permission to :action this page.', ['action' => $action]);
+
+                continue;
+            }
+
+            try {
+                $this->executeBulkAction($action, $page);
+                $processed++;
+            } catch (Throwable $e) {
+                $errors[$id] = $e->getMessage();
+            }
+        }
+
+        return response()->json([
+            'processed' => $processed,
+            'failed'    => count($errors),
+            'errors'    => $errors,
+        ]);
+    }
+
+    /**
+     * Get the policy method for a bulk action.
+     *
+     * @since 1.1.0
+     *
+     * @param  string  $action  The bulk action name.
+     *
+     * @return string The policy method name.
+     */
+    protected function getBulkPolicyMethod(string $action): string
+    {
+        return match ($action) {
+            'delete'  => 'delete',
+            'publish' => 'publish',
+            'draft'   => 'update',
+        };
+    }
+
+    /**
+     * Execute a bulk action on a single page.
+     *
+     * @since 1.1.0
+     *
+     * @param  string  $action  The bulk action to perform.
+     * @param  Page  $page  The page to perform the action on.
+     */
+    protected function executeBulkAction(string $action, Page $page): void
+    {
+        match ($action) {
+            'delete'  => $page->delete(),
+            'publish' => $page->update([
+                'status'       => ContentStatus::Published->value,
+                'published_at' => $page->published_at ?? now(),
+            ]),
+            'draft'   => $page->update([
+                'status'       => ContentStatus::Draft->value,
+                'published_at' => null,
+            ]),
+        };
     }
 }

--- a/src/Modules/Pages/Http/Controllers/PageController.php
+++ b/src/Modules/Pages/Http/Controllers/PageController.php
@@ -337,7 +337,8 @@ class PageController extends Controller
                 $this->executeBulkAction($action, $page);
                 $processed++;
             } catch (Throwable $e) {
-                $errors[$id] = $e->getMessage();
+                report($e);
+                $errors[$id] = __('Failed to :action page.', ['action' => $action]);
             }
         }
 
@@ -381,7 +382,7 @@ class PageController extends Controller
             'delete'  => $page->delete(),
             'publish' => $page->update([
                 'status'       => ContentStatus::Published->value,
-                'published_at' => $page->published_at ?? now(),
+                'published_at' => now(),
             ]),
             'draft'   => $page->update([
                 'status'       => ContentStatus::Draft->value,

--- a/src/Modules/Pages/Http/Controllers/PageController.php
+++ b/src/Modules/Pages/Http/Controllers/PageController.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare( strict_types=1 );
 
 /**
  * Page Controller for the CMS Framework Pages Module.
@@ -39,7 +39,7 @@ use Throwable;
  *
  * @since 1.0.0
  */
-#[Group('Pages', weight: 4)]
+#[Group( 'Pages', weight: 4 )]
 class PageController extends Controller
 {
     use AuthorizesRequests;
@@ -75,7 +75,7 @@ class PageController extends Controller
      *
      * @since 1.0.0
      */
-    public function __construct(PageManager $pageManager)
+    public function __construct( PageManager $pageManager )
     {
         $this->pageManager = $pageManager;
     }
@@ -89,15 +89,15 @@ class PageController extends Controller
      *
      * @return AnonymousResourceCollection The paginated collection of page resources.
      */
-    public function index(Request $request): AnonymousResourceCollection
+    public function index( Request $request ): AnonymousResourceCollection
     {
-        $this->authorize('viewAny', Page::class);
+        $this->authorize( 'viewAny', Page::class );
 
-        $filters  = $request->only(['status', 'author', 'template', 'search']);
-        $includes = $this->getRequestedIncludes($request);
-        $pages    = $this->pageManager->getPageQuery($filters)->with($includes)->paginate(15);
+        $filters  = $request->only( ['status', 'author', 'template', 'search'] );
+        $includes = $this->getRequestedIncludes( $request );
+        $pages    = $this->pageManager->getPageQuery( $filters )->with( $includes )->paginate( 15 );
 
-        return PageResource::collection($pages);
+        return PageResource::collection( $pages );
     }
 
     /**
@@ -109,14 +109,14 @@ class PageController extends Controller
      *
      * @return JsonResponse The page tree as JSON.
      */
-    public function tree(Request $request): JsonResponse
+    public function tree( Request $request ): JsonResponse
     {
-        $this->authorize('viewAny', Page::class);
+        $this->authorize( 'viewAny', Page::class );
 
-        $filters = $request->only(['status', 'author', 'template']);
-        $tree    = $this->pageManager->getPageTree($filters);
+        $filters = $request->only( ['status', 'author', 'template'] );
+        $tree    = $this->pageManager->getPageTree( $filters );
 
-        return response()->json(PageResource::collection($tree));
+        return response()->json( PageResource::collection( $tree ) );
     }
 
     /**
@@ -130,18 +130,18 @@ class PageController extends Controller
      *
      * @return JsonResponse Success response.
      */
-    public function reorder(Request $request): JsonResponse
+    public function reorder( Request $request ): JsonResponse
     {
-        $this->authorize('update', Page::class);
+        $this->authorize( 'update', Page::class );
 
-        $validated = $request->validate([
+        $validated = $request->validate( [
             'order'   => ['required', 'array'],
             'order.*' => ['required', 'integer', 'min:0'],
-        ]);
+        ] );
 
-        $this->pageManager->reorderPages($validated['order']);
+        $this->pageManager->reorderPages( $validated['order'] );
 
-        return response()->json(['message' => 'Pages reordered successfully']);
+        return response()->json( ['message' => 'Pages reordered successfully'] );
     }
 
     /**
@@ -156,21 +156,21 @@ class PageController extends Controller
      *
      * @return JsonResponse Success response.
      */
-    public function move(Request $request, int $id): JsonResponse
+    public function move( Request $request, int $id ): JsonResponse
     {
-        $page = Page::findOrFail($id);
-        $this->authorize('update', $page);
+        $page = Page::findOrFail( $id );
+        $this->authorize( 'update', $page );
 
-        $validated = $request->validate([
+        $validated = $request->validate( [
             'parent_id' => ['nullable', 'integer', 'exists:pages,id'],
-        ]);
+        ] );
 
         try {
-            $this->pageManager->movePage($id, $validated['parent_id'] ?? null);
+            $this->pageManager->movePage( $id, $validated['parent_id'] ?? null );
 
-            return response()->json(['message' => 'Page moved successfully']);
-        } catch (InvalidArgumentException $e) {
-            return response()->json(['error' => $e->getMessage()], 422);
+            return response()->json( ['message' => 'Page moved successfully'] );
+        } catch ( InvalidArgumentException $e ) {
+            return response()->json( ['error' => $e->getMessage()], 422 );
         }
     }
 
@@ -186,30 +186,30 @@ class PageController extends Controller
      *
      * @return JsonResponse The JSON response containing the created page resource.
      */
-    public function store(PageRequest $request): JsonResponse
+    public function store( PageRequest $request ): JsonResponse
     {
-        $this->authorize('create', Page::class);
+        $this->authorize( 'create', Page::class );
 
         $validated  = $request->validated();
         $categories = $validated['categories'] ?? [];
         $tags       = $validated['tags'] ?? [];
 
-        unset($validated['categories'], $validated['tags']);
+        unset( $validated['categories'], $validated['tags'] );
 
-        $page = Page::create($validated);
+        $page = Page::create( $validated );
 
         // Sync categories and tags
-        if (! empty($categories)) {
-            $page->categories()->sync($categories);
+        if ( ! empty( $categories ) ) {
+            $page->categories()->sync( $categories );
         }
 
-        if (! empty($tags)) {
-            $page->tags()->sync($tags);
+        if ( ! empty( $tags ) ) {
+            $page->tags()->sync( $tags );
         }
 
-        $page->load($this->getRequestedIncludes($request));
+        $page->load( $this->getRequestedIncludes( $request ) );
 
-        return response()->json(new PageResource($page), 201);
+        return response()->json( new PageResource( $page ), 201 );
     }
 
     /**
@@ -223,14 +223,14 @@ class PageController extends Controller
      *
      * @return PageResource The page resource.
      */
-    public function show(Request $request, int $id): PageResource
+    public function show( Request $request, int $id ): PageResource
     {
-        $page = Page::findOrFail($id);
-        $this->authorize('view', $page);
+        $page = Page::findOrFail( $id );
+        $this->authorize( 'view', $page );
 
-        $page->load($this->getRequestedIncludes($request));
+        $page->load( $this->getRequestedIncludes( $request ) );
 
-        return new PageResource($page);
+        return new PageResource( $page );
     }
 
     /**
@@ -246,31 +246,31 @@ class PageController extends Controller
      *
      * @return PageResource The updated page resource.
      */
-    public function update(PageRequest $request, int $id): PageResource
+    public function update( PageRequest $request, int $id ): PageResource
     {
-        $page = Page::findOrFail($id);
-        $this->authorize('update', $page);
+        $page = Page::findOrFail( $id );
+        $this->authorize( 'update', $page );
 
         $validated  = $request->validated();
         $categories = $validated['categories'] ?? null;
         $tags       = $validated['tags'] ?? null;
 
-        unset($validated['categories'], $validated['tags']);
+        unset( $validated['categories'], $validated['tags'] );
 
-        $page->update($validated);
+        $page->update( $validated );
 
         // Sync categories and tags if provided
-        if (null !== $categories) {
-            $page->categories()->sync($categories);
+        if ( null !== $categories ) {
+            $page->categories()->sync( $categories );
         }
 
-        if (null !== $tags) {
-            $page->tags()->sync($tags);
+        if ( null !== $tags ) {
+            $page->tags()->sync( $tags );
         }
 
-        $page->load($this->getRequestedIncludes($request));
+        $page->load( $this->getRequestedIncludes( $request ) );
 
-        return new PageResource($page);
+        return new PageResource( $page );
     }
 
     /**
@@ -285,10 +285,10 @@ class PageController extends Controller
      *
      * @return Response A response with 204 status code.
      */
-    public function destroy(int $id): Response
+    public function destroy( int $id ): Response
     {
-        $page = Page::findOrFail($id);
-        $this->authorize('delete', $page);
+        $page = Page::findOrFail( $id );
+        $this->authorize( 'delete', $page );
 
         $page->delete();
 
@@ -307,45 +307,45 @@ class PageController extends Controller
      *
      * @return JsonResponse Summary with processed count, failed count, and error details.
      */
-    public function bulk(BulkPageRequest $request): JsonResponse
+    public function bulk( BulkPageRequest $request ): JsonResponse
     {
-        $action       = $request->validated('action');
-        $ids          = $request->validated('ids');
-        $policyMethod = $this->getBulkPolicyMethod($action);
+        $action       = $request->validated( 'action' );
+        $ids          = $request->validated( 'ids' );
+        $policyMethod = $this->getBulkPolicyMethod( $action );
         $processed    = 0;
         $errors       = [];
 
-        $pages = Page::whereIn('id', $ids)->get()->keyBy('id');
+        $pages = Page::whereIn( 'id', $ids )->get()->keyBy( 'id' );
 
-        foreach ($ids as $id) {
-            $page = $pages->get($id);
+        foreach ( $ids as $id ) {
+            $page = $pages->get( $id );
 
-            if (null === $page) {
-                $errors[$id] = __('Page not found.');
+            if ( null === $page ) {
+                $errors[ $id ] = __( 'Page not found.' );
 
                 continue;
             }
 
-            if (! $request->user()->can($policyMethod, $page)) {
-                $errors[$id] = __('You do not have permission to :action this page.', ['action' => $action]);
+            if ( ! $request->user()->can( $policyMethod, $page ) ) {
+                $errors[ $id ] = __( 'You do not have permission to :action this page.', ['action' => $action] );
 
                 continue;
             }
 
             try {
-                $this->executeBulkAction($action, $page);
+                $this->executeBulkAction( $action, $page );
                 $processed++;
-            } catch (Throwable $e) {
-                report($e);
-                $errors[$id] = __('Failed to :action page.', ['action' => $action]);
+            } catch ( Throwable $e ) {
+                report( $e );
+                $errors[ $id ] = __( 'Failed to :action page.', ['action' => $action] );
             }
         }
 
-        return response()->json([
+        return response()->json( [
             'processed' => $processed,
-            'failed'    => count($errors),
+            'failed'    => count( $errors ),
             'errors'    => $errors,
-        ]);
+        ] );
     }
 
     /**
@@ -357,13 +357,13 @@ class PageController extends Controller
      *
      * @return string The policy method name.
      */
-    protected function getBulkPolicyMethod(string $action): string
+    protected function getBulkPolicyMethod( string $action ): string
     {
-        return match ($action) {
+        return match ( $action ) {
             'delete'  => 'delete',
             'publish' => 'publish',
             'draft'   => 'update',
-            default   => throw new InvalidArgumentException(__('Unsupported bulk action: :action', ['action' => $action])),
+            default   => throw new InvalidArgumentException( __( 'Unsupported bulk action: :action', ['action' => $action] ) ),
         };
     }
 
@@ -375,19 +375,19 @@ class PageController extends Controller
      * @param  string  $action  The bulk action to perform.
      * @param  Page  $page  The page to perform the action on.
      */
-    protected function executeBulkAction(string $action, Page $page): void
+    protected function executeBulkAction( string $action, Page $page ): void
     {
-        match ($action) {
+        match ( $action ) {
             'delete'  => $page->delete(),
-            'publish' => $page->update([
+            'publish' => $page->update( [
                 'status'       => ContentStatus::Published->value,
                 'published_at' => now(),
             ]),
-            'draft'   => $page->update([
+            'draft'   => $page->update( [
                 'status'       => ContentStatus::Draft->value,
                 'published_at' => null,
             ]),
-            default   => throw new InvalidArgumentException(__('Unsupported bulk action: :action', ['action' => $action])),
+            default   => throw new InvalidArgumentException( __( 'Unsupported bulk action: :action', ['action' => $action])),
         };
     }
 }

--- a/src/Modules/Pages/Http/Controllers/PageController.php
+++ b/src/Modules/Pages/Http/Controllers/PageController.php
@@ -1,6 +1,6 @@
 <?php
 
-declare( strict_types = 1 );
+declare(strict_types=1);
 
 /**
  * Page Controller for the CMS Framework Pages Module.
@@ -14,6 +14,7 @@ declare( strict_types = 1 );
 
 namespace ArtisanPackUI\CMSFramework\Modules\Pages\Http\Controllers;
 
+use ArtisanPackUI\CMSFramework\Http\Controllers\Concerns\HasIncludableRelationships;
 use ArtisanPackUI\CMSFramework\Modules\Pages\Http\Requests\PageRequest;
 use ArtisanPackUI\CMSFramework\Modules\Pages\Http\Resources\PageResource;
 use ArtisanPackUI\CMSFramework\Modules\Pages\Managers\PageManager;
@@ -37,6 +38,25 @@ use InvalidArgumentException;
 class PageController extends Controller
 {
     use AuthorizesRequests;
+    use HasIncludableRelationships;
+
+    /**
+     * The relationships that can be included via the include query parameter.
+     *
+     * @since 1.1.0
+     *
+     * @var array<int, string>
+     */
+    protected array $includableRelationships = ['author', 'categories', 'tags', 'parent', 'children'];
+
+    /**
+     * The default relationships to load when no include parameter is provided.
+     *
+     * @since 1.1.0
+     *
+     * @var array<int, string>
+     */
+    protected array $defaultIncludes = ['author', 'categories', 'tags', 'parent', 'children'];
 
     /**
      * The page manager instance.
@@ -50,7 +70,7 @@ class PageController extends Controller
      *
      * @since 1.0.0
      */
-    public function __construct( PageManager $pageManager )
+    public function __construct(PageManager $pageManager)
     {
         $this->pageManager = $pageManager;
     }
@@ -64,14 +84,15 @@ class PageController extends Controller
      *
      * @return AnonymousResourceCollection The paginated collection of page resources.
      */
-    public function index( Request $request ): AnonymousResourceCollection
+    public function index(Request $request): AnonymousResourceCollection
     {
-        $this->authorize( 'viewAny', Page::class );
+        $this->authorize('viewAny', Page::class);
 
-        $filters = $request->only( ['status', 'author', 'template', 'search'] );
-        $pages   = $this->pageManager->getPageQuery( $filters )->paginate( 15 );
+        $filters  = $request->only(['status', 'author', 'template', 'search']);
+        $includes = $this->getRequestedIncludes($request);
+        $pages    = $this->pageManager->getPageQuery($filters)->with($includes)->paginate(15);
 
-        return PageResource::collection( $pages );
+        return PageResource::collection($pages);
     }
 
     /**
@@ -83,14 +104,14 @@ class PageController extends Controller
      *
      * @return JsonResponse The page tree as JSON.
      */
-    public function tree( Request $request ): JsonResponse
+    public function tree(Request $request): JsonResponse
     {
-        $this->authorize( 'viewAny', Page::class );
+        $this->authorize('viewAny', Page::class);
 
-        $filters = $request->only( ['status', 'author', 'template'] );
-        $tree    = $this->pageManager->getPageTree( $filters );
+        $filters = $request->only(['status', 'author', 'template']);
+        $tree    = $this->pageManager->getPageTree($filters);
 
-        return response()->json( PageResource::collection( $tree ) );
+        return response()->json(PageResource::collection($tree));
     }
 
     /**
@@ -104,18 +125,18 @@ class PageController extends Controller
      *
      * @return JsonResponse Success response.
      */
-    public function reorder( Request $request ): JsonResponse
+    public function reorder(Request $request): JsonResponse
     {
-        $this->authorize( 'update', Page::class );
+        $this->authorize('update', Page::class);
 
-        $validated = $request->validate( [
+        $validated = $request->validate([
             'order'   => ['required', 'array'],
             'order.*' => ['required', 'integer', 'min:0'],
-        ] );
+        ]);
 
-        $this->pageManager->reorderPages( $validated['order'] );
+        $this->pageManager->reorderPages($validated['order']);
 
-        return response()->json( ['message' => 'Pages reordered successfully'] );
+        return response()->json(['message' => 'Pages reordered successfully']);
     }
 
     /**
@@ -130,21 +151,21 @@ class PageController extends Controller
      *
      * @return JsonResponse Success response.
      */
-    public function move( Request $request, int $id ): JsonResponse
+    public function move(Request $request, int $id): JsonResponse
     {
-        $page = Page::findOrFail( $id );
-        $this->authorize( 'update', $page );
+        $page = Page::findOrFail($id);
+        $this->authorize('update', $page);
 
-        $validated = $request->validate( [
+        $validated = $request->validate([
             'parent_id' => ['nullable', 'integer', 'exists:pages,id'],
-        ] );
+        ]);
 
         try {
-            $this->pageManager->movePage( $id, $validated['parent_id'] ?? null );
+            $this->pageManager->movePage($id, $validated['parent_id'] ?? null);
 
-            return response()->json( ['message' => 'Page moved successfully'] );
-        } catch ( InvalidArgumentException $e ) {
-            return response()->json( ['error' => $e->getMessage()], 422 );
+            return response()->json(['message' => 'Page moved successfully']);
+        } catch (InvalidArgumentException $e) {
+            return response()->json(['error' => $e->getMessage()], 422);
         }
     }
 
@@ -160,30 +181,30 @@ class PageController extends Controller
      *
      * @return JsonResponse The JSON response containing the created page resource.
      */
-    public function store( PageRequest $request ): JsonResponse
+    public function store(PageRequest $request): JsonResponse
     {
-        $this->authorize( 'create', Page::class );
+        $this->authorize('create', Page::class);
 
         $validated  = $request->validated();
         $categories = $validated['categories'] ?? [];
         $tags       = $validated['tags'] ?? [];
 
-        unset( $validated['categories'], $validated['tags'] );
+        unset($validated['categories'], $validated['tags']);
 
-        $page = Page::create( $validated );
+        $page = Page::create($validated);
 
         // Sync categories and tags
-        if ( ! empty( $categories ) ) {
-            $page->categories()->sync( $categories );
+        if (! empty($categories)) {
+            $page->categories()->sync($categories);
         }
 
-        if ( ! empty( $tags ) ) {
-            $page->tags()->sync( $tags );
+        if (! empty($tags)) {
+            $page->tags()->sync($tags);
         }
 
-        $page->load( ['author', 'categories', 'tags', 'parent', 'children'] );
+        $page->load($this->getRequestedIncludes($request));
 
-        return response()->json( new PageResource( $page ), 201 );
+        return response()->json(new PageResource($page), 201);
     }
 
     /**
@@ -197,12 +218,14 @@ class PageController extends Controller
      *
      * @return PageResource The page resource.
      */
-    public function show( int $id ): PageResource
+    public function show(Request $request, int $id): PageResource
     {
-        $page = Page::with( ['author', 'categories', 'tags', 'parent', 'children'] )->findOrFail( $id );
-        $this->authorize( 'view', $page );
+        $page = Page::findOrFail($id);
+        $this->authorize('view', $page);
 
-        return new PageResource( $page );
+        $page->load($this->getRequestedIncludes($request));
+
+        return new PageResource($page);
     }
 
     /**
@@ -218,31 +241,31 @@ class PageController extends Controller
      *
      * @return PageResource The updated page resource.
      */
-    public function update( PageRequest $request, int $id ): PageResource
+    public function update(PageRequest $request, int $id): PageResource
     {
-        $page = Page::findOrFail( $id );
-        $this->authorize( 'update', $page );
+        $page = Page::findOrFail($id);
+        $this->authorize('update', $page);
 
         $validated  = $request->validated();
         $categories = $validated['categories'] ?? null;
         $tags       = $validated['tags'] ?? null;
 
-        unset( $validated['categories'], $validated['tags'] );
+        unset($validated['categories'], $validated['tags']);
 
-        $page->update( $validated );
+        $page->update($validated);
 
         // Sync categories and tags if provided
-        if ( null !== $categories ) {
-            $page->categories()->sync( $categories );
+        if (null !== $categories) {
+            $page->categories()->sync($categories);
         }
 
-        if ( null !== $tags ) {
-            $page->tags()->sync( $tags );
+        if (null !== $tags) {
+            $page->tags()->sync($tags);
         }
 
-        $page->load( ['author', 'categories', 'tags', 'parent', 'children'] );
+        $page->load($this->getRequestedIncludes($request));
 
-        return new PageResource( $page );
+        return new PageResource($page);
     }
 
     /**
@@ -257,10 +280,10 @@ class PageController extends Controller
      *
      * @return Response A response with 204 status code.
      */
-    public function destroy( int $id ): Response
+    public function destroy(int $id): Response
     {
-        $page = Page::findOrFail( $id );
-        $this->authorize( 'delete', $page );
+        $page = Page::findOrFail($id);
+        $this->authorize('delete', $page);
 
         $page->delete();
 

--- a/src/Modules/Pages/Http/Controllers/PageController.php
+++ b/src/Modules/Pages/Http/Controllers/PageController.php
@@ -309,10 +309,11 @@ class PageController extends Controller
      */
     public function bulk(BulkPageRequest $request): JsonResponse
     {
-        $action    = $request->validated('action');
-        $ids       = $request->validated('ids');
-        $processed = 0;
-        $errors    = [];
+        $action       = $request->validated('action');
+        $ids          = $request->validated('ids');
+        $policyMethod = $this->getBulkPolicyMethod($action);
+        $processed    = 0;
+        $errors       = [];
 
         $pages = Page::whereIn('id', $ids)->get()->keyBy('id');
 
@@ -324,8 +325,6 @@ class PageController extends Controller
 
                 continue;
             }
-
-            $policyMethod = $this->getBulkPolicyMethod($action);
 
             if (! $request->user()->can($policyMethod, $page)) {
                 $errors[$id] = __('You do not have permission to :action this page.', ['action' => $action]);

--- a/src/Modules/Pages/Http/Controllers/PageController.php
+++ b/src/Modules/Pages/Http/Controllers/PageController.php
@@ -19,6 +19,7 @@ use ArtisanPackUI\CMSFramework\Modules\Pages\Http\Requests\PageRequest;
 use ArtisanPackUI\CMSFramework\Modules\Pages\Http\Resources\PageResource;
 use ArtisanPackUI\CMSFramework\Modules\Pages\Managers\PageManager;
 use ArtisanPackUI\CMSFramework\Modules\Pages\Models\Page;
+use Dedoc\Scramble\Attributes\Group;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
@@ -35,6 +36,7 @@ use InvalidArgumentException;
  *
  * @since 1.0.0
  */
+#[Group('Pages', weight: 4)]
 class PageController extends Controller
 {
     use AuthorizesRequests;

--- a/src/Modules/Pages/Http/Controllers/PageController.php
+++ b/src/Modules/Pages/Http/Controllers/PageController.php
@@ -382,11 +382,11 @@ class PageController extends Controller
             'publish' => $page->update( [
                 'status'       => ContentStatus::Published->value,
                 'published_at' => now(),
-            ]),
+            ] ),
             'draft'   => $page->update( [
                 'status'       => ContentStatus::Draft->value,
                 'published_at' => null,
-            ]),
+            ] ),
             default   => throw new InvalidArgumentException( __( 'Unsupported bulk action: :action', ['action' => $action])),
         };
     }

--- a/src/Modules/Pages/Http/Controllers/PageTagController.php
+++ b/src/Modules/Pages/Http/Controllers/PageTagController.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare( strict_types=1 );
 
 /**
  * PageTag Controller for the CMS Framework Pages Module.
@@ -31,7 +31,7 @@ use Illuminate\Routing\Controller;
  *
  * @since 1.0.0
  */
-#[Group('Page Tags', weight: 6)]
+#[Group( 'Page Tags', weight: 6 )]
 class PageTagController extends Controller
 {
     use AuthorizesRequests;
@@ -47,11 +47,11 @@ class PageTagController extends Controller
      */
     public function index(): AnonymousResourceCollection
     {
-        $this->authorize('viewAny', PageTag::class);
+        $this->authorize( 'viewAny', PageTag::class );
 
-        $tags = PageTag::orderBy('order')->paginate(15);
+        $tags = PageTag::orderBy( 'order' )->paginate( 15 );
 
-        return PageTagResource::collection($tags);
+        return PageTagResource::collection( $tags );
     }
 
     /**
@@ -66,14 +66,14 @@ class PageTagController extends Controller
      *
      * @return JsonResponse The JSON response containing the created tag resource.
      */
-    public function store(PageTagRequest $request): JsonResponse
+    public function store( PageTagRequest $request ): JsonResponse
     {
-        $this->authorize('create', PageTag::class);
+        $this->authorize( 'create', PageTag::class );
 
         $validated = $request->validated();
-        $tag       = PageTag::create($validated);
+        $tag       = PageTag::create( $validated );
 
-        return response()->json(new PageTagResource($tag), 201);
+        return response()->json( new PageTagResource( $tag ), 201 );
     }
 
     /**
@@ -87,12 +87,12 @@ class PageTagController extends Controller
      *
      * @return PageTagResource The tag resource.
      */
-    public function show(int $id): PageTagResource
+    public function show( int $id ): PageTagResource
     {
-        $tag = PageTag::findOrFail($id);
-        $this->authorize('view', $tag);
+        $tag = PageTag::findOrFail( $id );
+        $this->authorize( 'view', $tag );
 
-        return new PageTagResource($tag);
+        return new PageTagResource( $tag );
     }
 
     /**
@@ -108,15 +108,15 @@ class PageTagController extends Controller
      *
      * @return PageTagResource The updated tag resource.
      */
-    public function update(PageTagRequest $request, int $id): PageTagResource
+    public function update( PageTagRequest $request, int $id ): PageTagResource
     {
-        $tag = PageTag::findOrFail($id);
-        $this->authorize('update', $tag);
+        $tag = PageTag::findOrFail( $id );
+        $this->authorize( 'update', $tag );
 
         $validated = $request->validated();
-        $tag->update($validated);
+        $tag->update( $validated );
 
-        return new PageTagResource($tag);
+        return new PageTagResource( $tag );
     }
 
     /**
@@ -131,10 +131,10 @@ class PageTagController extends Controller
      *
      * @return Response A response with 204 status code.
      */
-    public function destroy(int $id): Response
+    public function destroy( int $id ): Response
     {
-        $tag = PageTag::findOrFail($id);
-        $this->authorize('delete', $tag);
+        $tag = PageTag::findOrFail( $id );
+        $this->authorize( 'delete', $tag );
 
         $tag->delete();
 

--- a/src/Modules/Pages/Http/Controllers/PageTagController.php
+++ b/src/Modules/Pages/Http/Controllers/PageTagController.php
@@ -89,9 +89,8 @@ class PageTagController extends Controller
      */
     public function show(int $id): PageTagResource
     {
-        $this->authorize('view', PageTag::class);
-
         $tag = PageTag::findOrFail($id);
+        $this->authorize('view', $tag);
 
         return new PageTagResource($tag);
     }

--- a/src/Modules/Pages/Http/Controllers/PageTagController.php
+++ b/src/Modules/Pages/Http/Controllers/PageTagController.php
@@ -1,6 +1,6 @@
 <?php
 
-declare( strict_types = 1 );
+declare(strict_types=1);
 
 /**
  * PageTag Controller for the CMS Framework Pages Module.
@@ -16,6 +16,7 @@ namespace ArtisanPackUI\CMSFramework\Modules\Pages\Http\Controllers;
 use ArtisanPackUI\CMSFramework\Modules\Pages\Http\Requests\PageTagRequest;
 use ArtisanPackUI\CMSFramework\Modules\Pages\Http\Resources\PageTagResource;
 use ArtisanPackUI\CMSFramework\Modules\Pages\Models\PageTag;
+use Dedoc\Scramble\Attributes\Group;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
@@ -30,6 +31,7 @@ use Illuminate\Routing\Controller;
  *
  * @since 1.0.0
  */
+#[Group('Page Tags', weight: 6)]
 class PageTagController extends Controller
 {
     use AuthorizesRequests;
@@ -45,11 +47,11 @@ class PageTagController extends Controller
      */
     public function index(): AnonymousResourceCollection
     {
-        $this->authorize( 'viewAny', PageTag::class );
+        $this->authorize('viewAny', PageTag::class);
 
-        $tags = PageTag::orderBy( 'order' )->paginate( 15 );
+        $tags = PageTag::orderBy('order')->paginate(15);
 
-        return PageTagResource::collection( $tags );
+        return PageTagResource::collection($tags);
     }
 
     /**
@@ -64,14 +66,14 @@ class PageTagController extends Controller
      *
      * @return JsonResponse The JSON response containing the created tag resource.
      */
-    public function store( PageTagRequest $request ): JsonResponse
+    public function store(PageTagRequest $request): JsonResponse
     {
-        $this->authorize( 'create', PageTag::class );
+        $this->authorize('create', PageTag::class);
 
         $validated = $request->validated();
-        $tag       = PageTag::create( $validated );
+        $tag       = PageTag::create($validated);
 
-        return response()->json( new PageTagResource( $tag ), 201 );
+        return response()->json(new PageTagResource($tag), 201);
     }
 
     /**
@@ -85,13 +87,13 @@ class PageTagController extends Controller
      *
      * @return PageTagResource The tag resource.
      */
-    public function show( int $id ): PageTagResource
+    public function show(int $id): PageTagResource
     {
-        $this->authorize( 'view', PageTag::class );
+        $this->authorize('view', PageTag::class);
 
-        $tag = PageTag::findOrFail( $id );
+        $tag = PageTag::findOrFail($id);
 
-        return new PageTagResource( $tag );
+        return new PageTagResource($tag);
     }
 
     /**
@@ -107,15 +109,15 @@ class PageTagController extends Controller
      *
      * @return PageTagResource The updated tag resource.
      */
-    public function update( PageTagRequest $request, int $id ): PageTagResource
+    public function update(PageTagRequest $request, int $id): PageTagResource
     {
-        $tag = PageTag::findOrFail( $id );
-        $this->authorize( 'update', $tag );
+        $tag = PageTag::findOrFail($id);
+        $this->authorize('update', $tag);
 
         $validated = $request->validated();
-        $tag->update( $validated );
+        $tag->update($validated);
 
-        return new PageTagResource( $tag );
+        return new PageTagResource($tag);
     }
 
     /**
@@ -130,10 +132,10 @@ class PageTagController extends Controller
      *
      * @return Response A response with 204 status code.
      */
-    public function destroy( int $id ): Response
+    public function destroy(int $id): Response
     {
-        $tag = PageTag::findOrFail( $id );
-        $this->authorize( 'delete', $tag );
+        $tag = PageTag::findOrFail($id);
+        $this->authorize('delete', $tag);
 
         $tag->delete();
 

--- a/src/Modules/Pages/Http/Requests/BulkPageRequest.php
+++ b/src/Modules/Pages/Http/Requests/BulkPageRequest.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare( strict_types=1 );
 
 /**
  * Bulk Page Request for the CMS Framework Pages Module.
@@ -59,7 +59,7 @@ class BulkPageRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'action' => ['required', 'string', Rule::in(self::allowedActions())],
+            'action' => ['required', 'string', Rule::in( self::allowedActions() )],
             'ids'    => ['required', 'array', 'min:1'],
             'ids.*'  => ['required', 'integer', 'exists:pages,id'],
         ];
@@ -75,11 +75,11 @@ class BulkPageRequest extends FormRequest
     public function messages(): array
     {
         return [
-            'action.required' => __('The bulk action is required.'),
-            'action.in'       => __('The selected action is invalid. Allowed actions: :values.', ['values' => implode(', ', self::allowedActions())]),
-            'ids.required'    => __('At least one page ID is required.'),
-            'ids.min'         => __('At least one page ID is required.'),
-            'ids.*.exists'    => __('One or more page IDs do not exist.'),
+            'action.required' => __( 'The bulk action is required.' ),
+            'action.in'       => __( 'The selected action is invalid. Allowed actions: :values.', ['values' => implode( ', ', self::allowedActions() )] ),
+            'ids.required'    => __( 'At least one page ID is required.' ),
+            'ids.min'         => __( 'At least one page ID is required.' ),
+            'ids.*.exists'    => __( 'One or more page IDs do not exist.' ),
         ];
     }
 }

--- a/src/Modules/Pages/Http/Requests/BulkPageRequest.php
+++ b/src/Modules/Pages/Http/Requests/BulkPageRequest.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Bulk Page Request for the CMS Framework Pages Module.
+ *
+ * This form request handles validation for bulk page operations,
+ * ensuring the action and IDs are valid.
+ *
+ * @since 1.1.0
+ */
+
+namespace ArtisanPackUI\CMSFramework\Modules\Pages\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+/**
+ * Form request for bulk page operations.
+ *
+ * Validates the action type and array of page IDs for bulk operations.
+ *
+ * @since 1.1.0
+ */
+class BulkPageRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @since 1.1.0
+     *
+     * @return bool True if the user is authorized, false otherwise.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the allowed actions for bulk page operations.
+     *
+     * @since 1.1.0
+     *
+     * @return array<int, string> The allowed action names.
+     */
+    public static function allowedActions(): array
+    {
+        return ['delete', 'publish', 'draft'];
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @since 1.1.0
+     *
+     * @return array<string, mixed> The validation rules.
+     */
+    public function rules(): array
+    {
+        return [
+            'action' => ['required', 'string', Rule::in(self::allowedActions())],
+            'ids'    => ['required', 'array', 'min:1'],
+            'ids.*'  => ['required', 'integer', 'exists:pages,id'],
+        ];
+    }
+
+    /**
+     * Get custom messages for validator errors.
+     *
+     * @since 1.1.0
+     *
+     * @return array<string, string> The custom error messages.
+     */
+    public function messages(): array
+    {
+        return [
+            'action.required' => __('The bulk action is required.'),
+            'action.in'       => __('The selected action is invalid. Allowed actions: :values.', ['values' => implode(', ', self::allowedActions())]),
+            'ids.required'    => __('At least one page ID is required.'),
+            'ids.min'         => __('At least one page ID is required.'),
+            'ids.*.exists'    => __('One or more page IDs do not exist.'),
+        ];
+    }
+}

--- a/src/Modules/Pages/Http/Requests/PageRequest.php
+++ b/src/Modules/Pages/Http/Requests/PageRequest.php
@@ -65,7 +65,7 @@ class PageRequest extends FormRequest
             'parent_id'    => ['nullable', 'integer', 'exists:pages,id'],
             'order'        => ['nullable', 'integer', 'min:0'],
             'template'     => ['nullable', 'string', 'max:255'],
-            'status'       => ['required', 'string', Rule::enum(ContentStatus::class)],
+            'status'       => ['required', 'string', ContentStatus::validationRule()],
             'published_at' => ['nullable', 'date'],
             'metadata'     => ['nullable', 'array'],
             'categories'   => ['nullable', 'array'],

--- a/src/Modules/Pages/Http/Requests/PageRequest.php
+++ b/src/Modules/Pages/Http/Requests/PageRequest.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare( strict_types=1 );
 
 /**
  * Page Request for the CMS Framework Pages Module.
@@ -48,7 +48,7 @@ class PageRequest extends FormRequest
      */
     public function rules(): array
     {
-        $id = $this->route('id');
+        $id = $this->route( 'id' );
 
         return [
             'title' => ['required', 'string', 'max:255'],
@@ -57,7 +57,7 @@ class PageRequest extends FormRequest
                 'string',
                 'max:255',
                 'regex:/^[a-z0-9]+(?:-[a-z0-9]+)*$/',
-                Rule::unique('pages', 'slug')->ignore($id),
+                Rule::unique( 'pages', 'slug' )->ignore( $id ),
             ],
             'content'      => ['nullable', 'string'],
             'excerpt'      => ['nullable', 'string'],
@@ -85,13 +85,13 @@ class PageRequest extends FormRequest
     public function messages(): array
     {
         return [
-            'title.required'     => __('The page title is required.'),
-            'slug.required'      => __('The page slug is required.'),
-            'slug.regex'         => __('The slug must be lowercase letters, numbers, and hyphens only.'),
-            'slug.unique'        => __('A page with this slug already exists.'),
-            'author_id.required' => __('The author is required.'),
-            'status.required'    => __('The page status is required.'),
-            'parent_id.exists'   => __('The selected parent page does not exist.'),
+            'title.required'     => __( 'The page title is required.' ),
+            'slug.required'      => __( 'The page slug is required.' ),
+            'slug.regex'         => __( 'The slug must be lowercase letters, numbers, and hyphens only.' ),
+            'slug.unique'        => __( 'A page with this slug already exists.' ),
+            'author_id.required' => __( 'The author is required.' ),
+            'status.required'    => __( 'The page status is required.' ),
+            'parent_id.exists'   => __( 'The selected parent page does not exist.'),
         ];
     }
 }

--- a/src/Modules/Pages/Http/Requests/PageRequest.php
+++ b/src/Modules/Pages/Http/Requests/PageRequest.php
@@ -1,6 +1,6 @@
 <?php
 
-declare( strict_types = 1 );
+declare(strict_types=1);
 
 /**
  * Page Request for the CMS Framework Pages Module.
@@ -13,6 +13,7 @@ declare( strict_types = 1 );
 
 namespace ArtisanPackUI\CMSFramework\Modules\Pages\Http\Requests;
 
+use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Enums\ContentStatus;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
 
@@ -47,7 +48,7 @@ class PageRequest extends FormRequest
      */
     public function rules(): array
     {
-        $id = $this->route( 'id' );
+        $id = $this->route('id');
 
         return [
             'title' => ['required', 'string', 'max:255'],
@@ -56,7 +57,7 @@ class PageRequest extends FormRequest
                 'string',
                 'max:255',
                 'regex:/^[a-z0-9]+(?:-[a-z0-9]+)*$/',
-                Rule::unique( 'pages', 'slug' )->ignore( $id ),
+                Rule::unique('pages', 'slug')->ignore($id),
             ],
             'content'      => ['nullable', 'string'],
             'excerpt'      => ['nullable', 'string'],
@@ -64,7 +65,7 @@ class PageRequest extends FormRequest
             'parent_id'    => ['nullable', 'integer', 'exists:pages,id'],
             'order'        => ['nullable', 'integer', 'min:0'],
             'template'     => ['nullable', 'string', 'max:255'],
-            'status'       => ['required', 'string', 'in:draft,published,scheduled,private'],
+            'status'       => ['required', 'string', Rule::enum(ContentStatus::class)],
             'published_at' => ['nullable', 'date'],
             'metadata'     => ['nullable', 'array'],
             'categories'   => ['nullable', 'array'],
@@ -84,13 +85,13 @@ class PageRequest extends FormRequest
     public function messages(): array
     {
         return [
-            'title.required'     => __( 'The page title is required.' ),
-            'slug.required'      => __( 'The page slug is required.' ),
-            'slug.regex'         => __( 'The slug must be lowercase letters, numbers, and hyphens only.' ),
-            'slug.unique'        => __( 'A page with this slug already exists.' ),
-            'author_id.required' => __( 'The author is required.' ),
-            'status.required'    => __( 'The page status is required.' ),
-            'parent_id.exists'   => __( 'The selected parent page does not exist.' ),
+            'title.required'     => __('The page title is required.'),
+            'slug.required'      => __('The page slug is required.'),
+            'slug.regex'         => __('The slug must be lowercase letters, numbers, and hyphens only.'),
+            'slug.unique'        => __('A page with this slug already exists.'),
+            'author_id.required' => __('The author is required.'),
+            'status.required'    => __('The page status is required.'),
+            'parent_id.exists'   => __('The selected parent page does not exist.'),
         ];
     }
 }

--- a/src/Modules/Pages/Http/Requests/PageRequest.php
+++ b/src/Modules/Pages/Http/Requests/PageRequest.php
@@ -91,7 +91,7 @@ class PageRequest extends FormRequest
             'slug.unique'        => __( 'A page with this slug already exists.' ),
             'author_id.required' => __( 'The author is required.' ),
             'status.required'    => __( 'The page status is required.' ),
-            'parent_id.exists'   => __( 'The selected parent page does not exist.'),
+            'parent_id.exists'   => __( 'The selected parent page does not exist.' ),
         ];
     }
 }

--- a/src/Modules/Pages/Managers/PageManager.php
+++ b/src/Modules/Pages/Managers/PageManager.php
@@ -257,9 +257,9 @@ class PageManager
         if (isset($filters['status'])) {
             $status = $filters['status'] instanceof ContentStatus
                 ? $filters['status']
-                : ContentStatus::from(sanitizeText($filters['status']));
+                : ContentStatus::tryFrom(sanitizeText($filters['status']));
 
-            if (ContentStatus::Published === $status) {
+            if (null === $status || ContentStatus::Published === $status) {
                 $query->published();
             } else {
                 $query->where('status', $status);

--- a/src/Modules/Pages/Managers/PageManager.php
+++ b/src/Modules/Pages/Managers/PageManager.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare( strict_types=1 );
 
 /**
  * Page Manager
@@ -35,20 +35,20 @@ class PageManager
      *
      * @param  array  $filters  Optional filters (status, author, template).
      */
-    public function getPageTree(array $filters = []): Collection
+    public function getPageTree( array $filters = [] ): Collection
     {
-        $query = Page::query()->topLevel()->with(['children' => function ($query): void {
-            $query->orderBy('order');
-        }]);
+        $query = Page::query()->topLevel()->with( ['children' => function ( $query ): void {
+            $query->orderBy( 'order' );
+        }] );
 
-        $this->applyFilters($query, $filters);
+        $this->applyFilters( $query, $filters );
 
-        $topLevel = $query->orderBy('order')->get();
+        $topLevel = $query->orderBy( 'order' )->get();
 
         // Recursively load all children
-        $topLevel->each(function ($page): void {
-            $this->loadChildrenRecursively($page);
-        });
+        $topLevel->each( function ( $page ): void {
+            $this->loadChildrenRecursively( $page );
+        } );
 
         return $topLevel;
     }
@@ -60,13 +60,13 @@ class PageManager
      *
      * @param  array  $filters  Optional filters (status, author, template).
      */
-    public function getTopLevelPages(array $filters = []): Collection
+    public function getTopLevelPages( array $filters = [] ): Collection
     {
         $query = Page::query()->topLevel();
 
-        $this->applyFilters($query, $filters);
+        $this->applyFilters( $query, $filters );
 
-        return $query->orderBy('order')->get();
+        return $query->orderBy( 'order' )->get();
     }
 
     /**
@@ -77,13 +77,13 @@ class PageManager
      * @param  string  $template  Template name to filter by.
      * @param  array  $filters  Optional filters (status, author).
      */
-    public function getPagesByTemplate(string $template, array $filters = []): Collection
+    public function getPagesByTemplate( string $template, array $filters = [] ): Collection
     {
-        $query = Page::query()->byTemplate($template);
+        $query = Page::query()->byTemplate( $template );
 
-        $this->applyFilters($query, $filters);
+        $this->applyFilters( $query, $filters );
 
-        return $query->orderBy('order')->get();
+        return $query->orderBy( 'order' )->get();
     }
 
     /**
@@ -94,10 +94,10 @@ class PageManager
      * @param  array  $order  Array of page IDs with their new order values.
      *                        Format: ['page_id' => order_value, ...]
      */
-    public function reorderPages(array $order): void
+    public function reorderPages( array $order ): void
     {
-        foreach ($order as $pageId => $orderValue) {
-            Page::where('id', sanitizeInt($pageId))->update(['order' => $orderValue]);
+        foreach ( $order as $pageId => $orderValue ) {
+            Page::where( 'id', sanitizeInt( $pageId ) )->update( ['order' => $orderValue] );
         }
     }
 
@@ -109,23 +109,23 @@ class PageManager
      * @param  int  $pageId  The ID of the page to move.
      * @param  int|null  $newParentId  The ID of the new parent page (null for top-level).
      */
-    public function movePage(int $pageId, ?int $newParentId = null): void
+    public function movePage( int $pageId, ?int $newParentId = null ): void
     {
-        $page = Page::findOrFail($pageId);
+        $page = Page::findOrFail( $pageId );
 
         // Prevent moving a page to itself or to its own descendant
-        if (null !== $newParentId) {
-            if ($newParentId === $pageId) {
-                throw new InvalidArgumentException('Cannot move a page to itself.');
+        if ( null !== $newParentId ) {
+            if ( $newParentId === $pageId ) {
+                throw new InvalidArgumentException( 'Cannot move a page to itself.' );
             }
 
-            $descendantIds = $page->descendants()->pluck('id')->toArray();
-            if (in_array($newParentId, $descendantIds)) {
-                throw new InvalidArgumentException('Cannot move a page to its own descendant.');
+            $descendantIds = $page->descendants()->pluck( 'id' )->toArray();
+            if ( in_array( $newParentId, $descendantIds ) ) {
+                throw new InvalidArgumentException( 'Cannot move a page to its own descendant.' );
             }
         }
 
-        $page->update(['parent_id' => $newParentId]);
+        $page->update( ['parent_id' => $newParentId] );
     }
 
     /**
@@ -135,14 +135,14 @@ class PageManager
      *
      * @param  array  $filters  Array of filters to apply (status, author, template, search).
      */
-    public function getPageQuery(array $filters = []): Builder
+    public function getPageQuery( array $filters = [] ): Builder
     {
-        $query = Page::query()->with(['author', 'categories', 'tags']);
+        $query = Page::query()->with( ['author', 'categories', 'tags'] );
 
-        $this->applyFilters($query, $filters);
+        $this->applyFilters( $query, $filters );
 
         // Order by order column and title
-        $query->orderBy('order')->orderBy('title');
+        $query->orderBy( 'order' )->orderBy( 'title' );
 
         return $query;
     }
@@ -154,9 +154,9 @@ class PageManager
      *
      * @param  int  $authorId  Author ID to filter by.
      */
-    public function getPagesByAuthor(int $authorId): Collection
+    public function getPagesByAuthor( int $authorId ): Collection
     {
-        return $this->getPageQuery(['author' => $authorId])->get();
+        return $this->getPageQuery( ['author' => $authorId] )->get();
     }
 
     /**
@@ -166,12 +166,12 @@ class PageManager
      *
      * @param  int|string  $category  Category ID or slug.
      */
-    public function getPagesByCategory($category): Collection
+    public function getPagesByCategory( $category ): Collection
     {
         // If category is a string (slug), find the category ID
-        if (is_string($category)) {
-            $categoryModel = \ArtisanPackUI\CMSFramework\Modules\Pages\Models\PageCategory::where('slug', sanitizeText($category))->first();
-            if ($categoryModel) {
+        if ( is_string( $category ) ) {
+            $categoryModel = \ArtisanPackUI\CMSFramework\Modules\Pages\Models\PageCategory::where( 'slug', sanitizeText( $category ) )->first();
+            if ( $categoryModel ) {
                 $category = $categoryModel->id;
             } else {
                 return collect();
@@ -179,9 +179,9 @@ class PageManager
         }
 
         $query = $this->getPageQuery();
-        $query->whereHas('categories', function ($q) use ($category): void {
-            $q->where('page_categories.id', sanitizeInt($category));
-        });
+        $query->whereHas( 'categories', function ( $q ) use ( $category ): void {
+            $q->where( 'page_categories.id', sanitizeInt( $category ) );
+        } );
 
         return $query->get();
     }
@@ -193,12 +193,12 @@ class PageManager
      *
      * @param  int|string  $tag  Tag ID or slug.
      */
-    public function getPagesByTag($tag): Collection
+    public function getPagesByTag( $tag ): Collection
     {
         // If tag is a string (slug), find the tag ID
-        if (is_string($tag)) {
-            $tagModel = \ArtisanPackUI\CMSFramework\Modules\Pages\Models\PageTag::where('slug', sanitizeText($tag))->first();
-            if ($tagModel) {
+        if ( is_string( $tag ) ) {
+            $tagModel = \ArtisanPackUI\CMSFramework\Modules\Pages\Models\PageTag::where( 'slug', sanitizeText( $tag ) )->first();
+            if ( $tagModel ) {
                 $tag = $tagModel->id;
             } else {
                 return collect();
@@ -206,9 +206,9 @@ class PageManager
         }
 
         $query = $this->getPageQuery();
-        $query->whereHas('tags', function ($q) use ($tag): void {
-            $q->where('page_tags.id', sanitizeInt($tag));
-        });
+        $query->whereHas( 'tags', function ( $q ) use ( $tag ): void {
+            $q->where( 'page_tags.id', sanitizeInt( $tag ) );
+        } );
 
         return $query->get();
     }
@@ -220,10 +220,10 @@ class PageManager
      *
      * @param  int  $limit  Number of pages to retrieve.
      */
-    public function getRecentPages(int $limit = 10): Collection
+    public function getRecentPages( int $limit = 10 ): Collection
     {
-        return $this->getPageQuery(['status' => ContentStatus::Published])
-            ->limit($limit)
+        return $this->getPageQuery( ['status' => ContentStatus::Published] )
+            ->limit( $limit )
             ->get();
     }
 
@@ -234,15 +234,15 @@ class PageManager
      *
      * @param  Page  $page  The page to load children for.
      */
-    protected function loadChildrenRecursively(Page $page): void
+    protected function loadChildrenRecursively( Page $page ): void
     {
-        if ($page->children->isNotEmpty()) {
-            $page->children->each(function ($child): void {
-                $child->load(['children' => function ($query): void {
-                    $query->orderBy('order');
-                }]);
-                $this->loadChildrenRecursively($child);
-            });
+        if ( $page->children->isNotEmpty() ) {
+            $page->children->each( function ( $child ): void {
+                $child->load( ['children' => function ( $query ): void {
+                    $query->orderBy( 'order' );
+                }] );
+                $this->loadChildrenRecursively( $child );
+            } );
         }
     }
 
@@ -254,16 +254,16 @@ class PageManager
      * @param  Builder  $query  The query builder instance.
      * @param  array  $filters  Array of filters to apply.
      */
-    protected function applyFilters(Builder $query, array $filters): void
+    protected function applyFilters( Builder $query, array $filters ): void
     {
         // Apply shared content filters
-        $this->applyStatusFilter($query, $filters, false);
-        $this->applyAuthorFilter($query, $filters);
-        $this->applySearchFilter($query, $filters);
+        $this->applyStatusFilter( $query, $filters, false);
+        $this->applyAuthorFilter( $query, $filters);
+        $this->applySearchFilter( $query, $filters);
 
         // Apply template filter (page-specific)
-        if (isset($filters['template'])) {
-            $query->byTemplate($filters['template']);
+        if ( isset( $filters['template'])) {
+            $query->byTemplate( $filters['template']);
         }
     }
 }

--- a/src/Modules/Pages/Managers/PageManager.php
+++ b/src/Modules/Pages/Managers/PageManager.php
@@ -257,12 +257,12 @@ class PageManager
     protected function applyFilters( Builder $query, array $filters ): void
     {
         // Apply shared content filters
-        $this->applyStatusFilter( $query, $filters, false);
-        $this->applyAuthorFilter( $query, $filters);
-        $this->applySearchFilter( $query, $filters);
+        $this->applyStatusFilter( $query, $filters, false );
+        $this->applyAuthorFilter( $query, $filters );
+        $this->applySearchFilter( $query, $filters );
 
         // Apply template filter (page-specific)
-        if ( isset( $filters['template'])) {
+        if ( isset( $filters['template'] ) ) {
             $query->byTemplate( $filters['template']);
         }
     }

--- a/src/Modules/Pages/Managers/PageManager.php
+++ b/src/Modules/Pages/Managers/PageManager.php
@@ -1,6 +1,6 @@
 <?php
 
-declare( strict_types = 1 );
+declare(strict_types=1);
 
 /**
  * Page Manager
@@ -12,6 +12,7 @@ declare( strict_types = 1 );
 
 namespace ArtisanPackUI\CMSFramework\Modules\Pages\Managers;
 
+use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Enums\ContentStatus;
 use ArtisanPackUI\CMSFramework\Modules\Pages\Models\Page;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Collection;
@@ -31,20 +32,20 @@ class PageManager
      *
      * @param  array  $filters  Optional filters (status, author, template).
      */
-    public function getPageTree( array $filters = [] ): Collection
+    public function getPageTree(array $filters = []): Collection
     {
-        $query = Page::query()->topLevel()->with( ['children' => function ( $query ): void {
-            $query->orderBy( 'order' );
-        }] );
+        $query = Page::query()->topLevel()->with(['children' => function ($query): void {
+            $query->orderBy('order');
+        }]);
 
-        $this->applyFilters( $query, $filters );
+        $this->applyFilters($query, $filters);
 
-        $topLevel = $query->orderBy( 'order' )->get();
+        $topLevel = $query->orderBy('order')->get();
 
         // Recursively load all children
-        $topLevel->each( function ( $page ): void {
-            $this->loadChildrenRecursively( $page );
-        } );
+        $topLevel->each(function ($page): void {
+            $this->loadChildrenRecursively($page);
+        });
 
         return $topLevel;
     }
@@ -56,13 +57,13 @@ class PageManager
      *
      * @param  array  $filters  Optional filters (status, author, template).
      */
-    public function getTopLevelPages( array $filters = [] ): Collection
+    public function getTopLevelPages(array $filters = []): Collection
     {
         $query = Page::query()->topLevel();
 
-        $this->applyFilters( $query, $filters );
+        $this->applyFilters($query, $filters);
 
-        return $query->orderBy( 'order' )->get();
+        return $query->orderBy('order')->get();
     }
 
     /**
@@ -73,13 +74,13 @@ class PageManager
      * @param  string  $template  Template name to filter by.
      * @param  array  $filters  Optional filters (status, author).
      */
-    public function getPagesByTemplate( string $template, array $filters = [] ): Collection
+    public function getPagesByTemplate(string $template, array $filters = []): Collection
     {
-        $query = Page::query()->byTemplate( $template );
+        $query = Page::query()->byTemplate($template);
 
-        $this->applyFilters( $query, $filters );
+        $this->applyFilters($query, $filters);
 
-        return $query->orderBy( 'order' )->get();
+        return $query->orderBy('order')->get();
     }
 
     /**
@@ -90,10 +91,10 @@ class PageManager
      * @param  array  $order  Array of page IDs with their new order values.
      *                        Format: ['page_id' => order_value, ...]
      */
-    public function reorderPages( array $order ): void
+    public function reorderPages(array $order): void
     {
-        foreach ( $order as $pageId => $orderValue ) {
-            Page::where( 'id', sanitizeInt( $pageId ) )->update( ['order' => $orderValue] );
+        foreach ($order as $pageId => $orderValue) {
+            Page::where('id', sanitizeInt($pageId))->update(['order' => $orderValue]);
         }
     }
 
@@ -105,23 +106,23 @@ class PageManager
      * @param  int  $pageId  The ID of the page to move.
      * @param  int|null  $newParentId  The ID of the new parent page (null for top-level).
      */
-    public function movePage( int $pageId, ?int $newParentId = null ): void
+    public function movePage(int $pageId, ?int $newParentId = null): void
     {
-        $page = Page::findOrFail( $pageId );
+        $page = Page::findOrFail($pageId);
 
         // Prevent moving a page to itself or to its own descendant
-        if ( null !== $newParentId ) {
-            if ( $newParentId === $pageId ) {
-                throw new InvalidArgumentException( 'Cannot move a page to itself.' );
+        if (null !== $newParentId) {
+            if ($newParentId === $pageId) {
+                throw new InvalidArgumentException('Cannot move a page to itself.');
             }
 
-            $descendantIds = $page->descendants()->pluck( 'id' )->toArray();
-            if ( in_array( $newParentId, $descendantIds ) ) {
-                throw new InvalidArgumentException( 'Cannot move a page to its own descendant.' );
+            $descendantIds = $page->descendants()->pluck('id')->toArray();
+            if (in_array($newParentId, $descendantIds)) {
+                throw new InvalidArgumentException('Cannot move a page to its own descendant.');
             }
         }
 
-        $page->update( ['parent_id' => $newParentId] );
+        $page->update(['parent_id' => $newParentId]);
     }
 
     /**
@@ -131,14 +132,14 @@ class PageManager
      *
      * @param  array  $filters  Array of filters to apply (status, author, template, search).
      */
-    public function getPageQuery( array $filters = [] ): Builder
+    public function getPageQuery(array $filters = []): Builder
     {
-        $query = Page::query()->with( ['author', 'categories', 'tags'] );
+        $query = Page::query()->with(['author', 'categories', 'tags']);
 
-        $this->applyFilters( $query, $filters );
+        $this->applyFilters($query, $filters);
 
         // Order by order column and title
-        $query->orderBy( 'order' )->orderBy( 'title' );
+        $query->orderBy('order')->orderBy('title');
 
         return $query;
     }
@@ -150,9 +151,9 @@ class PageManager
      *
      * @param  int  $authorId  Author ID to filter by.
      */
-    public function getPagesByAuthor( int $authorId ): Collection
+    public function getPagesByAuthor(int $authorId): Collection
     {
-        return $this->getPageQuery( ['author' => $authorId] )->get();
+        return $this->getPageQuery(['author' => $authorId])->get();
     }
 
     /**
@@ -162,12 +163,12 @@ class PageManager
      *
      * @param  int|string  $category  Category ID or slug.
      */
-    public function getPagesByCategory( $category ): Collection
+    public function getPagesByCategory($category): Collection
     {
         // If category is a string (slug), find the category ID
-        if ( is_string( $category ) ) {
-            $categoryModel = \ArtisanPackUI\CMSFramework\Modules\Pages\Models\PageCategory::where( 'slug', sanitizeText( $category ) )->first();
-            if ( $categoryModel ) {
+        if (is_string($category)) {
+            $categoryModel = \ArtisanPackUI\CMSFramework\Modules\Pages\Models\PageCategory::where('slug', sanitizeText($category))->first();
+            if ($categoryModel) {
                 $category = $categoryModel->id;
             } else {
                 return collect();
@@ -175,9 +176,9 @@ class PageManager
         }
 
         $query = $this->getPageQuery();
-        $query->whereHas( 'categories', function ( $q ) use ( $category ): void {
-            $q->where( 'page_categories.id', sanitizeInt( $category ) );
-        } );
+        $query->whereHas('categories', function ($q) use ($category): void {
+            $q->where('page_categories.id', sanitizeInt($category));
+        });
 
         return $query->get();
     }
@@ -189,12 +190,12 @@ class PageManager
      *
      * @param  int|string  $tag  Tag ID or slug.
      */
-    public function getPagesByTag( $tag ): Collection
+    public function getPagesByTag($tag): Collection
     {
         // If tag is a string (slug), find the tag ID
-        if ( is_string( $tag ) ) {
-            $tagModel = \ArtisanPackUI\CMSFramework\Modules\Pages\Models\PageTag::where( 'slug', sanitizeText( $tag ) )->first();
-            if ( $tagModel ) {
+        if (is_string($tag)) {
+            $tagModel = \ArtisanPackUI\CMSFramework\Modules\Pages\Models\PageTag::where('slug', sanitizeText($tag))->first();
+            if ($tagModel) {
                 $tag = $tagModel->id;
             } else {
                 return collect();
@@ -202,9 +203,9 @@ class PageManager
         }
 
         $query = $this->getPageQuery();
-        $query->whereHas( 'tags', function ( $q ) use ( $tag ): void {
-            $q->where( 'page_tags.id', sanitizeInt( $tag ) );
-        } );
+        $query->whereHas('tags', function ($q) use ($tag): void {
+            $q->where('page_tags.id', sanitizeInt($tag));
+        });
 
         return $query->get();
     }
@@ -216,10 +217,10 @@ class PageManager
      *
      * @param  int  $limit  Number of pages to retrieve.
      */
-    public function getRecentPages( int $limit = 10 ): Collection
+    public function getRecentPages(int $limit = 10): Collection
     {
-        return $this->getPageQuery( ['status' => 'published'] )
-            ->limit( $limit )
+        return $this->getPageQuery(['status' => ContentStatus::Published])
+            ->limit($limit)
             ->get();
     }
 
@@ -230,15 +231,15 @@ class PageManager
      *
      * @param  Page  $page  The page to load children for.
      */
-    protected function loadChildrenRecursively( Page $page ): void
+    protected function loadChildrenRecursively(Page $page): void
     {
-        if ( $page->children->isNotEmpty() ) {
-            $page->children->each( function ( $child ): void {
-                $child->load( ['children' => function ( $query ): void {
-                    $query->orderBy( 'order' );
-                }] );
-                $this->loadChildrenRecursively( $child );
-            } );
+        if ($page->children->isNotEmpty()) {
+            $page->children->each(function ($child): void {
+                $child->load(['children' => function ($query): void {
+                    $query->orderBy('order');
+                }]);
+                $this->loadChildrenRecursively($child);
+            });
         }
     }
 
@@ -250,34 +251,38 @@ class PageManager
      * @param  Builder  $query  The query builder instance.
      * @param  array  $filters  Array of filters to apply.
      */
-    protected function applyFilters( Builder $query, array $filters ): void
+    protected function applyFilters(Builder $query, array $filters): void
     {
         // Apply status filter
-        if ( isset( $filters['status'] ) ) {
-            if ( 'published' === $filters['status'] ) {
+        if (isset($filters['status'])) {
+            $status = $filters['status'] instanceof ContentStatus
+                ? $filters['status']
+                : ContentStatus::from(sanitizeText($filters['status']));
+
+            if (ContentStatus::Published === $status) {
                 $query->published();
             } else {
-                $query->where( 'status', sanitizeText( $filters['status'] ) );
+                $query->where('status', $status);
             }
         }
 
         // Apply author filter
-        if ( isset( $filters['author'] ) ) {
-            $query->byAuthor( $filters['author'] );
+        if (isset($filters['author'])) {
+            $query->byAuthor($filters['author']);
         }
 
         // Apply template filter
-        if ( isset( $filters['template'] ) ) {
-            $query->byTemplate( $filters['template'] );
+        if (isset($filters['template'])) {
+            $query->byTemplate($filters['template']);
         }
 
         // Apply search filter
-        if ( isset( $filters['search'] ) ) {
+        if (isset($filters['search'])) {
             $search = $filters['search'];
-            $query->where( function ( $q ) use ( $search ): void {
-                $q->where( 'title', 'like', "%{$search}%" )
-                    ->orWhere( 'content', 'like', "%{$search}%" )
-                    ->orWhere( 'excerpt', 'like', "%{$search}%");
+            $query->where(function ($q) use ($search): void {
+                $q->where('title', 'like', "%{$search}%")
+                    ->orWhere('content', 'like', "%{$search}%")
+                    ->orWhere('excerpt', 'like', "%{$search}%");
             });
         }
     }

--- a/src/Modules/Pages/Managers/PageManager.php
+++ b/src/Modules/Pages/Managers/PageManager.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace ArtisanPackUI\CMSFramework\Modules\Pages\Managers;
 
 use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Enums\ContentStatus;
+use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Managers\Concerns\HasContentFilters;
 use ArtisanPackUI\CMSFramework\Modules\Pages\Models\Page;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Collection;
@@ -25,6 +26,8 @@ use InvalidArgumentException;
  */
 class PageManager
 {
+    use HasContentFilters;
+
     /**
      * Get a hierarchical page tree structure.
      *
@@ -253,37 +256,14 @@ class PageManager
      */
     protected function applyFilters(Builder $query, array $filters): void
     {
-        // Apply status filter
-        if (isset($filters['status'])) {
-            $status = $filters['status'] instanceof ContentStatus
-                ? $filters['status']
-                : ContentStatus::tryFrom(sanitizeText($filters['status']));
+        // Apply shared content filters
+        $this->applyStatusFilter($query, $filters, false);
+        $this->applyAuthorFilter($query, $filters);
+        $this->applySearchFilter($query, $filters);
 
-            if (null === $status || ContentStatus::Published === $status) {
-                $query->published();
-            } else {
-                $query->where('status', $status);
-            }
-        }
-
-        // Apply author filter
-        if (isset($filters['author'])) {
-            $query->byAuthor($filters['author']);
-        }
-
-        // Apply template filter
+        // Apply template filter (page-specific)
         if (isset($filters['template'])) {
             $query->byTemplate($filters['template']);
-        }
-
-        // Apply search filter
-        if (isset($filters['search'])) {
-            $search = $filters['search'];
-            $query->where(function ($q) use ($search): void {
-                $q->where('title', 'like', "%{$search}%")
-                    ->orWhere('content', 'like', "%{$search}%")
-                    ->orWhere('excerpt', 'like', "%{$search}%");
-            });
         }
     }
 }

--- a/src/Modules/Pages/Models/Page.php
+++ b/src/Modules/Pages/Models/Page.php
@@ -1,6 +1,6 @@
 <?php
 
-declare( strict_types = 1 );
+declare(strict_types=1);
 
 /**
  * Page Model
@@ -12,6 +12,7 @@ declare( strict_types = 1 );
 
 namespace ArtisanPackUI\CMSFramework\Modules\Pages\Models;
 
+use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Enums\ContentStatus;
 use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Models\Concerns\HasCustomFields;
 use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Models\Concerns\HasFeaturedImage;
 use ArtisanPackUI\MediaLibrary\Models\Media;
@@ -82,7 +83,7 @@ class Page extends Model
      */
     public function author(): BelongsTo
     {
-        return $this->belongsTo( config( 'auth.providers.users.model' ), 'author_id' );
+        return $this->belongsTo(config('auth.providers.users.model'), 'author_id');
     }
 
     /**
@@ -92,7 +93,7 @@ class Page extends Model
      */
     public function featuredImageMedia(): BelongsTo
     {
-        return $this->belongsTo( Media::class, 'featured_image_id' );
+        return $this->belongsTo(Media::class, 'featured_image_id');
     }
 
     /**
@@ -102,7 +103,7 @@ class Page extends Model
      */
     public function parent(): BelongsTo
     {
-        return $this->belongsTo( Page::class, 'parent_id' );
+        return $this->belongsTo(Page::class, 'parent_id');
     }
 
     /**
@@ -112,7 +113,7 @@ class Page extends Model
      */
     public function children(): HasMany
     {
-        return $this->hasMany( Page::class, 'parent_id' )->orderBy( 'order' );
+        return $this->hasMany(Page::class, 'parent_id')->orderBy('order');
     }
 
     /**
@@ -122,7 +123,7 @@ class Page extends Model
      */
     public function categories(): BelongsToMany
     {
-        return $this->belongsToMany( PageCategory::class, 'page_category_pivots', 'page_id', 'page_category_id' );
+        return $this->belongsToMany(PageCategory::class, 'page_category_pivots', 'page_id', 'page_category_id');
     }
 
     /**
@@ -132,7 +133,7 @@ class Page extends Model
      */
     public function tags(): BelongsToMany
     {
-        return $this->belongsToMany( PageTag::class, 'page_tag_pivots', 'page_id', 'page_tag_id' );
+        return $this->belongsToMany(PageTag::class, 'page_tag_pivots', 'page_id', 'page_tag_id');
     }
 
     /**
@@ -143,9 +144,9 @@ class Page extends Model
     public function siblings(): HasMany
     {
         // phpcs:ignore ArtisanPackUIStandard.Security.ValidatedSanitizedInput.MissingUnslash -- Model ID is type-safe
-        return $this->hasMany( Page::class, 'parent_id', 'parent_id' )
-            ->where( 'id', '!=', $this->id )
-            ->orderBy( 'order' );
+        return $this->hasMany(Page::class, 'parent_id', 'parent_id')
+            ->where('id', '!=', $this->id)
+            ->orderBy('order');
     }
 
     /**
@@ -158,8 +159,8 @@ class Page extends Model
         $ancestors = collect();
         $parent    = $this->parent;
 
-        while ( $parent ) {
-            $ancestors->prepend( $parent );
+        while ($parent) {
+            $ancestors->prepend($parent);
             $parent = $parent->parent;
         }
 
@@ -175,9 +176,9 @@ class Page extends Model
     {
         $descendants = collect();
 
-        foreach ( $this->children as $child ) {
-            $descendants->push( $child );
-            $descendants = $descendants->merge( $child->descendants() );
+        foreach ($this->children as $child) {
+            $descendants->push($child);
+            $descendants = $descendants->merge($child->descendants());
         }
 
         return $descendants;
@@ -188,17 +189,15 @@ class Page extends Model
      *
      * @since 1.0.0
      *
-     * @param  \Illuminate\Database\Eloquent\Builder  $query
-     *
-     * @return \Illuminate\Database\Eloquent\Builder
+     * @return Builder
      */
-    public function scopePublished( Builder $query )
+    public function scopePublished(Builder $query)
     {
-        return $query->where( 'status', 'published' )
-            ->where( function ( $q ): void {
-                $q->whereNull( 'published_at' )
-                    ->orWhere( 'published_at', '<=', now() );
-            } );
+        return $query->where('status', ContentStatus::Published)
+            ->where(function ($q): void {
+                $q->whereNull('published_at')
+                    ->orWhere('published_at', '<=', now());
+            });
     }
 
     /**
@@ -206,13 +205,11 @@ class Page extends Model
      *
      * @since 1.0.0
      *
-     * @param  \Illuminate\Database\Eloquent\Builder  $query
-     *
-     * @return \Illuminate\Database\Eloquent\Builder
+     * @return Builder
      */
-    public function scopeDraft( Builder $query )
+    public function scopeDraft(Builder $query)
     {
-        return $query->where( 'status', 'draft' );
+        return $query->where('status', ContentStatus::Draft);
     }
 
     /**
@@ -220,13 +217,11 @@ class Page extends Model
      *
      * @since 1.0.0
      *
-     * @param  \Illuminate\Database\Eloquent\Builder  $query
-     *
-     * @return \Illuminate\Database\Eloquent\Builder
+     * @return Builder
      */
-    public function scopeByAuthor( Builder $query, int $authorId )
+    public function scopeByAuthor(Builder $query, int $authorId)
     {
-        return $query->where( 'author_id', sanitizeInt( $authorId ) );
+        return $query->where('author_id', sanitizeInt($authorId));
     }
 
     /**
@@ -234,13 +229,11 @@ class Page extends Model
      *
      * @since 1.0.0
      *
-     * @param  \Illuminate\Database\Eloquent\Builder  $query
-     *
-     * @return \Illuminate\Database\Eloquent\Builder
+     * @return Builder
      */
-    public function scopeTopLevel( Builder $query )
+    public function scopeTopLevel(Builder $query)
     {
-        return $query->whereNull( 'parent_id' );
+        return $query->whereNull('parent_id');
     }
 
     /**
@@ -248,13 +241,11 @@ class Page extends Model
      *
      * @since 1.0.0
      *
-     * @param  \Illuminate\Database\Eloquent\Builder  $query
-     *
-     * @return \Illuminate\Database\Eloquent\Builder
+     * @return Builder
      */
-    public function scopeByTemplate( Builder $query, string $template )
+    public function scopeByTemplate(Builder $query, string $template)
     {
-        return $query->where( 'template', sanitizeText( $template ) );
+        return $query->where('template', sanitizeText($template));
     }
 
     /**
@@ -264,8 +255,8 @@ class Page extends Model
      */
     public function isPublished(): bool
     {
-        return 'published' === $this->status &&
-            ( null === $this->published_at || $this->published_at->isPast() );
+        return ContentStatus::Published === $this->status &&
+            (null === $this->published_at || $this->published_at->isPast());
     }
 
     /**
@@ -277,7 +268,7 @@ class Page extends Model
     {
         $breadcrumb = [];
 
-        foreach ( $this->ancestors() as $ancestor ) {
+        foreach ($this->ancestors() as $ancestor) {
             $breadcrumb[] = [
                 'title' => $ancestor->title,
                 'url'   => $ancestor->permalink,
@@ -311,13 +302,13 @@ class Page extends Model
     {
         $ancestors = $this->ancestors();
 
-        if ( $ancestors->isEmpty() ) {
-            return url( "/{$this->slug}" );
+        if ($ancestors->isEmpty()) {
+            return url("/{$this->slug}");
         }
 
-        $path = $ancestors->pluck( 'slug' )->implode( '/' ) . '/' . $this->slug;
+        $path = $ancestors->pluck('slug')->implode('/').'/'.$this->slug;
 
-        return url( "/{$path}" );
+        return url("/{$path}");
     }
 
     /**
@@ -333,6 +324,7 @@ class Page extends Model
             'published_at' => 'datetime',
             'metadata'     => 'array',
             'order'        => 'integer',
+            'status'       => ContentStatus::class,
         ];
     }
 }

--- a/src/Modules/Pages/Models/Page.php
+++ b/src/Modules/Pages/Models/Page.php
@@ -38,7 +38,7 @@ use Illuminate\Support\Collection;
  * @property int|null $parent_id
  * @property int $order
  * @property string|null $template
- * @property string $status
+ * @property ContentStatus $status
  * @property Carbon|null $published_at
  * @property array|null $metadata
  * @property \Illuminate\Support\Carbon $created_at

--- a/src/Modules/Pages/Models/Page.php
+++ b/src/Modules/Pages/Models/Page.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace ArtisanPackUI\CMSFramework\Modules\Pages\Models;
 
 use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Enums\ContentStatus;
+use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Models\Concerns\HasContentStatus;
 use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Models\Concerns\HasCustomFields;
 use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Models\Concerns\HasFeaturedImage;
 use ArtisanPackUI\MediaLibrary\Models\Media;
@@ -49,6 +50,7 @@ use Illuminate\Support\Collection;
  */
 class Page extends Model
 {
+    use HasContentStatus;
     use HasCustomFields;
     use HasFactory;
     use HasFeaturedImage;
@@ -185,34 +187,6 @@ class Page extends Model
     }
 
     /**
-     * Scope a query to only include published pages.
-     *
-     * @since 1.0.0
-     *
-     * @return Builder
-     */
-    public function scopePublished(Builder $query)
-    {
-        return $query->where('status', ContentStatus::Published)
-            ->where(function ($q): void {
-                $q->whereNull('published_at')
-                    ->orWhere('published_at', '<=', now());
-            });
-    }
-
-    /**
-     * Scope a query to only include draft pages.
-     *
-     * @since 1.0.0
-     *
-     * @return Builder
-     */
-    public function scopeDraft(Builder $query)
-    {
-        return $query->where('status', ContentStatus::Draft);
-    }
-
-    /**
      * Scope a query to pages by a specific author.
      *
      * @since 1.0.0
@@ -246,17 +220,6 @@ class Page extends Model
     public function scopeByTemplate(Builder $query, string $template)
     {
         return $query->where('template', sanitizeText($template));
-    }
-
-    /**
-     * Check if the page is published.
-     *
-     * @since 1.0.0
-     */
-    public function isPublished(): bool
-    {
-        return ContentStatus::Published === $this->status &&
-            (null === $this->published_at || $this->published_at->isPast());
     }
 
     /**

--- a/src/Modules/Pages/Models/Page.php
+++ b/src/Modules/Pages/Models/Page.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare( strict_types=1 );
 
 /**
  * Page Model
@@ -85,7 +85,7 @@ class Page extends Model
      */
     public function author(): BelongsTo
     {
-        return $this->belongsTo(config('auth.providers.users.model'), 'author_id');
+        return $this->belongsTo( config( 'auth.providers.users.model' ), 'author_id' );
     }
 
     /**
@@ -95,7 +95,7 @@ class Page extends Model
      */
     public function featuredImageMedia(): BelongsTo
     {
-        return $this->belongsTo(Media::class, 'featured_image_id');
+        return $this->belongsTo( Media::class, 'featured_image_id' );
     }
 
     /**
@@ -105,7 +105,7 @@ class Page extends Model
      */
     public function parent(): BelongsTo
     {
-        return $this->belongsTo(Page::class, 'parent_id');
+        return $this->belongsTo( Page::class, 'parent_id' );
     }
 
     /**
@@ -115,7 +115,7 @@ class Page extends Model
      */
     public function children(): HasMany
     {
-        return $this->hasMany(Page::class, 'parent_id')->orderBy('order');
+        return $this->hasMany( Page::class, 'parent_id' )->orderBy( 'order' );
     }
 
     /**
@@ -125,7 +125,7 @@ class Page extends Model
      */
     public function categories(): BelongsToMany
     {
-        return $this->belongsToMany(PageCategory::class, 'page_category_pivots', 'page_id', 'page_category_id');
+        return $this->belongsToMany( PageCategory::class, 'page_category_pivots', 'page_id', 'page_category_id' );
     }
 
     /**
@@ -135,7 +135,7 @@ class Page extends Model
      */
     public function tags(): BelongsToMany
     {
-        return $this->belongsToMany(PageTag::class, 'page_tag_pivots', 'page_id', 'page_tag_id');
+        return $this->belongsToMany( PageTag::class, 'page_tag_pivots', 'page_id', 'page_tag_id' );
     }
 
     /**
@@ -146,9 +146,9 @@ class Page extends Model
     public function siblings(): HasMany
     {
         // phpcs:ignore ArtisanPackUIStandard.Security.ValidatedSanitizedInput.MissingUnslash -- Model ID is type-safe
-        return $this->hasMany(Page::class, 'parent_id', 'parent_id')
-            ->where('id', '!=', $this->id)
-            ->orderBy('order');
+        return $this->hasMany( Page::class, 'parent_id', 'parent_id' )
+            ->where( 'id', '!=', $this->id )
+            ->orderBy( 'order' );
     }
 
     /**
@@ -161,8 +161,8 @@ class Page extends Model
         $ancestors = collect();
         $parent    = $this->parent;
 
-        while ($parent) {
-            $ancestors->prepend($parent);
+        while ( $parent ) {
+            $ancestors->prepend( $parent );
             $parent = $parent->parent;
         }
 
@@ -178,9 +178,9 @@ class Page extends Model
     {
         $descendants = collect();
 
-        foreach ($this->children as $child) {
-            $descendants->push($child);
-            $descendants = $descendants->merge($child->descendants());
+        foreach ( $this->children as $child ) {
+            $descendants->push( $child );
+            $descendants = $descendants->merge( $child->descendants() );
         }
 
         return $descendants;
@@ -193,9 +193,9 @@ class Page extends Model
      *
      * @return Builder
      */
-    public function scopeByAuthor(Builder $query, int $authorId)
+    public function scopeByAuthor( Builder $query, int $authorId )
     {
-        return $query->where('author_id', sanitizeInt($authorId));
+        return $query->where( 'author_id', sanitizeInt( $authorId ) );
     }
 
     /**
@@ -205,9 +205,9 @@ class Page extends Model
      *
      * @return Builder
      */
-    public function scopeTopLevel(Builder $query)
+    public function scopeTopLevel( Builder $query )
     {
-        return $query->whereNull('parent_id');
+        return $query->whereNull( 'parent_id' );
     }
 
     /**
@@ -217,9 +217,9 @@ class Page extends Model
      *
      * @return Builder
      */
-    public function scopeByTemplate(Builder $query, string $template)
+    public function scopeByTemplate( Builder $query, string $template )
     {
-        return $query->where('template', sanitizeText($template));
+        return $query->where( 'template', sanitizeText( $template ) );
     }
 
     /**
@@ -231,7 +231,7 @@ class Page extends Model
     {
         $breadcrumb = [];
 
-        foreach ($this->ancestors() as $ancestor) {
+        foreach ( $this->ancestors() as $ancestor ) {
             $breadcrumb[] = [
                 'title' => $ancestor->title,
                 'url'   => $ancestor->permalink,
@@ -265,13 +265,13 @@ class Page extends Model
     {
         $ancestors = $this->ancestors();
 
-        if ($ancestors->isEmpty()) {
-            return url("/{$this->slug}");
+        if ( $ancestors->isEmpty() ) {
+            return url( "/{$this->slug}" );
         }
 
-        $path = $ancestors->pluck('slug')->implode('/').'/'.$this->slug;
+        $path = $ancestors->pluck( 'slug' )->implode( '/' ) . '/' . $this->slug;
 
-        return url("/{$path}");
+        return url( "/{$path}" );
     }
 
     /**

--- a/src/Modules/Pages/Policies/PagePolicy.php
+++ b/src/Modules/Pages/Policies/PagePolicy.php
@@ -185,6 +185,6 @@ class PagePolicy
          *
          * @return string Filtered capability slug.
          */
-        return $user->can( applyFilters( 'pages.publish', 'pages.publish', $page ));
+        return $user->can( applyFilters( 'pages.publish', 'pages.publish', $page ) );
     }
 }

--- a/src/Modules/Pages/database/factories/PageFactory.php
+++ b/src/Modules/Pages/database/factories/PageFactory.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare( strict_types=1 );
 
 /**
  * Page Factory for the CMS Framework Pages Module.
@@ -50,16 +50,16 @@ class PageFactory extends Factory
      */
     public function definition(): array
     {
-        $title = fake()->sentence(4, true);
+        $title = fake()->sentence( 4, true );
 
         return [
             'title'        => $title,
-            'slug'         => Str::slug($title),
-            'content'      => fake()->paragraphs(3, true),
+            'slug'         => Str::slug( $title ),
+            'content'      => fake()->paragraphs( 3, true ),
             'excerpt'      => fake()->paragraph(),
             'author_id'    => User::factory(),
             'parent_id'    => null,
-            'order'        => fake()->numberBetween(0, 100),
+            'order'        => fake()->numberBetween( 0, 100 ),
             'template'     => 'default',
             'status'       => ContentStatus::Published->value,
             'published_at' => now(),
@@ -81,10 +81,10 @@ class PageFactory extends Factory
      */
     public function draft(): static
     {
-        return $this->state(fn (array $attributes) => [
+        return $this->state( fn ( array $attributes ) => [
             'status'       => ContentStatus::Draft->value,
             'published_at' => null,
-        ]);
+        ] );
     }
 
     /**
@@ -98,10 +98,10 @@ class PageFactory extends Factory
      */
     public function published(): static
     {
-        return $this->state(fn (array $attributes) => [
+        return $this->state( fn ( array $attributes ) => [
             'status'       => ContentStatus::Published->value,
-            'published_at' => now()->subDays(rand(0, 365)),
-        ]);
+            'published_at' => now()->subDays( rand( 0, 365 ) ),
+        ] );
     }
 
     /**
@@ -113,11 +113,11 @@ class PageFactory extends Factory
      *
      * @return static The factory instance for method chaining.
      */
-    public function withParent(int $parentId): static
+    public function withParent( int $parentId ): static
     {
-        return $this->state(fn (array $attributes) => [
+        return $this->state( fn ( array $attributes ) => [
             'parent_id' => $parentId,
-        ]);
+        ] );
     }
 
     /**
@@ -129,9 +129,9 @@ class PageFactory extends Factory
      */
     public function topLevel(): static
     {
-        return $this->state(fn (array $attributes) => [
+        return $this->state( fn ( array $attributes ) => [
             'parent_id' => null,
-        ]);
+        ] );
     }
 
     /**
@@ -143,11 +143,11 @@ class PageFactory extends Factory
      *
      * @return static The factory instance for method chaining.
      */
-    public function withTemplate(string $template): static
+    public function withTemplate( string $template ): static
     {
-        return $this->state(fn (array $attributes) => [
+        return $this->state( fn ( array $attributes ) => [
             'template' => $template,
-        ]);
+        ] );
     }
 
     /**
@@ -159,11 +159,11 @@ class PageFactory extends Factory
      *
      * @return static The factory instance for method chaining.
      */
-    public function byAuthor(int $authorId): static
+    public function byAuthor( int $authorId ): static
     {
-        return $this->state(fn (array $attributes) => [
+        return $this->state( fn ( array $attributes ) => [
             'author_id' => $authorId,
-        ]);
+        ] );
     }
 
     /**
@@ -175,9 +175,9 @@ class PageFactory extends Factory
      *
      * @return static The factory instance for method chaining.
      */
-    public function withOrder(int $order): static
+    public function withOrder( int $order ): static
     {
-        return $this->state(fn (array $attributes) => [
+        return $this->state( fn ( array $attributes) => [
             'order' => $order,
         ]);
     }

--- a/src/Modules/Pages/database/factories/PageFactory.php
+++ b/src/Modules/Pages/database/factories/PageFactory.php
@@ -1,6 +1,6 @@
 <?php
 
-declare( strict_types = 1 );
+declare(strict_types=1);
 
 /**
  * Page Factory for the CMS Framework Pages Module.
@@ -14,6 +14,7 @@ declare( strict_types = 1 );
 namespace ArtisanPackUI\CMSFramework\Modules\Pages\Database\Factories;
 
 use App\Models\User;
+use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Enums\ContentStatus;
 use ArtisanPackUI\CMSFramework\Modules\Pages\Models\Page;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Support\Str;
@@ -49,18 +50,18 @@ class PageFactory extends Factory
      */
     public function definition(): array
     {
-        $title = fake()->sentence( 4, true );
+        $title = fake()->sentence(4, true);
 
         return [
             'title'        => $title,
-            'slug'         => Str::slug( $title ),
-            'content'      => fake()->paragraphs( 3, true ),
+            'slug'         => Str::slug($title),
+            'content'      => fake()->paragraphs(3, true),
             'excerpt'      => fake()->paragraph(),
             'author_id'    => User::factory(),
             'parent_id'    => null,
-            'order'        => fake()->numberBetween( 0, 100 ),
+            'order'        => fake()->numberBetween(0, 100),
             'template'     => 'default',
-            'status'       => 'published',
+            'status'       => ContentStatus::Published,
             'published_at' => now(),
             'metadata'     => [
                 'seo_title'       => $title,
@@ -80,10 +81,10 @@ class PageFactory extends Factory
      */
     public function draft(): static
     {
-        return $this->state( fn ( array $attributes ) => [
-            'status'       => 'draft',
+        return $this->state(fn (array $attributes) => [
+            'status'       => ContentStatus::Draft,
             'published_at' => null,
-        ] );
+        ]);
     }
 
     /**
@@ -97,10 +98,10 @@ class PageFactory extends Factory
      */
     public function published(): static
     {
-        return $this->state( fn ( array $attributes ) => [
-            'status'       => 'published',
-            'published_at' => now()->subDays( rand( 0, 365 ) ),
-        ] );
+        return $this->state(fn (array $attributes) => [
+            'status'       => ContentStatus::Published,
+            'published_at' => now()->subDays(rand(0, 365)),
+        ]);
     }
 
     /**
@@ -112,11 +113,11 @@ class PageFactory extends Factory
      *
      * @return static The factory instance for method chaining.
      */
-    public function withParent( int $parentId ): static
+    public function withParent(int $parentId): static
     {
-        return $this->state( fn ( array $attributes ) => [
+        return $this->state(fn (array $attributes) => [
             'parent_id' => $parentId,
-        ] );
+        ]);
     }
 
     /**
@@ -128,9 +129,9 @@ class PageFactory extends Factory
      */
     public function topLevel(): static
     {
-        return $this->state( fn ( array $attributes ) => [
+        return $this->state(fn (array $attributes) => [
             'parent_id' => null,
-        ] );
+        ]);
     }
 
     /**
@@ -142,11 +143,11 @@ class PageFactory extends Factory
      *
      * @return static The factory instance for method chaining.
      */
-    public function withTemplate( string $template ): static
+    public function withTemplate(string $template): static
     {
-        return $this->state( fn ( array $attributes ) => [
+        return $this->state(fn (array $attributes) => [
             'template' => $template,
-        ] );
+        ]);
     }
 
     /**
@@ -158,11 +159,11 @@ class PageFactory extends Factory
      *
      * @return static The factory instance for method chaining.
      */
-    public function byAuthor( int $authorId ): static
+    public function byAuthor(int $authorId): static
     {
-        return $this->state( fn ( array $attributes ) => [
+        return $this->state(fn (array $attributes) => [
             'author_id' => $authorId,
-        ] );
+        ]);
     }
 
     /**
@@ -174,9 +175,9 @@ class PageFactory extends Factory
      *
      * @return static The factory instance for method chaining.
      */
-    public function withOrder( int $order ): static
+    public function withOrder(int $order): static
     {
-        return $this->state( fn ( array $attributes ) => [
+        return $this->state(fn (array $attributes) => [
             'order' => $order,
         ]);
     }

--- a/src/Modules/Pages/database/factories/PageFactory.php
+++ b/src/Modules/Pages/database/factories/PageFactory.php
@@ -61,7 +61,7 @@ class PageFactory extends Factory
             'parent_id'    => null,
             'order'        => fake()->numberBetween(0, 100),
             'template'     => 'default',
-            'status'       => ContentStatus::Published,
+            'status'       => ContentStatus::Published->value,
             'published_at' => now(),
             'metadata'     => [
                 'seo_title'       => $title,
@@ -82,7 +82,7 @@ class PageFactory extends Factory
     public function draft(): static
     {
         return $this->state(fn (array $attributes) => [
-            'status'       => ContentStatus::Draft,
+            'status'       => ContentStatus::Draft->value,
             'published_at' => null,
         ]);
     }
@@ -99,7 +99,7 @@ class PageFactory extends Factory
     public function published(): static
     {
         return $this->state(fn (array $attributes) => [
-            'status'       => ContentStatus::Published,
+            'status'       => ContentStatus::Published->value,
             'published_at' => now()->subDays(rand(0, 365)),
         ]);
     }

--- a/src/Modules/Pages/database/factories/PageFactory.php
+++ b/src/Modules/Pages/database/factories/PageFactory.php
@@ -177,7 +177,7 @@ class PageFactory extends Factory
      */
     public function withOrder( int $order ): static
     {
-        return $this->state( fn ( array $attributes) => [
+        return $this->state( fn ( array $attributes ) => [
             'order' => $order,
         ]);
     }

--- a/src/Modules/Pages/database/migrations/2025_01_11_000001_create_pages_table.php
+++ b/src/Modules/Pages/database/migrations/2025_01_11_000001_create_pages_table.php
@@ -38,6 +38,6 @@ return new class extends Migration {
      */
     public function down(): void
     {
-        Schema::dropIfExists( 'pages');
+        Schema::dropIfExists( 'pages' );
     }
 };

--- a/src/Modules/Pages/database/migrations/2025_01_11_000002_create_page_categories_table.php
+++ b/src/Modules/Pages/database/migrations/2025_01_11_000002_create_page_categories_table.php
@@ -30,6 +30,6 @@ return new class extends Migration {
      */
     public function down(): void
     {
-        Schema::dropIfExists( 'page_categories');
+        Schema::dropIfExists( 'page_categories' );
     }
 };

--- a/src/Modules/Pages/database/migrations/2025_01_11_000004_create_page_tags_table.php
+++ b/src/Modules/Pages/database/migrations/2025_01_11_000004_create_page_tags_table.php
@@ -28,6 +28,6 @@ return new class extends Migration {
      */
     public function down(): void
     {
-        Schema::dropIfExists( 'page_tags');
+        Schema::dropIfExists( 'page_tags' );
     }
 };

--- a/src/Modules/Pages/database/migrations/2025_01_11_000006_add_featured_image_to_pages_table.php
+++ b/src/Modules/Pages/database/migrations/2025_01_11_000006_add_featured_image_to_pages_table.php
@@ -23,6 +23,6 @@ return new class extends Migration {
         Schema::table( 'pages', function ( Blueprint $table ): void {
             $table->dropForeign( ['featured_image_id'] );
             $table->dropColumn( 'featured_image_id' );
-        });
+        } );
     }
 };

--- a/src/Modules/Pages/routes/api.php
+++ b/src/Modules/Pages/routes/api.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare( strict_types=1 );
 
 /**
  * Pages Module API Routes
@@ -19,17 +19,17 @@ use Illuminate\Support\Facades\Route;
 |--------------------------------------------------------------------------
 */
 
-Route::prefix('pages')->middleware('auth')->group(function (): void {
-    Route::get('/', [PageController::class, 'index']);
-    Route::post('/', [PageController::class, 'store']);
-    Route::post('/bulk', [PageController::class, 'bulk']);
-    Route::get('/tree', [PageController::class, 'tree']);
-    Route::post('/reorder', [PageController::class, 'reorder']);
-    Route::post('/{id}/move', [PageController::class, 'move']);
-    Route::get('/{id}', [PageController::class, 'show']);
-    Route::put('/{id}', [PageController::class, 'update']);
-    Route::delete('/{id}', [PageController::class, 'destroy']);
-});
+Route::prefix( 'pages' )->middleware( 'auth' )->group( function (): void {
+    Route::get( '/', [PageController::class, 'index'] );
+    Route::post( '/', [PageController::class, 'store'] );
+    Route::post( '/bulk', [PageController::class, 'bulk'] );
+    Route::get( '/tree', [PageController::class, 'tree'] );
+    Route::post( '/reorder', [PageController::class, 'reorder'] );
+    Route::post( '/{id}/move', [PageController::class, 'move'] );
+    Route::get( '/{id}', [PageController::class, 'show'] );
+    Route::put( '/{id}', [PageController::class, 'update'] );
+    Route::delete( '/{id}', [PageController::class, 'destroy'] );
+} );
 
 /*
 |--------------------------------------------------------------------------
@@ -37,13 +37,13 @@ Route::prefix('pages')->middleware('auth')->group(function (): void {
 |--------------------------------------------------------------------------
 */
 
-Route::prefix('page-categories')->middleware('auth')->group(function (): void {
-    Route::get('/', [PageCategoryController::class, 'index']);
-    Route::post('/', [PageCategoryController::class, 'store']);
-    Route::get('/{id}', [PageCategoryController::class, 'show']);
-    Route::put('/{id}', [PageCategoryController::class, 'update']);
-    Route::delete('/{id}', [PageCategoryController::class, 'destroy']);
-});
+Route::prefix( 'page-categories' )->middleware( 'auth' )->group( function (): void {
+    Route::get( '/', [PageCategoryController::class, 'index'] );
+    Route::post( '/', [PageCategoryController::class, 'store'] );
+    Route::get( '/{id}', [PageCategoryController::class, 'show'] );
+    Route::put( '/{id}', [PageCategoryController::class, 'update'] );
+    Route::delete( '/{id}', [PageCategoryController::class, 'destroy'] );
+} );
 
 /*
 |--------------------------------------------------------------------------
@@ -51,10 +51,10 @@ Route::prefix('page-categories')->middleware('auth')->group(function (): void {
 |--------------------------------------------------------------------------
 */
 
-Route::prefix('page-tags')->middleware('auth')->group(function (): void {
-    Route::get('/', [PageTagController::class, 'index']);
-    Route::post('/', [PageTagController::class, 'store']);
-    Route::get('/{id}', [PageTagController::class, 'show']);
-    Route::put('/{id}', [PageTagController::class, 'update']);
-    Route::delete('/{id}', [PageTagController::class, 'destroy']);
+Route::prefix( 'page-tags' )->middleware( 'auth' )->group( function (): void {
+    Route::get( '/', [PageTagController::class, 'index'] );
+    Route::post( '/', [PageTagController::class, 'store'] );
+    Route::get( '/{id}', [PageTagController::class, 'show'] );
+    Route::put( '/{id}', [PageTagController::class, 'update']);
+    Route::delete( '/{id}', [PageTagController::class, 'destroy']);
 });

--- a/src/Modules/Pages/routes/api.php
+++ b/src/Modules/Pages/routes/api.php
@@ -1,6 +1,6 @@
 <?php
 
-declare( strict_types = 1 );
+declare(strict_types=1);
 
 /**
  * Pages Module API Routes
@@ -19,16 +19,17 @@ use Illuminate\Support\Facades\Route;
 |--------------------------------------------------------------------------
 */
 
-Route::prefix( 'pages' )->middleware( 'auth' )->group( function (): void {
-    Route::get( '/', [PageController::class, 'index'] );
-    Route::post( '/', [PageController::class, 'store'] );
-    Route::get( '/tree', [PageController::class, 'tree'] );
-    Route::post( '/reorder', [PageController::class, 'reorder'] );
-    Route::post( '/{id}/move', [PageController::class, 'move'] );
-    Route::get( '/{id}', [PageController::class, 'show'] );
-    Route::put( '/{id}', [PageController::class, 'update'] );
-    Route::delete( '/{id}', [PageController::class, 'destroy'] );
-} );
+Route::prefix('pages')->middleware('auth')->group(function (): void {
+    Route::get('/', [PageController::class, 'index']);
+    Route::post('/', [PageController::class, 'store']);
+    Route::post('/bulk', [PageController::class, 'bulk']);
+    Route::get('/tree', [PageController::class, 'tree']);
+    Route::post('/reorder', [PageController::class, 'reorder']);
+    Route::post('/{id}/move', [PageController::class, 'move']);
+    Route::get('/{id}', [PageController::class, 'show']);
+    Route::put('/{id}', [PageController::class, 'update']);
+    Route::delete('/{id}', [PageController::class, 'destroy']);
+});
 
 /*
 |--------------------------------------------------------------------------
@@ -36,13 +37,13 @@ Route::prefix( 'pages' )->middleware( 'auth' )->group( function (): void {
 |--------------------------------------------------------------------------
 */
 
-Route::prefix( 'page-categories' )->middleware( 'auth' )->group( function (): void {
-    Route::get( '/', [PageCategoryController::class, 'index'] );
-    Route::post( '/', [PageCategoryController::class, 'store'] );
-    Route::get( '/{id}', [PageCategoryController::class, 'show'] );
-    Route::put( '/{id}', [PageCategoryController::class, 'update'] );
-    Route::delete( '/{id}', [PageCategoryController::class, 'destroy'] );
-} );
+Route::prefix('page-categories')->middleware('auth')->group(function (): void {
+    Route::get('/', [PageCategoryController::class, 'index']);
+    Route::post('/', [PageCategoryController::class, 'store']);
+    Route::get('/{id}', [PageCategoryController::class, 'show']);
+    Route::put('/{id}', [PageCategoryController::class, 'update']);
+    Route::delete('/{id}', [PageCategoryController::class, 'destroy']);
+});
 
 /*
 |--------------------------------------------------------------------------
@@ -50,10 +51,10 @@ Route::prefix( 'page-categories' )->middleware( 'auth' )->group( function (): vo
 |--------------------------------------------------------------------------
 */
 
-Route::prefix( 'page-tags' )->middleware( 'auth' )->group( function (): void {
-    Route::get( '/', [PageTagController::class, 'index'] );
-    Route::post( '/', [PageTagController::class, 'store'] );
-    Route::get( '/{id}', [PageTagController::class, 'show'] );
-    Route::put( '/{id}', [PageTagController::class, 'update'] );
-    Route::delete( '/{id}', [PageTagController::class, 'destroy'] );
-} );
+Route::prefix('page-tags')->middleware('auth')->group(function (): void {
+    Route::get('/', [PageTagController::class, 'index']);
+    Route::post('/', [PageTagController::class, 'store']);
+    Route::get('/{id}', [PageTagController::class, 'show']);
+    Route::put('/{id}', [PageTagController::class, 'update']);
+    Route::delete('/{id}', [PageTagController::class, 'destroy']);
+});

--- a/src/Modules/Pages/routes/api.php
+++ b/src/Modules/Pages/routes/api.php
@@ -55,6 +55,6 @@ Route::prefix( 'page-tags' )->middleware( 'auth' )->group( function (): void {
     Route::get( '/', [PageTagController::class, 'index'] );
     Route::post( '/', [PageTagController::class, 'store'] );
     Route::get( '/{id}', [PageTagController::class, 'show'] );
-    Route::put( '/{id}', [PageTagController::class, 'update']);
-    Route::delete( '/{id}', [PageTagController::class, 'destroy']);
-});
+    Route::put( '/{id}', [PageTagController::class, 'update'] );
+    Route::delete( '/{id}', [PageTagController::class, 'destroy'] );
+} );

--- a/src/Modules/Plugins/Http/Controllers/PluginsController.php
+++ b/src/Modules/Plugins/Http/Controllers/PluginsController.php
@@ -163,7 +163,7 @@ class PluginsController extends Controller
         } catch ( Exception $e ) {
             return response()->json( [
                 'message' => 'Update failed: ' . $e->getMessage(),
-            ], 422);
+            ], 422 );
         }
     }
 }

--- a/src/Modules/Plugins/Http/Controllers/PluginsController.php
+++ b/src/Modules/Plugins/Http/Controllers/PluginsController.php
@@ -1,23 +1,24 @@
 <?php
 
-declare( strict_types = 1 );
+declare(strict_types=1);
 
 namespace ArtisanPackUI\CMSFramework\Modules\Plugins\Http\Controllers;
 
 use ArtisanPackUI\CMSFramework\Modules\Plugins\Managers\PluginManager;
 use ArtisanPackUI\CMSFramework\Modules\Plugins\Managers\UpdateManager;
+use Dedoc\Scramble\Attributes\Group;
 use Exception;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
 
+#[Group('Plugins', weight: 15)]
 class PluginsController extends Controller
 {
     public function __construct(
         private PluginManager $pluginManager,
         private UpdateManager $updateManager,
-    ) {
-    }
+    ) {}
 
     /**
      * GET /api/v1/plugins
@@ -27,52 +28,52 @@ class PluginsController extends Controller
     {
         $plugins = $this->pluginManager->discoverPlugins();
 
-        return response()->json( [
+        return response()->json([
             'plugins' => $plugins,
-        ] );
+        ]);
     }
 
     /**
      * GET /api/v1/plugins/{slug}
      * Get specific plugin details.
      */
-    public function show( string $slug ): JsonResponse
+    public function show(string $slug): JsonResponse
     {
-        $plugin = $this->pluginManager->getPlugin( $slug );
+        $plugin = $this->pluginManager->getPlugin($slug);
 
-        if ( ! $plugin ) {
-            return response()->json( [
+        if (! $plugin) {
+            return response()->json([
                 'message' => 'Plugin not found',
-            ], 404 );
+            ], 404);
         }
 
-        return response()->json( [
+        return response()->json([
             'plugin' => $plugin,
-        ] );
+        ]);
     }
 
     /**
      * POST /api/v1/plugins/install
      * Upload and install plugin ZIP.
      */
-    public function install( Request $request ): JsonResponse
+    public function install(Request $request): JsonResponse
     {
-        $request->validate( [
-            'plugin_zip' => 'required|file|mimes:zip|max:' . ( config( 'cms.plugins.maxUploadSize' ) / 1024 ),
-        ] );
+        $request->validate([
+            'plugin_zip' => 'required|file|mimes:zip|max:'.(config('cms.plugins.maxUploadSize') / 1024),
+        ]);
 
         try {
-            $zipPath = $request->file( 'plugin_zip' )->path();
-            $plugin  = $this->pluginManager->installFromZip( $zipPath );
+            $zipPath = $request->file('plugin_zip')->path();
+            $plugin  = $this->pluginManager->installFromZip($zipPath);
 
-            return response()->json( [
+            return response()->json([
                 'message' => 'Plugin installed successfully',
                 'plugin'  => $plugin,
-            ], 201 );
-        } catch ( Exception $e ) {
-            return response()->json( [
-                'message' => 'Installation failed: ' . $e->getMessage(),
-            ], 422 );
+            ], 201);
+        } catch (Exception $e) {
+            return response()->json([
+                'message' => 'Installation failed: '.$e->getMessage(),
+            ], 422);
         }
     }
 
@@ -80,18 +81,18 @@ class PluginsController extends Controller
      * POST /api/v1/plugins/{slug}/activate
      * Activate a plugin.
      */
-    public function activate( string $slug ): JsonResponse
+    public function activate(string $slug): JsonResponse
     {
         try {
-            $this->pluginManager->activate( $slug );
+            $this->pluginManager->activate($slug);
 
-            return response()->json( [
+            return response()->json([
                 'message' => 'Plugin activated successfully',
-            ] );
-        } catch ( Exception $e ) {
-            return response()->json( [
-                'message' => 'Activation failed: ' . $e->getMessage(),
-            ], 422 );
+            ]);
+        } catch (Exception $e) {
+            return response()->json([
+                'message' => 'Activation failed: '.$e->getMessage(),
+            ], 422);
         }
     }
 
@@ -99,18 +100,18 @@ class PluginsController extends Controller
      * POST /api/v1/plugins/{slug}/deactivate
      * Deactivate a plugin.
      */
-    public function deactivate( string $slug ): JsonResponse
+    public function deactivate(string $slug): JsonResponse
     {
         try {
-            $this->pluginManager->deactivate( $slug );
+            $this->pluginManager->deactivate($slug);
 
-            return response()->json( [
+            return response()->json([
                 'message' => 'Plugin deactivated successfully',
-            ] );
-        } catch ( Exception $e ) {
-            return response()->json( [
-                'message' => 'Deactivation failed: ' . $e->getMessage(),
-            ], 422 );
+            ]);
+        } catch (Exception $e) {
+            return response()->json([
+                'message' => 'Deactivation failed: '.$e->getMessage(),
+            ], 422);
         }
     }
 
@@ -118,18 +119,18 @@ class PluginsController extends Controller
      * DELETE /api/v1/plugins/{slug}
      * Delete a plugin.
      */
-    public function destroy( string $slug ): JsonResponse
+    public function destroy(string $slug): JsonResponse
     {
         try {
-            $this->pluginManager->delete( $slug );
+            $this->pluginManager->delete($slug);
 
-            return response()->json( [
+            return response()->json([
                 'message' => 'Plugin deleted successfully',
-            ] );
-        } catch ( Exception $e ) {
-            return response()->json( [
-                'message' => 'Deletion failed: ' . $e->getMessage(),
-            ], 422 );
+            ]);
+        } catch (Exception $e) {
+            return response()->json([
+                'message' => 'Deletion failed: '.$e->getMessage(),
+            ], 422);
         }
     }
 
@@ -141,27 +142,27 @@ class PluginsController extends Controller
     {
         $updates = $this->updateManager->checkForUpdates();
 
-        return response()->json( [
+        return response()->json([
             'updates' => $updates,
-        ] );
+        ]);
     }
 
     /**
      * POST /api/v1/plugins/{slug}/update
      * Update a plugin to latest version.
      */
-    public function update( string $slug ): JsonResponse
+    public function update(string $slug): JsonResponse
     {
         try {
-            $this->updateManager->updatePlugin( $slug );
+            $this->updateManager->updatePlugin($slug);
 
-            return response()->json( [
+            return response()->json([
                 'message' => 'Plugin updated successfully',
-            ] );
-        } catch ( Exception $e ) {
-            return response()->json( [
-                'message' => 'Update failed: ' . $e->getMessage(),
-            ], 422 );
+            ]);
+        } catch (Exception $e) {
+            return response()->json([
+                'message' => 'Update failed: '.$e->getMessage(),
+            ], 422);
         }
     }
 }

--- a/src/Modules/Plugins/Http/Controllers/PluginsController.php
+++ b/src/Modules/Plugins/Http/Controllers/PluginsController.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare( strict_types=1 );
 
 namespace ArtisanPackUI\CMSFramework\Modules\Plugins\Http\Controllers;
 
@@ -12,13 +12,14 @@ use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
 
-#[Group('Plugins', weight: 15)]
+#[Group( 'Plugins', weight: 15 )]
 class PluginsController extends Controller
 {
     public function __construct(
         private PluginManager $pluginManager,
         private UpdateManager $updateManager,
-    ) {}
+    ) {
+    }
 
     /**
      * GET /api/v1/plugins
@@ -28,52 +29,52 @@ class PluginsController extends Controller
     {
         $plugins = $this->pluginManager->discoverPlugins();
 
-        return response()->json([
+        return response()->json( [
             'plugins' => $plugins,
-        ]);
+        ] );
     }
 
     /**
      * GET /api/v1/plugins/{slug}
      * Get specific plugin details.
      */
-    public function show(string $slug): JsonResponse
+    public function show( string $slug ): JsonResponse
     {
-        $plugin = $this->pluginManager->getPlugin($slug);
+        $plugin = $this->pluginManager->getPlugin( $slug );
 
-        if (! $plugin) {
-            return response()->json([
+        if ( ! $plugin ) {
+            return response()->json( [
                 'message' => 'Plugin not found',
-            ], 404);
+            ], 404 );
         }
 
-        return response()->json([
+        return response()->json( [
             'plugin' => $plugin,
-        ]);
+        ] );
     }
 
     /**
      * POST /api/v1/plugins/install
      * Upload and install plugin ZIP.
      */
-    public function install(Request $request): JsonResponse
+    public function install( Request $request ): JsonResponse
     {
-        $request->validate([
-            'plugin_zip' => 'required|file|mimes:zip|max:'.(config('cms.plugins.maxUploadSize') / 1024),
-        ]);
+        $request->validate( [
+            'plugin_zip' => 'required|file|mimes:zip|max:' . ( config( 'cms.plugins.maxUploadSize' ) / 1024 ),
+        ] );
 
         try {
-            $zipPath = $request->file('plugin_zip')->path();
-            $plugin  = $this->pluginManager->installFromZip($zipPath);
+            $zipPath = $request->file( 'plugin_zip' )->path();
+            $plugin  = $this->pluginManager->installFromZip( $zipPath );
 
-            return response()->json([
+            return response()->json( [
                 'message' => 'Plugin installed successfully',
                 'plugin'  => $plugin,
-            ], 201);
-        } catch (Exception $e) {
-            return response()->json([
-                'message' => 'Installation failed: '.$e->getMessage(),
-            ], 422);
+            ], 201 );
+        } catch ( Exception $e ) {
+            return response()->json( [
+                'message' => 'Installation failed: ' . $e->getMessage(),
+            ], 422 );
         }
     }
 
@@ -81,18 +82,18 @@ class PluginsController extends Controller
      * POST /api/v1/plugins/{slug}/activate
      * Activate a plugin.
      */
-    public function activate(string $slug): JsonResponse
+    public function activate( string $slug ): JsonResponse
     {
         try {
-            $this->pluginManager->activate($slug);
+            $this->pluginManager->activate( $slug );
 
-            return response()->json([
+            return response()->json( [
                 'message' => 'Plugin activated successfully',
-            ]);
-        } catch (Exception $e) {
-            return response()->json([
-                'message' => 'Activation failed: '.$e->getMessage(),
-            ], 422);
+            ] );
+        } catch ( Exception $e ) {
+            return response()->json( [
+                'message' => 'Activation failed: ' . $e->getMessage(),
+            ], 422 );
         }
     }
 
@@ -100,18 +101,18 @@ class PluginsController extends Controller
      * POST /api/v1/plugins/{slug}/deactivate
      * Deactivate a plugin.
      */
-    public function deactivate(string $slug): JsonResponse
+    public function deactivate( string $slug ): JsonResponse
     {
         try {
-            $this->pluginManager->deactivate($slug);
+            $this->pluginManager->deactivate( $slug );
 
-            return response()->json([
+            return response()->json( [
                 'message' => 'Plugin deactivated successfully',
-            ]);
-        } catch (Exception $e) {
-            return response()->json([
-                'message' => 'Deactivation failed: '.$e->getMessage(),
-            ], 422);
+            ] );
+        } catch ( Exception $e ) {
+            return response()->json( [
+                'message' => 'Deactivation failed: ' . $e->getMessage(),
+            ], 422 );
         }
     }
 
@@ -119,18 +120,18 @@ class PluginsController extends Controller
      * DELETE /api/v1/plugins/{slug}
      * Delete a plugin.
      */
-    public function destroy(string $slug): JsonResponse
+    public function destroy( string $slug ): JsonResponse
     {
         try {
-            $this->pluginManager->delete($slug);
+            $this->pluginManager->delete( $slug );
 
-            return response()->json([
+            return response()->json( [
                 'message' => 'Plugin deleted successfully',
-            ]);
-        } catch (Exception $e) {
-            return response()->json([
-                'message' => 'Deletion failed: '.$e->getMessage(),
-            ], 422);
+            ] );
+        } catch ( Exception $e ) {
+            return response()->json( [
+                'message' => 'Deletion failed: ' . $e->getMessage(),
+            ], 422 );
         }
     }
 
@@ -142,26 +143,26 @@ class PluginsController extends Controller
     {
         $updates = $this->updateManager->checkForUpdates();
 
-        return response()->json([
+        return response()->json( [
             'updates' => $updates,
-        ]);
+        ] );
     }
 
     /**
      * POST /api/v1/plugins/{slug}/update
      * Update a plugin to latest version.
      */
-    public function update(string $slug): JsonResponse
+    public function update( string $slug ): JsonResponse
     {
         try {
-            $this->updateManager->updatePlugin($slug);
+            $this->updateManager->updatePlugin( $slug );
 
-            return response()->json([
+            return response()->json( [
                 'message' => 'Plugin updated successfully',
-            ]);
-        } catch (Exception $e) {
-            return response()->json([
-                'message' => 'Update failed: '.$e->getMessage(),
+            ] );
+        } catch ( Exception $e ) {
+            return response()->json( [
+                'message' => 'Update failed: ' . $e->getMessage(),
             ], 422);
         }
     }

--- a/src/Modules/Plugins/Managers/PluginManager.php
+++ b/src/Modules/Plugins/Managers/PluginManager.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace ArtisanPackUI\CMSFramework\Modules\Plugins\Managers;
 
+use ArtisanPackUI\CMSFramework\Modules\Core\Managers\Concerns\HasManifestParsing;
 use ArtisanPackUI\CMSFramework\Modules\Plugins\Exceptions\PluginInstallationException;
 use ArtisanPackUI\CMSFramework\Modules\Plugins\Exceptions\PluginNotFoundException;
 use ArtisanPackUI\CMSFramework\Modules\Plugins\Exceptions\PluginValidationException;
@@ -19,6 +20,8 @@ use ZipArchive;
 
 class PluginManager
 {
+    use HasManifestParsing;
+
     private ClassLoader $classLoader;
 
     public function __construct()
@@ -63,23 +66,16 @@ class PluginManager
     public function getPlugin(string $slug): ?array
     {
         // Validate slug format (alphanumeric, hyphens, underscores only)
-        if (! preg_match('/^[a-zA-Z0-9_-]+$/', $slug)) {
+        if (! $this->validateSlug($slug)) {
             return null;
         }
 
-        // Build and validate path
+        // Build and validate path within plugins directory
         $pluginsBasePath = $this->getPluginsPath();
-        $pluginPath      = $pluginsBasePath.'/'.$slug;
+        $realPluginPath  = $this->resolveSecurePath($pluginsBasePath.'/'.$slug, $pluginsBasePath);
 
-        // Resolve real path and verify it's within plugins directory
-        $realPluginPath = realpath($pluginPath);
-        if (false === $realPluginPath) {
+        if (null === $realPluginPath) {
             return null;
-        }
-
-        $realBasePath = realpath($pluginsBasePath);
-        if (false === $realBasePath || 0 !== strpos($realPluginPath, $realBasePath.DIRECTORY_SEPARATOR)) {
-            return null; // Path traversal attempt detected
         }
 
         // Check if plugin.json exists
@@ -397,7 +393,7 @@ class PluginManager
         }
 
         // Validate slug format
-        if (! preg_match('/^[a-zA-Z0-9_-]+$/', $manifest['slug'])) {
+        if (! $this->validateSlug($manifest['slug'])) {
             throw PluginValidationException::invalidManifest('Invalid slug format. Use alphanumeric, hyphens, and underscores only.');
         }
 
@@ -491,29 +487,6 @@ class PluginManager
         $zip->close();
 
         return $slug;
-    }
-
-    /**
-     * Parse plugin.json manifest file.
-     *
-     * @param  string  $manifestPath  Path to plugin.json
-     *
-     * @return array|null Parsed manifest or null if invalid
-     */
-    protected function parseManifest(string $manifestPath): ?array
-    {
-        if (! File::exists($manifestPath)) {
-            return null;
-        }
-
-        $content  = File::get($manifestPath);
-        $manifest = json_decode($content, true);
-
-        if (JSON_ERROR_NONE !== json_last_error()) {
-            return null;
-        }
-
-        return $manifest;
     }
 
     /**

--- a/src/Modules/Plugins/Managers/PluginManager.php
+++ b/src/Modules/Plugins/Managers/PluginManager.php
@@ -543,7 +543,7 @@ class PluginManager
      */
     protected function getPluginsPath(): string
     {
-        return base_path( config( 'cms.plugins.directory', 'plugins'));
+        return base_path( config( 'cms.plugins.directory', 'plugins' ) );
     }
 
     /**
@@ -551,7 +551,7 @@ class PluginManager
      */
     protected function clearCaches(): void
     {
-        Cache::forget( config( 'cms.plugins.cacheKey'));
+        Cache::forget( config( 'cms.plugins.cacheKey' ) );
     }
 
     /**
@@ -562,8 +562,8 @@ class PluginManager
      */
     private function getComposerClassLoader(): ClassLoader
     {
-        foreach ( spl_autoload_functions() as $autoloader) {
-            if ( is_array( $autoloader) && $autoloader[0] instanceof ClassLoader) {
+        foreach ( spl_autoload_functions() as $autoloader ) {
+            if ( is_array( $autoloader ) && $autoloader[0] instanceof ClassLoader ) {
                 return $autoloader[0];
             }
         }

--- a/src/Modules/Plugins/Managers/PluginManager.php
+++ b/src/Modules/Plugins/Managers/PluginManager.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare( strict_types=1 );
 
 namespace ArtisanPackUI\CMSFramework\Modules\Plugins\Managers;
 
@@ -42,10 +42,10 @@ class PluginManager
      */
     public function discoverPlugins(): array
     {
-        if (config('cms.plugins.cacheEnabled')) {
+        if ( config( 'cms.plugins.cacheEnabled' ) ) {
             return Cache::remember(
-                config('cms.plugins.cacheKey'),
-                config('cms.plugins.cacheTtl'),
+                config( 'cms.plugins.cacheKey' ),
+                config( 'cms.plugins.cacheTtl' ),
                 fn () => $this->scanPluginsDirectory(),
             );
         }
@@ -63,35 +63,35 @@ class PluginManager
      *
      * @return array|null Plugin data or null if not found
      */
-    public function getPlugin(string $slug): ?array
+    public function getPlugin( string $slug ): ?array
     {
         // Validate slug format (alphanumeric, hyphens, underscores only)
-        if (! $this->validateSlug($slug)) {
+        if ( ! $this->validateSlug( $slug ) ) {
             return null;
         }
 
         // Build and validate path within plugins directory
         $pluginsBasePath = $this->getPluginsPath();
-        $realPluginPath  = $this->resolveSecurePath($pluginsBasePath.'/'.$slug, $pluginsBasePath);
+        $realPluginPath  = $this->resolveSecurePath( $pluginsBasePath . '/' . $slug, $pluginsBasePath );
 
-        if (null === $realPluginPath) {
+        if ( null === $realPluginPath ) {
             return null;
         }
 
         // Check if plugin.json exists
-        $manifestPath = $realPluginPath.'/plugin.json';
-        if (! File::exists($manifestPath)) {
+        $manifestPath = $realPluginPath . '/plugin.json';
+        if ( ! File::exists( $manifestPath ) ) {
             return null;
         }
 
         // Parse manifest
-        $manifest = $this->parseManifest($manifestPath);
-        if (null === $manifest) {
+        $manifest = $this->parseManifest( $manifestPath );
+        if ( null === $manifest ) {
             return null;
         }
 
         // Get database record if exists
-        $dbPlugin = Plugin::where('slug', sanitizeText($slug))->first();
+        $dbPlugin = Plugin::where( 'slug', sanitizeText( $slug ) )->first();
 
         return [
             'slug'        => $slug,
@@ -123,25 +123,25 @@ class PluginManager
      *
      * @return Plugin The installed plugin model
      */
-    public function installFromZip(string $zipPath): Plugin
+    public function installFromZip( string $zipPath ): Plugin
     {
-        $this->validateZip($zipPath);
+        $this->validateZip( $zipPath );
 
-        $slug         = $this->extractZip($zipPath);
-        $manifestPath = $this->getPluginsPath().'/'.$slug.'/plugin.json';
-        $manifest     = $this->parseManifest($manifestPath);
+        $slug         = $this->extractZip( $zipPath );
+        $manifestPath = $this->getPluginsPath() . '/' . $slug . '/plugin.json';
+        $manifest     = $this->parseManifest( $manifestPath );
 
-        $this->validateManifest($manifest);
+        $this->validateManifest( $manifest );
 
         // Check if already installed
-        if (Plugin::where('slug', sanitizeText($slug))->exists()) {
-            throw PluginInstallationException::alreadyInstalled($slug);
+        if ( Plugin::where( 'slug', sanitizeText( $slug ) )->exists() ) {
+            throw PluginInstallationException::alreadyInstalled( $slug );
         }
 
-        doAction('plugin.installing', $slug);
+        doAction( 'plugin.installing', $slug );
 
         // Register in database
-        $plugin = Plugin::create([
+        $plugin = Plugin::create( [
             'slug'             => $slug,
             'name'             => $manifest['name'],
             'version'          => $manifest['version'],
@@ -149,11 +149,11 @@ class PluginManager
             'service_provider' => $manifest['service_provider'] ?? null,
             'meta'             => $manifest,
             'installed_at'     => now(),
-        ]);
+        ] );
 
         $this->clearCaches();
 
-        doAction('plugin.installed', $slug, $plugin);
+        doAction( 'plugin.installed', $slug, $plugin );
 
         return $plugin;
     }
@@ -175,40 +175,40 @@ class PluginManager
      *
      * @return bool True on success
      */
-    public function activate(string $slug): bool
+    public function activate( string $slug ): bool
     {
-        $plugin = Plugin::where('slug', sanitizeText($slug))->first();
+        $plugin = Plugin::where( 'slug', sanitizeText( $slug ) )->first();
 
-        if (! $plugin) {
-            throw PluginNotFoundException::forSlug($slug);
+        if ( ! $plugin ) {
+            throw PluginNotFoundException::forSlug( $slug );
         }
 
-        doAction('plugin.activating', $slug);
+        doAction( 'plugin.activating', $slug );
 
-        DB::transaction(function () use ($plugin): void {
+        DB::transaction( function () use ( $plugin ): void {
             // Register autoloader
-            if (isset($plugin->meta['autoload'])) {
-                $this->registerAutoloader($plugin->slug, $plugin->meta['autoload']);
+            if ( isset( $plugin->meta['autoload'] ) ) {
+                $this->registerAutoloader( $plugin->slug, $plugin->meta['autoload'] );
             }
 
             // Run migrations
-            if (isset($plugin->meta['migrations_path'])) {
-                $this->runMigrations($plugin->slug, $plugin->meta['migrations_path']);
+            if ( isset( $plugin->meta['migrations_path'] ) ) {
+                $this->runMigrations( $plugin->slug, $plugin->meta['migrations_path'] );
             }
 
             // Register service provider
-            if ($plugin->hasServiceProvider()) {
-                app()->register($plugin->service_provider);
+            if ( $plugin->hasServiceProvider() ) {
+                app()->register( $plugin->service_provider );
             }
 
             // Mark as active
             $plugin->is_active = true;
             $plugin->save();
-        });
+        } );
 
         $this->clearCaches();
 
-        doAction('plugin.activated', $slug, $plugin);
+        doAction( 'plugin.activated', $slug, $plugin );
 
         return true;
     }
@@ -228,22 +228,22 @@ class PluginManager
      *
      * @return bool True on success
      */
-    public function deactivate(string $slug): bool
+    public function deactivate( string $slug ): bool
     {
-        $plugin = Plugin::where('slug', sanitizeText($slug))->first();
+        $plugin = Plugin::where( 'slug', sanitizeText( $slug ) )->first();
 
-        if (! $plugin) {
-            throw PluginNotFoundException::forSlug($slug);
+        if ( ! $plugin ) {
+            throw PluginNotFoundException::forSlug( $slug );
         }
 
-        doAction('plugin.deactivating', $slug);
+        doAction( 'plugin.deactivating', $slug );
 
         $plugin->is_active = false;
         $plugin->save();
 
         $this->clearCaches();
 
-        doAction('plugin.deactivated', $slug);
+        doAction( 'plugin.deactivated', $slug );
 
         return true;
     }
@@ -265,35 +265,35 @@ class PluginManager
      *
      * @return bool True on success
      */
-    public function delete(string $slug, bool $deleteFiles = true): bool
+    public function delete( string $slug, bool $deleteFiles = true ): bool
     {
-        $plugin = Plugin::where('slug', sanitizeText($slug))->first();
+        $plugin = Plugin::where( 'slug', sanitizeText( $slug ) )->first();
 
-        if (! $plugin) {
-            throw PluginNotFoundException::forSlug($slug);
+        if ( ! $plugin ) {
+            throw PluginNotFoundException::forSlug( $slug );
         }
 
         // Deactivate if active
-        if ($plugin->is_active) {
-            $this->deactivate($slug);
+        if ( $plugin->is_active ) {
+            $this->deactivate( $slug );
         }
 
-        doAction('plugin.deleting', $slug);
+        doAction( 'plugin.deleting', $slug );
 
         // Remove from database
         $plugin->delete();
 
         // Remove from filesystem
-        if ($deleteFiles) {
-            $pluginPath = $this->getPluginsPath().'/'.$slug;
-            if (File::exists($pluginPath)) {
-                File::deleteDirectory($pluginPath);
+        if ( $deleteFiles ) {
+            $pluginPath = $this->getPluginsPath() . '/' . $slug;
+            if ( File::exists( $pluginPath ) ) {
+                File::deleteDirectory( $pluginPath );
             }
         }
 
         $this->clearCaches();
 
-        doAction('plugin.deleted', $slug);
+        doAction( 'plugin.deleted', $slug );
 
         return true;
     }
@@ -308,21 +308,21 @@ class PluginManager
     {
         $activePlugins = Plugin::active()->get();
 
-        foreach ($activePlugins as $plugin) {
+        foreach ( $activePlugins as $plugin ) {
             // Register autoloader
-            if (isset($plugin->meta['autoload'])) {
-                $this->registerAutoloader($plugin->slug, $plugin->meta['autoload']);
+            if ( isset( $plugin->meta['autoload'] ) ) {
+                $this->registerAutoloader( $plugin->slug, $plugin->meta['autoload'] );
             }
 
             // Register service provider
-            if ($plugin->hasServiceProvider()) {
+            if ( $plugin->hasServiceProvider() ) {
                 try {
-                    app()->register($plugin->service_provider);
-                } catch (Exception $e) {
+                    app()->register( $plugin->service_provider );
+                } catch ( Exception $e ) {
                     // Log error but don't break application
-                    logger()->error("Failed to register plugin service provider: {$plugin->slug}", [
+                    logger()->error( "Failed to register plugin service provider: {$plugin->slug}", [
                         'exception' => $e->getMessage(),
-                    ]);
+                    ] );
                 }
             }
         }
@@ -334,19 +334,19 @@ class PluginManager
      * @param  string  $slug  Plugin slug
      * @param  string  $migrationsPath  Relative path to migrations directory
      */
-    protected function runMigrations(string $slug, string $migrationsPath): void
+    protected function runMigrations( string $slug, string $migrationsPath ): void
     {
-        $fullPath = $this->getPluginsPath().'/'.$slug.'/'.$migrationsPath;
+        $fullPath = $this->getPluginsPath() . '/' . $slug . '/' . $migrationsPath;
 
-        if (! File::isDirectory($fullPath)) {
+        if ( ! File::isDirectory( $fullPath ) ) {
             return;
         }
 
         // Run migrations using Artisan
-        Artisan::call('migrate', [
-            '--path'  => str_replace(base_path(), '', $fullPath),
+        Artisan::call( 'migrate', [
+            '--path'  => str_replace( base_path(), '', $fullPath ),
             '--force' => true,
-        ]);
+        ] );
     }
 
     /**
@@ -355,23 +355,23 @@ class PluginManager
      * @param  string  $slug  Plugin slug
      * @param  array  $autoloadConfig  Autoload configuration from plugin.json
      */
-    protected function registerAutoloader(string $slug, array $autoloadConfig): void
+    protected function registerAutoloader( string $slug, array $autoloadConfig ): void
     {
-        if (! isset($autoloadConfig['psr-4'])) {
+        if ( ! isset( $autoloadConfig['psr-4'] ) ) {
             return;
         }
 
-        $pluginPath = $this->getPluginsPath().'/'.$slug;
+        $pluginPath = $this->getPluginsPath() . '/' . $slug;
 
-        foreach ($autoloadConfig['psr-4'] as $namespace => $path) {
+        foreach ( $autoloadConfig['psr-4'] as $namespace => $path ) {
             $this->classLoader->addPsr4(
                 $namespace,
-                $pluginPath.'/'.$path,
+                $pluginPath . '/' . $path,
             );
         }
 
         // Re-register the autoloader
-        $this->classLoader->register(true);
+        $this->classLoader->register( true );
     }
 
     /**
@@ -381,26 +381,26 @@ class PluginManager
      *
      * @throws PluginValidationException If validation fails
      */
-    protected function validateManifest(array $manifest): void
+    protected function validateManifest( array $manifest ): void
     {
         // Check required fields
         $required = ['slug', 'name', 'version'];
 
-        foreach ($required as $field) {
-            if (! isset($manifest[$field]) || empty($manifest[$field])) {
-                throw PluginValidationException::invalidManifest("Missing required field: {$field}");
+        foreach ( $required as $field ) {
+            if ( ! isset( $manifest[ $field ] ) || empty( $manifest[ $field ] ) ) {
+                throw PluginValidationException::invalidManifest( "Missing required field: {$field}" );
             }
         }
 
         // Validate slug format
-        if (! $this->validateSlug($manifest['slug'])) {
-            throw PluginValidationException::invalidManifest('Invalid slug format. Use alphanumeric, hyphens, and underscores only.');
+        if ( ! $this->validateSlug( $manifest['slug'] ) ) {
+            throw PluginValidationException::invalidManifest( 'Invalid slug format. Use alphanumeric, hyphens, and underscores only.' );
         }
 
         // Validate version format (basic semver check)
         // Anchored at end to prevent injection attempts like "1.0.0'; DROP TABLE"
-        if (! preg_match('/^\d+\.\d+\.\d+$/', $manifest['version'])) {
-            throw PluginValidationException::invalidManifest('Invalid version format. Use semantic versioning (e.g., 1.0.0).');
+        if ( ! preg_match( '/^\d+\.\d+\.\d+$/', $manifest['version'] ) ) {
+            throw PluginValidationException::invalidManifest( 'Invalid version format. Use semantic versioning (e.g., 1.0.0).' );
         }
     }
 
@@ -411,40 +411,40 @@ class PluginManager
      *
      * @throws PluginValidationException If ZIP is invalid
      */
-    protected function validateZip(string $zipPath): void
+    protected function validateZip( string $zipPath ): void
     {
         // Check file exists
-        if (! File::exists($zipPath)) {
-            throw PluginValidationException::invalidZip('ZIP file not found');
+        if ( ! File::exists( $zipPath ) ) {
+            throw PluginValidationException::invalidZip( 'ZIP file not found' );
         }
 
         // Check MIME type using finfo (mime_content_type is deprecated)
-        $finfo        = finfo_open(FILEINFO_MIME_TYPE);
-        $mimeType     = finfo_file($finfo, $zipPath);
-        finfo_close($finfo);
-        $allowedTypes = config('cms.plugins.allowedMimeTypes');
+        $finfo        = finfo_open( FILEINFO_MIME_TYPE );
+        $mimeType     = finfo_file( $finfo, $zipPath );
+        finfo_close( $finfo );
+        $allowedTypes = config( 'cms.plugins.allowedMimeTypes' );
 
-        if (! in_array($mimeType, $allowedTypes)) {
-            throw PluginValidationException::invalidZip('Invalid file type. Must be a ZIP file.');
+        if ( ! in_array( $mimeType, $allowedTypes ) ) {
+            throw PluginValidationException::invalidZip( 'Invalid file type. Must be a ZIP file.' );
         }
 
         // Check file size
-        $maxSize = config('cms.plugins.maxUploadSize');
-        if (filesize($zipPath) > $maxSize) {
-            throw PluginValidationException::invalidZip('File size exceeds maximum allowed size.');
+        $maxSize = config( 'cms.plugins.maxUploadSize' );
+        if ( filesize( $zipPath ) > $maxSize ) {
+            throw PluginValidationException::invalidZip( 'File size exceeds maximum allowed size.' );
         }
 
         // Validate ZIP integrity
         $zip = new ZipArchive;
-        if (true !== $zip->open($zipPath)) {
-            throw PluginValidationException::invalidZip('Invalid or corrupted ZIP file.');
+        if ( true !== $zip->open( $zipPath ) ) {
+            throw PluginValidationException::invalidZip( 'Invalid or corrupted ZIP file.' );
         }
 
         // Check for plugin.json in ZIP
         $manifestFound = false;
-        for ($i = 0; $i < $zip->numFiles; $i++) {
-            $filename = $zip->getNameIndex($i);
-            if (str_ends_with($filename, 'plugin.json')) {
+        for ( $i = 0; $i < $zip->numFiles; $i++ ) {
+            $filename = $zip->getNameIndex( $i );
+            if ( str_ends_with( $filename, 'plugin.json' ) ) {
                 $manifestFound = true;
                 break;
             }
@@ -452,8 +452,8 @@ class PluginManager
 
         $zip->close();
 
-        if (! $manifestFound) {
-            throw PluginValidationException::invalidZip('Plugin manifest (plugin.json) not found in ZIP.');
+        if ( ! $manifestFound ) {
+            throw PluginValidationException::invalidZip( 'Plugin manifest (plugin.json) not found in ZIP.' );
         }
     }
 
@@ -466,22 +466,22 @@ class PluginManager
      *
      * @return string Plugin slug
      */
-    protected function extractZip(string $zipPath): string
+    protected function extractZip( string $zipPath ): string
     {
         $zip = new ZipArchive;
-        if (true !== $zip->open($zipPath)) {
-            throw PluginInstallationException::extractionFailed('unknown');
+        if ( true !== $zip->open( $zipPath ) ) {
+            throw PluginInstallationException::extractionFailed( 'unknown' );
         }
 
         // Get the first directory name (plugin slug)
-        $firstEntry = $zip->getNameIndex(0);
-        $slug       = explode('/', $firstEntry)[0];
+        $firstEntry = $zip->getNameIndex( 0 );
+        $slug       = explode( '/', $firstEntry )[0];
 
         // Extract to plugins directory
         $extractPath = $this->getPluginsPath();
-        if (! $zip->extractTo($extractPath)) {
+        if ( ! $zip->extractTo( $extractPath ) ) {
             $zip->close();
-            throw PluginInstallationException::extractionFailed($slug);
+            throw PluginInstallationException::extractionFailed( $slug );
         }
 
         $zip->close();
@@ -499,27 +499,27 @@ class PluginManager
         $pluginsPath = $this->getPluginsPath();
         $plugins     = [];
 
-        if (! File::isDirectory($pluginsPath)) {
+        if ( ! File::isDirectory( $pluginsPath ) ) {
             return $plugins;
         }
 
-        $directories = File::directories($pluginsPath);
+        $directories = File::directories( $pluginsPath );
 
-        foreach ($directories as $directory) {
-            $slug         = basename($directory);
-            $manifestPath = $directory.'/plugin.json';
+        foreach ( $directories as $directory ) {
+            $slug         = basename( $directory );
+            $manifestPath = $directory . '/plugin.json';
 
-            if (! File::exists($manifestPath)) {
+            if ( ! File::exists( $manifestPath ) ) {
                 continue;
             }
 
-            $manifest = $this->parseManifest($manifestPath);
-            if (null === $manifest) {
+            $manifest = $this->parseManifest( $manifestPath );
+            if ( null === $manifest ) {
                 continue;
             }
 
             // Get database record if exists
-            $dbPlugin = Plugin::where('slug', sanitizeText($slug))->first();
+            $dbPlugin = Plugin::where( 'slug', sanitizeText( $slug ) )->first();
 
             $plugins[] = [
                 'slug'        => $slug,
@@ -543,7 +543,7 @@ class PluginManager
      */
     protected function getPluginsPath(): string
     {
-        return base_path(config('cms.plugins.directory', 'plugins'));
+        return base_path( config( 'cms.plugins.directory', 'plugins'));
     }
 
     /**
@@ -551,7 +551,7 @@ class PluginManager
      */
     protected function clearCaches(): void
     {
-        Cache::forget(config('cms.plugins.cacheKey'));
+        Cache::forget( config( 'cms.plugins.cacheKey'));
     }
 
     /**
@@ -562,12 +562,12 @@ class PluginManager
      */
     private function getComposerClassLoader(): ClassLoader
     {
-        foreach (spl_autoload_functions() as $autoloader) {
-            if (is_array($autoloader) && $autoloader[0] instanceof ClassLoader) {
+        foreach ( spl_autoload_functions() as $autoloader) {
+            if ( is_array( $autoloader) && $autoloader[0] instanceof ClassLoader) {
                 return $autoloader[0];
             }
         }
 
-        throw new RuntimeException('Composer ClassLoader not found in registered autoloaders');
+        throw new RuntimeException( 'Composer ClassLoader not found in registered autoloaders');
     }
 }

--- a/src/Modules/Plugins/Providers/PluginsServiceProvider.php
+++ b/src/Modules/Plugins/Providers/PluginsServiceProvider.php
@@ -55,7 +55,7 @@ class PluginsServiceProvider extends ServiceProvider
             }
         } catch ( Exception $e ) {
             // Silently fail during installation/migration
-            logger()->debug( 'Plugin loading skipped: ' . $e->getMessage());
+            logger()->debug( 'Plugin loading skipped: ' . $e->getMessage() );
         }
     }
 }

--- a/src/Modules/Plugins/Providers/PluginsServiceProvider.php
+++ b/src/Modules/Plugins/Providers/PluginsServiceProvider.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare( strict_types=1 );
 
 namespace ArtisanPackUI\CMSFramework\Modules\Plugins\Providers;
 
@@ -15,20 +15,20 @@ class PluginsServiceProvider extends ServiceProvider
     public function register(): void
     {
         // Register PluginManager as singleton
-        $this->app->singleton(PluginManager::class, function ($app) {
+        $this->app->singleton( PluginManager::class, function ( $app ) {
             return new PluginManager;
-        });
+        } );
 
         // Register UpdateManager as singleton
-        $this->app->singleton(UpdateManager::class, function ($app) {
+        $this->app->singleton( UpdateManager::class, function ( $app ) {
             return new UpdateManager(
-                $app->make(PluginManager::class),
+                $app->make( PluginManager::class ),
             );
-        });
+        } );
 
         // Merge config
         $this->mergeConfigFrom(
-            __DIR__.'/../config/plugins.php',
+            __DIR__ . '/../config/plugins.php',
             'cms.plugins',
         );
     }
@@ -36,26 +36,26 @@ class PluginsServiceProvider extends ServiceProvider
     public function boot(): void
     {
         // Publish config
-        $this->publishes([
-            __DIR__.'/../config/plugins.php' => config_path('cms/plugins.php'),
-        ], 'cms-plugins-config');
+        $this->publishes( [
+            __DIR__ . '/../config/plugins.php' => config_path( 'cms/plugins.php' ),
+        ], 'cms-plugins-config' );
 
         // Load API routes
-        $this->loadRoutesFrom(__DIR__.'/../routes/api.php');
+        $this->loadRoutesFrom( __DIR__ . '/../routes/api.php' );
 
         // Load migrations
-        $this->loadMigrationsFrom(__DIR__.'/../../../database/migrations');
+        $this->loadMigrationsFrom( __DIR__ . '/../../../database/migrations' );
 
         // Load active plugins EARLY in boot cycle
         // Only attempt if the plugins table exists (to handle fresh installations)
         try {
-            if (Schema::hasTable('plugins')) {
-                $pluginManager = $this->app->make(PluginManager::class);
+            if ( Schema::hasTable( 'plugins' ) ) {
+                $pluginManager = $this->app->make( PluginManager::class );
                 $pluginManager->loadActivePlugins();
             }
-        } catch (Exception $e) {
+        } catch ( Exception $e ) {
             // Silently fail during installation/migration
-            logger()->debug('Plugin loading skipped: '.$e->getMessage());
+            logger()->debug( 'Plugin loading skipped: ' . $e->getMessage());
         }
     }
 }

--- a/src/Modules/Plugins/routes/api.php
+++ b/src/Modules/Plugins/routes/api.php
@@ -33,4 +33,4 @@ Route::prefix( 'api/v1' )
             // Delete plugin
             Route::delete( '{slug}', [PluginsController::class, 'destroy'] )->name( 'api.plugins.destroy' );
         } );
-    });
+    } );

--- a/src/Modules/Settings/Enums/SettingType.php
+++ b/src/Modules/Settings/Enums/SettingType.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace ArtisanPackUI\CMSFramework\Modules\Settings\Enums;
 
+use JsonException;
+
 /**
  * Enum for setting data types.
  *
@@ -20,12 +22,6 @@ namespace ArtisanPackUI\CMSFramework\Modules\Settings\Enums;
  */
 enum SettingType: string
 {
-    case String  = 'string';
-    case Integer = 'integer';
-    case Boolean = 'boolean';
-    case Float   = 'float';
-    case Json    = 'json';
-
     /**
      * Detect the appropriate SettingType from a PHP value.
      *
@@ -53,6 +49,8 @@ enum SettingType: string
      *
      * @param  mixed  $value  The raw value from the database.
      *
+     * @throws JsonException If the value is malformed JSON when type is Json.
+     *
      * @return mixed The value cast to the appropriate PHP type.
      */
     public function cast(mixed $value): mixed
@@ -65,7 +63,7 @@ enum SettingType: string
             self::Boolean => filter_var($value, FILTER_VALIDATE_BOOLEAN),
             self::Integer => (int) $value,
             self::Float   => (float) $value,
-            self::Json    => json_decode($value, true),
+            self::Json    => json_decode($value, true, 512, JSON_THROW_ON_ERROR),
             self::String  => (string) $value,
         };
     }
@@ -77,6 +75,8 @@ enum SettingType: string
      *
      * @param  mixed  $value  The PHP value to serialize.
      *
+     * @throws JsonException If the value cannot be encoded when type is Json.
+     *
      * @return string The serialized string for storage.
      */
     public function serialize(mixed $value): string
@@ -84,8 +84,13 @@ enum SettingType: string
         return match ($this) {
             self::Boolean              => $value ? '1' : '0',
             self::Integer, self::Float => (string) $value,
-            self::Json                 => json_encode($value),
+            self::Json                 => json_encode($value, JSON_THROW_ON_ERROR),
             self::String               => is_null($value) ? '' : (string) $value,
         };
     }
+    case String  = 'string';
+    case Integer = 'integer';
+    case Boolean = 'boolean';
+    case Float   = 'float';
+    case Json    = 'json';
 }

--- a/src/Modules/Settings/Enums/SettingType.php
+++ b/src/Modules/Settings/Enums/SettingType.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare( strict_types=1 );
 
 /**
  * Setting Type Enum
@@ -31,13 +31,13 @@ enum SettingType: string
      *
      * @return self The detected setting type.
      */
-    public static function fromValue(mixed $value): self
+    public static function fromValue( mixed $value ): self
     {
-        return match (true) {
-            is_bool($value)                        => self::Boolean,
-            is_int($value)                         => self::Integer,
-            is_float($value)                       => self::Float,
-            is_array($value), is_object($value)    => self::Json,
+        return match ( true ) {
+            is_bool( $value )                        => self::Boolean,
+            is_int( $value )                         => self::Integer,
+            is_float( $value )                       => self::Float,
+            is_array( $value ), is_object( $value )    => self::Json,
             default                                => self::String,
         };
     }
@@ -53,17 +53,17 @@ enum SettingType: string
      *
      * @return mixed The value cast to the appropriate PHP type.
      */
-    public function cast(mixed $value): mixed
+    public function cast( mixed $value ): mixed
     {
-        if (is_null($value)) {
-            return (self::String === $this) ? '' : null;
+        if ( is_null( $value ) ) {
+            return ( self::String === $this ) ? '' : null;
         }
 
-        return match ($this) {
-            self::Boolean => filter_var($value, FILTER_VALIDATE_BOOLEAN),
+        return match ( $this ) {
+            self::Boolean => filter_var( $value, FILTER_VALIDATE_BOOLEAN ),
             self::Integer => (int) $value,
             self::Float   => (float) $value,
-            self::Json    => json_decode($value, true, 512, JSON_THROW_ON_ERROR),
+            self::Json    => json_decode( $value, true, 512, JSON_THROW_ON_ERROR ),
             self::String  => (string) $value,
         };
     }
@@ -79,13 +79,13 @@ enum SettingType: string
      *
      * @return string The serialized string for storage.
      */
-    public function serialize(mixed $value): string
+    public function serialize( mixed $value ): string
     {
-        return match ($this) {
+        return match ( $this ) {
             self::Boolean              => $value ? '1' : '0',
             self::Integer, self::Float => (string) $value,
-            self::Json                 => json_encode($value, JSON_THROW_ON_ERROR),
-            self::String               => is_null($value) ? '' : (string) $value,
+            self::Json                 => json_encode( $value, JSON_THROW_ON_ERROR ),
+            self::String               => is_null( $value ) ? '' : (string) $value,
         };
     }
     case String  = 'string';

--- a/src/Modules/Settings/Enums/SettingType.php
+++ b/src/Modules/Settings/Enums/SettingType.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Setting Type Enum
+ *
+ * Defines the available data types for stored settings and centralizes
+ * type detection, casting, and serialization logic.
+ *
+ * @since 1.1.0
+ */
+
+namespace ArtisanPackUI\CMSFramework\Modules\Settings\Enums;
+
+/**
+ * Enum for setting data types.
+ *
+ * @since 1.1.0
+ */
+enum SettingType: string
+{
+    case String  = 'string';
+    case Integer = 'integer';
+    case Boolean = 'boolean';
+    case Float   = 'float';
+    case Json    = 'json';
+
+    /**
+     * Detect the appropriate SettingType from a PHP value.
+     *
+     * @since 1.1.0
+     *
+     * @param  mixed  $value  The PHP value to detect the type of.
+     *
+     * @return self The detected setting type.
+     */
+    public static function fromValue(mixed $value): self
+    {
+        return match (true) {
+            is_bool($value)                        => self::Boolean,
+            is_int($value)                         => self::Integer,
+            is_float($value)                       => self::Float,
+            is_array($value), is_object($value)    => self::Json,
+            default                                => self::String,
+        };
+    }
+
+    /**
+     * Cast a raw stored value back to its native PHP type.
+     *
+     * @since 1.1.0
+     *
+     * @param  mixed  $value  The raw value from the database.
+     *
+     * @return mixed The value cast to the appropriate PHP type.
+     */
+    public function cast(mixed $value): mixed
+    {
+        if (is_null($value)) {
+            return (self::String === $this) ? '' : null;
+        }
+
+        return match ($this) {
+            self::Boolean => filter_var($value, FILTER_VALIDATE_BOOLEAN),
+            self::Integer => (int) $value,
+            self::Float   => (float) $value,
+            self::Json    => json_decode($value, true),
+            self::String  => (string) $value,
+        };
+    }
+
+    /**
+     * Serialize a PHP value for database storage.
+     *
+     * @since 1.1.0
+     *
+     * @param  mixed  $value  The PHP value to serialize.
+     *
+     * @return string The serialized string for storage.
+     */
+    public function serialize(mixed $value): string
+    {
+        return match ($this) {
+            self::Boolean              => $value ? '1' : '0',
+            self::Integer, self::Float => (string) $value,
+            self::Json                 => json_encode($value),
+            self::String               => is_null($value) ? '' : (string) $value,
+        };
+    }
+}

--- a/src/Modules/Settings/Http/Controllers/SettingController.php
+++ b/src/Modules/Settings/Http/Controllers/SettingController.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare( strict_types=1 );
 
 /**
  * Setting Controller for the CMS Framework Settings Module.
@@ -31,7 +31,7 @@ use Illuminate\Routing\Controller;
  *
  * @since 1.0.0
  */
-#[Group('Settings', weight: 13)]
+#[Group( 'Settings', weight: 13 )]
 class SettingController extends Controller
 {
     use AuthorizesRequests;
@@ -48,11 +48,11 @@ class SettingController extends Controller
      */
     public function index(): AnonymousResourceCollection
     {
-        $this->authorize('viewAny', Setting::class);
+        $this->authorize( 'viewAny', Setting::class );
 
-        $settings = Setting::paginate(15);
+        $settings = Setting::paginate( 15 );
 
-        return SettingResource::collection($settings);
+        return SettingResource::collection( $settings );
     }
 
     /**
@@ -68,15 +68,15 @@ class SettingController extends Controller
      *
      * @return JsonResponse The JSON response containing the created setting resource.
      */
-    public function store(SettingRequest $request): JsonResponse // Correct return type hint
+    public function store( SettingRequest $request ): JsonResponse // Correct return type hint
     {
-        $this->authorize('create', Setting::class);
+        $this->authorize( 'create', Setting::class );
 
         $validated = $request->validated();
-        $setting   = Setting::create($validated);
+        $setting   = Setting::create( $validated );
 
         // Return JsonResponse explicitly with 201 status
-        return response()->json(new SettingResource($setting), 201);
+        return response()->json( new SettingResource( $setting ), 201 );
     }
 
     /**
@@ -91,12 +91,12 @@ class SettingController extends Controller
      *
      * @return SettingResource The setting resource with loaded permissions.
      */
-    public function show(string|int $id): SettingResource
+    public function show( string|int $id ): SettingResource
     {
-        $setting = Setting::findOrFail($id);
-        $this->authorize('view', $setting);
+        $setting = Setting::findOrFail( $id );
+        $this->authorize( 'view', $setting );
 
-        return new SettingResource($setting);
+        return new SettingResource( $setting );
     }
 
     /**
@@ -112,14 +112,14 @@ class SettingController extends Controller
      *
      * @return SettingResource The updated setting resource with loaded permissions.
      */
-    public function update(SettingRequest $request, string|int $id): SettingResource
+    public function update( SettingRequest $request, string|int $id ): SettingResource
     {
-        $setting = Setting::findOrFail($id);
-        $this->authorize('update', $setting);
+        $setting = Setting::findOrFail( $id );
+        $this->authorize( 'update', $setting );
         $validated = $request->validated();
-        $setting->update($validated);
+        $setting->update( $validated );
 
-        return new SettingResource($setting);
+        return new SettingResource( $setting );
     }
 
     /**
@@ -135,10 +135,10 @@ class SettingController extends Controller
      *
      * @return Response A response with 204 status code.
      */
-    public function destroy(string|int $id): Response // Correct return type hint
+    public function destroy( string|int $id ): Response // Correct return type hint
     {
-        $setting = Setting::findOrFail($id);
-        $this->authorize('delete', $setting);
+        $setting = Setting::findOrFail( $id );
+        $this->authorize( 'delete', $setting );
         $setting->delete();
 
         return response()->noContent();

--- a/src/Modules/Settings/Http/Controllers/SettingController.php
+++ b/src/Modules/Settings/Http/Controllers/SettingController.php
@@ -93,9 +93,8 @@ class SettingController extends Controller
      */
     public function show(string|int $id): SettingResource
     {
-        $this->authorize('view', Setting::class);
-
         $setting = Setting::findOrFail($id);
+        $this->authorize('view', $setting);
 
         return new SettingResource($setting);
     }

--- a/src/Modules/Settings/Http/Controllers/SettingController.php
+++ b/src/Modules/Settings/Http/Controllers/SettingController.php
@@ -1,6 +1,6 @@
 <?php
 
-declare( strict_types = 1 );
+declare(strict_types=1);
 
 /**
  * Setting Controller for the CMS Framework Settings Module.
@@ -16,6 +16,7 @@ namespace ArtisanPackUI\CMSFramework\Modules\Settings\Http\Controllers;
 use ArtisanPackUI\CMSFramework\Modules\Settings\Http\Requests\SettingRequest;
 use ArtisanPackUI\CMSFramework\Modules\Settings\Http\Resources\SettingResource;
 use ArtisanPackUI\CMSFramework\Modules\Settings\Models\Setting;
+use Dedoc\Scramble\Attributes\Group;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
@@ -30,6 +31,7 @@ use Illuminate\Routing\Controller;
  *
  * @since 1.0.0
  */
+#[Group('Settings', weight: 13)]
 class SettingController extends Controller
 {
     use AuthorizesRequests;
@@ -46,11 +48,11 @@ class SettingController extends Controller
      */
     public function index(): AnonymousResourceCollection
     {
-        $this->authorize( 'viewAny', Setting::class );
+        $this->authorize('viewAny', Setting::class);
 
-        $settings = Setting::paginate( 15 );
+        $settings = Setting::paginate(15);
 
-        return SettingResource::collection( $settings );
+        return SettingResource::collection($settings);
     }
 
     /**
@@ -66,15 +68,15 @@ class SettingController extends Controller
      *
      * @return JsonResponse The JSON response containing the created setting resource.
      */
-    public function store( SettingRequest $request ): JsonResponse // Correct return type hint
+    public function store(SettingRequest $request): JsonResponse // Correct return type hint
     {
-        $this->authorize( 'create', Setting::class );
+        $this->authorize('create', Setting::class);
 
         $validated = $request->validated();
-        $setting   = Setting::create( $validated );
+        $setting   = Setting::create($validated);
 
         // Return JsonResponse explicitly with 201 status
-        return response()->json( new SettingResource( $setting ), 201 );
+        return response()->json(new SettingResource($setting), 201);
     }
 
     /**
@@ -89,13 +91,13 @@ class SettingController extends Controller
      *
      * @return SettingResource The setting resource with loaded permissions.
      */
-    public function show( string|int $id ): SettingResource
+    public function show(string|int $id): SettingResource
     {
-        $this->authorize( 'view', Setting::class );
+        $this->authorize('view', Setting::class);
 
-        $setting = Setting::findOrFail( $id );
+        $setting = Setting::findOrFail($id);
 
-        return new SettingResource( $setting );
+        return new SettingResource($setting);
     }
 
     /**
@@ -111,14 +113,14 @@ class SettingController extends Controller
      *
      * @return SettingResource The updated setting resource with loaded permissions.
      */
-    public function update( SettingRequest $request, string|int $id ): SettingResource
+    public function update(SettingRequest $request, string|int $id): SettingResource
     {
-        $setting = Setting::findOrFail( $id );
-        $this->authorize( 'update', $setting );
+        $setting = Setting::findOrFail($id);
+        $this->authorize('update', $setting);
         $validated = $request->validated();
-        $setting->update( $validated );
+        $setting->update($validated);
 
-        return new SettingResource( $setting );
+        return new SettingResource($setting);
     }
 
     /**
@@ -134,10 +136,10 @@ class SettingController extends Controller
      *
      * @return Response A response with 204 status code.
      */
-    public function destroy( string|int $id ): Response // Correct return type hint
+    public function destroy(string|int $id): Response // Correct return type hint
     {
-        $setting = Setting::findOrFail( $id );
-        $this->authorize( 'delete', $setting );
+        $setting = Setting::findOrFail($id);
+        $this->authorize('delete', $setting);
         $setting->delete();
 
         return response()->noContent();

--- a/src/Modules/Settings/Managers/SettingsManager.php
+++ b/src/Modules/Settings/Managers/SettingsManager.php
@@ -138,16 +138,28 @@ class SettingsManager
             ? call_user_func($def['callback'], $value)
             : $value;
 
+        $registeredType = ($def['type'] ?? null) instanceof SettingType ? $def['type'] : null;
         $currentSetting = Setting::where('key', sanitizeText($key))->first();
 
         if ($currentSetting) {
             $currentSetting->value = $sanitized;
+
+            if ($registeredType) {
+                $currentSetting->type = $registeredType->value;
+            }
+
             $currentSetting->save();
         } else {
-            Setting::create([
+            $attributes = [
                 'key'   => $key,
                 'value' => $sanitized,
-            ]);
+            ];
+
+            if ($registeredType) {
+                $attributes['type'] = $registeredType->value;
+            }
+
+            Setting::create($attributes);
         }
     }
 }

--- a/src/Modules/Settings/Managers/SettingsManager.php
+++ b/src/Modules/Settings/Managers/SettingsManager.php
@@ -159,7 +159,7 @@ class SettingsManager
                 $attributes['type'] = $registeredType->value;
             }
 
-            Setting::create( $attributes);
+            Setting::create( $attributes );
         }
     }
 }

--- a/src/Modules/Settings/Managers/SettingsManager.php
+++ b/src/Modules/Settings/Managers/SettingsManager.php
@@ -1,6 +1,6 @@
 <?php
 
-declare( strict_types = 1 );
+declare(strict_types=1);
 
 /**
  * Settings Manager
@@ -14,6 +14,7 @@ declare( strict_types = 1 );
 
 namespace ArtisanPackUI\CMSFramework\Modules\Settings\Managers;
 
+use ArtisanPackUI\CMSFramework\Modules\Settings\Enums\SettingType;
 use ArtisanPackUI\CMSFramework\Modules\Settings\Models\Setting;
 use Illuminate\Support\Facades\Schema;
 
@@ -35,9 +36,9 @@ class SettingsManager
      * @param  string  $key  Unique key for the setting.
      * @param  mixed  $defaultValue  Default value returned when no stored value exists.
      * @param  callable  $callback  Sanitization callback used to clean values on update.
-     * @param  string  $type  Data type of the setting (e.g., 'string', 'boolean', 'integer').
+     * @param  SettingType  $type  Data type of the setting.
      */
-    public function registerSetting( string $key, mixed $defaultValue, callable $callback, string $type = 'string' ): void
+    public function registerSetting(string $key, mixed $defaultValue, callable $callback, SettingType $type = SettingType::String): void
     {
         /**
          * Filters the array of registered settings to add or modify items.
@@ -50,19 +51,19 @@ class SettingsManager
          * @hook  ap.settings.registeredSettings
          *
          * @param  array  $settings  Associative array of registered settings keyed by setting key. Each item
-         *                           contains: 'default' (mixed), 'type' (string), and 'callback' (callable).
+         *                           contains: 'default' (mixed), 'type' (SettingType), and 'callback' (callable).
          *
          * @return array Filtered settings array.
          */
-        addFilter( 'ap.settings.registeredSettings', function ( $settings ) use ( $key, $defaultValue, $type, $callback ) {
-            $settings[ $key ] = [
+        addFilter('ap.settings.registeredSettings', function ($settings) use ($key, $defaultValue, $type, $callback) {
+            $settings[$key] = [
                 'default'  => $defaultValue,
                 'type'     => $type,
                 'callback' => $callback,
             ];
 
             return $settings;
-        } );
+        });
     }
 
     /**
@@ -79,12 +80,12 @@ class SettingsManager
      *
      * @return mixed The setting value.
      */
-    public function getSetting( string $key, mixed $default = null ): mixed
+    public function getSetting(string $key, mixed $default = null): mixed
     {
-        if ( Schema::hasTable( 'settings' ) ) {
-            $setting = Setting::where( 'key', sanitizeText( $key ) )->first();
+        if (Schema::hasTable('settings')) {
+            $setting = Setting::where('key', sanitizeText($key))->first();
 
-            if ( $setting ) {
+            if ($setting) {
                 return $setting->value;
             }
         }
@@ -100,8 +101,8 @@ class SettingsManager
          *
          * @return array Filtered settings array.
          */
-        $settings          = applyFilters( 'ap.settings.registeredSettings', [] );
-        $registeredDefault = $settings[ $key ]['default'] ?? null;
+        $settings          = applyFilters('ap.settings.registeredSettings', []);
+        $registeredDefault = $settings[$key]['default'] ?? null;
 
         return $default ?? $registeredDefault;
     }
@@ -116,9 +117,9 @@ class SettingsManager
      * @param  string  $key  Unique key for the setting.
      * @param  mixed  $value  New value to store for the setting (will be sanitized first).
      */
-    public function updateSetting( string $key, mixed $value ): void
+    public function updateSetting(string $key, mixed $value): void
     {
-        if ( ! Schema::hasTable( 'settings' ) ) {
+        if (! Schema::hasTable('settings')) {
             return;
         }
 
@@ -131,22 +132,22 @@ class SettingsManager
          *
          * @return array Filtered settings array.
          */
-        $settings  = applyFilters( 'ap.settings.registeredSettings', [] );
-        $def       = $settings[ $key ] ?? null;
-        $sanitized = is_array( $def ) && isset( $def['callback'] ) && is_callable( $def['callback'] )
-            ? call_user_func( $def['callback'], $value )
+        $settings  = applyFilters('ap.settings.registeredSettings', []);
+        $def       = $settings[$key] ?? null;
+        $sanitized = is_array($def) && isset($def['callback']) && is_callable($def['callback'])
+            ? call_user_func($def['callback'], $value)
             : $value;
 
-        $currentSetting = Setting::where( 'key', sanitizeText( $key ) )->first();
+        $currentSetting = Setting::where('key', sanitizeText($key))->first();
 
-        if ( $currentSetting ) {
+        if ($currentSetting) {
             $currentSetting->value = $sanitized;
             $currentSetting->save();
         } else {
-            Setting::create( [
+            Setting::create([
                 'key'   => $key,
                 'value' => $sanitized,
-            ] );
+            ]);
         }
     }
 }

--- a/src/Modules/Settings/Managers/SettingsManager.php
+++ b/src/Modules/Settings/Managers/SettingsManager.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare( strict_types=1 );
 
 /**
  * Settings Manager
@@ -38,7 +38,7 @@ class SettingsManager
      * @param  callable  $callback  Sanitization callback used to clean values on update.
      * @param  SettingType  $type  Data type of the setting.
      */
-    public function registerSetting(string $key, mixed $defaultValue, callable $callback, SettingType $type = SettingType::String): void
+    public function registerSetting( string $key, mixed $defaultValue, callable $callback, SettingType $type = SettingType::String ): void
     {
         /**
          * Filters the array of registered settings to add or modify items.
@@ -55,15 +55,15 @@ class SettingsManager
          *
          * @return array Filtered settings array.
          */
-        addFilter('ap.settings.registeredSettings', function ($settings) use ($key, $defaultValue, $type, $callback) {
-            $settings[$key] = [
+        addFilter( 'ap.settings.registeredSettings', function ( $settings ) use ( $key, $defaultValue, $type, $callback ) {
+            $settings[ $key ] = [
                 'default'  => $defaultValue,
                 'type'     => $type,
                 'callback' => $callback,
             ];
 
             return $settings;
-        });
+        } );
     }
 
     /**
@@ -80,12 +80,12 @@ class SettingsManager
      *
      * @return mixed The setting value.
      */
-    public function getSetting(string $key, mixed $default = null): mixed
+    public function getSetting( string $key, mixed $default = null ): mixed
     {
-        if (Schema::hasTable('settings')) {
-            $setting = Setting::where('key', sanitizeText($key))->first();
+        if ( Schema::hasTable( 'settings' ) ) {
+            $setting = Setting::where( 'key', sanitizeText( $key ) )->first();
 
-            if ($setting) {
+            if ( $setting ) {
                 return $setting->value;
             }
         }
@@ -101,8 +101,8 @@ class SettingsManager
          *
          * @return array Filtered settings array.
          */
-        $settings          = applyFilters('ap.settings.registeredSettings', []);
-        $registeredDefault = $settings[$key]['default'] ?? null;
+        $settings          = applyFilters( 'ap.settings.registeredSettings', [] );
+        $registeredDefault = $settings[ $key ]['default'] ?? null;
 
         return $default ?? $registeredDefault;
     }
@@ -117,9 +117,9 @@ class SettingsManager
      * @param  string  $key  Unique key for the setting.
      * @param  mixed  $value  New value to store for the setting (will be sanitized first).
      */
-    public function updateSetting(string $key, mixed $value): void
+    public function updateSetting( string $key, mixed $value ): void
     {
-        if (! Schema::hasTable('settings')) {
+        if ( ! Schema::hasTable( 'settings' ) ) {
             return;
         }
 
@@ -132,19 +132,19 @@ class SettingsManager
          *
          * @return array Filtered settings array.
          */
-        $settings  = applyFilters('ap.settings.registeredSettings', []);
-        $def       = $settings[$key] ?? null;
-        $sanitized = is_array($def) && isset($def['callback']) && is_callable($def['callback'])
-            ? call_user_func($def['callback'], $value)
+        $settings  = applyFilters( 'ap.settings.registeredSettings', [] );
+        $def       = $settings[ $key ] ?? null;
+        $sanitized = is_array( $def ) && isset( $def['callback'] ) && is_callable( $def['callback'] )
+            ? call_user_func( $def['callback'], $value )
             : $value;
 
-        $registeredType = ($def['type'] ?? null) instanceof SettingType ? $def['type'] : null;
-        $currentSetting = Setting::where('key', sanitizeText($key))->first();
+        $registeredType = ( $def['type'] ?? null ) instanceof SettingType ? $def['type'] : null;
+        $currentSetting = Setting::where( 'key', sanitizeText( $key ) )->first();
 
-        if ($currentSetting) {
+        if ( $currentSetting ) {
             $currentSetting->value = $sanitized;
 
-            if ($registeredType) {
+            if ( $registeredType ) {
                 $currentSetting->type = $registeredType->value;
             }
 
@@ -155,11 +155,11 @@ class SettingsManager
                 'value' => $sanitized,
             ];
 
-            if ($registeredType) {
+            if ( $registeredType ) {
                 $attributes['type'] = $registeredType->value;
             }
 
-            Setting::create($attributes);
+            Setting::create( $attributes);
         }
     }
 }

--- a/src/Modules/Settings/Models/Setting.php
+++ b/src/Modules/Settings/Models/Setting.php
@@ -1,9 +1,10 @@
 <?php
 
-declare( strict_types = 1 );
+declare(strict_types=1);
 
 namespace ArtisanPackUI\CMSFramework\Modules\Settings\Models;
 
+use ArtisanPackUI\CMSFramework\Modules\Settings\Enums\SettingType;
 use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
@@ -18,7 +19,7 @@ use Illuminate\Database\Eloquent\Model;
  *
  * @property string $key The unique key for the setting.
  * @property mixed $value The value of the setting (casted).
- * @property string $type The stored type identifier ('string', 'integer', 'boolean', 'json', 'float').
+ * @property SettingType $type The stored type identifier.
  */
 class Setting extends Model
 {
@@ -72,57 +73,19 @@ class Setting extends Model
     protected function value(): Attribute
     {
         return Attribute::make(
-            get: function ( $value ) {
-                // Getter: cast stored value using the saved type (default to string)
-                $type = $this->attributes['type'] ?? 'string';
+            get: function ($value) {
+                $type = SettingType::tryFrom($this->attributes['type'] ?? 'string') ?? SettingType::String;
 
-                return $this->castValue( $value, $type );
+                return $type->cast($value);
             },
-            set: function ( $value ) {
-                // Determine type based on PHP value
-                $type = match ( true ) {
-                    is_bool( $value )  => 'boolean',
-                    is_int( $value )   => 'integer',
-                    is_float( $value ) => 'float',
-                    is_array( $value ), is_object( $value ) => 'json',
-                    default => 'string', // Includes null
-                };
+            set: function ($value) {
+                $type = SettingType::fromValue($value);
 
-                // Prepare the value for storage based on determined type
-                $stored = match ( $type ) {
-                    'boolean' => $value ? '1' : '0',
-                    'integer', 'float' => (string) $value, // Store numerics as strings
-                    'json'  => json_encode( $value ),
-                    default => is_null( $value ) ? '' : (string) $value, // Store null as empty string for string type
-                };
-
-                // IMPORTANT: Return an attribute array so both fields are persisted
                 return [
-                    'type'  => $type,
-                    'value' => $stored,
+                    'type'  => $type->value,
+                    'value' => $type->serialize($value),
                 ];
             },
         );
-    }
-
-    /**
-     * Casts a raw value based on the determined type.
-     */
-    protected function castValue( mixed $value, string $type ): mixed
-    {
-        // Handle actual NULL from DB first
-        if ( is_null( $value ) ) {
-            // Return null for non-string types if DB was NULL
-            return ( 'string' === $type ) ? '' : null;
-        }
-
-        // --- Simplified Casting ---
-        return match ( $type ) {
-            'boolean' => filter_var( $value, FILTER_VALIDATE_BOOLEAN ), // Robust boolean check
-            'integer' => (int) $value,
-            'float'   => (float) $value,
-            'json', 'array' => json_decode( $value, true ), // Decode JSON/Array
-            default => (string) $value,                      // Includes 'string'
-        };
     }
 }

--- a/src/Modules/Settings/Models/Setting.php
+++ b/src/Modules/Settings/Models/Setting.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare( strict_types=1 );
 
 namespace ArtisanPackUI\CMSFramework\Modules\Settings\Models;
 
@@ -73,17 +73,17 @@ class Setting extends Model
     protected function value(): Attribute
     {
         return Attribute::make(
-            get: function ($value) {
-                $type = SettingType::tryFrom($this->attributes['type'] ?? 'string') ?? SettingType::String;
+            get: function ( $value ) {
+                $type = SettingType::tryFrom( $this->attributes['type'] ?? 'string' ) ?? SettingType::String;
 
-                return $type->cast($value);
+                return $type->cast( $value );
             },
-            set: function ($value) {
-                $type = SettingType::fromValue($value);
+            set: function ( $value ) {
+                $type = SettingType::fromValue( $value );
 
                 return [
                     'type'  => $type->value,
-                    'value' => $type->serialize($value),
+                    'value' => $type->serialize( $value ),
                 ];
             },
         );

--- a/src/Modules/Settings/helpers.php
+++ b/src/Modules/Settings/helpers.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare( strict_types=1 );
 
 /**
  * Helper functions for the CMS Framework Settings Module.
@@ -13,7 +13,7 @@ declare(strict_types=1);
 use ArtisanPackUI\CMSFramework\Modules\Settings\Enums\SettingType;
 use ArtisanPackUI\CMSFramework\Modules\Settings\Managers\SettingsManager;
 
-if (! function_exists('apGetSetting')) {
+if ( ! function_exists( 'apGetSetting' ) ) {
     /**
      * Retrieve a setting value with optional default fallback.
      *
@@ -27,13 +27,13 @@ if (! function_exists('apGetSetting')) {
      *
      * @return mixed The setting value.
      */
-    function apGetSetting(string $key, mixed $default = null): mixed
+    function apGetSetting( string $key, mixed $default = null ): mixed
     {
-        return app(SettingsManager::class)->getSetting($key, $default);
+        return app( SettingsManager::class )->getSetting( $key, $default );
     }
 }
 
-if (! function_exists('apRegisterSetting')) {
+if ( ! function_exists( 'apRegisterSetting' ) ) {
     /**
      * Register a setting definition that includes type and sanitization callback.
      *
@@ -44,13 +44,13 @@ if (! function_exists('apRegisterSetting')) {
      * @param  callable  $callback  Sanitization callback to clean values on update.
      * @param  SettingType  $type  Data type of the setting.
      */
-    function apRegisterSetting(string $key, mixed $defaultValue, callable $callback, SettingType $type = SettingType::String): void
+    function apRegisterSetting( string $key, mixed $defaultValue, callable $callback, SettingType $type = SettingType::String ): void
     {
-        app(SettingsManager::class)->registerSetting($key, $defaultValue, $callback, $type);
+        app( SettingsManager::class )->registerSetting( $key, $defaultValue, $callback, $type );
     }
 }
 
-if (! function_exists('apUpdateSetting')) {
+if ( ! function_exists( 'apUpdateSetting' ) ) {
     /**
      * Update a setting value after sanitizing it using the registered callback.
      *
@@ -59,8 +59,8 @@ if (! function_exists('apUpdateSetting')) {
      * @param  string  $key  Unique key for the setting.
      * @param  mixed  $value  The new value to store.
      */
-    function apUpdateSetting(string $key, mixed $value): void
+    function apUpdateSetting( string $key, mixed $value ): void
     {
-        app(SettingsManager::class)->updateSetting($key, $value);
+        app( SettingsManager::class )->updateSetting( $key, $value);
     }
 }

--- a/src/Modules/Settings/helpers.php
+++ b/src/Modules/Settings/helpers.php
@@ -1,6 +1,6 @@
 <?php
 
-declare( strict_types = 1 );
+declare(strict_types=1);
 
 /**
  * Helper functions for the CMS Framework Settings Module.
@@ -10,9 +10,10 @@ declare( strict_types = 1 );
  * @since 1.0.0
  */
 
+use ArtisanPackUI\CMSFramework\Modules\Settings\Enums\SettingType;
 use ArtisanPackUI\CMSFramework\Modules\Settings\Managers\SettingsManager;
 
-if ( ! function_exists( 'apGetSetting' ) ) {
+if (! function_exists('apGetSetting')) {
     /**
      * Retrieve a setting value with optional default fallback.
      *
@@ -26,13 +27,13 @@ if ( ! function_exists( 'apGetSetting' ) ) {
      *
      * @return mixed The setting value.
      */
-    function apGetSetting( string $key, mixed $default = null ): mixed
+    function apGetSetting(string $key, mixed $default = null): mixed
     {
-        return app( SettingsManager::class )->getSetting( $key, $default );
+        return app(SettingsManager::class)->getSetting($key, $default);
     }
 }
 
-if ( ! function_exists( 'apRegisterSetting' ) ) {
+if (! function_exists('apRegisterSetting')) {
     /**
      * Register a setting definition that includes type and sanitization callback.
      *
@@ -41,15 +42,15 @@ if ( ! function_exists( 'apRegisterSetting' ) ) {
      * @param  string  $key  Unique key for the setting.
      * @param  mixed  $defaultValue  Default value if none stored.
      * @param  callable  $callback  Sanitization callback to clean values on update.
-     * @param  string  $type  Data type of the setting.
+     * @param  SettingType  $type  Data type of the setting.
      */
-    function apRegisterSetting( string $key, mixed $defaultValue, callable $callback, string $type = 'string' ): void
+    function apRegisterSetting(string $key, mixed $defaultValue, callable $callback, SettingType $type = SettingType::String): void
     {
-        app( SettingsManager::class )->registerSetting( $key, $defaultValue, $callback, $type );
+        app(SettingsManager::class)->registerSetting($key, $defaultValue, $callback, $type);
     }
 }
 
-if ( ! function_exists( 'apUpdateSetting' ) ) {
+if (! function_exists('apUpdateSetting')) {
     /**
      * Update a setting value after sanitizing it using the registered callback.
      *
@@ -58,8 +59,8 @@ if ( ! function_exists( 'apUpdateSetting' ) ) {
      * @param  string  $key  Unique key for the setting.
      * @param  mixed  $value  The new value to store.
      */
-    function apUpdateSetting( string $key, mixed $value ): void
+    function apUpdateSetting(string $key, mixed $value): void
     {
-        app( SettingsManager::class )->updateSetting( $key, $value );
+        app(SettingsManager::class)->updateSetting($key, $value);
     }
 }

--- a/src/Modules/Settings/helpers.php
+++ b/src/Modules/Settings/helpers.php
@@ -61,6 +61,6 @@ if ( ! function_exists( 'apUpdateSetting' ) ) {
      */
     function apUpdateSetting( string $key, mixed $value ): void
     {
-        app( SettingsManager::class )->updateSetting( $key, $value);
+        app( SettingsManager::class )->updateSetting( $key, $value );
     }
 }

--- a/src/Modules/Themes/Http/Controllers/ThemesController.php
+++ b/src/Modules/Themes/Http/Controllers/ThemesController.php
@@ -8,7 +8,7 @@
  * @since      1.0.0
  */
 
-declare(strict_types=1);
+declare( strict_types=1 );
 
 namespace ArtisanPackUI\CMSFramework\Modules\Themes\Http\Controllers;
 
@@ -29,7 +29,7 @@ use Illuminate\Routing\Controller;
  *
  * @since 1.0.0
  */
-#[Group('Themes', weight: 16)]
+#[Group( 'Themes', weight: 16 )]
 class ThemesController extends Controller
 {
     /**
@@ -41,7 +41,8 @@ class ThemesController extends Controller
      */
     public function __construct(
         private ThemeManager $themeManager,
-    ) {}
+    ) {
+    }
 
     /**
      * Lists all available themes.
@@ -60,10 +61,10 @@ class ThemesController extends Controller
         $themes      = $this->themeManager->discoverThemes();
         $activeTheme = $this->themeManager->getActiveTheme();
 
-        return response()->json([
+        return response()->json( [
             'themes' => $themes,
             'active' => $activeTheme['slug'] ?? null,
-        ]);
+        ] );
     }
 
     /**
@@ -80,17 +81,17 @@ class ThemesController extends Controller
      *
      * @return JsonResponse JSON response with theme data or error message.
      */
-    public function show(string $slug): JsonResponse
+    public function show( string $slug ): JsonResponse
     {
-        $theme = $this->themeManager->getTheme($slug);
+        $theme = $this->themeManager->getTheme( $slug );
 
-        if (! $theme) {
-            return response()->json([
-                'message' => __('Theme not found.'),
-            ], 404);
+        if ( ! $theme ) {
+            return response()->json( [
+                'message' => __( 'Theme not found.' ),
+            ], 404 );
         }
 
-        return response()->json($theme);
+        return response()->json( $theme );
     }
 
     /**
@@ -108,24 +109,24 @@ class ThemesController extends Controller
      *
      * @return JsonResponse JSON response with success message and theme data, or error.
      */
-    public function activate(string $slug): JsonResponse
+    public function activate( string $slug ): JsonResponse
     {
         try {
-            $this->themeManager->activateTheme($slug);
+            $this->themeManager->activateTheme( $slug );
 
-            return response()->json([
-                'message' => __('Theme activated successfully.'),
-                'theme'   => $this->themeManager->getTheme($slug),
-            ]);
-        } catch (ThemeNotFoundException) {
-            return response()->json([
-                'message' => __('Theme ":slug" not found.', ['slug' => $slug]),
-            ], 404);
-        } catch (Exception $e) {
-            report($e);
+            return response()->json( [
+                'message' => __( 'Theme activated successfully.' ),
+                'theme'   => $this->themeManager->getTheme( $slug ),
+            ] );
+        } catch ( ThemeNotFoundException ) {
+            return response()->json( [
+                'message' => __( 'Theme ":slug" not found.', ['slug' => $slug] ),
+            ], 404 );
+        } catch ( Exception $e ) {
+            report( $e );
 
-            return response()->json([
-                'message' => __('An unexpected error occurred while activating the theme.'),
+            return response()->json( [
+                'message' => __( 'An unexpected error occurred while activating the theme.'),
             ], 500);
         }
     }

--- a/src/Modules/Themes/Http/Controllers/ThemesController.php
+++ b/src/Modules/Themes/Http/Controllers/ThemesController.php
@@ -126,8 +126,8 @@ class ThemesController extends Controller
             report( $e );
 
             return response()->json( [
-                'message' => __( 'An unexpected error occurred while activating the theme.'),
-            ], 500);
+                'message' => __( 'An unexpected error occurred while activating the theme.' ),
+            ], 500 );
         }
     }
 }

--- a/src/Modules/Themes/Http/Controllers/ThemesController.php
+++ b/src/Modules/Themes/Http/Controllers/ThemesController.php
@@ -8,11 +8,12 @@
  * @since      1.0.0
  */
 
-declare( strict_types = 1 );
+declare(strict_types=1);
 
 namespace ArtisanPackUI\CMSFramework\Modules\Themes\Http\Controllers;
 
 use ArtisanPackUI\CMSFramework\Modules\Themes\Managers\ThemeManager;
+use Dedoc\Scramble\Attributes\Group;
 use Exception;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Routing\Controller;
@@ -27,6 +28,7 @@ use Illuminate\Routing\Controller;
  *
  * @since 1.0.0
  */
+#[Group('Themes', weight: 16)]
 class ThemesController extends Controller
 {
     /**
@@ -38,8 +40,7 @@ class ThemesController extends Controller
      */
     public function __construct(
         private ThemeManager $themeManager,
-    ) {
-    }
+    ) {}
 
     /**
      * Lists all available themes.
@@ -58,10 +59,10 @@ class ThemesController extends Controller
         $themes      = $this->themeManager->discoverThemes();
         $activeTheme = $this->themeManager->getActiveTheme();
 
-        return response()->json( [
+        return response()->json([
             'themes' => $themes,
             'active' => $activeTheme['slug'] ?? null,
-        ] );
+        ]);
     }
 
     /**
@@ -78,17 +79,17 @@ class ThemesController extends Controller
      *
      * @return JsonResponse JSON response with theme data or error message.
      */
-    public function show( string $slug ): JsonResponse
+    public function show(string $slug): JsonResponse
     {
-        $theme = $this->themeManager->getTheme( $slug );
+        $theme = $this->themeManager->getTheme($slug);
 
-        if ( ! $theme ) {
-            return response()->json( [
+        if (! $theme) {
+            return response()->json([
                 'message' => 'Theme not found',
-            ], 404 );
+            ], 404);
         }
 
-        return response()->json( $theme );
+        return response()->json($theme);
     }
 
     /**
@@ -106,19 +107,19 @@ class ThemesController extends Controller
      *
      * @return JsonResponse JSON response with success message and theme data, or error.
      */
-    public function activate( string $slug ): JsonResponse
+    public function activate(string $slug): JsonResponse
     {
         try {
-            $success = $this->themeManager->activateTheme( $slug );
+            $success = $this->themeManager->activateTheme($slug);
 
-            return response()->json( [
+            return response()->json([
                 'message' => 'Theme activated successfully',
-                'theme'   => $this->themeManager->getTheme( $slug ),
-            ] );
-        } catch ( Exception $e ) {
-            return response()->json( [
+                'theme'   => $this->themeManager->getTheme($slug),
+            ]);
+        } catch (Exception $e) {
+            return response()->json([
                 'message' => $e->getMessage(),
-            ], 400 );
+            ], 400);
         }
     }
 }

--- a/src/Modules/Themes/Http/Controllers/ThemesController.php
+++ b/src/Modules/Themes/Http/Controllers/ThemesController.php
@@ -86,7 +86,7 @@ class ThemesController extends Controller
 
         if (! $theme) {
             return response()->json([
-                'message' => 'Theme not found',
+                'message' => __('Theme not found.'),
             ], 404);
         }
 
@@ -117,9 +117,9 @@ class ThemesController extends Controller
                 'message' => __('Theme activated successfully.'),
                 'theme'   => $this->themeManager->getTheme($slug),
             ]);
-        } catch (ThemeNotFoundException $e) {
+        } catch (ThemeNotFoundException) {
             return response()->json([
-                'message' => $e->getMessage(),
+                'message' => __('Theme ":slug" not found.', ['slug' => $slug]),
             ], 404);
         } catch (Exception $e) {
             report($e);

--- a/src/Modules/Themes/Http/Controllers/ThemesController.php
+++ b/src/Modules/Themes/Http/Controllers/ThemesController.php
@@ -112,14 +112,22 @@ class ThemesController extends Controller
         try {
             $success = $this->themeManager->activateTheme($slug);
 
+            if (! $success) {
+                return response()->json([
+                    'message' => __('Failed to activate theme.'),
+                ], 422);
+            }
+
             return response()->json([
-                'message' => 'Theme activated successfully',
+                'message' => __('Theme activated successfully.'),
                 'theme'   => $this->themeManager->getTheme($slug),
             ]);
         } catch (Exception $e) {
+            report($e);
+
             return response()->json([
-                'message' => $e->getMessage(),
-            ], 400);
+                'message' => __('An unexpected error occurred while activating the theme.'),
+            ], 500);
         }
     }
 }

--- a/src/Modules/Themes/Http/Controllers/ThemesController.php
+++ b/src/Modules/Themes/Http/Controllers/ThemesController.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace ArtisanPackUI\CMSFramework\Modules\Themes\Http\Controllers;
 
+use ArtisanPackUI\CMSFramework\Modules\Themes\Exceptions\ThemeNotFoundException;
 use ArtisanPackUI\CMSFramework\Modules\Themes\Managers\ThemeManager;
 use Dedoc\Scramble\Attributes\Group;
 use Exception;
@@ -110,18 +111,16 @@ class ThemesController extends Controller
     public function activate(string $slug): JsonResponse
     {
         try {
-            $success = $this->themeManager->activateTheme($slug);
-
-            if (! $success) {
-                return response()->json([
-                    'message' => __('Failed to activate theme.'),
-                ], 422);
-            }
+            $this->themeManager->activateTheme($slug);
 
             return response()->json([
                 'message' => __('Theme activated successfully.'),
                 'theme'   => $this->themeManager->getTheme($slug),
             ]);
+        } catch (ThemeNotFoundException $e) {
+            return response()->json([
+                'message' => $e->getMessage(),
+            ], 404);
         } catch (Exception $e) {
             report($e);
 

--- a/src/Modules/Themes/Managers/ThemeManager.php
+++ b/src/Modules/Themes/Managers/ThemeManager.php
@@ -377,12 +377,12 @@ class ThemeManager
     {
         $activeSlug = $this->settingsManager->getSetting(
             'themes.activeTheme',
-            config( 'cms.themes.default', 'digital-shopfront'),
+            config( 'cms.themes.default', 'digital-shopfront' ),
         );
 
-        return array_map( function ( $theme) use ( $activeSlug) {
+        return array_map( function ( $theme ) use ( $activeSlug ) {
             // Defensive check: ensure slug key exists before comparing
-            $theme['is_active'] = isset( $theme['slug']) && $theme['slug'] === $activeSlug;
+            $theme['is_active'] = isset( $theme['slug'] ) && $theme['slug'] === $activeSlug;
 
             return $theme;
         }, $themes);

--- a/src/Modules/Themes/Managers/ThemeManager.php
+++ b/src/Modules/Themes/Managers/ThemeManager.php
@@ -8,11 +8,12 @@
  * @since      1.0.0
  */
 
-declare( strict_types = 1 );
+declare(strict_types=1);
 
 namespace ArtisanPackUI\CMSFramework\Modules\Themes\Managers;
 
 use Artisan;
+use ArtisanPackUI\CMSFramework\Modules\Core\Managers\Concerns\HasManifestParsing;
 use ArtisanPackUI\CMSFramework\Modules\Settings\Managers\SettingsManager;
 use ArtisanPackUI\CMSFramework\Modules\Themes\Exceptions\ThemeNotFoundException;
 use Exception;
@@ -34,6 +35,8 @@ use Illuminate\Support\Facades\View;
  */
 class ThemeManager
 {
+    use HasManifestParsing;
+
     /**
      * Constructs the ThemeManager instance.
      *
@@ -43,8 +46,7 @@ class ThemeManager
      */
     public function __construct(
         private SettingsManager $settingsManager,
-    ) {
-    }
+    ) {}
 
     /**
      * Discovers all themes in the themes directory.
@@ -58,43 +60,43 @@ class ThemeManager
      */
     public function discoverThemes(): array
     {
-        $cacheEnabled = config( 'cms.themes.cacheEnabled', true );
-        $cacheKey     = config( 'cms.themes.cacheKey', 'cms.themes.discovered' );
-        $cacheTtl     = config( 'cms.themes.cacheTtl', 3600 );
+        $cacheEnabled = config('cms.themes.cacheEnabled', true);
+        $cacheKey     = config('cms.themes.cacheKey', 'cms.themes.discovered');
+        $cacheTtl     = config('cms.themes.cacheTtl', 3600);
 
-        if ( $cacheEnabled ) {
-            $themes = Cache::get( $cacheKey );
+        if ($cacheEnabled) {
+            $themes = Cache::get($cacheKey);
 
-            if ( null !== $themes ) {
-                return $this->markActiveTheme( $themes );
+            if (null !== $themes) {
+                return $this->markActiveTheme($themes);
             }
         }
 
         $themesPath = $this->getThemesPath();
         $themes     = [];
 
-        if ( ! File::isDirectory( $themesPath ) ) {
+        if (! File::isDirectory($themesPath)) {
             return $themes;
         }
 
-        $directories = File::directories( $themesPath );
+        $directories = File::directories($themesPath);
 
-        foreach ( $directories as $directory ) {
-            if ( $this->validateTheme( $directory ) ) {
-                $manifestPath = $directory . '/theme.json';
-                $manifest     = $this->parseManifest( $manifestPath );
+        foreach ($directories as $directory) {
+            if ($this->validateTheme($directory)) {
+                $manifestPath = $directory.'/theme.json';
+                $manifest     = $this->parseManifest($manifestPath);
 
-                if ( ! empty( $manifest ) ) {
+                if (null !== $manifest) {
                     $themes[] = $manifest;
                 }
             }
         }
 
-        if ( $cacheEnabled ) {
-            Cache::put( $cacheKey, $themes, $cacheTtl );
+        if ($cacheEnabled) {
+            Cache::put($cacheKey, $themes, $cacheTtl);
         }
 
-        return $this->markActiveTheme( $themes );
+        return $this->markActiveTheme($themes);
     }
 
     /**
@@ -111,14 +113,14 @@ class ThemeManager
     {
         $activeSlug = $this->settingsManager->getSetting(
             'themes.activeTheme',
-            config( 'cms.themes.default', 'digital-shopfront' ),
+            config('cms.themes.default', 'digital-shopfront'),
         );
 
-        if ( empty( $activeSlug ) ) {
+        if (empty($activeSlug)) {
             return null;
         }
 
-        return $this->getTheme( $activeSlug );
+        return $this->getTheme($activeSlug);
     }
 
     /**
@@ -135,29 +137,29 @@ class ThemeManager
      *
      * @return bool True on successful activation.
      */
-    public function activateTheme( string $slug ): bool
+    public function activateTheme(string $slug): bool
     {
-        $theme = $this->getTheme( $slug );
+        $theme = $this->getTheme($slug);
 
-        if ( null === $theme ) {
-            throw ThemeNotFoundException::forSlug( $slug );
+        if (null === $theme) {
+            throw ThemeNotFoundException::forSlug($slug);
         }
 
-        $this->settingsManager->updateSetting( 'themes.activeTheme', $slug );
+        $this->settingsManager->updateSetting('themes.activeTheme', $slug);
 
         // Clear theme cache
-        $cacheKey = config( 'cms.themes.cacheKey', 'cms.themes.discovered' );
-        Cache::forget( $cacheKey );
+        $cacheKey = config('cms.themes.cacheKey', 'cms.themes.discovered');
+        Cache::forget($cacheKey);
 
         // Clear view cache
         try {
-            Artisan::call( 'view:clear' );
-        } catch ( Exception $e ) {
+            Artisan::call('view:clear');
+        } catch (Exception $e) {
             // Log the error but don't fail activation
-            if ( function_exists( 'logger' ) ) {
-                logger()->warning( 'Failed to clear view cache during theme activation', [
+            if (function_exists('logger')) {
+                logger()->warning('Failed to clear view cache during theme activation', [
                     'error' => $e->getMessage(),
-                ] );
+                ]);
             }
         }
 
@@ -177,38 +179,29 @@ class ThemeManager
      *
      * @return array|null Theme manifest array, or null if not found, invalid, or contains invalid characters.
      */
-    public function getTheme( string $slug ): ?array
+    public function getTheme(string $slug): ?array
     {
         // Validate slug to prevent path traversal attacks
-        // Only allow alphanumeric characters, hyphens, and underscores
-        if ( ! preg_match( '/^[a-zA-Z0-9_-]+$/', $slug ) ) {
+        if (! $this->validateSlug($slug)) {
             return null;
         }
 
+        // Resolve and validate path within themes directory
         $themesBasePath = $this->getThemesPath();
-        $themePath      = $themesBasePath . '/' . $slug;
+        $realThemePath  = $this->resolveSecurePath($themesBasePath.'/'.$slug, $themesBasePath);
 
-        // Resolve real path and verify it's within the themes directory
-        $realThemePath = realpath( $themePath );
-
-        if ( false === $realThemePath ) {
-            return null;
-        }
-
-        $realBasePath = realpath( $themesBasePath );
-
-        if ( false === $realBasePath || 0 !== strpos( $realThemePath, $realBasePath . DIRECTORY_SEPARATOR ) ) {
+        if (null === $realThemePath) {
             return null;
         }
 
         // Now safe to proceed with validation and manifest parsing
-        $manifestPath = $realThemePath . '/theme.json';
+        $manifestPath = $realThemePath.'/theme.json';
 
-        if ( ! $this->validateTheme( $realThemePath ) ) {
+        if (! $this->validateTheme($realThemePath)) {
             return null;
         }
 
-        return $this->parseManifest( $manifestPath );
+        return $this->parseManifest($manifestPath);
     }
 
     /**
@@ -223,20 +216,20 @@ class ThemeManager
     {
         $activeTheme = $this->getActiveTheme();
 
-        if ( null === $activeTheme ) {
+        if (null === $activeTheme) {
             return;
         }
 
         // Defensive check: ensure slug key exists in the manifest
-        if ( ! is_array( $activeTheme ) || empty( $activeTheme['slug'] ) ) {
+        if (! is_array($activeTheme) || empty($activeTheme['slug'])) {
             return;
         }
 
-        $themePath = $this->getThemesPath() . '/' . $activeTheme['slug'];
+        $themePath = $this->getThemesPath().'/'.$activeTheme['slug'];
 
-        if ( File::isDirectory( $themePath ) ) {
+        if (File::isDirectory($themePath)) {
             // Prepend the theme path to give it priority
-            View::getFinder()->prependLocation( $themePath );
+            View::getFinder()->prependLocation($themePath);
         }
     }
 
@@ -260,20 +253,20 @@ class ThemeManager
      *
      * @return string Template name without .blade.php extension.
      */
-    public function resolveTemplate( string $contentType, ?string $slug = null ): string
+    public function resolveTemplate(string $contentType, ?string $slug = null): string
     {
         // Sanitize inputs to prevent path traversal
-        if ( ! preg_match( '/^[a-zA-Z0-9_-]+$/', $contentType ) ) {
+        if (! $this->validateSlug($contentType)) {
             return 'index';
         }
 
-        if ( null !== $slug && ! preg_match( '/^[a-zA-Z0-9_-]+$/', $slug ) ) {
+        if (null !== $slug && ! $this->validateSlug($slug)) {
             $slug = null;
         }
 
         $templates = [];
 
-        if ( null !== $slug ) {
+        if (null !== $slug) {
             $templates[] = "single-{$contentType}-{$slug}";
         }
 
@@ -281,8 +274,8 @@ class ThemeManager
         $templates[] = 'single';
         $templates[] = 'index';
 
-        foreach ( $templates as $template ) {
-            if ( $this->templateExists( $template ) ) {
+        foreach ($templates as $template) {
+            if ($this->templateExists($template)) {
                 return $template;
             }
         }
@@ -301,18 +294,23 @@ class ThemeManager
      *
      * @return bool True if template exists, false otherwise.
      */
-    public function templateExists( string $template ): bool
+    public function templateExists(string $template): bool
     {
-        $activeTheme = $this->getActiveTheme();
-
-        if ( null === $activeTheme ) {
+        // Validate template name to prevent path traversal
+        if (! $this->validateSlug($template)) {
             return false;
         }
 
-        $themePath    = $this->getThemesPath() . '/' . $activeTheme['slug'];
-        $templatePath = $themePath . '/' . $template . '.blade.php';
+        $activeTheme = $this->getActiveTheme();
 
-        return File::exists( $templatePath );
+        if (null === $activeTheme) {
+            return false;
+        }
+
+        $themePath    = $this->getThemesPath().'/'.$activeTheme['slug'];
+        $templatePath = $themePath.'/'.$template.'.blade.php';
+
+        return File::exists($templatePath);
     }
 
     /**
@@ -327,49 +325,21 @@ class ThemeManager
      *
      * @return bool True if theme is valid, false otherwise.
      */
-    protected function validateTheme( string $themePath ): bool
+    protected function validateTheme(string $themePath): bool
     {
-        if ( ! File::isDirectory( $themePath ) ) {
+        if (! File::isDirectory($themePath)) {
             return false;
         }
 
-        $requiredFiles = config( 'cms.themes.requiredFiles', ['theme.json'] );
+        $requiredFiles = config('cms.themes.requiredFiles', ['theme.json']);
 
-        foreach ( $requiredFiles as $file ) {
-            if ( ! File::exists( $themePath . '/' . $file ) ) {
+        foreach ($requiredFiles as $file) {
+            if (! File::exists($themePath.'/'.$file)) {
                 return false;
             }
         }
 
         return true;
-    }
-
-    /**
-     * Parses a theme.json manifest file.
-     *
-     * Reads and decodes the theme manifest JSON file, returning an empty array
-     * if the file doesn't exist or contains invalid JSON.
-     *
-     * @since 1.0.0
-     *
-     * @param  string  $manifestPath  Absolute path to theme.json file.
-     *
-     * @return array Parsed manifest data, or empty array on error.
-     */
-    protected function parseManifest( string $manifestPath ): array
-    {
-        if ( ! File::exists( $manifestPath ) ) {
-            return [];
-        }
-
-        $content = File::get( $manifestPath );
-        $data    = json_decode( $content, true );
-
-        if ( JSON_ERROR_NONE !== json_last_error() ) {
-            return [];
-        }
-
-        return $data;
     }
 
     /**
@@ -384,9 +354,9 @@ class ThemeManager
      */
     protected function getThemesPath(): string
     {
-        $directory = config( 'cms.themes.directory', 'themes' );
+        $directory = config('cms.themes.directory', 'themes');
 
-        return base_path( $directory );
+        return base_path($directory);
     }
 
     /**
@@ -402,16 +372,16 @@ class ThemeManager
      *
      * @return array Themes array with is_active flag added to each theme.
      */
-    protected function markActiveTheme( array $themes ): array
+    protected function markActiveTheme(array $themes): array
     {
         $activeSlug = $this->settingsManager->getSetting(
             'themes.activeTheme',
-            config( 'cms.themes.default', 'digital-shopfront' ),
+            config('cms.themes.default', 'digital-shopfront'),
         );
 
-        return array_map( function ( $theme ) use ( $activeSlug ) {
+        return array_map(function ($theme) use ($activeSlug) {
             // Defensive check: ensure slug key exists before comparing
-            $theme['is_active'] = isset( $theme['slug'] ) && $theme['slug'] === $activeSlug;
+            $theme['is_active'] = isset($theme['slug']) && $theme['slug'] === $activeSlug;
 
             return $theme;
         }, $themes);

--- a/src/Modules/Themes/Managers/ThemeManager.php
+++ b/src/Modules/Themes/Managers/ThemeManager.php
@@ -8,7 +8,7 @@
  * @since      1.0.0
  */
 
-declare(strict_types=1);
+declare( strict_types=1 );
 
 namespace ArtisanPackUI\CMSFramework\Modules\Themes\Managers;
 
@@ -46,7 +46,8 @@ class ThemeManager
      */
     public function __construct(
         private SettingsManager $settingsManager,
-    ) {}
+    ) {
+    }
 
     /**
      * Discovers all themes in the themes directory.
@@ -60,43 +61,43 @@ class ThemeManager
      */
     public function discoverThemes(): array
     {
-        $cacheEnabled = config('cms.themes.cacheEnabled', true);
-        $cacheKey     = config('cms.themes.cacheKey', 'cms.themes.discovered');
-        $cacheTtl     = config('cms.themes.cacheTtl', 3600);
+        $cacheEnabled = config( 'cms.themes.cacheEnabled', true );
+        $cacheKey     = config( 'cms.themes.cacheKey', 'cms.themes.discovered' );
+        $cacheTtl     = config( 'cms.themes.cacheTtl', 3600 );
 
-        if ($cacheEnabled) {
-            $themes = Cache::get($cacheKey);
+        if ( $cacheEnabled ) {
+            $themes = Cache::get( $cacheKey );
 
-            if (null !== $themes) {
-                return $this->markActiveTheme($themes);
+            if ( null !== $themes ) {
+                return $this->markActiveTheme( $themes );
             }
         }
 
         $themesPath = $this->getThemesPath();
         $themes     = [];
 
-        if (! File::isDirectory($themesPath)) {
+        if ( ! File::isDirectory( $themesPath ) ) {
             return $themes;
         }
 
-        $directories = File::directories($themesPath);
+        $directories = File::directories( $themesPath );
 
-        foreach ($directories as $directory) {
-            if ($this->validateTheme($directory)) {
-                $manifestPath = $directory.'/theme.json';
-                $manifest     = $this->parseManifest($manifestPath);
+        foreach ( $directories as $directory ) {
+            if ( $this->validateTheme( $directory ) ) {
+                $manifestPath = $directory . '/theme.json';
+                $manifest     = $this->parseManifest( $manifestPath );
 
-                if (null !== $manifest) {
+                if ( null !== $manifest ) {
                     $themes[] = $manifest;
                 }
             }
         }
 
-        if ($cacheEnabled) {
-            Cache::put($cacheKey, $themes, $cacheTtl);
+        if ( $cacheEnabled ) {
+            Cache::put( $cacheKey, $themes, $cacheTtl );
         }
 
-        return $this->markActiveTheme($themes);
+        return $this->markActiveTheme( $themes );
     }
 
     /**
@@ -113,14 +114,14 @@ class ThemeManager
     {
         $activeSlug = $this->settingsManager->getSetting(
             'themes.activeTheme',
-            config('cms.themes.default', 'digital-shopfront'),
+            config( 'cms.themes.default', 'digital-shopfront' ),
         );
 
-        if (empty($activeSlug)) {
+        if ( empty( $activeSlug ) ) {
             return null;
         }
 
-        return $this->getTheme($activeSlug);
+        return $this->getTheme( $activeSlug );
     }
 
     /**
@@ -137,29 +138,29 @@ class ThemeManager
      *
      * @return bool True on successful activation.
      */
-    public function activateTheme(string $slug): bool
+    public function activateTheme( string $slug ): bool
     {
-        $theme = $this->getTheme($slug);
+        $theme = $this->getTheme( $slug );
 
-        if (null === $theme) {
-            throw ThemeNotFoundException::forSlug($slug);
+        if ( null === $theme ) {
+            throw ThemeNotFoundException::forSlug( $slug );
         }
 
-        $this->settingsManager->updateSetting('themes.activeTheme', $slug);
+        $this->settingsManager->updateSetting( 'themes.activeTheme', $slug );
 
         // Clear theme cache
-        $cacheKey = config('cms.themes.cacheKey', 'cms.themes.discovered');
-        Cache::forget($cacheKey);
+        $cacheKey = config( 'cms.themes.cacheKey', 'cms.themes.discovered' );
+        Cache::forget( $cacheKey );
 
         // Clear view cache
         try {
-            Artisan::call('view:clear');
-        } catch (Exception $e) {
+            Artisan::call( 'view:clear' );
+        } catch ( Exception $e ) {
             // Log the error but don't fail activation
-            if (function_exists('logger')) {
-                logger()->warning('Failed to clear view cache during theme activation', [
+            if ( function_exists( 'logger' ) ) {
+                logger()->warning( 'Failed to clear view cache during theme activation', [
                     'error' => $e->getMessage(),
-                ]);
+                ] );
             }
         }
 
@@ -179,29 +180,29 @@ class ThemeManager
      *
      * @return array|null Theme manifest array, or null if not found, invalid, or contains invalid characters.
      */
-    public function getTheme(string $slug): ?array
+    public function getTheme( string $slug ): ?array
     {
         // Validate slug to prevent path traversal attacks
-        if (! $this->validateSlug($slug)) {
+        if ( ! $this->validateSlug( $slug ) ) {
             return null;
         }
 
         // Resolve and validate path within themes directory
         $themesBasePath = $this->getThemesPath();
-        $realThemePath  = $this->resolveSecurePath($themesBasePath.'/'.$slug, $themesBasePath);
+        $realThemePath  = $this->resolveSecurePath( $themesBasePath . '/' . $slug, $themesBasePath );
 
-        if (null === $realThemePath) {
+        if ( null === $realThemePath ) {
             return null;
         }
 
         // Now safe to proceed with validation and manifest parsing
-        $manifestPath = $realThemePath.'/theme.json';
+        $manifestPath = $realThemePath . '/theme.json';
 
-        if (! $this->validateTheme($realThemePath)) {
+        if ( ! $this->validateTheme( $realThemePath ) ) {
             return null;
         }
 
-        return $this->parseManifest($manifestPath);
+        return $this->parseManifest( $manifestPath );
     }
 
     /**
@@ -216,20 +217,20 @@ class ThemeManager
     {
         $activeTheme = $this->getActiveTheme();
 
-        if (null === $activeTheme) {
+        if ( null === $activeTheme ) {
             return;
         }
 
         // Defensive check: ensure slug key exists in the manifest
-        if (! is_array($activeTheme) || empty($activeTheme['slug'])) {
+        if ( ! is_array( $activeTheme ) || empty( $activeTheme['slug'] ) ) {
             return;
         }
 
-        $themePath = $this->getThemesPath().'/'.$activeTheme['slug'];
+        $themePath = $this->getThemesPath() . '/' . $activeTheme['slug'];
 
-        if (File::isDirectory($themePath)) {
+        if ( File::isDirectory( $themePath ) ) {
             // Prepend the theme path to give it priority
-            View::getFinder()->prependLocation($themePath);
+            View::getFinder()->prependLocation( $themePath );
         }
     }
 
@@ -253,20 +254,20 @@ class ThemeManager
      *
      * @return string Template name without .blade.php extension.
      */
-    public function resolveTemplate(string $contentType, ?string $slug = null): string
+    public function resolveTemplate( string $contentType, ?string $slug = null ): string
     {
         // Sanitize inputs to prevent path traversal
-        if (! $this->validateSlug($contentType)) {
+        if ( ! $this->validateSlug( $contentType ) ) {
             return 'index';
         }
 
-        if (null !== $slug && ! $this->validateSlug($slug)) {
+        if ( null !== $slug && ! $this->validateSlug( $slug ) ) {
             $slug = null;
         }
 
         $templates = [];
 
-        if (null !== $slug) {
+        if ( null !== $slug ) {
             $templates[] = "single-{$contentType}-{$slug}";
         }
 
@@ -274,8 +275,8 @@ class ThemeManager
         $templates[] = 'single';
         $templates[] = 'index';
 
-        foreach ($templates as $template) {
-            if ($this->templateExists($template)) {
+        foreach ( $templates as $template ) {
+            if ( $this->templateExists( $template ) ) {
                 return $template;
             }
         }
@@ -294,23 +295,23 @@ class ThemeManager
      *
      * @return bool True if template exists, false otherwise.
      */
-    public function templateExists(string $template): bool
+    public function templateExists( string $template ): bool
     {
         // Validate template name to prevent path traversal
-        if (! $this->validateSlug($template)) {
+        if ( ! $this->validateSlug( $template ) ) {
             return false;
         }
 
         $activeTheme = $this->getActiveTheme();
 
-        if (null === $activeTheme) {
+        if ( null === $activeTheme ) {
             return false;
         }
 
-        $themePath    = $this->getThemesPath().'/'.$activeTheme['slug'];
-        $templatePath = $themePath.'/'.$template.'.blade.php';
+        $themePath    = $this->getThemesPath() . '/' . $activeTheme['slug'];
+        $templatePath = $themePath . '/' . $template . '.blade.php';
 
-        return File::exists($templatePath);
+        return File::exists( $templatePath );
     }
 
     /**
@@ -325,16 +326,16 @@ class ThemeManager
      *
      * @return bool True if theme is valid, false otherwise.
      */
-    protected function validateTheme(string $themePath): bool
+    protected function validateTheme( string $themePath ): bool
     {
-        if (! File::isDirectory($themePath)) {
+        if ( ! File::isDirectory( $themePath ) ) {
             return false;
         }
 
-        $requiredFiles = config('cms.themes.requiredFiles', ['theme.json']);
+        $requiredFiles = config( 'cms.themes.requiredFiles', ['theme.json'] );
 
-        foreach ($requiredFiles as $file) {
-            if (! File::exists($themePath.'/'.$file)) {
+        foreach ( $requiredFiles as $file ) {
+            if ( ! File::exists( $themePath . '/' . $file ) ) {
                 return false;
             }
         }
@@ -354,9 +355,9 @@ class ThemeManager
      */
     protected function getThemesPath(): string
     {
-        $directory = config('cms.themes.directory', 'themes');
+        $directory = config( 'cms.themes.directory', 'themes' );
 
-        return base_path($directory);
+        return base_path( $directory );
     }
 
     /**
@@ -372,16 +373,16 @@ class ThemeManager
      *
      * @return array Themes array with is_active flag added to each theme.
      */
-    protected function markActiveTheme(array $themes): array
+    protected function markActiveTheme( array $themes ): array
     {
         $activeSlug = $this->settingsManager->getSetting(
             'themes.activeTheme',
-            config('cms.themes.default', 'digital-shopfront'),
+            config( 'cms.themes.default', 'digital-shopfront'),
         );
 
-        return array_map(function ($theme) use ($activeSlug) {
+        return array_map( function ( $theme) use ( $activeSlug) {
             // Defensive check: ensure slug key exists before comparing
-            $theme['is_active'] = isset($theme['slug']) && $theme['slug'] === $activeSlug;
+            $theme['is_active'] = isset( $theme['slug']) && $theme['slug'] === $activeSlug;
 
             return $theme;
         }, $themes);

--- a/src/Modules/Themes/Providers/ThemesServiceProvider.php
+++ b/src/Modules/Themes/Providers/ThemesServiceProvider.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace ArtisanPackUI\CMSFramework\Modules\Themes\Providers;
 
+use ArtisanPackUI\CMSFramework\Modules\Settings\Enums\SettingType;
 use ArtisanPackUI\CMSFramework\Modules\Settings\Managers\SettingsManager;
 use ArtisanPackUI\CMSFramework\Modules\Themes\Managers\ThemeManager;
 use Illuminate\Support\ServiceProvider;
@@ -84,7 +85,7 @@ class ThemesServiceProvider extends ServiceProvider
             'themes.activeTheme',
             config('cms.themes.default', 'digital-shopfront'),
             fn ($value) => is_string($value) ? sanitizeText($value) : '',
-            'string',
+            SettingType::String,
         );
     }
 }

--- a/src/Modules/Themes/Providers/ThemesServiceProvider.php
+++ b/src/Modules/Themes/Providers/ThemesServiceProvider.php
@@ -8,7 +8,7 @@
  * @since      1.0.0
  */
 
-declare(strict_types=1);
+declare( strict_types=1 );
 
 namespace ArtisanPackUI\CMSFramework\Modules\Themes\Providers;
 
@@ -42,15 +42,15 @@ class ThemesServiceProvider extends ServiceProvider
     public function register(): void
     {
         // Register ThemeManager as singleton
-        $this->app->singleton(ThemeManager::class, function ($app) {
+        $this->app->singleton( ThemeManager::class, function ( $app ) {
             return new ThemeManager(
-                $app->make(SettingsManager::class),
+                $app->make( SettingsManager::class ),
             );
-        });
+        } );
 
         // Merge config
         $this->mergeConfigFrom(
-            __DIR__.'/../config/themes.php',
+            __DIR__ . '/../config/themes.php',
             'cms.themes',
         );
     }
@@ -68,23 +68,23 @@ class ThemesServiceProvider extends ServiceProvider
     public function boot(): void
     {
         // Publish config
-        $this->publishes([
-            __DIR__.'/../config/themes.php' => config_path('cms/themes.php'),
-        ], 'cms-themes-config');
+        $this->publishes( [
+            __DIR__ . '/../config/themes.php' => config_path( 'cms/themes.php' ),
+        ], 'cms-themes-config' );
 
         // Register theme view paths early in the boot cycle
-        $themeManager = $this->app->make(ThemeManager::class);
+        $themeManager = $this->app->make( ThemeManager::class );
         $themeManager->registerThemeViewPath();
 
         // Load API routes
-        $this->loadRoutesFrom(__DIR__.'/../routes/api.php');
+        $this->loadRoutesFrom( __DIR__ . '/../routes/api.php' );
 
         // Register default setting
-        $settingsManager = $this->app->make(SettingsManager::class);
+        $settingsManager = $this->app->make( SettingsManager::class );
         $settingsManager->registerSetting(
             'themes.activeTheme',
-            config('cms.themes.default', 'digital-shopfront'),
-            fn ($value) => is_string($value) ? sanitizeText($value) : '',
+            config( 'cms.themes.default', 'digital-shopfront' ),
+            fn ( $value ) => is_string( $value ) ? sanitizeText( $value ) : '',
             SettingType::String,
         );
     }

--- a/src/Modules/Users/Http/Controllers/PermissionController.php
+++ b/src/Modules/Users/Http/Controllers/PermissionController.php
@@ -137,6 +137,6 @@ class PermissionController extends Controller
         $permission = Permission::findOrFail( $id );
         $permission->delete();
 
-        return response()->json( [], 204);
+        return response()->json( [], 204 );
     }
 }

--- a/src/Modules/Users/Http/Controllers/PermissionController.php
+++ b/src/Modules/Users/Http/Controllers/PermissionController.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare( strict_types=1 );
 
 /**
  * Permission Controller for the CMS Framework Users Module.
@@ -29,7 +29,7 @@ use Illuminate\Routing\Controller;
  *
  * @since 1.0.0
  */
-#[Group('Permissions', weight: 12)]
+#[Group( 'Permissions', weight: 12 )]
 class PermissionController extends Controller
 {
     /**
@@ -44,9 +44,9 @@ class PermissionController extends Controller
      */
     public function index(): AnonymousResourceCollection
     {
-        $permissions = Permission::with('roles')->paginate(15);
+        $permissions = Permission::with( 'roles' )->paginate( 15 );
 
-        return PermissionResource::collection($permissions);
+        return PermissionResource::collection( $permissions );
     }
 
     /**
@@ -61,17 +61,17 @@ class PermissionController extends Controller
      *
      * @return PermissionResource The created permission resource with loaded roles.
      */
-    public function store(Request $request): PermissionResource
+    public function store( Request $request ): PermissionResource
     {
-        $validated = $request->validate([
+        $validated = $request->validate( [
             'name' => 'required|string|max:255',
             'slug' => 'required|string|max:255|unique:permissions',
-        ]);
+        ] );
 
-        $permission = Permission::create($validated);
-        $permission->load('roles');
+        $permission = Permission::create( $validated );
+        $permission->load( 'roles' );
 
-        return new PermissionResource($permission);
+        return new PermissionResource( $permission );
     }
 
     /**
@@ -86,11 +86,11 @@ class PermissionController extends Controller
      *
      * @return PermissionResource The permission resource with loaded roles.
      */
-    public function show(string|int $id): PermissionResource
+    public function show( string|int $id ): PermissionResource
     {
-        $permission = Permission::with('roles')->findOrFail($id);
+        $permission = Permission::with( 'roles' )->findOrFail( $id );
 
-        return new PermissionResource($permission);
+        return new PermissionResource( $permission );
     }
 
     /**
@@ -106,18 +106,18 @@ class PermissionController extends Controller
      *
      * @return PermissionResource The updated permission resource with loaded roles.
      */
-    public function update(Request $request, string|int $id): PermissionResource
+    public function update( Request $request, string|int $id ): PermissionResource
     {
-        $permission = Permission::findOrFail($id);
-        $validated  = $request->validate([
+        $permission = Permission::findOrFail( $id );
+        $validated  = $request->validate( [
             'name' => 'sometimes|required|string|max:255',
-            'slug' => 'sometimes|required|string|max:255|unique:permissions,slug,'.$permission->id,
-        ]);
+            'slug' => 'sometimes|required|string|max:255|unique:permissions,slug,' . $permission->id,
+        ] );
 
-        $permission->update($validated);
-        $permission->load('roles');
+        $permission->update( $validated );
+        $permission->load( 'roles' );
 
-        return new PermissionResource($permission);
+        return new PermissionResource( $permission );
     }
 
     /**
@@ -132,11 +132,11 @@ class PermissionController extends Controller
      *
      * @return JsonResponse A JSON response with 204 status code.
      */
-    public function destroy(string|int $id): JsonResponse
+    public function destroy( string|int $id ): JsonResponse
     {
-        $permission = Permission::findOrFail($id);
+        $permission = Permission::findOrFail( $id );
         $permission->delete();
 
-        return response()->json([], 204);
+        return response()->json( [], 204);
     }
 }

--- a/src/Modules/Users/Http/Controllers/PermissionController.php
+++ b/src/Modules/Users/Http/Controllers/PermissionController.php
@@ -1,6 +1,6 @@
 <?php
 
-declare( strict_types = 1 );
+declare(strict_types=1);
 
 /**
  * Permission Controller for the CMS Framework Users Module.
@@ -15,6 +15,7 @@ namespace ArtisanPackUI\CMSFramework\Modules\Users\Http\Controllers;
 
 use ArtisanPackUI\CMSFramework\Modules\Users\Http\Resources\PermissionResource;
 use ArtisanPackUI\CMSFramework\Modules\Users\Models\Permission;
+use Dedoc\Scramble\Attributes\Group;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
@@ -28,6 +29,7 @@ use Illuminate\Routing\Controller;
  *
  * @since 1.0.0
  */
+#[Group('Permissions', weight: 12)]
 class PermissionController extends Controller
 {
     /**
@@ -42,9 +44,9 @@ class PermissionController extends Controller
      */
     public function index(): AnonymousResourceCollection
     {
-        $permissions = Permission::with( 'roles' )->paginate( 15 );
+        $permissions = Permission::with('roles')->paginate(15);
 
-        return PermissionResource::collection( $permissions );
+        return PermissionResource::collection($permissions);
     }
 
     /**
@@ -59,17 +61,17 @@ class PermissionController extends Controller
      *
      * @return PermissionResource The created permission resource with loaded roles.
      */
-    public function store( Request $request ): PermissionResource
+    public function store(Request $request): PermissionResource
     {
-        $validated = $request->validate( [
+        $validated = $request->validate([
             'name' => 'required|string|max:255',
             'slug' => 'required|string|max:255|unique:permissions',
-        ] );
+        ]);
 
-        $permission = Permission::create( $validated );
-        $permission->load( 'roles' );
+        $permission = Permission::create($validated);
+        $permission->load('roles');
 
-        return new PermissionResource( $permission );
+        return new PermissionResource($permission);
     }
 
     /**
@@ -84,11 +86,11 @@ class PermissionController extends Controller
      *
      * @return PermissionResource The permission resource with loaded roles.
      */
-    public function show( string|int $id ): PermissionResource
+    public function show(string|int $id): PermissionResource
     {
-        $permission = Permission::with( 'roles' )->findOrFail( $id );
+        $permission = Permission::with('roles')->findOrFail($id);
 
-        return new PermissionResource( $permission );
+        return new PermissionResource($permission);
     }
 
     /**
@@ -104,18 +106,18 @@ class PermissionController extends Controller
      *
      * @return PermissionResource The updated permission resource with loaded roles.
      */
-    public function update( Request $request, string|int $id ): PermissionResource
+    public function update(Request $request, string|int $id): PermissionResource
     {
-        $permission = Permission::findOrFail( $id );
-        $validated  = $request->validate( [
+        $permission = Permission::findOrFail($id);
+        $validated  = $request->validate([
             'name' => 'sometimes|required|string|max:255',
-            'slug' => 'sometimes|required|string|max:255|unique:permissions,slug,' . $permission->id,
-        ] );
+            'slug' => 'sometimes|required|string|max:255|unique:permissions,slug,'.$permission->id,
+        ]);
 
-        $permission->update( $validated );
-        $permission->load( 'roles' );
+        $permission->update($validated);
+        $permission->load('roles');
 
-        return new PermissionResource( $permission );
+        return new PermissionResource($permission);
     }
 
     /**
@@ -130,11 +132,11 @@ class PermissionController extends Controller
      *
      * @return JsonResponse A JSON response with 204 status code.
      */
-    public function destroy( string|int $id ): JsonResponse
+    public function destroy(string|int $id): JsonResponse
     {
-        $permission = Permission::findOrFail( $id );
+        $permission = Permission::findOrFail($id);
         $permission->delete();
 
-        return response()->json( [], 204 );
+        return response()->json([], 204);
     }
 }

--- a/src/Modules/Users/Http/Controllers/RoleController.php
+++ b/src/Modules/Users/Http/Controllers/RoleController.php
@@ -16,6 +16,7 @@ namespace ArtisanPackUI\CMSFramework\Modules\Users\Http\Controllers;
 use ArtisanPackUI\CMSFramework\Http\Controllers\Concerns\HasIncludableRelationships;
 use ArtisanPackUI\CMSFramework\Modules\Users\Http\Resources\RoleResource;
 use ArtisanPackUI\CMSFramework\Modules\Users\Models\Role;
+use Dedoc\Scramble\Attributes\Group;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
@@ -30,6 +31,7 @@ use Illuminate\Routing\Controller;
  *
  * @since 1.0.0
  */
+#[Group('Roles', weight: 11)]
 class RoleController extends Controller
 {
     use AuthorizesRequests;

--- a/src/Modules/Users/Http/Controllers/RoleController.php
+++ b/src/Modules/Users/Http/Controllers/RoleController.php
@@ -167,10 +167,10 @@ class RoleController extends Controller
     public function destroy( string|int $id ): JsonResponse
     {
         $role = Role::findOrFail( $id );
-        $this->authorize( 'delete', $role);
+        $this->authorize( 'delete', $role );
 
         $role->delete();
 
-        return response()->json( [], 204);
+        return response()->json( [], 204 );
     }
 }

--- a/src/Modules/Users/Http/Controllers/RoleController.php
+++ b/src/Modules/Users/Http/Controllers/RoleController.php
@@ -1,6 +1,6 @@
 <?php
 
-declare( strict_types = 1 );
+declare(strict_types=1);
 
 /**
  * Role Controller for the CMS Framework Users Module.
@@ -13,6 +13,7 @@ declare( strict_types = 1 );
 
 namespace ArtisanPackUI\CMSFramework\Modules\Users\Http\Controllers;
 
+use ArtisanPackUI\CMSFramework\Http\Controllers\Concerns\HasIncludableRelationships;
 use ArtisanPackUI\CMSFramework\Modules\Users\Http\Resources\RoleResource;
 use ArtisanPackUI\CMSFramework\Modules\Users\Models\Role;
 use Illuminate\Http\JsonResponse;
@@ -30,6 +31,26 @@ use Illuminate\Routing\Controller;
  */
 class RoleController extends Controller
 {
+    use HasIncludableRelationships;
+
+    /**
+     * The relationships that can be included via the include query parameter.
+     *
+     * @since 1.1.0
+     *
+     * @var array<int, string>
+     */
+    protected array $includableRelationships = ['permissions'];
+
+    /**
+     * The default relationships to load when no include parameter is provided.
+     *
+     * @since 1.1.0
+     *
+     * @var array<int, string>
+     */
+    protected array $defaultIncludes = ['permissions'];
+
     /**
      * Display a listing of roles.
      *
@@ -40,11 +61,11 @@ class RoleController extends Controller
      *
      * @return AnonymousResourceCollection The paginated collection of role resources.
      */
-    public function index(): AnonymousResourceCollection
+    public function index(Request $request): AnonymousResourceCollection
     {
-        $roles = Role::with( 'permissions' )->paginate( 15 );
+        $roles = Role::with($this->getRequestedIncludes($request))->paginate(15);
 
-        return RoleResource::collection( $roles );
+        return RoleResource::collection($roles);
     }
 
     /**
@@ -59,17 +80,17 @@ class RoleController extends Controller
      *
      * @return RoleResource The created role resource with loaded permissions.
      */
-    public function store( Request $request ): RoleResource
+    public function store(Request $request): RoleResource
     {
-        $validated = $request->validate( [
+        $validated = $request->validate([
             'name' => 'required|string|max:255',
             'slug' => 'required|string|max:255|unique:roles',
-        ] );
+        ]);
 
-        $role = Role::create( $validated );
-        $role->load( 'permissions' );
+        $role = Role::create($validated);
+        $role->load($this->getRequestedIncludes($request));
 
-        return new RoleResource( $role );
+        return new RoleResource($role);
     }
 
     /**
@@ -84,11 +105,11 @@ class RoleController extends Controller
      *
      * @return RoleResource The role resource with loaded permissions.
      */
-    public function show( string|int $id ): RoleResource
+    public function show(Request $request, string|int $id): RoleResource
     {
-        $role = Role::with( 'permissions' )->findOrFail( $id );
+        $role = Role::with($this->getRequestedIncludes($request))->findOrFail($id);
 
-        return new RoleResource( $role );
+        return new RoleResource($role);
     }
 
     /**
@@ -104,18 +125,18 @@ class RoleController extends Controller
      *
      * @return RoleResource The updated role resource with loaded permissions.
      */
-    public function update( Request $request, string|int $id ): RoleResource
+    public function update(Request $request, string|int $id): RoleResource
     {
-        $role      = Role::findOrFail( $id );
-        $validated = $request->validate( [
+        $role      = Role::findOrFail($id);
+        $validated = $request->validate([
             'name' => 'sometimes|required|string|max:255',
-            'slug' => 'sometimes|required|string|max:255|unique:roles,slug,' . $role->id,
-        ] );
+            'slug' => 'sometimes|required|string|max:255|unique:roles,slug,'.$role->id,
+        ]);
 
-        $role->update( $validated );
-        $role->load( 'permissions' );
+        $role->update($validated);
+        $role->load($this->getRequestedIncludes($request));
 
-        return new RoleResource( $role );
+        return new RoleResource($role);
     }
 
     /**
@@ -130,11 +151,11 @@ class RoleController extends Controller
      *
      * @return JsonResponse A JSON response with 204 status code.
      */
-    public function destroy( string|int $id ): JsonResponse
+    public function destroy(string|int $id): JsonResponse
     {
-        $role = Role::findOrFail( $id );
+        $role = Role::findOrFail($id);
         $role->delete();
 
-        return response()->json( [], 204 );
+        return response()->json([], 204);
     }
 }

--- a/src/Modules/Users/Http/Controllers/RoleController.php
+++ b/src/Modules/Users/Http/Controllers/RoleController.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare( strict_types=1 );
 
 /**
  * Role Controller for the CMS Framework Users Module.
@@ -31,7 +31,7 @@ use Illuminate\Routing\Controller;
  *
  * @since 1.0.0
  */
-#[Group('Roles', weight: 11)]
+#[Group( 'Roles', weight: 11 )]
 class RoleController extends Controller
 {
     use AuthorizesRequests;
@@ -65,13 +65,13 @@ class RoleController extends Controller
      *
      * @return AnonymousResourceCollection The paginated collection of role resources.
      */
-    public function index(Request $request): AnonymousResourceCollection
+    public function index( Request $request ): AnonymousResourceCollection
     {
-        $this->authorize('viewAny', Role::class);
+        $this->authorize( 'viewAny', Role::class );
 
-        $roles = Role::with($this->getRequestedIncludes($request))->paginate(15);
+        $roles = Role::with( $this->getRequestedIncludes( $request ) )->paginate( 15 );
 
-        return RoleResource::collection($roles);
+        return RoleResource::collection( $roles );
     }
 
     /**
@@ -86,19 +86,19 @@ class RoleController extends Controller
      *
      * @return RoleResource The created role resource with loaded permissions.
      */
-    public function store(Request $request): JsonResponse
+    public function store( Request $request ): JsonResponse
     {
-        $this->authorize('create', Role::class);
+        $this->authorize( 'create', Role::class );
 
-        $validated = $request->validate([
+        $validated = $request->validate( [
             'name' => 'required|string|max:255',
             'slug' => 'required|string|max:255|unique:roles',
-        ]);
+        ] );
 
-        $role = Role::create($validated);
-        $role->load($this->getRequestedIncludes($request));
+        $role = Role::create( $validated );
+        $role->load( $this->getRequestedIncludes( $request ) );
 
-        return (new RoleResource($role))->response()->setStatusCode(201);
+        return (new RoleResource( $role ))->response()->setStatusCode( 201 );
     }
 
     /**
@@ -113,14 +113,14 @@ class RoleController extends Controller
      *
      * @return RoleResource The role resource with loaded permissions.
      */
-    public function show(Request $request, string|int $id): RoleResource
+    public function show( Request $request, string|int $id ): RoleResource
     {
-        $role = Role::findOrFail($id);
-        $this->authorize('view', $role);
+        $role = Role::findOrFail( $id );
+        $this->authorize( 'view', $role );
 
-        $role->load($this->getRequestedIncludes($request));
+        $role->load( $this->getRequestedIncludes( $request ) );
 
-        return new RoleResource($role);
+        return new RoleResource( $role );
     }
 
     /**
@@ -136,20 +136,20 @@ class RoleController extends Controller
      *
      * @return RoleResource The updated role resource with loaded permissions.
      */
-    public function update(Request $request, string|int $id): RoleResource
+    public function update( Request $request, string|int $id ): RoleResource
     {
-        $role = Role::findOrFail($id);
-        $this->authorize('update', $role);
+        $role = Role::findOrFail( $id );
+        $this->authorize( 'update', $role );
 
-        $validated = $request->validate([
+        $validated = $request->validate( [
             'name' => 'sometimes|required|string|max:255',
-            'slug' => 'sometimes|required|string|max:255|unique:roles,slug,'.$role->id,
-        ]);
+            'slug' => 'sometimes|required|string|max:255|unique:roles,slug,' . $role->id,
+        ] );
 
-        $role->update($validated);
-        $role->load($this->getRequestedIncludes($request));
+        $role->update( $validated );
+        $role->load( $this->getRequestedIncludes( $request ) );
 
-        return new RoleResource($role);
+        return new RoleResource( $role );
     }
 
     /**
@@ -164,13 +164,13 @@ class RoleController extends Controller
      *
      * @return JsonResponse A JSON response with 204 status code.
      */
-    public function destroy(string|int $id): JsonResponse
+    public function destroy( string|int $id ): JsonResponse
     {
-        $role = Role::findOrFail($id);
-        $this->authorize('delete', $role);
+        $role = Role::findOrFail( $id );
+        $this->authorize( 'delete', $role);
 
         $role->delete();
 
-        return response()->json([], 204);
+        return response()->json( [], 204);
     }
 }

--- a/src/Modules/Users/Http/Controllers/RoleController.php
+++ b/src/Modules/Users/Http/Controllers/RoleController.php
@@ -16,6 +16,7 @@ namespace ArtisanPackUI\CMSFramework\Modules\Users\Http\Controllers;
 use ArtisanPackUI\CMSFramework\Http\Controllers\Concerns\HasIncludableRelationships;
 use ArtisanPackUI\CMSFramework\Modules\Users\Http\Resources\RoleResource;
 use ArtisanPackUI\CMSFramework\Modules\Users\Models\Role;
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
@@ -31,6 +32,7 @@ use Illuminate\Routing\Controller;
  */
 class RoleController extends Controller
 {
+    use AuthorizesRequests;
     use HasIncludableRelationships;
 
     /**
@@ -63,6 +65,8 @@ class RoleController extends Controller
      */
     public function index(Request $request): AnonymousResourceCollection
     {
+        $this->authorize('viewAny', Role::class);
+
         $roles = Role::with($this->getRequestedIncludes($request))->paginate(15);
 
         return RoleResource::collection($roles);
@@ -80,8 +84,10 @@ class RoleController extends Controller
      *
      * @return RoleResource The created role resource with loaded permissions.
      */
-    public function store(Request $request): RoleResource
+    public function store(Request $request): JsonResponse
     {
+        $this->authorize('create', Role::class);
+
         $validated = $request->validate([
             'name' => 'required|string|max:255',
             'slug' => 'required|string|max:255|unique:roles',
@@ -90,7 +96,7 @@ class RoleController extends Controller
         $role = Role::create($validated);
         $role->load($this->getRequestedIncludes($request));
 
-        return new RoleResource($role);
+        return (new RoleResource($role))->response()->setStatusCode(201);
     }
 
     /**
@@ -107,7 +113,10 @@ class RoleController extends Controller
      */
     public function show(Request $request, string|int $id): RoleResource
     {
-        $role = Role::with($this->getRequestedIncludes($request))->findOrFail($id);
+        $role = Role::findOrFail($id);
+        $this->authorize('view', $role);
+
+        $role->load($this->getRequestedIncludes($request));
 
         return new RoleResource($role);
     }
@@ -127,7 +136,9 @@ class RoleController extends Controller
      */
     public function update(Request $request, string|int $id): RoleResource
     {
-        $role      = Role::findOrFail($id);
+        $role = Role::findOrFail($id);
+        $this->authorize('update', $role);
+
         $validated = $request->validate([
             'name' => 'sometimes|required|string|max:255',
             'slug' => 'sometimes|required|string|max:255|unique:roles,slug,'.$role->id,
@@ -154,6 +165,8 @@ class RoleController extends Controller
     public function destroy(string|int $id): JsonResponse
     {
         $role = Role::findOrFail($id);
+        $this->authorize('delete', $role);
+
         $role->delete();
 
         return response()->json([], 204);

--- a/src/Modules/Users/Http/Controllers/UserController.php
+++ b/src/Modules/Users/Http/Controllers/UserController.php
@@ -15,6 +15,7 @@ namespace ArtisanPackUI\CMSFramework\Modules\Users\Http\Controllers;
 
 use App\Models\User;
 use ArtisanPackUI\CMSFramework\Http\Controllers\Concerns\HasIncludableRelationships;
+use ArtisanPackUI\CMSFramework\Modules\Users\Http\Requests\BulkUserRequest;
 use ArtisanPackUI\CMSFramework\Modules\Users\Http\Resources\UserResource;
 use Dedoc\Scramble\Attributes\Group;
 use Illuminate\Http\JsonResponse;
@@ -22,6 +23,7 @@ use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
 use Illuminate\Http\Response;
 use Illuminate\Routing\Controller;
+use Throwable;
 
 /**
  * API controller for managing users.
@@ -177,5 +179,75 @@ class UserController extends Controller
         $user->delete();
 
         return response()->noContent();
+    }
+
+    /**
+     * Perform a bulk action on multiple users.
+     *
+     * Processes the requested action on each user individually.
+     * Returns a summary of successes and failures.
+     *
+     * @since 1.1.0
+     *
+     * @param  BulkUserRequest  $request  The validated bulk action request.
+     *
+     * @return JsonResponse Summary with processed count, failed count, and error details.
+     */
+    public function bulk(BulkUserRequest $request): JsonResponse
+    {
+        $action    = $request->validated('action');
+        $ids       = $request->validated('ids');
+        $processed = 0;
+        $errors    = [];
+
+        $userModel = config('artisanpack.cms-framework.user_model');
+        $users     = $userModel::whereIn('id', $ids)->get()->keyBy('id');
+
+        foreach ($ids as $id) {
+            $user = $users->get($id);
+
+            if (null === $user) {
+                $errors[$id] = __('User not found.');
+
+                continue;
+            }
+
+            // Prevent users from performing bulk actions on themselves
+            if ($request->user() && $user->id === $request->user()->id) {
+                $errors[$id] = __('You cannot perform bulk actions on your own account.');
+
+                continue;
+            }
+
+            try {
+                $this->executeBulkAction($action, $user);
+                $processed++;
+            } catch (Throwable $e) {
+                $errors[$id] = $e->getMessage();
+            }
+        }
+
+        return response()->json([
+            'processed' => $processed,
+            'failed'    => count($errors),
+            'errors'    => $errors,
+        ]);
+    }
+
+    /**
+     * Execute a bulk action on a single user.
+     *
+     * @since 1.1.0
+     *
+     * @param  string  $action  The bulk action to perform.
+     * @param  mixed  $user  The user model instance to perform the action on.
+     */
+    protected function executeBulkAction(string $action, mixed $user): void
+    {
+        match ($action) {
+            'delete'     => $user->delete(),
+            'activate'   => $user->update(['email_verified_at' => now()]),
+            'deactivate' => $user->update(['email_verified_at' => null]),
+        };
     }
 }

--- a/src/Modules/Users/Http/Controllers/UserController.php
+++ b/src/Modules/Users/Http/Controllers/UserController.php
@@ -23,6 +23,8 @@ use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
 use Illuminate\Http\Response;
 use Illuminate\Routing\Controller;
+use Illuminate\Support\Facades\Gate;
+use InvalidArgumentException;
 use Throwable;
 
 /**
@@ -219,6 +221,14 @@ class UserController extends Controller
                 continue;
             }
 
+            $permission = $this->getBulkPermission($action);
+
+            if (! Gate::forUser($request->user())->allows($permission)) {
+                $errors[$id] = __('You do not have permission to :action this user.', ['action' => $action]);
+
+                continue;
+            }
+
             try {
                 $this->executeBulkAction($action, $user);
                 $processed++;
@@ -235,6 +245,24 @@ class UserController extends Controller
     }
 
     /**
+     * Get the Gate permission for a bulk action.
+     *
+     * @since 1.1.0
+     *
+     * @param  string  $action  The bulk action name.
+     *
+     * @return string The Gate permission name.
+     */
+    protected function getBulkPermission(string $action): string
+    {
+        return match ($action) {
+            'delete'              => 'users.delete',
+            'activate', 'deactivate' => 'users.manage',
+            default               => throw new InvalidArgumentException(__('Unsupported bulk action: :action', ['action' => $action])),
+        };
+    }
+
+    /**
      * Execute a bulk action on a single user.
      *
      * @since 1.1.0
@@ -248,6 +276,7 @@ class UserController extends Controller
             'delete'     => $user->delete(),
             'activate'   => $user->update(['email_verified_at' => now()]),
             'deactivate' => $user->update(['email_verified_at' => null]),
+            default      => throw new InvalidArgumentException(__('Unsupported bulk action: :action', ['action' => $action])),
         };
     }
 }

--- a/src/Modules/Users/Http/Controllers/UserController.php
+++ b/src/Modules/Users/Http/Controllers/UserController.php
@@ -19,6 +19,7 @@ use ArtisanPackUI\CMSFramework\Modules\Users\Http\Resources\UserResource;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
+use Illuminate\Http\Response;
 use Illuminate\Routing\Controller;
 
 /**
@@ -167,12 +168,12 @@ class UserController extends Controller
      *
      * @return JsonResponse A JSON response with 204 status code.
      */
-    public function destroy(string|int $id): JsonResponse
+    public function destroy(string|int $id): Response
     {
         $userModel = config('artisanpack.cms-framework.user_model');
         $user      = $userModel::findOrFail($id);
         $user->delete();
 
-        return response()->json([], 204);
+        return response()->noContent();
     }
 }

--- a/src/Modules/Users/Http/Controllers/UserController.php
+++ b/src/Modules/Users/Http/Controllers/UserController.php
@@ -81,7 +81,7 @@ class UserController extends Controller
      *
      * @param  Request  $request  The HTTP request containing user data.
      *
-     * @return UserResource The created user resource with loaded roles.
+     * @return JsonResponse The created user resource with a 201 status code.
      */
     public function store(Request $request): JsonResponse
     {
@@ -166,7 +166,7 @@ class UserController extends Controller
      *
      * @param  int|string  $id  The ID of the user to delete.
      *
-     * @return JsonResponse A JSON response with 204 status code.
+     * @return Response A response with 204 status code.
      */
     public function destroy(string|int $id): Response
     {

--- a/src/Modules/Users/Http/Controllers/UserController.php
+++ b/src/Modules/Users/Http/Controllers/UserController.php
@@ -82,7 +82,7 @@ class UserController extends Controller
      *
      * @return UserResource The created user resource with loaded roles.
      */
-    public function store(Request $request): UserResource
+    public function store(Request $request): JsonResponse
     {
         $userModel = config('artisanpack.cms-framework.user_model');
 
@@ -97,7 +97,7 @@ class UserController extends Controller
         $user = $userModel::create($validated);
         $user->load($this->getRequestedIncludes($request));
 
-        return new UserResource($user);
+        return (new UserResource($user))->response()->setStatusCode(201);
     }
 
     /**

--- a/src/Modules/Users/Http/Controllers/UserController.php
+++ b/src/Modules/Users/Http/Controllers/UserController.php
@@ -274,9 +274,9 @@ class UserController extends Controller
     {
         match ( $action ) {
             'delete'     => $user->delete(),
-            'activate'   => $user->update( ['email_verified_at' => now()]),
-            'deactivate' => $user->update( ['email_verified_at' => null]),
-            default      => throw new InvalidArgumentException( __( 'Unsupported bulk action: :action', ['action' => $action])),
+            'activate'   => $user->update( ['email_verified_at' => now()] ),
+            'deactivate' => $user->update( ['email_verified_at' => null] ),
+            default      => throw new InvalidArgumentException( __( 'Unsupported bulk action: :action', ['action' => $action] ) ),
         };
     }
 }

--- a/src/Modules/Users/Http/Controllers/UserController.php
+++ b/src/Modules/Users/Http/Controllers/UserController.php
@@ -1,6 +1,6 @@
 <?php
 
-declare( strict_types = 1 );
+declare(strict_types=1);
 
 /**
  * User Controller for the CMS Framework Users Module.
@@ -14,6 +14,7 @@ declare( strict_types = 1 );
 namespace ArtisanPackUI\CMSFramework\Modules\Users\Http\Controllers;
 
 use App\Models\User;
+use ArtisanPackUI\CMSFramework\Http\Controllers\Concerns\HasIncludableRelationships;
 use ArtisanPackUI\CMSFramework\Modules\Users\Http\Resources\UserResource;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
@@ -30,6 +31,26 @@ use Illuminate\Routing\Controller;
  */
 class UserController extends Controller
 {
+    use HasIncludableRelationships;
+
+    /**
+     * The relationships that can be included via the include query parameter.
+     *
+     * @since 1.1.0
+     *
+     * @var array<int, string>
+     */
+    protected array $includableRelationships = ['roles'];
+
+    /**
+     * The default relationships to load when no include parameter is provided.
+     *
+     * @since 1.1.0
+     *
+     * @var array<int, string>
+     */
+    protected array $defaultIncludes = ['roles'];
+
     /**
      * Display a listing of users.
      *
@@ -40,12 +61,13 @@ class UserController extends Controller
      *
      * @return AnonymousResourceCollection The paginated collection of user resources.
      */
-    public function index(): AnonymousResourceCollection
+    public function index(Request $request): AnonymousResourceCollection
     {
-        $userModel = config( 'artisanpack.cms-framework.user_model' );
-        $users     = $userModel::with( 'roles' )->paginate( 15 );
+        $userModel = config('artisanpack.cms-framework.user_model');
+        $includes  = $this->getRequestedIncludes($request);
+        $users     = $userModel::with($includes)->paginate(15);
 
-        return UserResource::collection( $users );
+        return UserResource::collection($users);
     }
 
     /**
@@ -60,22 +82,22 @@ class UserController extends Controller
      *
      * @return UserResource The created user resource with loaded roles.
      */
-    public function store( Request $request ): UserResource
+    public function store(Request $request): UserResource
     {
-        $userModel = config( 'artisanpack.cms-framework.user_model' );
+        $userModel = config('artisanpack.cms-framework.user_model');
 
-        $validated = $request->validate( [
+        $validated = $request->validate([
             'name'     => 'required|string|max:255',
             'email'    => 'required|string|email|max:255|unique:users',
             'password' => 'required|string|min:8',
-        ] );
+        ]);
 
-        $validated['password'] = bcrypt( $validated['password'] );
+        $validated['password'] = bcrypt($validated['password']);
 
-        $user = $userModel::create( $validated );
-        $user->load( 'roles' );
+        $user = $userModel::create($validated);
+        $user->load($this->getRequestedIncludes($request));
 
-        return new UserResource( $user );
+        return new UserResource($user);
     }
 
     /**
@@ -90,12 +112,13 @@ class UserController extends Controller
      *
      * @return UserResource The user resource with loaded roles.
      */
-    public function show( string|int $id ): UserResource
+    public function show(Request $request, string|int $id): UserResource
     {
-        $userModel = config( 'artisanpack.cms-framework.user_model' );
-        $user      = $userModel::with( 'roles' )->findOrFail( $id );
+        $userModel = config('artisanpack.cms-framework.user_model');
+        $includes  = $this->getRequestedIncludes($request);
+        $user      = $userModel::with($includes)->findOrFail($id);
 
-        return new UserResource( $user );
+        return new UserResource($user);
     }
 
     /**
@@ -112,24 +135,24 @@ class UserController extends Controller
      *
      * @return UserResource The updated user resource with loaded roles.
      */
-    public function update( Request $request, string|int $id ): UserResource
+    public function update(Request $request, string|int $id): UserResource
     {
-        $userModel = config( 'artisanpack.cms-framework.user_model' );
-        $user      = $userModel::findOrFail( $id );
-        $validated = $request->validate( [
+        $userModel = config('artisanpack.cms-framework.user_model');
+        $user      = $userModel::findOrFail($id);
+        $validated = $request->validate([
             'name'     => 'sometimes|required|string|max:255',
-            'email'    => 'sometimes|required|string|email|max:255|unique:users,email,' . $user->id,
+            'email'    => 'sometimes|required|string|email|max:255|unique:users,email,'.$user->id,
             'password' => 'sometimes|required|string|min:8',
-        ] );
+        ]);
 
-        if ( isset( $validated['password'] ) ) {
-            $validated['password'] = bcrypt( $validated['password'] );
+        if (isset($validated['password'])) {
+            $validated['password'] = bcrypt($validated['password']);
         }
 
-        $user->update( $validated );
-        $user->load( 'roles' );
+        $user->update($validated);
+        $user->load($this->getRequestedIncludes($request));
 
-        return new UserResource( $user );
+        return new UserResource($user);
     }
 
     /**
@@ -144,12 +167,12 @@ class UserController extends Controller
      *
      * @return JsonResponse A JSON response with 204 status code.
      */
-    public function destroy( string|int $id ): JsonResponse
+    public function destroy(string|int $id): JsonResponse
     {
-        $userModel = config( 'artisanpack.cms-framework.user_model' );
-        $user      = $userModel::findOrFail( $id );
+        $userModel = config('artisanpack.cms-framework.user_model');
+        $user      = $userModel::findOrFail($id);
         $user->delete();
 
-        return response()->json( [], 204 );
+        return response()->json([], 204);
     }
 }

--- a/src/Modules/Users/Http/Controllers/UserController.php
+++ b/src/Modules/Users/Http/Controllers/UserController.php
@@ -197,10 +197,11 @@ class UserController extends Controller
      */
     public function bulk(BulkUserRequest $request): JsonResponse
     {
-        $action    = $request->validated('action');
-        $ids       = $request->validated('ids');
-        $processed = 0;
-        $errors    = [];
+        $action     = $request->validated('action');
+        $ids        = $request->validated('ids');
+        $permission = $this->getBulkPermission($action);
+        $processed  = 0;
+        $errors     = [];
 
         $userModel = config('artisanpack.cms-framework.user_model');
         $users     = $userModel::whereIn('id', $ids)->get()->keyBy('id');
@@ -221,9 +222,7 @@ class UserController extends Controller
                 continue;
             }
 
-            $permission = $this->getBulkPermission($action);
-
-            if (! Gate::forUser($request->user())->allows($permission)) {
+            if (! Gate::forUser($request->user())->allows($permission, $user)) {
                 $errors[$id] = __('You do not have permission to :action this user.', ['action' => $action]);
 
                 continue;

--- a/src/Modules/Users/Http/Controllers/UserController.php
+++ b/src/Modules/Users/Http/Controllers/UserController.php
@@ -16,6 +16,7 @@ namespace ArtisanPackUI\CMSFramework\Modules\Users\Http\Controllers;
 use App\Models\User;
 use ArtisanPackUI\CMSFramework\Http\Controllers\Concerns\HasIncludableRelationships;
 use ArtisanPackUI\CMSFramework\Modules\Users\Http\Resources\UserResource;
+use Dedoc\Scramble\Attributes\Group;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
@@ -30,6 +31,7 @@ use Illuminate\Routing\Controller;
  *
  * @since 1.0.0
  */
+#[Group('Users', weight: 10)]
 class UserController extends Controller
 {
     use HasIncludableRelationships;

--- a/src/Modules/Users/Http/Controllers/UserController.php
+++ b/src/Modules/Users/Http/Controllers/UserController.php
@@ -233,7 +233,8 @@ class UserController extends Controller
                 $this->executeBulkAction($action, $user);
                 $processed++;
             } catch (Throwable $e) {
-                $errors[$id] = $e->getMessage();
+                report($e);
+                $errors[$id] = __('Failed to :action user.', ['action' => $action]);
             }
         }
 

--- a/src/Modules/Users/Http/Controllers/UserController.php
+++ b/src/Modules/Users/Http/Controllers/UserController.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare( strict_types=1 );
 
 /**
  * User Controller for the CMS Framework Users Module.
@@ -35,7 +35,7 @@ use Throwable;
  *
  * @since 1.0.0
  */
-#[Group('Users', weight: 10)]
+#[Group( 'Users', weight: 10 )]
 class UserController extends Controller
 {
     use HasIncludableRelationships;
@@ -68,13 +68,13 @@ class UserController extends Controller
      *
      * @return AnonymousResourceCollection The paginated collection of user resources.
      */
-    public function index(Request $request): AnonymousResourceCollection
+    public function index( Request $request ): AnonymousResourceCollection
     {
-        $userModel = config('artisanpack.cms-framework.user_model');
-        $includes  = $this->getRequestedIncludes($request);
-        $users     = $userModel::with($includes)->paginate(15);
+        $userModel = config( 'artisanpack.cms-framework.user_model' );
+        $includes  = $this->getRequestedIncludes( $request );
+        $users     = $userModel::with( $includes )->paginate( 15 );
 
-        return UserResource::collection($users);
+        return UserResource::collection( $users );
     }
 
     /**
@@ -89,22 +89,22 @@ class UserController extends Controller
      *
      * @return JsonResponse The created user resource with a 201 status code.
      */
-    public function store(Request $request): JsonResponse
+    public function store( Request $request ): JsonResponse
     {
-        $userModel = config('artisanpack.cms-framework.user_model');
+        $userModel = config( 'artisanpack.cms-framework.user_model' );
 
-        $validated = $request->validate([
+        $validated = $request->validate( [
             'name'     => 'required|string|max:255',
             'email'    => 'required|string|email|max:255|unique:users',
             'password' => 'required|string|min:8',
-        ]);
+        ] );
 
-        $validated['password'] = bcrypt($validated['password']);
+        $validated['password'] = bcrypt( $validated['password'] );
 
-        $user = $userModel::create($validated);
-        $user->load($this->getRequestedIncludes($request));
+        $user = $userModel::create( $validated );
+        $user->load( $this->getRequestedIncludes( $request ) );
 
-        return (new UserResource($user))->response()->setStatusCode(201);
+        return (new UserResource( $user ))->response()->setStatusCode( 201 );
     }
 
     /**
@@ -119,13 +119,13 @@ class UserController extends Controller
      *
      * @return UserResource The user resource with loaded roles.
      */
-    public function show(Request $request, string|int $id): UserResource
+    public function show( Request $request, string|int $id ): UserResource
     {
-        $userModel = config('artisanpack.cms-framework.user_model');
-        $includes  = $this->getRequestedIncludes($request);
-        $user      = $userModel::with($includes)->findOrFail($id);
+        $userModel = config( 'artisanpack.cms-framework.user_model' );
+        $includes  = $this->getRequestedIncludes( $request );
+        $user      = $userModel::with( $includes )->findOrFail( $id );
 
-        return new UserResource($user);
+        return new UserResource( $user );
     }
 
     /**
@@ -142,24 +142,24 @@ class UserController extends Controller
      *
      * @return UserResource The updated user resource with loaded roles.
      */
-    public function update(Request $request, string|int $id): UserResource
+    public function update( Request $request, string|int $id ): UserResource
     {
-        $userModel = config('artisanpack.cms-framework.user_model');
-        $user      = $userModel::findOrFail($id);
-        $validated = $request->validate([
+        $userModel = config( 'artisanpack.cms-framework.user_model' );
+        $user      = $userModel::findOrFail( $id );
+        $validated = $request->validate( [
             'name'     => 'sometimes|required|string|max:255',
-            'email'    => 'sometimes|required|string|email|max:255|unique:users,email,'.$user->id,
+            'email'    => 'sometimes|required|string|email|max:255|unique:users,email,' . $user->id,
             'password' => 'sometimes|required|string|min:8',
-        ]);
+        ] );
 
-        if (isset($validated['password'])) {
-            $validated['password'] = bcrypt($validated['password']);
+        if ( isset( $validated['password'] ) ) {
+            $validated['password'] = bcrypt( $validated['password'] );
         }
 
-        $user->update($validated);
-        $user->load($this->getRequestedIncludes($request));
+        $user->update( $validated );
+        $user->load( $this->getRequestedIncludes( $request ) );
 
-        return new UserResource($user);
+        return new UserResource( $user );
     }
 
     /**
@@ -174,10 +174,10 @@ class UserController extends Controller
      *
      * @return Response A response with 204 status code.
      */
-    public function destroy(string|int $id): Response
+    public function destroy( string|int $id ): Response
     {
-        $userModel = config('artisanpack.cms-framework.user_model');
-        $user      = $userModel::findOrFail($id);
+        $userModel = config( 'artisanpack.cms-framework.user_model' );
+        $user      = $userModel::findOrFail( $id );
         $user->delete();
 
         return response()->noContent();
@@ -195,53 +195,53 @@ class UserController extends Controller
      *
      * @return JsonResponse Summary with processed count, failed count, and error details.
      */
-    public function bulk(BulkUserRequest $request): JsonResponse
+    public function bulk( BulkUserRequest $request ): JsonResponse
     {
-        $action     = $request->validated('action');
-        $ids        = $request->validated('ids');
-        $permission = $this->getBulkPermission($action);
+        $action     = $request->validated( 'action' );
+        $ids        = $request->validated( 'ids' );
+        $permission = $this->getBulkPermission( $action );
         $processed  = 0;
         $errors     = [];
 
-        $userModel = config('artisanpack.cms-framework.user_model');
-        $users     = $userModel::whereIn('id', $ids)->get()->keyBy('id');
+        $userModel = config( 'artisanpack.cms-framework.user_model' );
+        $users     = $userModel::whereIn( 'id', $ids )->get()->keyBy( 'id' );
 
-        foreach ($ids as $id) {
-            $user = $users->get($id);
+        foreach ( $ids as $id ) {
+            $user = $users->get( $id );
 
-            if (null === $user) {
-                $errors[$id] = __('User not found.');
+            if ( null === $user ) {
+                $errors[ $id ] = __( 'User not found.' );
 
                 continue;
             }
 
             // Prevent users from performing bulk actions on themselves
-            if ($request->user() && $user->id === $request->user()->id) {
-                $errors[$id] = __('You cannot perform bulk actions on your own account.');
+            if ( $request->user() && $user->id === $request->user()->id ) {
+                $errors[ $id ] = __( 'You cannot perform bulk actions on your own account.' );
 
                 continue;
             }
 
-            if (! Gate::forUser($request->user())->allows($permission, $user)) {
-                $errors[$id] = __('You do not have permission to :action this user.', ['action' => $action]);
+            if ( ! Gate::forUser( $request->user() )->allows( $permission, $user ) ) {
+                $errors[ $id ] = __( 'You do not have permission to :action this user.', ['action' => $action] );
 
                 continue;
             }
 
             try {
-                $this->executeBulkAction($action, $user);
+                $this->executeBulkAction( $action, $user );
                 $processed++;
-            } catch (Throwable $e) {
-                report($e);
-                $errors[$id] = __('Failed to :action user.', ['action' => $action]);
+            } catch ( Throwable $e ) {
+                report( $e );
+                $errors[ $id ] = __( 'Failed to :action user.', ['action' => $action] );
             }
         }
 
-        return response()->json([
+        return response()->json( [
             'processed' => $processed,
-            'failed'    => count($errors),
+            'failed'    => count( $errors ),
             'errors'    => $errors,
-        ]);
+        ] );
     }
 
     /**
@@ -253,12 +253,12 @@ class UserController extends Controller
      *
      * @return string The Gate permission name.
      */
-    protected function getBulkPermission(string $action): string
+    protected function getBulkPermission( string $action ): string
     {
-        return match ($action) {
+        return match ( $action ) {
             'delete'              => 'users.delete',
             'activate', 'deactivate' => 'users.manage',
-            default               => throw new InvalidArgumentException(__('Unsupported bulk action: :action', ['action' => $action])),
+            default               => throw new InvalidArgumentException( __( 'Unsupported bulk action: :action', ['action' => $action] ) ),
         };
     }
 
@@ -270,13 +270,13 @@ class UserController extends Controller
      * @param  string  $action  The bulk action to perform.
      * @param  mixed  $user  The user model instance to perform the action on.
      */
-    protected function executeBulkAction(string $action, mixed $user): void
+    protected function executeBulkAction( string $action, mixed $user ): void
     {
-        match ($action) {
+        match ( $action ) {
             'delete'     => $user->delete(),
-            'activate'   => $user->update(['email_verified_at' => now()]),
-            'deactivate' => $user->update(['email_verified_at' => null]),
-            default      => throw new InvalidArgumentException(__('Unsupported bulk action: :action', ['action' => $action])),
+            'activate'   => $user->update( ['email_verified_at' => now()]),
+            'deactivate' => $user->update( ['email_verified_at' => null]),
+            default      => throw new InvalidArgumentException( __( 'Unsupported bulk action: :action', ['action' => $action])),
         };
     }
 }

--- a/src/Modules/Users/Http/Requests/BulkUserRequest.php
+++ b/src/Modules/Users/Http/Requests/BulkUserRequest.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare( strict_types=1 );
 
 /**
  * Bulk User Request for the CMS Framework Users Module.
@@ -59,7 +59,7 @@ class BulkUserRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'action' => ['required', 'string', Rule::in(self::allowedActions())],
+            'action' => ['required', 'string', Rule::in( self::allowedActions() )],
             'ids'    => ['required', 'array', 'min:1'],
             'ids.*'  => ['required', 'integer', 'exists:users,id'],
         ];
@@ -75,11 +75,11 @@ class BulkUserRequest extends FormRequest
     public function messages(): array
     {
         return [
-            'action.required' => __('The bulk action is required.'),
-            'action.in'       => __('The selected action is invalid. Allowed actions: :values.', ['values' => implode(', ', self::allowedActions())]),
-            'ids.required'    => __('At least one user ID is required.'),
-            'ids.min'         => __('At least one user ID is required.'),
-            'ids.*.exists'    => __('One or more user IDs do not exist.'),
+            'action.required' => __( 'The bulk action is required.' ),
+            'action.in'       => __( 'The selected action is invalid. Allowed actions: :values.', ['values' => implode( ', ', self::allowedActions() )] ),
+            'ids.required'    => __( 'At least one user ID is required.' ),
+            'ids.min'         => __( 'At least one user ID is required.' ),
+            'ids.*.exists'    => __( 'One or more user IDs do not exist.' ),
         ];
     }
 }

--- a/src/Modules/Users/Http/Requests/BulkUserRequest.php
+++ b/src/Modules/Users/Http/Requests/BulkUserRequest.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Bulk User Request for the CMS Framework Users Module.
+ *
+ * This form request handles validation for bulk user operations,
+ * ensuring the action and IDs are valid.
+ *
+ * @since 1.1.0
+ */
+
+namespace ArtisanPackUI\CMSFramework\Modules\Users\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+/**
+ * Form request for bulk user operations.
+ *
+ * Validates the action type and array of user IDs for bulk operations.
+ *
+ * @since 1.1.0
+ */
+class BulkUserRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @since 1.1.0
+     *
+     * @return bool True if the user is authorized, false otherwise.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the allowed actions for bulk user operations.
+     *
+     * @since 1.1.0
+     *
+     * @return array<int, string> The allowed action names.
+     */
+    public static function allowedActions(): array
+    {
+        return ['delete', 'activate', 'deactivate'];
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @since 1.1.0
+     *
+     * @return array<string, mixed> The validation rules.
+     */
+    public function rules(): array
+    {
+        return [
+            'action' => ['required', 'string', Rule::in(self::allowedActions())],
+            'ids'    => ['required', 'array', 'min:1'],
+            'ids.*'  => ['required', 'integer', 'exists:users,id'],
+        ];
+    }
+
+    /**
+     * Get custom messages for validator errors.
+     *
+     * @since 1.1.0
+     *
+     * @return array<string, string> The custom error messages.
+     */
+    public function messages(): array
+    {
+        return [
+            'action.required' => __('The bulk action is required.'),
+            'action.in'       => __('The selected action is invalid. Allowed actions: :values.', ['values' => implode(', ', self::allowedActions())]),
+            'ids.required'    => __('At least one user ID is required.'),
+            'ids.min'         => __('At least one user ID is required.'),
+            'ids.*.exists'    => __('One or more user IDs do not exist.'),
+        ];
+    }
+}

--- a/src/Modules/Users/Models/Role.php
+++ b/src/Modules/Users/Models/Role.php
@@ -43,16 +43,6 @@ class Role extends Model
     ];
 
     /**
-     * Create a new factory instance for the model.
-     *
-     * @since 1.0.0
-     */
-    protected static function newFactory()
-    {
-        return \ArtisanPackUI\Database\Factories\RoleFactory::new();
-    }
-
-    /**
      * Get the users that belong to the role.
      *
      * Defines a many-to-many relationship between roles and users using
@@ -133,5 +123,15 @@ class Role extends Model
         $this->permissions()->syncWithoutDetaching( $permissionsToGive );
 
         return $this;
+    }
+
+    /**
+     * Create a new factory instance for the model.
+     *
+     * @since 1.0.0
+     */
+    protected static function newFactory()
+    {
+        return \ArtisanPackUI\Database\Factories\RoleFactory::new();
     }
 }

--- a/src/Modules/Users/Policies/PermissionPolicy.php
+++ b/src/Modules/Users/Policies/PermissionPolicy.php
@@ -216,6 +216,6 @@ class PermissionPolicy
          *
          * @return string Filtered capability slug.
          */
-        return $user->can( applyFilters( 'permissions.forceDelete', 'permissions.forceDelete'));
+        return $user->can( applyFilters( 'permissions.forceDelete', 'permissions.forceDelete' ));
     }
 }

--- a/src/Modules/Users/helpers.php
+++ b/src/Modules/Users/helpers.php
@@ -107,6 +107,6 @@ if ( ! function_exists( 'apRegisterUserSettingsSection' ) ) {
             $sections[ $key ] = compact( 'label', 'order' );
 
             return $sections;
-        });
+        } );
     }
 }

--- a/src/Modules/Users/routes/api.php
+++ b/src/Modules/Users/routes/api.php
@@ -1,6 +1,6 @@
 <?php
 
-declare( strict_types = 1 );
+declare(strict_types=1);
 
 /**
  * API Routes for the CMS Framework Users Module.
@@ -16,6 +16,7 @@ use ArtisanPackUI\CMSFramework\Modules\Users\Http\Controllers\RoleController;
 use ArtisanPackUI\CMSFramework\Modules\Users\Http\Controllers\UserController;
 use Illuminate\Support\Facades\Route;
 
-Route::apiResource( 'users', UserController::class );
-Route::apiResource( 'roles', RoleController::class );
-Route::apiResource( 'permissions', PermissionController::class );
+Route::apiResource('users', UserController::class);
+Route::post('users/bulk', [UserController::class, 'bulk'])->middleware('auth');
+Route::apiResource('roles', RoleController::class);
+Route::apiResource('permissions', PermissionController::class);

--- a/src/Modules/Users/routes/api.php
+++ b/src/Modules/Users/routes/api.php
@@ -17,6 +17,9 @@ use ArtisanPackUI\CMSFramework\Modules\Users\Http\Controllers\UserController;
 use Illuminate\Support\Facades\Route;
 
 Route::apiResource('users', UserController::class);
-Route::post('users/bulk', [UserController::class, 'bulk'])->middleware('auth');
 Route::apiResource('roles', RoleController::class);
 Route::apiResource('permissions', PermissionController::class);
+
+Route::middleware('auth')->group(function (): void {
+    Route::post('users/bulk', [UserController::class, 'bulk']);
+});

--- a/src/Modules/Users/routes/api.php
+++ b/src/Modules/Users/routes/api.php
@@ -22,4 +22,4 @@ Route::apiResource( 'permissions', PermissionController::class );
 
 Route::middleware( 'auth' )->group( function (): void {
     Route::post( 'users/bulk', [UserController::class, 'bulk'] );
-});
+} );

--- a/src/Modules/Users/routes/api.php
+++ b/src/Modules/Users/routes/api.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare( strict_types=1 );
 
 /**
  * API Routes for the CMS Framework Users Module.
@@ -16,10 +16,10 @@ use ArtisanPackUI\CMSFramework\Modules\Users\Http\Controllers\RoleController;
 use ArtisanPackUI\CMSFramework\Modules\Users\Http\Controllers\UserController;
 use Illuminate\Support\Facades\Route;
 
-Route::apiResource('users', UserController::class);
-Route::apiResource('roles', RoleController::class);
-Route::apiResource('permissions', PermissionController::class);
+Route::apiResource( 'users', UserController::class );
+Route::apiResource( 'roles', RoleController::class );
+Route::apiResource( 'permissions', PermissionController::class );
 
-Route::middleware('auth')->group(function (): void {
-    Route::post('users/bulk', [UserController::class, 'bulk']);
+Route::middleware( 'auth' )->group( function (): void {
+    Route::post( 'users/bulk', [UserController::class, 'bulk'] );
 });

--- a/tests/Feature/BulkPageActionTest.php
+++ b/tests/Feature/BulkPageActionTest.php
@@ -1,0 +1,289 @@
+<?php
+
+declare(strict_types=1);
+
+use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Enums\ContentStatus;
+use ArtisanPackUI\CMSFramework\Modules\Pages\Models\Page;
+use ArtisanPackUI\CMSFramework\Tests\Support\TestUser;
+use Illuminate\Support\Facades\Gate;
+use Illuminate\Support\Str;
+
+/**
+ * Grant all page-related permissions via Gate.
+ */
+function grantAllPagePermissions(): void
+{
+    Gate::define('pages.view', fn () => true);
+    Gate::define('pages.create', fn () => true);
+    Gate::define('pages.edit', fn () => true);
+    Gate::define('pages.editOwn', fn () => true);
+    Gate::define('pages.delete', fn () => true);
+    Gate::define('pages.deleteOwn', fn () => true);
+    Gate::define('pages.publish', fn () => true);
+}
+
+/**
+ * Grant only view and edit permissions (no delete/publish).
+ */
+function grantLimitedPagePermissions(): void
+{
+    Gate::define('pages.view', fn () => true);
+    Gate::define('pages.edit', fn () => true);
+    Gate::define('pages.editOwn', fn () => true);
+}
+
+/**
+ * Create a test page with the given attributes.
+ *
+ * @param  array<string, mixed>  $attributes
+ */
+function createTestPage(array $attributes = []): Page
+{
+    $title = fake()->sentence(4, true);
+
+    return Page::create(array_merge([
+        'title'        => $title,
+        'slug'         => Str::slug($title).'-'.Str::random(5),
+        'content'      => fake()->paragraphs(3, true),
+        'excerpt'      => fake()->paragraph(),
+        'status'       => ContentStatus::Published->value,
+        'published_at' => now(),
+        'order'        => 0,
+        'template'     => 'default',
+    ], $attributes));
+}
+
+// --- Bulk Delete ---
+
+test('bulk page delete soft-deletes multiple pages', function (): void {
+    grantAllPagePermissions();
+    $user = TestUser::factory()->create();
+
+    $pages = collect();
+    for ($i = 0; $i < 3; $i++) {
+        $pages->push(createTestPage(['author_id' => $user->id]));
+    }
+
+    $response = $this->actingAs($user)->postJson('/api/v1/pages/bulk', [
+        'action' => 'delete',
+        'ids'    => $pages->pluck('id')->toArray(),
+    ]);
+
+    $response->assertSuccessful();
+    expect($response->json('processed'))->toBe(3);
+    expect($response->json('failed'))->toBe(0);
+    expect($response->json('errors'))->toBeEmpty();
+
+    foreach ($pages as $page) {
+        expect(Page::find($page->id))->toBeNull();
+        expect(Page::withTrashed()->find($page->id))->not->toBeNull();
+    }
+});
+
+// --- Bulk Publish ---
+
+test('bulk page publish sets status to published', function (): void {
+    grantAllPagePermissions();
+    $user = TestUser::factory()->create();
+
+    $pages = collect();
+    for ($i = 0; $i < 3; $i++) {
+        $pages->push(createTestPage([
+            'author_id'    => $user->id,
+            'status'       => ContentStatus::Draft->value,
+            'published_at' => null,
+        ]));
+    }
+
+    $response = $this->actingAs($user)->postJson('/api/v1/pages/bulk', [
+        'action' => 'publish',
+        'ids'    => $pages->pluck('id')->toArray(),
+    ]);
+
+    $response->assertSuccessful();
+    expect($response->json('processed'))->toBe(3);
+    expect($response->json('failed'))->toBe(0);
+
+    foreach ($pages as $page) {
+        $page->refresh();
+        expect($page->status)->toBe(ContentStatus::Published);
+        expect($page->published_at)->not->toBeNull();
+    }
+});
+
+// --- Bulk Draft ---
+
+test('bulk page draft sets status to draft', function (): void {
+    grantAllPagePermissions();
+    $user = TestUser::factory()->create();
+
+    $pages = collect();
+    for ($i = 0; $i < 3; $i++) {
+        $pages->push(createTestPage([
+            'author_id'    => $user->id,
+            'status'       => ContentStatus::Published->value,
+            'published_at' => now(),
+        ]));
+    }
+
+    $response = $this->actingAs($user)->postJson('/api/v1/pages/bulk', [
+        'action' => 'draft',
+        'ids'    => $pages->pluck('id')->toArray(),
+    ]);
+
+    $response->assertSuccessful();
+    expect($response->json('processed'))->toBe(3);
+    expect($response->json('failed'))->toBe(0);
+
+    foreach ($pages as $page) {
+        $page->refresh();
+        expect($page->status)->toBe(ContentStatus::Draft);
+        expect($page->published_at)->toBeNull();
+    }
+});
+
+// --- Authorization failures ---
+
+test('bulk page delete respects per-item authorization', function (): void {
+    grantLimitedPagePermissions();
+    $user = TestUser::factory()->create();
+
+    $pages = collect();
+    for ($i = 0; $i < 2; $i++) {
+        $pages->push(createTestPage(['author_id' => $user->id]));
+    }
+
+    $response = $this->actingAs($user)->postJson('/api/v1/pages/bulk', [
+        'action' => 'delete',
+        'ids'    => $pages->pluck('id')->toArray(),
+    ]);
+
+    $response->assertSuccessful();
+    expect($response->json('processed'))->toBe(0);
+    expect($response->json('failed'))->toBe(2);
+    expect($response->json('errors'))->toHaveCount(2);
+});
+
+test('bulk page publish respects per-item authorization', function (): void {
+    grantLimitedPagePermissions();
+    $user = TestUser::factory()->create();
+
+    $pages = collect();
+    for ($i = 0; $i < 2; $i++) {
+        $pages->push(createTestPage([
+            'author_id'    => $user->id,
+            'status'       => ContentStatus::Draft->value,
+            'published_at' => null,
+        ]));
+    }
+
+    $response = $this->actingAs($user)->postJson('/api/v1/pages/bulk', [
+        'action' => 'publish',
+        'ids'    => $pages->pluck('id')->toArray(),
+    ]);
+
+    $response->assertSuccessful();
+    expect($response->json('processed'))->toBe(0);
+    expect($response->json('failed'))->toBe(2);
+});
+
+// --- Validation ---
+
+test('bulk page action requires action field', function (): void {
+    $user = TestUser::factory()->create();
+
+    $response = $this->actingAs($user)->postJson('/api/v1/pages/bulk', [
+        'ids' => [1],
+    ]);
+
+    $response->assertStatus(422);
+    $response->assertJsonValidationErrors(['action']);
+});
+
+test('bulk page action requires ids field', function (): void {
+    $user = TestUser::factory()->create();
+
+    $response = $this->actingAs($user)->postJson('/api/v1/pages/bulk', [
+        'action' => 'delete',
+    ]);
+
+    $response->assertStatus(422);
+    $response->assertJsonValidationErrors(['ids']);
+});
+
+test('bulk page action rejects invalid action', function (): void {
+    $user = TestUser::factory()->create();
+
+    $response = $this->actingAs($user)->postJson('/api/v1/pages/bulk', [
+        'action' => 'archive',
+        'ids'    => [1],
+    ]);
+
+    $response->assertStatus(422);
+    $response->assertJsonValidationErrors(['action']);
+});
+
+test('bulk page action rejects empty ids array', function (): void {
+    $user = TestUser::factory()->create();
+
+    $response = $this->actingAs($user)->postJson('/api/v1/pages/bulk', [
+        'action' => 'delete',
+        'ids'    => [],
+    ]);
+
+    $response->assertStatus(422);
+    $response->assertJsonValidationErrors(['ids']);
+});
+
+test('bulk page action validates ids exist in database', function (): void {
+    $user = TestUser::factory()->create();
+
+    $response = $this->actingAs($user)->postJson('/api/v1/pages/bulk', [
+        'action' => 'delete',
+        'ids'    => [9999],
+    ]);
+
+    $response->assertStatus(422);
+    $response->assertJsonValidationErrors(['ids.0']);
+});
+
+// --- Mixed results ---
+
+test('bulk page action returns mixed results when some items fail authorization', function (): void {
+    $owner = TestUser::factory()->create();
+    $other = TestUser::factory()->create();
+
+    // Grant delete own only
+    Gate::define('pages.view', fn () => true);
+    Gate::define('pages.deleteOwn', fn () => true);
+
+    $ownPage   = createTestPage(['author_id' => $owner->id]);
+    $otherPage = createTestPage(['author_id' => $other->id]);
+
+    $response = $this->actingAs($owner)->postJson('/api/v1/pages/bulk', [
+        'action' => 'delete',
+        'ids'    => [$ownPage->id, $otherPage->id],
+    ]);
+
+    $response->assertSuccessful();
+    expect($response->json('processed'))->toBe(1);
+    expect($response->json('failed'))->toBe(1);
+    expect($response->json('errors'))->toHaveKey((string) $otherPage->id);
+});
+
+// --- Response structure ---
+
+test('bulk page action returns correct response structure', function (): void {
+    grantAllPagePermissions();
+    $user = TestUser::factory()->create();
+
+    $page = createTestPage(['author_id' => $user->id]);
+
+    $response = $this->actingAs($user)->postJson('/api/v1/pages/bulk', [
+        'action' => 'delete',
+        'ids'    => [$page->id],
+    ]);
+
+    $response->assertSuccessful();
+    $response->assertJsonStructure(['processed', 'failed', 'errors']);
+});

--- a/tests/Feature/BulkPageActionTest.php
+++ b/tests/Feature/BulkPageActionTest.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare( strict_types=1 );
 
 use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Enums\ContentStatus;
 use ArtisanPackUI\CMSFramework\Modules\Pages\Models\Page;
@@ -13,13 +13,13 @@ use Illuminate\Support\Str;
  */
 function grantAllPagePermissions(): void
 {
-    Gate::define('pages.view', fn () => true);
-    Gate::define('pages.create', fn () => true);
-    Gate::define('pages.edit', fn () => true);
-    Gate::define('pages.editOwn', fn () => true);
-    Gate::define('pages.delete', fn () => true);
-    Gate::define('pages.deleteOwn', fn () => true);
-    Gate::define('pages.publish', fn () => true);
+    Gate::define( 'pages.view', fn () => true );
+    Gate::define( 'pages.create', fn () => true );
+    Gate::define( 'pages.edit', fn () => true );
+    Gate::define( 'pages.editOwn', fn () => true );
+    Gate::define( 'pages.delete', fn () => true );
+    Gate::define( 'pages.deleteOwn', fn () => true );
+    Gate::define( 'pages.publish', fn () => true );
 }
 
 /**
@@ -27,9 +27,9 @@ function grantAllPagePermissions(): void
  */
 function grantLimitedPagePermissions(): void
 {
-    Gate::define('pages.view', fn () => true);
-    Gate::define('pages.edit', fn () => true);
-    Gate::define('pages.editOwn', fn () => true);
+    Gate::define( 'pages.view', fn () => true );
+    Gate::define( 'pages.edit', fn () => true );
+    Gate::define( 'pages.editOwn', fn () => true );
 }
 
 /**
@@ -37,253 +37,253 @@ function grantLimitedPagePermissions(): void
  *
  * @param  array<string, mixed>  $attributes
  */
-function createTestPage(array $attributes = []): Page
+function createTestPage( array $attributes = [] ): Page
 {
-    $title = fake()->sentence(4, true);
+    $title = fake()->sentence( 4, true );
 
-    return Page::create(array_merge([
+    return Page::create( array_merge( [
         'title'        => $title,
-        'slug'         => Str::slug($title).'-'.Str::random(5),
-        'content'      => fake()->paragraphs(3, true),
+        'slug'         => Str::slug( $title ) . '-' . Str::random( 5 ),
+        'content'      => fake()->paragraphs( 3, true ),
         'excerpt'      => fake()->paragraph(),
         'status'       => ContentStatus::Published->value,
         'published_at' => now(),
         'order'        => 0,
         'template'     => 'default',
-    ], $attributes));
+    ], $attributes ) );
 }
 
 // --- Bulk Delete ---
 
-test('bulk page delete soft-deletes multiple pages', function (): void {
+test( 'bulk page delete soft-deletes multiple pages', function (): void {
     grantAllPagePermissions();
     $user = TestUser::factory()->create();
 
     $pages = collect();
-    for ($i = 0; $i < 3; $i++) {
-        $pages->push(createTestPage(['author_id' => $user->id]));
+    for ( $i = 0; $i < 3; $i++ ) {
+        $pages->push( createTestPage( ['author_id' => $user->id] ) );
     }
 
-    $response = $this->actingAs($user)->postJson('/api/v1/pages/bulk', [
+    $response = $this->actingAs( $user )->postJson( '/api/v1/pages/bulk', [
         'action' => 'delete',
-        'ids'    => $pages->pluck('id')->toArray(),
-    ]);
+        'ids'    => $pages->pluck( 'id' )->toArray(),
+    ] );
 
     $response->assertSuccessful();
-    expect($response->json('processed'))->toBe(3);
-    expect($response->json('failed'))->toBe(0);
-    expect($response->json('errors'))->toBeEmpty();
+    expect( $response->json( 'processed' ) )->toBe( 3 );
+    expect( $response->json( 'failed' ) )->toBe( 0 );
+    expect( $response->json( 'errors' ) )->toBeEmpty();
 
-    foreach ($pages as $page) {
-        expect(Page::find($page->id))->toBeNull();
-        expect(Page::withTrashed()->find($page->id))->not->toBeNull();
+    foreach ( $pages as $page ) {
+        expect( Page::find( $page->id ) )->toBeNull();
+        expect( Page::withTrashed()->find( $page->id ) )->not->toBeNull();
     }
-});
+} );
 
 // --- Bulk Publish ---
 
-test('bulk page publish sets status to published', function (): void {
+test( 'bulk page publish sets status to published', function (): void {
     grantAllPagePermissions();
     $user = TestUser::factory()->create();
 
     $pages = collect();
-    for ($i = 0; $i < 3; $i++) {
-        $pages->push(createTestPage([
+    for ( $i = 0; $i < 3; $i++ ) {
+        $pages->push( createTestPage( [
             'author_id'    => $user->id,
             'status'       => ContentStatus::Draft->value,
             'published_at' => null,
-        ]));
+        ] ) );
     }
 
-    $response = $this->actingAs($user)->postJson('/api/v1/pages/bulk', [
+    $response = $this->actingAs( $user )->postJson( '/api/v1/pages/bulk', [
         'action' => 'publish',
-        'ids'    => $pages->pluck('id')->toArray(),
-    ]);
+        'ids'    => $pages->pluck( 'id' )->toArray(),
+    ] );
 
     $response->assertSuccessful();
-    expect($response->json('processed'))->toBe(3);
-    expect($response->json('failed'))->toBe(0);
+    expect( $response->json( 'processed' ) )->toBe( 3 );
+    expect( $response->json( 'failed' ) )->toBe( 0 );
 
-    foreach ($pages as $page) {
+    foreach ( $pages as $page ) {
         $page->refresh();
-        expect($page->status)->toBe(ContentStatus::Published);
-        expect($page->published_at)->not->toBeNull();
+        expect( $page->status )->toBe( ContentStatus::Published );
+        expect( $page->published_at )->not->toBeNull();
     }
-});
+} );
 
 // --- Bulk Draft ---
 
-test('bulk page draft sets status to draft', function (): void {
+test( 'bulk page draft sets status to draft', function (): void {
     grantAllPagePermissions();
     $user = TestUser::factory()->create();
 
     $pages = collect();
-    for ($i = 0; $i < 3; $i++) {
-        $pages->push(createTestPage([
+    for ( $i = 0; $i < 3; $i++ ) {
+        $pages->push( createTestPage( [
             'author_id'    => $user->id,
             'status'       => ContentStatus::Published->value,
             'published_at' => now(),
-        ]));
+        ] ) );
     }
 
-    $response = $this->actingAs($user)->postJson('/api/v1/pages/bulk', [
+    $response = $this->actingAs( $user )->postJson( '/api/v1/pages/bulk', [
         'action' => 'draft',
-        'ids'    => $pages->pluck('id')->toArray(),
-    ]);
+        'ids'    => $pages->pluck( 'id' )->toArray(),
+    ] );
 
     $response->assertSuccessful();
-    expect($response->json('processed'))->toBe(3);
-    expect($response->json('failed'))->toBe(0);
+    expect( $response->json( 'processed' ) )->toBe( 3 );
+    expect( $response->json( 'failed' ) )->toBe( 0 );
 
-    foreach ($pages as $page) {
+    foreach ( $pages as $page ) {
         $page->refresh();
-        expect($page->status)->toBe(ContentStatus::Draft);
-        expect($page->published_at)->toBeNull();
+        expect( $page->status )->toBe( ContentStatus::Draft );
+        expect( $page->published_at )->toBeNull();
     }
-});
+} );
 
 // --- Authorization failures ---
 
-test('bulk page delete respects per-item authorization', function (): void {
+test( 'bulk page delete respects per-item authorization', function (): void {
     grantLimitedPagePermissions();
     $user = TestUser::factory()->create();
 
     $pages = collect();
-    for ($i = 0; $i < 2; $i++) {
-        $pages->push(createTestPage(['author_id' => $user->id]));
+    for ( $i = 0; $i < 2; $i++ ) {
+        $pages->push( createTestPage( ['author_id' => $user->id] ) );
     }
 
-    $response = $this->actingAs($user)->postJson('/api/v1/pages/bulk', [
+    $response = $this->actingAs( $user )->postJson( '/api/v1/pages/bulk', [
         'action' => 'delete',
-        'ids'    => $pages->pluck('id')->toArray(),
-    ]);
+        'ids'    => $pages->pluck( 'id' )->toArray(),
+    ] );
 
     $response->assertSuccessful();
-    expect($response->json('processed'))->toBe(0);
-    expect($response->json('failed'))->toBe(2);
-    expect($response->json('errors'))->toHaveCount(2);
-});
+    expect( $response->json( 'processed' ) )->toBe( 0 );
+    expect( $response->json( 'failed' ) )->toBe( 2 );
+    expect( $response->json( 'errors' ) )->toHaveCount( 2 );
+} );
 
-test('bulk page publish respects per-item authorization', function (): void {
+test( 'bulk page publish respects per-item authorization', function (): void {
     grantLimitedPagePermissions();
     $user = TestUser::factory()->create();
 
     $pages = collect();
-    for ($i = 0; $i < 2; $i++) {
-        $pages->push(createTestPage([
+    for ( $i = 0; $i < 2; $i++ ) {
+        $pages->push( createTestPage( [
             'author_id'    => $user->id,
             'status'       => ContentStatus::Draft->value,
             'published_at' => null,
-        ]));
+        ] ) );
     }
 
-    $response = $this->actingAs($user)->postJson('/api/v1/pages/bulk', [
+    $response = $this->actingAs( $user )->postJson( '/api/v1/pages/bulk', [
         'action' => 'publish',
-        'ids'    => $pages->pluck('id')->toArray(),
-    ]);
+        'ids'    => $pages->pluck( 'id' )->toArray(),
+    ] );
 
     $response->assertSuccessful();
-    expect($response->json('processed'))->toBe(0);
-    expect($response->json('failed'))->toBe(2);
-});
+    expect( $response->json( 'processed' ) )->toBe( 0 );
+    expect( $response->json( 'failed' ) )->toBe( 2 );
+} );
 
 // --- Validation ---
 
-test('bulk page action requires action field', function (): void {
+test( 'bulk page action requires action field', function (): void {
     $user = TestUser::factory()->create();
 
-    $response = $this->actingAs($user)->postJson('/api/v1/pages/bulk', [
+    $response = $this->actingAs( $user )->postJson( '/api/v1/pages/bulk', [
         'ids' => [1],
-    ]);
+    ] );
 
-    $response->assertStatus(422);
-    $response->assertJsonValidationErrors(['action']);
-});
+    $response->assertStatus( 422 );
+    $response->assertJsonValidationErrors( ['action'] );
+} );
 
-test('bulk page action requires ids field', function (): void {
+test( 'bulk page action requires ids field', function (): void {
     $user = TestUser::factory()->create();
 
-    $response = $this->actingAs($user)->postJson('/api/v1/pages/bulk', [
+    $response = $this->actingAs( $user )->postJson( '/api/v1/pages/bulk', [
         'action' => 'delete',
-    ]);
+    ] );
 
-    $response->assertStatus(422);
-    $response->assertJsonValidationErrors(['ids']);
-});
+    $response->assertStatus( 422 );
+    $response->assertJsonValidationErrors( ['ids'] );
+} );
 
-test('bulk page action rejects invalid action', function (): void {
+test( 'bulk page action rejects invalid action', function (): void {
     $user = TestUser::factory()->create();
 
-    $response = $this->actingAs($user)->postJson('/api/v1/pages/bulk', [
+    $response = $this->actingAs( $user )->postJson( '/api/v1/pages/bulk', [
         'action' => 'archive',
         'ids'    => [1],
-    ]);
+    ] );
 
-    $response->assertStatus(422);
-    $response->assertJsonValidationErrors(['action']);
-});
+    $response->assertStatus( 422 );
+    $response->assertJsonValidationErrors( ['action'] );
+} );
 
-test('bulk page action rejects empty ids array', function (): void {
+test( 'bulk page action rejects empty ids array', function (): void {
     $user = TestUser::factory()->create();
 
-    $response = $this->actingAs($user)->postJson('/api/v1/pages/bulk', [
+    $response = $this->actingAs( $user )->postJson( '/api/v1/pages/bulk', [
         'action' => 'delete',
         'ids'    => [],
-    ]);
+    ] );
 
-    $response->assertStatus(422);
-    $response->assertJsonValidationErrors(['ids']);
-});
+    $response->assertStatus( 422 );
+    $response->assertJsonValidationErrors( ['ids'] );
+} );
 
-test('bulk page action validates ids exist in database', function (): void {
+test( 'bulk page action validates ids exist in database', function (): void {
     $user = TestUser::factory()->create();
 
-    $response = $this->actingAs($user)->postJson('/api/v1/pages/bulk', [
+    $response = $this->actingAs( $user )->postJson( '/api/v1/pages/bulk', [
         'action' => 'delete',
         'ids'    => [9999],
-    ]);
+    ] );
 
-    $response->assertStatus(422);
-    $response->assertJsonValidationErrors(['ids.0']);
-});
+    $response->assertStatus( 422 );
+    $response->assertJsonValidationErrors( ['ids.0'] );
+} );
 
 // --- Mixed results ---
 
-test('bulk page action returns mixed results when some items fail authorization', function (): void {
+test( 'bulk page action returns mixed results when some items fail authorization', function (): void {
     $owner = TestUser::factory()->create();
     $other = TestUser::factory()->create();
 
     // Grant delete own only
-    Gate::define('pages.view', fn () => true);
-    Gate::define('pages.deleteOwn', fn () => true);
+    Gate::define( 'pages.view', fn () => true );
+    Gate::define( 'pages.deleteOwn', fn () => true );
 
-    $ownPage   = createTestPage(['author_id' => $owner->id]);
-    $otherPage = createTestPage(['author_id' => $other->id]);
+    $ownPage   = createTestPage( ['author_id' => $owner->id] );
+    $otherPage = createTestPage( ['author_id' => $other->id] );
 
-    $response = $this->actingAs($owner)->postJson('/api/v1/pages/bulk', [
+    $response = $this->actingAs( $owner )->postJson( '/api/v1/pages/bulk', [
         'action' => 'delete',
         'ids'    => [$ownPage->id, $otherPage->id],
-    ]);
+    ] );
 
     $response->assertSuccessful();
-    expect($response->json('processed'))->toBe(1);
-    expect($response->json('failed'))->toBe(1);
-    expect($response->json('errors'))->toHaveKey((string) $otherPage->id);
+    expect( $response->json( 'processed' ) )->toBe( 1 );
+    expect( $response->json( 'failed' ) )->toBe( 1 );
+    expect( $response->json( 'errors' ) )->toHaveKey( (string) $otherPage->id);
 });
 
 // --- Response structure ---
 
-test('bulk page action returns correct response structure', function (): void {
+test( 'bulk page action returns correct response structure', function (): void {
     grantAllPagePermissions();
     $user = TestUser::factory()->create();
 
-    $page = createTestPage(['author_id' => $user->id]);
+    $page = createTestPage( ['author_id' => $user->id]);
 
-    $response = $this->actingAs($user)->postJson('/api/v1/pages/bulk', [
+    $response = $this->actingAs( $user)->postJson( '/api/v1/pages/bulk', [
         'action' => 'delete',
         'ids'    => [$page->id],
     ]);
 
     $response->assertSuccessful();
-    $response->assertJsonStructure(['processed', 'failed', 'errors']);
+    $response->assertJsonStructure( ['processed', 'failed', 'errors']);
 });

--- a/tests/Feature/BulkPageActionTest.php
+++ b/tests/Feature/BulkPageActionTest.php
@@ -268,8 +268,8 @@ test( 'bulk page action returns mixed results when some items fail authorization
     $response->assertSuccessful();
     expect( $response->json( 'processed' ) )->toBe( 1 );
     expect( $response->json( 'failed' ) )->toBe( 1 );
-    expect( $response->json( 'errors' ) )->toHaveKey( (string) $otherPage->id);
-});
+    expect( $response->json( 'errors' ) )->toHaveKey( (string) $otherPage->id );
+} );
 
 // --- Response structure ---
 
@@ -277,13 +277,13 @@ test( 'bulk page action returns correct response structure', function (): void {
     grantAllPagePermissions();
     $user = TestUser::factory()->create();
 
-    $page = createTestPage( ['author_id' => $user->id]);
+    $page = createTestPage( ['author_id' => $user->id] );
 
-    $response = $this->actingAs( $user)->postJson( '/api/v1/pages/bulk', [
+    $response = $this->actingAs( $user )->postJson( '/api/v1/pages/bulk', [
         'action' => 'delete',
         'ids'    => [$page->id],
-    ]);
+    ] );
 
     $response->assertSuccessful();
-    $response->assertJsonStructure( ['processed', 'failed', 'errors']);
-});
+    $response->assertJsonStructure( ['processed', 'failed', 'errors'] );
+} );

--- a/tests/Feature/BulkPostActionTest.php
+++ b/tests/Feature/BulkPostActionTest.php
@@ -140,30 +140,19 @@ test('bulk post draft sets status to draft', function (): void {
     }
 });
 
-// --- Bulk Archive ---
+// --- Archive is not a valid action ---
 
-test('bulk post archive soft-deletes posts', function (): void {
-    grantAllPostPermissions();
+test('bulk post action rejects archive as invalid action', function (): void {
     $user = TestUser::factory()->create();
-
-    $posts = collect();
-    for ($i = 0; $i < 2; $i++) {
-        $posts->push(createTestPost(['author_id' => $user->id]));
-    }
+    $post = createTestPost(['author_id' => $user->id]);
 
     $response = $this->actingAs($user)->postJson('/api/v1/posts/bulk', [
         'action' => 'archive',
-        'ids'    => $posts->pluck('id')->toArray(),
+        'ids'    => [$post->id],
     ]);
 
-    $response->assertSuccessful();
-    expect($response->json('processed'))->toBe(2);
-    expect($response->json('failed'))->toBe(0);
-
-    foreach ($posts as $post) {
-        expect(Post::find($post->id))->toBeNull();
-        expect(Post::withTrashed()->find($post->id))->not->toBeNull();
-    }
+    $response->assertStatus(422);
+    $response->assertJsonValidationErrors(['action']);
 });
 
 // --- Authorization failures ---

--- a/tests/Feature/BulkPostActionTest.php
+++ b/tests/Feature/BulkPostActionTest.php
@@ -281,8 +281,8 @@ test( 'bulk post action returns mixed results when some items fail authorization
     $response->assertSuccessful();
     expect( $response->json( 'processed' ) )->toBe( 1 );
     expect( $response->json( 'failed' ) )->toBe( 1 );
-    expect( $response->json( 'errors' ))->toHaveKey( (string) $otherPost->id);
-});
+    expect( $response->json( 'errors' ) )->toHaveKey( (string) $otherPost->id );
+} );
 
 // --- Response structure ---
 
@@ -290,13 +290,13 @@ test( 'bulk post action returns correct response structure', function (): void {
     grantAllPostPermissions();
     $user = TestUser::factory()->create();
 
-    $post = createTestPost( ['author_id' => $user->id]);
+    $post = createTestPost( ['author_id' => $user->id] );
 
-    $response = $this->actingAs( $user)->postJson( '/api/v1/posts/bulk', [
+    $response = $this->actingAs( $user )->postJson( '/api/v1/posts/bulk', [
         'action' => 'delete',
         'ids'    => [$post->id],
-    ]);
+    ] );
 
     $response->assertSuccessful();
-    $response->assertJsonStructure( ['processed', 'failed', 'errors']);
-});
+    $response->assertJsonStructure( ['processed', 'failed', 'errors'] );
+} );

--- a/tests/Feature/BulkPostActionTest.php
+++ b/tests/Feature/BulkPostActionTest.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare( strict_types=1 );
 
 use ArtisanPackUI\CMSFramework\Modules\Blog\Models\Post;
 use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Enums\ContentStatus;
@@ -13,13 +13,13 @@ use Illuminate\Support\Str;
  */
 function grantAllPostPermissions(): void
 {
-    Gate::define('posts.view', fn () => true);
-    Gate::define('posts.create', fn () => true);
-    Gate::define('posts.edit', fn () => true);
-    Gate::define('posts.editOwn', fn () => true);
-    Gate::define('posts.delete', fn () => true);
-    Gate::define('posts.deleteOwn', fn () => true);
-    Gate::define('posts.publish', fn () => true);
+    Gate::define( 'posts.view', fn () => true );
+    Gate::define( 'posts.create', fn () => true );
+    Gate::define( 'posts.edit', fn () => true );
+    Gate::define( 'posts.editOwn', fn () => true );
+    Gate::define( 'posts.delete', fn () => true );
+    Gate::define( 'posts.deleteOwn', fn () => true );
+    Gate::define( 'posts.publish', fn () => true );
 }
 
 /**
@@ -27,9 +27,9 @@ function grantAllPostPermissions(): void
  */
 function grantLimitedPostPermissions(): void
 {
-    Gate::define('posts.view', fn () => true);
-    Gate::define('posts.edit', fn () => true);
-    Gate::define('posts.editOwn', fn () => true);
+    Gate::define( 'posts.view', fn () => true );
+    Gate::define( 'posts.edit', fn () => true );
+    Gate::define( 'posts.editOwn', fn () => true );
 }
 
 /**
@@ -37,266 +37,266 @@ function grantLimitedPostPermissions(): void
  *
  * @param  array<string, mixed>  $attributes
  */
-function createTestPost(array $attributes = []): Post
+function createTestPost( array $attributes = [] ): Post
 {
-    $title = fake()->sentence(6, true);
+    $title = fake()->sentence( 6, true );
 
-    return Post::create(array_merge([
+    return Post::create( array_merge( [
         'title'        => $title,
-        'slug'         => Str::slug($title).'-'.Str::random(5),
-        'content'      => fake()->paragraphs(3, true),
+        'slug'         => Str::slug( $title ) . '-' . Str::random( 5 ),
+        'content'      => fake()->paragraphs( 3, true ),
         'excerpt'      => fake()->paragraph(),
         'status'       => ContentStatus::Published->value,
         'published_at' => now(),
-    ], $attributes));
+    ], $attributes ) );
 }
 
 // --- Bulk Delete ---
 
-test('bulk post delete soft-deletes multiple posts', function (): void {
+test( 'bulk post delete soft-deletes multiple posts', function (): void {
     grantAllPostPermissions();
     $user = TestUser::factory()->create();
 
     $posts = collect();
-    for ($i = 0; $i < 3; $i++) {
-        $posts->push(createTestPost(['author_id' => $user->id]));
+    for ( $i = 0; $i < 3; $i++ ) {
+        $posts->push( createTestPost( ['author_id' => $user->id] ) );
     }
 
-    $response = $this->actingAs($user)->postJson('/api/v1/posts/bulk', [
+    $response = $this->actingAs( $user )->postJson( '/api/v1/posts/bulk', [
         'action' => 'delete',
-        'ids'    => $posts->pluck('id')->toArray(),
-    ]);
+        'ids'    => $posts->pluck( 'id' )->toArray(),
+    ] );
 
     $response->assertSuccessful();
-    expect($response->json('processed'))->toBe(3);
-    expect($response->json('failed'))->toBe(0);
-    expect($response->json('errors'))->toBeEmpty();
+    expect( $response->json( 'processed' ) )->toBe( 3 );
+    expect( $response->json( 'failed' ) )->toBe( 0 );
+    expect( $response->json( 'errors' ) )->toBeEmpty();
 
-    foreach ($posts as $post) {
-        expect(Post::find($post->id))->toBeNull();
-        expect(Post::withTrashed()->find($post->id))->not->toBeNull();
+    foreach ( $posts as $post ) {
+        expect( Post::find( $post->id ) )->toBeNull();
+        expect( Post::withTrashed()->find( $post->id ) )->not->toBeNull();
     }
-});
+} );
 
 // --- Bulk Publish ---
 
-test('bulk post publish sets status to published', function (): void {
+test( 'bulk post publish sets status to published', function (): void {
     grantAllPostPermissions();
     $user = TestUser::factory()->create();
 
     $posts = collect();
-    for ($i = 0; $i < 3; $i++) {
-        $posts->push(createTestPost([
+    for ( $i = 0; $i < 3; $i++ ) {
+        $posts->push( createTestPost( [
             'author_id'    => $user->id,
             'status'       => ContentStatus::Draft->value,
             'published_at' => null,
-        ]));
+        ] ) );
     }
 
-    $response = $this->actingAs($user)->postJson('/api/v1/posts/bulk', [
+    $response = $this->actingAs( $user )->postJson( '/api/v1/posts/bulk', [
         'action' => 'publish',
-        'ids'    => $posts->pluck('id')->toArray(),
-    ]);
+        'ids'    => $posts->pluck( 'id' )->toArray(),
+    ] );
 
     $response->assertSuccessful();
-    expect($response->json('processed'))->toBe(3);
-    expect($response->json('failed'))->toBe(0);
+    expect( $response->json( 'processed' ) )->toBe( 3 );
+    expect( $response->json( 'failed' ) )->toBe( 0 );
 
-    foreach ($posts as $post) {
+    foreach ( $posts as $post ) {
         $post->refresh();
-        expect($post->status)->toBe(ContentStatus::Published);
-        expect($post->published_at)->not->toBeNull();
+        expect( $post->status )->toBe( ContentStatus::Published );
+        expect( $post->published_at )->not->toBeNull();
     }
-});
+} );
 
 // --- Bulk Draft ---
 
-test('bulk post draft sets status to draft', function (): void {
+test( 'bulk post draft sets status to draft', function (): void {
     grantAllPostPermissions();
     $user = TestUser::factory()->create();
 
     $posts = collect();
-    for ($i = 0; $i < 3; $i++) {
-        $posts->push(createTestPost([
+    for ( $i = 0; $i < 3; $i++ ) {
+        $posts->push( createTestPost( [
             'author_id'    => $user->id,
             'status'       => ContentStatus::Published->value,
             'published_at' => now(),
-        ]));
+        ] ) );
     }
 
-    $response = $this->actingAs($user)->postJson('/api/v1/posts/bulk', [
+    $response = $this->actingAs( $user )->postJson( '/api/v1/posts/bulk', [
         'action' => 'draft',
-        'ids'    => $posts->pluck('id')->toArray(),
-    ]);
+        'ids'    => $posts->pluck( 'id' )->toArray(),
+    ] );
 
     $response->assertSuccessful();
-    expect($response->json('processed'))->toBe(3);
-    expect($response->json('failed'))->toBe(0);
+    expect( $response->json( 'processed' ) )->toBe( 3 );
+    expect( $response->json( 'failed' ) )->toBe( 0 );
 
-    foreach ($posts as $post) {
+    foreach ( $posts as $post ) {
         $post->refresh();
-        expect($post->status)->toBe(ContentStatus::Draft);
-        expect($post->published_at)->toBeNull();
+        expect( $post->status )->toBe( ContentStatus::Draft );
+        expect( $post->published_at )->toBeNull();
     }
-});
+} );
 
 // --- Archive is not a valid action ---
 
-test('bulk post action rejects archive as invalid action', function (): void {
+test( 'bulk post action rejects archive as invalid action', function (): void {
     $user = TestUser::factory()->create();
-    $post = createTestPost(['author_id' => $user->id]);
+    $post = createTestPost( ['author_id' => $user->id] );
 
-    $response = $this->actingAs($user)->postJson('/api/v1/posts/bulk', [
+    $response = $this->actingAs( $user )->postJson( '/api/v1/posts/bulk', [
         'action' => 'archive',
         'ids'    => [$post->id],
-    ]);
+    ] );
 
-    $response->assertStatus(422);
-    $response->assertJsonValidationErrors(['action']);
-});
+    $response->assertStatus( 422 );
+    $response->assertJsonValidationErrors( ['action'] );
+} );
 
 // --- Authorization failures ---
 
-test('bulk post delete respects per-item authorization', function (): void {
+test( 'bulk post delete respects per-item authorization', function (): void {
     grantLimitedPostPermissions();
     $user = TestUser::factory()->create();
 
     $posts = collect();
-    for ($i = 0; $i < 2; $i++) {
-        $posts->push(createTestPost(['author_id' => $user->id]));
+    for ( $i = 0; $i < 2; $i++ ) {
+        $posts->push( createTestPost( ['author_id' => $user->id] ) );
     }
 
-    $response = $this->actingAs($user)->postJson('/api/v1/posts/bulk', [
+    $response = $this->actingAs( $user )->postJson( '/api/v1/posts/bulk', [
         'action' => 'delete',
-        'ids'    => $posts->pluck('id')->toArray(),
-    ]);
+        'ids'    => $posts->pluck( 'id' )->toArray(),
+    ] );
 
     $response->assertSuccessful();
-    expect($response->json('processed'))->toBe(0);
-    expect($response->json('failed'))->toBe(2);
-    expect($response->json('errors'))->toHaveCount(2);
-});
+    expect( $response->json( 'processed' ) )->toBe( 0 );
+    expect( $response->json( 'failed' ) )->toBe( 2 );
+    expect( $response->json( 'errors' ) )->toHaveCount( 2 );
+} );
 
-test('bulk post publish respects per-item authorization', function (): void {
+test( 'bulk post publish respects per-item authorization', function (): void {
     grantLimitedPostPermissions();
     $user = TestUser::factory()->create();
 
     $posts = collect();
-    for ($i = 0; $i < 2; $i++) {
-        $posts->push(createTestPost([
+    for ( $i = 0; $i < 2; $i++ ) {
+        $posts->push( createTestPost( [
             'author_id'    => $user->id,
             'status'       => ContentStatus::Draft->value,
             'published_at' => null,
-        ]));
+        ] ) );
     }
 
-    $response = $this->actingAs($user)->postJson('/api/v1/posts/bulk', [
+    $response = $this->actingAs( $user )->postJson( '/api/v1/posts/bulk', [
         'action' => 'publish',
-        'ids'    => $posts->pluck('id')->toArray(),
-    ]);
+        'ids'    => $posts->pluck( 'id' )->toArray(),
+    ] );
 
     $response->assertSuccessful();
-    expect($response->json('processed'))->toBe(0);
-    expect($response->json('failed'))->toBe(2);
-});
+    expect( $response->json( 'processed' ) )->toBe( 0 );
+    expect( $response->json( 'failed' ) )->toBe( 2 );
+} );
 
 // --- Validation ---
 
-test('bulk post action requires action field', function (): void {
+test( 'bulk post action requires action field', function (): void {
     $user = TestUser::factory()->create();
 
-    $response = $this->actingAs($user)->postJson('/api/v1/posts/bulk', [
+    $response = $this->actingAs( $user )->postJson( '/api/v1/posts/bulk', [
         'ids' => [1],
-    ]);
+    ] );
 
-    $response->assertStatus(422);
-    $response->assertJsonValidationErrors(['action']);
-});
+    $response->assertStatus( 422 );
+    $response->assertJsonValidationErrors( ['action'] );
+} );
 
-test('bulk post action requires ids field', function (): void {
+test( 'bulk post action requires ids field', function (): void {
     $user = TestUser::factory()->create();
 
-    $response = $this->actingAs($user)->postJson('/api/v1/posts/bulk', [
+    $response = $this->actingAs( $user )->postJson( '/api/v1/posts/bulk', [
         'action' => 'delete',
-    ]);
+    ] );
 
-    $response->assertStatus(422);
-    $response->assertJsonValidationErrors(['ids']);
-});
+    $response->assertStatus( 422 );
+    $response->assertJsonValidationErrors( ['ids'] );
+} );
 
-test('bulk post action rejects invalid action', function (): void {
+test( 'bulk post action rejects invalid action', function (): void {
     $user = TestUser::factory()->create();
 
-    $response = $this->actingAs($user)->postJson('/api/v1/posts/bulk', [
+    $response = $this->actingAs( $user )->postJson( '/api/v1/posts/bulk', [
         'action' => 'invalid',
         'ids'    => [1],
-    ]);
+    ] );
 
-    $response->assertStatus(422);
-    $response->assertJsonValidationErrors(['action']);
-});
+    $response->assertStatus( 422 );
+    $response->assertJsonValidationErrors( ['action'] );
+} );
 
-test('bulk post action rejects empty ids array', function (): void {
+test( 'bulk post action rejects empty ids array', function (): void {
     $user = TestUser::factory()->create();
 
-    $response = $this->actingAs($user)->postJson('/api/v1/posts/bulk', [
+    $response = $this->actingAs( $user )->postJson( '/api/v1/posts/bulk', [
         'action' => 'delete',
         'ids'    => [],
-    ]);
+    ] );
 
-    $response->assertStatus(422);
-    $response->assertJsonValidationErrors(['ids']);
-});
+    $response->assertStatus( 422 );
+    $response->assertJsonValidationErrors( ['ids'] );
+} );
 
-test('bulk post action validates ids exist in database', function (): void {
+test( 'bulk post action validates ids exist in database', function (): void {
     $user = TestUser::factory()->create();
 
-    $response = $this->actingAs($user)->postJson('/api/v1/posts/bulk', [
+    $response = $this->actingAs( $user )->postJson( '/api/v1/posts/bulk', [
         'action' => 'delete',
         'ids'    => [9999],
-    ]);
+    ] );
 
-    $response->assertStatus(422);
-    $response->assertJsonValidationErrors(['ids.0']);
-});
+    $response->assertStatus( 422 );
+    $response->assertJsonValidationErrors( ['ids.0'] );
+} );
 
 // --- Mixed results ---
 
-test('bulk post action returns mixed results when some items fail authorization', function (): void {
+test( 'bulk post action returns mixed results when some items fail authorization', function (): void {
     $owner = TestUser::factory()->create();
     $other = TestUser::factory()->create();
 
     // Grant delete own only
-    Gate::define('posts.view', fn () => true);
-    Gate::define('posts.deleteOwn', fn () => true);
+    Gate::define( 'posts.view', fn () => true );
+    Gate::define( 'posts.deleteOwn', fn () => true );
 
-    $ownPost   = createTestPost(['author_id' => $owner->id]);
-    $otherPost = createTestPost(['author_id' => $other->id]);
+    $ownPost   = createTestPost( ['author_id' => $owner->id] );
+    $otherPost = createTestPost( ['author_id' => $other->id] );
 
-    $response = $this->actingAs($owner)->postJson('/api/v1/posts/bulk', [
+    $response = $this->actingAs( $owner )->postJson( '/api/v1/posts/bulk', [
         'action' => 'delete',
         'ids'    => [$ownPost->id, $otherPost->id],
-    ]);
+    ] );
 
     $response->assertSuccessful();
-    expect($response->json('processed'))->toBe(1);
-    expect($response->json('failed'))->toBe(1);
-    expect($response->json('errors'))->toHaveKey((string) $otherPost->id);
+    expect( $response->json( 'processed' ) )->toBe( 1 );
+    expect( $response->json( 'failed' ) )->toBe( 1 );
+    expect( $response->json( 'errors' ))->toHaveKey( (string) $otherPost->id);
 });
 
 // --- Response structure ---
 
-test('bulk post action returns correct response structure', function (): void {
+test( 'bulk post action returns correct response structure', function (): void {
     grantAllPostPermissions();
     $user = TestUser::factory()->create();
 
-    $post = createTestPost(['author_id' => $user->id]);
+    $post = createTestPost( ['author_id' => $user->id]);
 
-    $response = $this->actingAs($user)->postJson('/api/v1/posts/bulk', [
+    $response = $this->actingAs( $user)->postJson( '/api/v1/posts/bulk', [
         'action' => 'delete',
         'ids'    => [$post->id],
     ]);
 
     $response->assertSuccessful();
-    $response->assertJsonStructure(['processed', 'failed', 'errors']);
+    $response->assertJsonStructure( ['processed', 'failed', 'errors']);
 });

--- a/tests/Feature/BulkPostActionTest.php
+++ b/tests/Feature/BulkPostActionTest.php
@@ -1,0 +1,313 @@
+<?php
+
+declare(strict_types=1);
+
+use ArtisanPackUI\CMSFramework\Modules\Blog\Models\Post;
+use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Enums\ContentStatus;
+use ArtisanPackUI\CMSFramework\Tests\Support\TestUser;
+use Illuminate\Support\Facades\Gate;
+use Illuminate\Support\Str;
+
+/**
+ * Grant all post-related permissions via Gate.
+ */
+function grantAllPostPermissions(): void
+{
+    Gate::define('posts.view', fn () => true);
+    Gate::define('posts.create', fn () => true);
+    Gate::define('posts.edit', fn () => true);
+    Gate::define('posts.editOwn', fn () => true);
+    Gate::define('posts.delete', fn () => true);
+    Gate::define('posts.deleteOwn', fn () => true);
+    Gate::define('posts.publish', fn () => true);
+}
+
+/**
+ * Grant only view and edit permissions (no delete/publish).
+ */
+function grantLimitedPostPermissions(): void
+{
+    Gate::define('posts.view', fn () => true);
+    Gate::define('posts.edit', fn () => true);
+    Gate::define('posts.editOwn', fn () => true);
+}
+
+/**
+ * Create a test post with the given attributes.
+ *
+ * @param  array<string, mixed>  $attributes
+ */
+function createTestPost(array $attributes = []): Post
+{
+    $title = fake()->sentence(6, true);
+
+    return Post::create(array_merge([
+        'title'        => $title,
+        'slug'         => Str::slug($title).'-'.Str::random(5),
+        'content'      => fake()->paragraphs(3, true),
+        'excerpt'      => fake()->paragraph(),
+        'status'       => ContentStatus::Published->value,
+        'published_at' => now(),
+    ], $attributes));
+}
+
+// --- Bulk Delete ---
+
+test('bulk post delete soft-deletes multiple posts', function (): void {
+    grantAllPostPermissions();
+    $user = TestUser::factory()->create();
+
+    $posts = collect();
+    for ($i = 0; $i < 3; $i++) {
+        $posts->push(createTestPost(['author_id' => $user->id]));
+    }
+
+    $response = $this->actingAs($user)->postJson('/api/v1/posts/bulk', [
+        'action' => 'delete',
+        'ids'    => $posts->pluck('id')->toArray(),
+    ]);
+
+    $response->assertSuccessful();
+    expect($response->json('processed'))->toBe(3);
+    expect($response->json('failed'))->toBe(0);
+    expect($response->json('errors'))->toBeEmpty();
+
+    foreach ($posts as $post) {
+        expect(Post::find($post->id))->toBeNull();
+        expect(Post::withTrashed()->find($post->id))->not->toBeNull();
+    }
+});
+
+// --- Bulk Publish ---
+
+test('bulk post publish sets status to published', function (): void {
+    grantAllPostPermissions();
+    $user = TestUser::factory()->create();
+
+    $posts = collect();
+    for ($i = 0; $i < 3; $i++) {
+        $posts->push(createTestPost([
+            'author_id'    => $user->id,
+            'status'       => ContentStatus::Draft->value,
+            'published_at' => null,
+        ]));
+    }
+
+    $response = $this->actingAs($user)->postJson('/api/v1/posts/bulk', [
+        'action' => 'publish',
+        'ids'    => $posts->pluck('id')->toArray(),
+    ]);
+
+    $response->assertSuccessful();
+    expect($response->json('processed'))->toBe(3);
+    expect($response->json('failed'))->toBe(0);
+
+    foreach ($posts as $post) {
+        $post->refresh();
+        expect($post->status)->toBe(ContentStatus::Published);
+        expect($post->published_at)->not->toBeNull();
+    }
+});
+
+// --- Bulk Draft ---
+
+test('bulk post draft sets status to draft', function (): void {
+    grantAllPostPermissions();
+    $user = TestUser::factory()->create();
+
+    $posts = collect();
+    for ($i = 0; $i < 3; $i++) {
+        $posts->push(createTestPost([
+            'author_id'    => $user->id,
+            'status'       => ContentStatus::Published->value,
+            'published_at' => now(),
+        ]));
+    }
+
+    $response = $this->actingAs($user)->postJson('/api/v1/posts/bulk', [
+        'action' => 'draft',
+        'ids'    => $posts->pluck('id')->toArray(),
+    ]);
+
+    $response->assertSuccessful();
+    expect($response->json('processed'))->toBe(3);
+    expect($response->json('failed'))->toBe(0);
+
+    foreach ($posts as $post) {
+        $post->refresh();
+        expect($post->status)->toBe(ContentStatus::Draft);
+        expect($post->published_at)->toBeNull();
+    }
+});
+
+// --- Bulk Archive ---
+
+test('bulk post archive soft-deletes posts', function (): void {
+    grantAllPostPermissions();
+    $user = TestUser::factory()->create();
+
+    $posts = collect();
+    for ($i = 0; $i < 2; $i++) {
+        $posts->push(createTestPost(['author_id' => $user->id]));
+    }
+
+    $response = $this->actingAs($user)->postJson('/api/v1/posts/bulk', [
+        'action' => 'archive',
+        'ids'    => $posts->pluck('id')->toArray(),
+    ]);
+
+    $response->assertSuccessful();
+    expect($response->json('processed'))->toBe(2);
+    expect($response->json('failed'))->toBe(0);
+
+    foreach ($posts as $post) {
+        expect(Post::find($post->id))->toBeNull();
+        expect(Post::withTrashed()->find($post->id))->not->toBeNull();
+    }
+});
+
+// --- Authorization failures ---
+
+test('bulk post delete respects per-item authorization', function (): void {
+    grantLimitedPostPermissions();
+    $user = TestUser::factory()->create();
+
+    $posts = collect();
+    for ($i = 0; $i < 2; $i++) {
+        $posts->push(createTestPost(['author_id' => $user->id]));
+    }
+
+    $response = $this->actingAs($user)->postJson('/api/v1/posts/bulk', [
+        'action' => 'delete',
+        'ids'    => $posts->pluck('id')->toArray(),
+    ]);
+
+    $response->assertSuccessful();
+    expect($response->json('processed'))->toBe(0);
+    expect($response->json('failed'))->toBe(2);
+    expect($response->json('errors'))->toHaveCount(2);
+});
+
+test('bulk post publish respects per-item authorization', function (): void {
+    grantLimitedPostPermissions();
+    $user = TestUser::factory()->create();
+
+    $posts = collect();
+    for ($i = 0; $i < 2; $i++) {
+        $posts->push(createTestPost([
+            'author_id'    => $user->id,
+            'status'       => ContentStatus::Draft->value,
+            'published_at' => null,
+        ]));
+    }
+
+    $response = $this->actingAs($user)->postJson('/api/v1/posts/bulk', [
+        'action' => 'publish',
+        'ids'    => $posts->pluck('id')->toArray(),
+    ]);
+
+    $response->assertSuccessful();
+    expect($response->json('processed'))->toBe(0);
+    expect($response->json('failed'))->toBe(2);
+});
+
+// --- Validation ---
+
+test('bulk post action requires action field', function (): void {
+    $user = TestUser::factory()->create();
+
+    $response = $this->actingAs($user)->postJson('/api/v1/posts/bulk', [
+        'ids' => [1],
+    ]);
+
+    $response->assertStatus(422);
+    $response->assertJsonValidationErrors(['action']);
+});
+
+test('bulk post action requires ids field', function (): void {
+    $user = TestUser::factory()->create();
+
+    $response = $this->actingAs($user)->postJson('/api/v1/posts/bulk', [
+        'action' => 'delete',
+    ]);
+
+    $response->assertStatus(422);
+    $response->assertJsonValidationErrors(['ids']);
+});
+
+test('bulk post action rejects invalid action', function (): void {
+    $user = TestUser::factory()->create();
+
+    $response = $this->actingAs($user)->postJson('/api/v1/posts/bulk', [
+        'action' => 'invalid',
+        'ids'    => [1],
+    ]);
+
+    $response->assertStatus(422);
+    $response->assertJsonValidationErrors(['action']);
+});
+
+test('bulk post action rejects empty ids array', function (): void {
+    $user = TestUser::factory()->create();
+
+    $response = $this->actingAs($user)->postJson('/api/v1/posts/bulk', [
+        'action' => 'delete',
+        'ids'    => [],
+    ]);
+
+    $response->assertStatus(422);
+    $response->assertJsonValidationErrors(['ids']);
+});
+
+test('bulk post action validates ids exist in database', function (): void {
+    $user = TestUser::factory()->create();
+
+    $response = $this->actingAs($user)->postJson('/api/v1/posts/bulk', [
+        'action' => 'delete',
+        'ids'    => [9999],
+    ]);
+
+    $response->assertStatus(422);
+    $response->assertJsonValidationErrors(['ids.0']);
+});
+
+// --- Mixed results ---
+
+test('bulk post action returns mixed results when some items fail authorization', function (): void {
+    $owner = TestUser::factory()->create();
+    $other = TestUser::factory()->create();
+
+    // Grant delete own only
+    Gate::define('posts.view', fn () => true);
+    Gate::define('posts.deleteOwn', fn () => true);
+
+    $ownPost   = createTestPost(['author_id' => $owner->id]);
+    $otherPost = createTestPost(['author_id' => $other->id]);
+
+    $response = $this->actingAs($owner)->postJson('/api/v1/posts/bulk', [
+        'action' => 'delete',
+        'ids'    => [$ownPost->id, $otherPost->id],
+    ]);
+
+    $response->assertSuccessful();
+    expect($response->json('processed'))->toBe(1);
+    expect($response->json('failed'))->toBe(1);
+    expect($response->json('errors'))->toHaveKey((string) $otherPost->id);
+});
+
+// --- Response structure ---
+
+test('bulk post action returns correct response structure', function (): void {
+    grantAllPostPermissions();
+    $user = TestUser::factory()->create();
+
+    $post = createTestPost(['author_id' => $user->id]);
+
+    $response = $this->actingAs($user)->postJson('/api/v1/posts/bulk', [
+        'action' => 'delete',
+        'ids'    => [$post->id],
+    ]);
+
+    $response->assertSuccessful();
+    $response->assertJsonStructure(['processed', 'failed', 'errors']);
+});

--- a/tests/Feature/BulkUserActionTest.php
+++ b/tests/Feature/BulkUserActionTest.php
@@ -216,11 +216,11 @@ test( 'bulk user action returns correct response structure', function (): void {
     $actor = TestUser::factory()->create();
     $user  = TestUser::factory()->create();
 
-    $response = $this->actingAs( $actor)->postJson( '/api/v1/users/bulk', [
+    $response = $this->actingAs( $actor )->postJson( '/api/v1/users/bulk', [
         'action' => 'delete',
         'ids'    => [$user->id],
-    ]);
+    ] );
 
     $response->assertSuccessful();
-    $response->assertJsonStructure( ['processed', 'failed', 'errors']);
-});
+    $response->assertJsonStructure( ['processed', 'failed', 'errors'] );
+} );

--- a/tests/Feature/BulkUserActionTest.php
+++ b/tests/Feature/BulkUserActionTest.php
@@ -1,0 +1,165 @@
+<?php
+
+declare(strict_types=1);
+
+use ArtisanPackUI\CMSFramework\Tests\Support\TestUser;
+
+// --- Bulk Delete ---
+
+test('bulk user delete removes multiple users', function (): void {
+    $actor = TestUser::factory()->create();
+    $users = TestUser::factory()->count(3)->create();
+
+    $response = $this->actingAs($actor)->postJson('/api/v1/users/bulk', [
+        'action' => 'delete',
+        'ids'    => $users->pluck('id')->toArray(),
+    ]);
+
+    $response->assertSuccessful();
+    expect($response->json('processed'))->toBe(3);
+    expect($response->json('failed'))->toBe(0);
+    expect($response->json('errors'))->toBeEmpty();
+
+    foreach ($users as $user) {
+        expect(TestUser::find($user->id))->toBeNull();
+    }
+});
+
+// --- Bulk Activate ---
+
+test('bulk user activate sets email_verified_at', function (): void {
+    $actor = TestUser::factory()->create();
+    $users = TestUser::factory()->count(3)->create(['email_verified_at' => null]);
+
+    $response = $this->actingAs($actor)->postJson('/api/v1/users/bulk', [
+        'action' => 'activate',
+        'ids'    => $users->pluck('id')->toArray(),
+    ]);
+
+    $response->assertSuccessful();
+    expect($response->json('processed'))->toBe(3);
+    expect($response->json('failed'))->toBe(0);
+
+    foreach ($users as $user) {
+        $user->refresh();
+        expect($user->email_verified_at)->not->toBeNull();
+    }
+});
+
+// --- Bulk Deactivate ---
+
+test('bulk user deactivate clears email_verified_at', function (): void {
+    $actor = TestUser::factory()->create();
+    $users = TestUser::factory()->count(3)->create(['email_verified_at' => now()]);
+
+    $response = $this->actingAs($actor)->postJson('/api/v1/users/bulk', [
+        'action' => 'deactivate',
+        'ids'    => $users->pluck('id')->toArray(),
+    ]);
+
+    $response->assertSuccessful();
+    expect($response->json('processed'))->toBe(3);
+    expect($response->json('failed'))->toBe(0);
+
+    foreach ($users as $user) {
+        $user->refresh();
+        expect($user->email_verified_at)->toBeNull();
+    }
+});
+
+// --- Self-action prevention ---
+
+test('bulk user action prevents acting on own account', function (): void {
+    $actor = TestUser::factory()->create();
+    $other = TestUser::factory()->create();
+
+    $response = $this->actingAs($actor)->postJson('/api/v1/users/bulk', [
+        'action' => 'delete',
+        'ids'    => [$actor->id, $other->id],
+    ]);
+
+    $response->assertSuccessful();
+    expect($response->json('processed'))->toBe(1);
+    expect($response->json('failed'))->toBe(1);
+    expect($response->json('errors'))->toHaveKey((string) $actor->id);
+
+    // Actor should still exist
+    expect(TestUser::find($actor->id))->not->toBeNull();
+    // Other user should be deleted
+    expect(TestUser::find($other->id))->toBeNull();
+});
+
+// --- Validation ---
+
+test('bulk user action requires action field', function (): void {
+    $user = TestUser::factory()->create();
+
+    $response = $this->actingAs($user)->postJson('/api/v1/users/bulk', [
+        'ids' => [1],
+    ]);
+
+    $response->assertStatus(422);
+    $response->assertJsonValidationErrors(['action']);
+});
+
+test('bulk user action requires ids field', function (): void {
+    $user = TestUser::factory()->create();
+
+    $response = $this->actingAs($user)->postJson('/api/v1/users/bulk', [
+        'action' => 'delete',
+    ]);
+
+    $response->assertStatus(422);
+    $response->assertJsonValidationErrors(['ids']);
+});
+
+test('bulk user action rejects invalid action', function (): void {
+    $user = TestUser::factory()->create();
+
+    $response = $this->actingAs($user)->postJson('/api/v1/users/bulk', [
+        'action' => 'invalid',
+        'ids'    => [1],
+    ]);
+
+    $response->assertStatus(422);
+    $response->assertJsonValidationErrors(['action']);
+});
+
+test('bulk user action rejects empty ids array', function (): void {
+    $user = TestUser::factory()->create();
+
+    $response = $this->actingAs($user)->postJson('/api/v1/users/bulk', [
+        'action' => 'delete',
+        'ids'    => [],
+    ]);
+
+    $response->assertStatus(422);
+    $response->assertJsonValidationErrors(['ids']);
+});
+
+test('bulk user action validates ids exist in database', function (): void {
+    $user = TestUser::factory()->create();
+
+    $response = $this->actingAs($user)->postJson('/api/v1/users/bulk', [
+        'action' => 'delete',
+        'ids'    => [9999],
+    ]);
+
+    $response->assertStatus(422);
+    $response->assertJsonValidationErrors(['ids.0']);
+});
+
+// --- Response structure ---
+
+test('bulk user action returns correct response structure', function (): void {
+    $actor = TestUser::factory()->create();
+    $user  = TestUser::factory()->create();
+
+    $response = $this->actingAs($actor)->postJson('/api/v1/users/bulk', [
+        'action' => 'delete',
+        'ids'    => [$user->id],
+    ]);
+
+    $response->assertSuccessful();
+    $response->assertJsonStructure(['processed', 'failed', 'errors']);
+});

--- a/tests/Feature/BulkUserActionTest.php
+++ b/tests/Feature/BulkUserActionTest.php
@@ -3,10 +3,21 @@
 declare(strict_types=1);
 
 use ArtisanPackUI\CMSFramework\Tests\Support\TestUser;
+use Illuminate\Support\Facades\Gate;
+
+/**
+ * Grant all user bulk action permissions via Gate.
+ */
+function grantAllUserPermissions(): void
+{
+    Gate::define('users.delete', fn () => true);
+    Gate::define('users.manage', fn () => true);
+}
 
 // --- Bulk Delete ---
 
 test('bulk user delete removes multiple users', function (): void {
+    grantAllUserPermissions();
     $actor = TestUser::factory()->create();
     $users = TestUser::factory()->count(3)->create();
 
@@ -28,6 +39,7 @@ test('bulk user delete removes multiple users', function (): void {
 // --- Bulk Activate ---
 
 test('bulk user activate sets email_verified_at', function (): void {
+    grantAllUserPermissions();
     $actor = TestUser::factory()->create();
     $users = TestUser::factory()->count(3)->create(['email_verified_at' => null]);
 
@@ -49,6 +61,7 @@ test('bulk user activate sets email_verified_at', function (): void {
 // --- Bulk Deactivate ---
 
 test('bulk user deactivate clears email_verified_at', function (): void {
+    grantAllUserPermissions();
     $actor = TestUser::factory()->create();
     $users = TestUser::factory()->count(3)->create(['email_verified_at' => now()]);
 
@@ -70,6 +83,7 @@ test('bulk user deactivate clears email_verified_at', function (): void {
 // --- Self-action prevention ---
 
 test('bulk user action prevents acting on own account', function (): void {
+    grantAllUserPermissions();
     $actor = TestUser::factory()->create();
     $other = TestUser::factory()->create();
 
@@ -87,6 +101,52 @@ test('bulk user action prevents acting on own account', function (): void {
     expect(TestUser::find($actor->id))->not->toBeNull();
     // Other user should be deleted
     expect(TestUser::find($other->id))->toBeNull();
+});
+
+// --- Authorization failures ---
+
+test('bulk user delete fails without users.delete permission', function (): void {
+    // No permissions granted
+    $actor = TestUser::factory()->create();
+    $users = TestUser::factory()->count(2)->create();
+
+    $response = $this->actingAs($actor)->postJson('/api/v1/users/bulk', [
+        'action' => 'delete',
+        'ids'    => $users->pluck('id')->toArray(),
+    ]);
+
+    $response->assertSuccessful();
+    expect($response->json('processed'))->toBe(0);
+    expect($response->json('failed'))->toBe(2);
+    expect($response->json('errors'))->toHaveCount(2);
+
+    // Users should still exist
+    foreach ($users as $user) {
+        expect(TestUser::find($user->id))->not->toBeNull();
+    }
+});
+
+test('bulk user activate fails without users.manage permission', function (): void {
+    // Only grant delete, not manage
+    Gate::define('users.delete', fn () => true);
+
+    $actor = TestUser::factory()->create();
+    $users = TestUser::factory()->count(2)->create(['email_verified_at' => null]);
+
+    $response = $this->actingAs($actor)->postJson('/api/v1/users/bulk', [
+        'action' => 'activate',
+        'ids'    => $users->pluck('id')->toArray(),
+    ]);
+
+    $response->assertSuccessful();
+    expect($response->json('processed'))->toBe(0);
+    expect($response->json('failed'))->toBe(2);
+
+    // Users should still be unverified
+    foreach ($users as $user) {
+        $user->refresh();
+        expect($user->email_verified_at)->toBeNull();
+    }
 });
 
 // --- Validation ---
@@ -152,6 +212,7 @@ test('bulk user action validates ids exist in database', function (): void {
 // --- Response structure ---
 
 test('bulk user action returns correct response structure', function (): void {
+    grantAllUserPermissions();
     $actor = TestUser::factory()->create();
     $user  = TestUser::factory()->create();
 

--- a/tests/Feature/BulkUserActionTest.php
+++ b/tests/Feature/BulkUserActionTest.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare( strict_types=1 );
 
 use ArtisanPackUI\CMSFramework\Tests\Support\TestUser;
 use Illuminate\Support\Facades\Gate;
@@ -10,217 +10,217 @@ use Illuminate\Support\Facades\Gate;
  */
 function grantAllUserPermissions(): void
 {
-    Gate::define('users.delete', fn () => true);
-    Gate::define('users.manage', fn () => true);
+    Gate::define( 'users.delete', fn () => true );
+    Gate::define( 'users.manage', fn () => true );
 }
 
 // --- Bulk Delete ---
 
-test('bulk user delete removes multiple users', function (): void {
+test( 'bulk user delete removes multiple users', function (): void {
     grantAllUserPermissions();
     $actor = TestUser::factory()->create();
-    $users = TestUser::factory()->count(3)->create();
+    $users = TestUser::factory()->count( 3 )->create();
 
-    $response = $this->actingAs($actor)->postJson('/api/v1/users/bulk', [
+    $response = $this->actingAs( $actor )->postJson( '/api/v1/users/bulk', [
         'action' => 'delete',
-        'ids'    => $users->pluck('id')->toArray(),
-    ]);
+        'ids'    => $users->pluck( 'id' )->toArray(),
+    ] );
 
     $response->assertSuccessful();
-    expect($response->json('processed'))->toBe(3);
-    expect($response->json('failed'))->toBe(0);
-    expect($response->json('errors'))->toBeEmpty();
+    expect( $response->json( 'processed' ) )->toBe( 3 );
+    expect( $response->json( 'failed' ) )->toBe( 0 );
+    expect( $response->json( 'errors' ) )->toBeEmpty();
 
-    foreach ($users as $user) {
-        expect(TestUser::find($user->id))->toBeNull();
+    foreach ( $users as $user ) {
+        expect( TestUser::find( $user->id ) )->toBeNull();
     }
-});
+} );
 
 // --- Bulk Activate ---
 
-test('bulk user activate sets email_verified_at', function (): void {
+test( 'bulk user activate sets email_verified_at', function (): void {
     grantAllUserPermissions();
     $actor = TestUser::factory()->create();
-    $users = TestUser::factory()->count(3)->create(['email_verified_at' => null]);
+    $users = TestUser::factory()->count( 3 )->create( ['email_verified_at' => null] );
 
-    $response = $this->actingAs($actor)->postJson('/api/v1/users/bulk', [
+    $response = $this->actingAs( $actor )->postJson( '/api/v1/users/bulk', [
         'action' => 'activate',
-        'ids'    => $users->pluck('id')->toArray(),
-    ]);
+        'ids'    => $users->pluck( 'id' )->toArray(),
+    ] );
 
     $response->assertSuccessful();
-    expect($response->json('processed'))->toBe(3);
-    expect($response->json('failed'))->toBe(0);
+    expect( $response->json( 'processed' ) )->toBe( 3 );
+    expect( $response->json( 'failed' ) )->toBe( 0 );
 
-    foreach ($users as $user) {
+    foreach ( $users as $user ) {
         $user->refresh();
-        expect($user->email_verified_at)->not->toBeNull();
+        expect( $user->email_verified_at )->not->toBeNull();
     }
-});
+} );
 
 // --- Bulk Deactivate ---
 
-test('bulk user deactivate clears email_verified_at', function (): void {
+test( 'bulk user deactivate clears email_verified_at', function (): void {
     grantAllUserPermissions();
     $actor = TestUser::factory()->create();
-    $users = TestUser::factory()->count(3)->create(['email_verified_at' => now()]);
+    $users = TestUser::factory()->count( 3 )->create( ['email_verified_at' => now()] );
 
-    $response = $this->actingAs($actor)->postJson('/api/v1/users/bulk', [
+    $response = $this->actingAs( $actor )->postJson( '/api/v1/users/bulk', [
         'action' => 'deactivate',
-        'ids'    => $users->pluck('id')->toArray(),
-    ]);
+        'ids'    => $users->pluck( 'id' )->toArray(),
+    ] );
 
     $response->assertSuccessful();
-    expect($response->json('processed'))->toBe(3);
-    expect($response->json('failed'))->toBe(0);
+    expect( $response->json( 'processed' ) )->toBe( 3 );
+    expect( $response->json( 'failed' ) )->toBe( 0 );
 
-    foreach ($users as $user) {
+    foreach ( $users as $user ) {
         $user->refresh();
-        expect($user->email_verified_at)->toBeNull();
+        expect( $user->email_verified_at )->toBeNull();
     }
-});
+} );
 
 // --- Self-action prevention ---
 
-test('bulk user action prevents acting on own account', function (): void {
+test( 'bulk user action prevents acting on own account', function (): void {
     grantAllUserPermissions();
     $actor = TestUser::factory()->create();
     $other = TestUser::factory()->create();
 
-    $response = $this->actingAs($actor)->postJson('/api/v1/users/bulk', [
+    $response = $this->actingAs( $actor )->postJson( '/api/v1/users/bulk', [
         'action' => 'delete',
         'ids'    => [$actor->id, $other->id],
-    ]);
+    ] );
 
     $response->assertSuccessful();
-    expect($response->json('processed'))->toBe(1);
-    expect($response->json('failed'))->toBe(1);
-    expect($response->json('errors'))->toHaveKey((string) $actor->id);
+    expect( $response->json( 'processed' ) )->toBe( 1 );
+    expect( $response->json( 'failed' ) )->toBe( 1 );
+    expect( $response->json( 'errors' ) )->toHaveKey( (string) $actor->id );
 
     // Actor should still exist
-    expect(TestUser::find($actor->id))->not->toBeNull();
+    expect( TestUser::find( $actor->id ) )->not->toBeNull();
     // Other user should be deleted
-    expect(TestUser::find($other->id))->toBeNull();
-});
+    expect( TestUser::find( $other->id ) )->toBeNull();
+} );
 
 // --- Authorization failures ---
 
-test('bulk user delete fails without users.delete permission', function (): void {
+test( 'bulk user delete fails without users.delete permission', function (): void {
     // No permissions granted
     $actor = TestUser::factory()->create();
-    $users = TestUser::factory()->count(2)->create();
+    $users = TestUser::factory()->count( 2 )->create();
 
-    $response = $this->actingAs($actor)->postJson('/api/v1/users/bulk', [
+    $response = $this->actingAs( $actor )->postJson( '/api/v1/users/bulk', [
         'action' => 'delete',
-        'ids'    => $users->pluck('id')->toArray(),
-    ]);
+        'ids'    => $users->pluck( 'id' )->toArray(),
+    ] );
 
     $response->assertSuccessful();
-    expect($response->json('processed'))->toBe(0);
-    expect($response->json('failed'))->toBe(2);
-    expect($response->json('errors'))->toHaveCount(2);
+    expect( $response->json( 'processed' ) )->toBe( 0 );
+    expect( $response->json( 'failed' ) )->toBe( 2 );
+    expect( $response->json( 'errors' ) )->toHaveCount( 2 );
 
     // Users should still exist
-    foreach ($users as $user) {
-        expect(TestUser::find($user->id))->not->toBeNull();
+    foreach ( $users as $user ) {
+        expect( TestUser::find( $user->id ) )->not->toBeNull();
     }
-});
+} );
 
-test('bulk user activate fails without users.manage permission', function (): void {
+test( 'bulk user activate fails without users.manage permission', function (): void {
     // Only grant delete, not manage
-    Gate::define('users.delete', fn () => true);
+    Gate::define( 'users.delete', fn () => true );
 
     $actor = TestUser::factory()->create();
-    $users = TestUser::factory()->count(2)->create(['email_verified_at' => null]);
+    $users = TestUser::factory()->count( 2 )->create( ['email_verified_at' => null] );
 
-    $response = $this->actingAs($actor)->postJson('/api/v1/users/bulk', [
+    $response = $this->actingAs( $actor )->postJson( '/api/v1/users/bulk', [
         'action' => 'activate',
-        'ids'    => $users->pluck('id')->toArray(),
-    ]);
+        'ids'    => $users->pluck( 'id' )->toArray(),
+    ] );
 
     $response->assertSuccessful();
-    expect($response->json('processed'))->toBe(0);
-    expect($response->json('failed'))->toBe(2);
+    expect( $response->json( 'processed' ) )->toBe( 0 );
+    expect( $response->json( 'failed' ) )->toBe( 2 );
 
     // Users should still be unverified
-    foreach ($users as $user) {
+    foreach ( $users as $user ) {
         $user->refresh();
-        expect($user->email_verified_at)->toBeNull();
+        expect( $user->email_verified_at )->toBeNull();
     }
-});
+} );
 
 // --- Validation ---
 
-test('bulk user action requires action field', function (): void {
+test( 'bulk user action requires action field', function (): void {
     $user = TestUser::factory()->create();
 
-    $response = $this->actingAs($user)->postJson('/api/v1/users/bulk', [
+    $response = $this->actingAs( $user )->postJson( '/api/v1/users/bulk', [
         'ids' => [1],
-    ]);
+    ] );
 
-    $response->assertStatus(422);
-    $response->assertJsonValidationErrors(['action']);
-});
+    $response->assertStatus( 422 );
+    $response->assertJsonValidationErrors( ['action'] );
+} );
 
-test('bulk user action requires ids field', function (): void {
+test( 'bulk user action requires ids field', function (): void {
     $user = TestUser::factory()->create();
 
-    $response = $this->actingAs($user)->postJson('/api/v1/users/bulk', [
+    $response = $this->actingAs( $user )->postJson( '/api/v1/users/bulk', [
         'action' => 'delete',
-    ]);
+    ] );
 
-    $response->assertStatus(422);
-    $response->assertJsonValidationErrors(['ids']);
-});
+    $response->assertStatus( 422 );
+    $response->assertJsonValidationErrors( ['ids'] );
+} );
 
-test('bulk user action rejects invalid action', function (): void {
+test( 'bulk user action rejects invalid action', function (): void {
     $user = TestUser::factory()->create();
 
-    $response = $this->actingAs($user)->postJson('/api/v1/users/bulk', [
+    $response = $this->actingAs( $user )->postJson( '/api/v1/users/bulk', [
         'action' => 'invalid',
         'ids'    => [1],
-    ]);
+    ] );
 
-    $response->assertStatus(422);
-    $response->assertJsonValidationErrors(['action']);
-});
+    $response->assertStatus( 422 );
+    $response->assertJsonValidationErrors( ['action'] );
+} );
 
-test('bulk user action rejects empty ids array', function (): void {
+test( 'bulk user action rejects empty ids array', function (): void {
     $user = TestUser::factory()->create();
 
-    $response = $this->actingAs($user)->postJson('/api/v1/users/bulk', [
+    $response = $this->actingAs( $user )->postJson( '/api/v1/users/bulk', [
         'action' => 'delete',
         'ids'    => [],
-    ]);
+    ] );
 
-    $response->assertStatus(422);
-    $response->assertJsonValidationErrors(['ids']);
-});
+    $response->assertStatus( 422 );
+    $response->assertJsonValidationErrors( ['ids'] );
+} );
 
-test('bulk user action validates ids exist in database', function (): void {
+test( 'bulk user action validates ids exist in database', function (): void {
     $user = TestUser::factory()->create();
 
-    $response = $this->actingAs($user)->postJson('/api/v1/users/bulk', [
+    $response = $this->actingAs( $user )->postJson( '/api/v1/users/bulk', [
         'action' => 'delete',
         'ids'    => [9999],
-    ]);
+    ] );
 
-    $response->assertStatus(422);
-    $response->assertJsonValidationErrors(['ids.0']);
-});
+    $response->assertStatus( 422 );
+    $response->assertJsonValidationErrors( ['ids.0'] );
+} );
 
 // --- Response structure ---
 
-test('bulk user action returns correct response structure', function (): void {
+test( 'bulk user action returns correct response structure', function (): void {
     grantAllUserPermissions();
     $actor = TestUser::factory()->create();
     $user  = TestUser::factory()->create();
 
-    $response = $this->actingAs($actor)->postJson('/api/v1/users/bulk', [
+    $response = $this->actingAs( $actor)->postJson( '/api/v1/users/bulk', [
         'action' => 'delete',
         'ids'    => [$user->id],
     ]);
 
     $response->assertSuccessful();
-    $response->assertJsonStructure(['processed', 'failed', 'errors']);
+    $response->assertJsonStructure( ['processed', 'failed', 'errors']);
 });

--- a/tests/Feature/ExampleTest.php
+++ b/tests/Feature/ExampleTest.php
@@ -12,5 +12,5 @@ test( 'service provider is loaded', function (): void {
 
 test( 'application has basic configuration', function (): void {
     expect( config( 'app.key' ) )->not()->toBeNull();
-    expect( config( 'database.default' ) )->toBe( 'testing');
-});
+    expect( config( 'database.default' ) )->toBe( 'testing' );
+} );

--- a/tests/Feature/Exceptions/JsonErrorResponseTest.php
+++ b/tests/Feature/Exceptions/JsonErrorResponseTest.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare( strict_types=1 );
 
 /**
  * Tests for standardized JSON error response format.
@@ -19,36 +19,36 @@ use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 
-beforeEach(function (): void {
-    $this->artisan('migrate', ['--database' => 'testing']);
+beforeEach( function (): void {
+    $this->artisan( 'migrate', ['--database' => 'testing'] );
 
     // Register test routes that throw each exception type.
-    Route::middleware(['api'])->group(function (): void {
-        Route::get('/test/server-error', function (): void {
-            throw new CMSFrameworkException('Something went wrong.');
-        });
+    Route::middleware( ['api'] )->group( function (): void {
+        Route::get( '/test/server-error', function (): void {
+            throw new CMSFrameworkException( 'Something went wrong.' );
+        } );
 
-        Route::get('/test/not-found', function (): void {
-            throw NotFoundException::resource('Post', 'my-post');
-        });
+        Route::get( '/test/not-found', function (): void {
+            throw NotFoundException::resource( 'Post', 'my-post' );
+        } );
 
-        Route::get('/test/not-found-model', function (): void {
-            throw NotFoundException::model('App\Models\Post', 42);
-        });
+        Route::get( '/test/not-found-model', function (): void {
+            throw NotFoundException::model( 'App\Models\Post', 42 );
+        } );
 
-        Route::get('/test/unauthorized-action', function (): void {
-            throw UnauthorizedException::forAction('delete this post');
-        });
+        Route::get( '/test/unauthorized-action', function (): void {
+            throw UnauthorizedException::forAction( 'delete this post' );
+        } );
 
-        Route::get('/test/unauthorized-resource', function (): void {
-            throw UnauthorizedException::forResource('posts', 'edit');
-        });
+        Route::get( '/test/unauthorized-resource', function (): void {
+            throw UnauthorizedException::forResource( 'posts', 'edit' );
+        } );
 
-        Route::get('/test/unauthorized-permission', function (): void {
-            throw UnauthorizedException::requiresPermission('manage_posts');
-        });
+        Route::get( '/test/unauthorized-permission', function (): void {
+            throw UnauthorizedException::requiresPermission( 'manage_posts' );
+        } );
 
-        Route::get('/test/validation-error', function (): void {
+        Route::get( '/test/validation-error', function (): void {
             throw ValidationException::withErrors(
                 'The given data was invalid.',
                 [
@@ -56,120 +56,120 @@ beforeEach(function (): void {
                     'slug'  => ['The slug has already been taken.'],
                 ],
             );
-        });
+        } );
 
-        Route::get('/test/validation-error-no-fields', function (): void {
-            throw new ValidationException('Validation failed.');
-        });
-    });
-});
+        Route::get( '/test/validation-error-no-fields', function (): void {
+            throw new ValidationException( 'Validation failed.' );
+        } );
+    } );
+} );
 
 // --- Base CMSFrameworkException ---
 
-test('base exception renders as 500 server error with consistent JSON format', function (): void {
-    $response = $this->getJson('/test/server-error');
+test( 'base exception renders as 500 server error with consistent JSON format', function (): void {
+    $response = $this->getJson( '/test/server-error' );
 
-    $response->assertStatus(500);
-    $response->assertExactJson([
+    $response->assertStatus( 500 );
+    $response->assertExactJson( [
         'error' => [
             'code'    => 'SERVER_ERROR',
             'message' => 'Something went wrong.',
         ],
-    ]);
-});
+    ] );
+} );
 
-test('base exception has correct error code and status code', function (): void {
-    $exception = new CMSFrameworkException('Test error.');
+test( 'base exception has correct error code and status code', function (): void {
+    $exception = new CMSFrameworkException( 'Test error.' );
 
-    expect($exception->getErrorCode())->toBe('SERVER_ERROR');
-    expect($exception->getStatusCode())->toBe(500);
-});
+    expect( $exception->getErrorCode() )->toBe( 'SERVER_ERROR' );
+    expect( $exception->getStatusCode() )->toBe( 500 );
+} );
 
 // --- NotFoundException ---
 
-test('not found exception renders as 404 with consistent JSON format', function (): void {
-    $response = $this->getJson('/test/not-found');
+test( 'not found exception renders as 404 with consistent JSON format', function (): void {
+    $response = $this->getJson( '/test/not-found' );
 
-    $response->assertStatus(404);
-    $response->assertExactJson([
+    $response->assertStatus( 404 );
+    $response->assertExactJson( [
         'error' => [
             'code'    => 'NOT_FOUND',
             'message' => "Post 'my-post' not found.",
         ],
-    ]);
-});
+    ] );
+} );
 
-test('not found model exception renders as 404 with model details', function (): void {
-    $response = $this->getJson('/test/not-found-model');
+test( 'not found model exception renders as 404 with model details', function (): void {
+    $response = $this->getJson( '/test/not-found-model' );
 
-    $response->assertStatus(404);
-    $response->assertExactJson([
+    $response->assertStatus( 404 );
+    $response->assertExactJson( [
         'error' => [
             'code'    => 'NOT_FOUND',
             'message' => 'Model App\Models\Post with ID 42 not found.',
         ],
-    ]);
-});
+    ] );
+} );
 
-test('not found exception has correct error code and status code', function (): void {
-    $exception = NotFoundException::resource('Page', 'about');
+test( 'not found exception has correct error code and status code', function (): void {
+    $exception = NotFoundException::resource( 'Page', 'about' );
 
-    expect($exception->getErrorCode())->toBe('NOT_FOUND');
-    expect($exception->getStatusCode())->toBe(404);
-});
+    expect( $exception->getErrorCode() )->toBe( 'NOT_FOUND' );
+    expect( $exception->getStatusCode() )->toBe( 404 );
+} );
 
 // --- UnauthorizedException ---
 
-test('unauthorized action exception renders as 403 with consistent JSON format', function (): void {
-    $response = $this->getJson('/test/unauthorized-action');
+test( 'unauthorized action exception renders as 403 with consistent JSON format', function (): void {
+    $response = $this->getJson( '/test/unauthorized-action' );
 
-    $response->assertStatus(403);
-    $response->assertExactJson([
+    $response->assertStatus( 403 );
+    $response->assertExactJson( [
         'error' => [
             'code'    => 'FORBIDDEN',
             'message' => 'You are not authorized to delete this post.',
         ],
-    ]);
-});
+    ] );
+} );
 
-test('unauthorized resource exception renders as 403', function (): void {
-    $response = $this->getJson('/test/unauthorized-resource');
+test( 'unauthorized resource exception renders as 403', function (): void {
+    $response = $this->getJson( '/test/unauthorized-resource' );
 
-    $response->assertStatus(403);
-    $response->assertExactJson([
+    $response->assertStatus( 403 );
+    $response->assertExactJson( [
         'error' => [
             'code'    => 'FORBIDDEN',
             'message' => 'You are not authorized to edit posts.',
         ],
-    ]);
-});
+    ] );
+} );
 
-test('unauthorized permission exception renders as 403', function (): void {
-    $response = $this->getJson('/test/unauthorized-permission');
+test( 'unauthorized permission exception renders as 403', function (): void {
+    $response = $this->getJson( '/test/unauthorized-permission' );
 
-    $response->assertStatus(403);
-    $response->assertExactJson([
+    $response->assertStatus( 403 );
+    $response->assertExactJson( [
         'error' => [
             'code'    => 'FORBIDDEN',
             'message' => "This action requires the 'manage_posts' permission.",
         ],
-    ]);
-});
+    ] );
+} );
 
-test('unauthorized exception has correct error code and status code', function (): void {
-    $exception = UnauthorizedException::forAction('test');
+test( 'unauthorized exception has correct error code and status code', function (): void {
+    $exception = UnauthorizedException::forAction( 'test' );
 
-    expect($exception->getErrorCode())->toBe('FORBIDDEN');
-    expect($exception->getStatusCode())->toBe(403);
-});
+    expect( $exception->getErrorCode() )->toBe( 'FORBIDDEN' );
+    expect( $exception->getStatusCode() )->toBe( 403 );
+} );
 
 // --- ValidationException ---
 
-test('validation exception renders as 422 with field-level errors', function (): void {
-    $response = $this->getJson('/test/validation-error');
+test( 'validation exception renders as 422 with field-level errors', function (): void {
+    $response = $this->getJson( '/test/validation-error' );
 
-    $response->assertStatus(422);
-    $response->assertExactJson([
+    $response->assertStatus( 422 );
+    $response->assertExactJson( [
         'error' => [
             'code'    => 'VALIDATION_ERROR',
             'message' => 'The given data was invalid.',
@@ -178,69 +178,69 @@ test('validation exception renders as 422 with field-level errors', function ():
                 'slug'  => ['The slug has already been taken.'],
             ],
         ],
-    ]);
-});
+    ] );
+} );
 
-test('validation exception without field errors omits errors key', function (): void {
-    $response = $this->getJson('/test/validation-error-no-fields');
+test( 'validation exception without field errors omits errors key', function (): void {
+    $response = $this->getJson( '/test/validation-error-no-fields' );
 
-    $response->assertStatus(422);
-    $response->assertExactJson([
+    $response->assertStatus( 422 );
+    $response->assertExactJson( [
         'error' => [
             'code'    => 'VALIDATION_ERROR',
             'message' => 'Validation failed.',
         ],
-    ]);
-});
+    ] );
+} );
 
-test('validation exception has correct error code and status code', function (): void {
-    $exception = ValidationException::withErrors('Invalid.', ['name' => ['Required.']]);
+test( 'validation exception has correct error code and status code', function (): void {
+    $exception = ValidationException::withErrors( 'Invalid.', ['name' => ['Required.']] );
 
-    expect($exception->getErrorCode())->toBe('VALIDATION_ERROR');
-    expect($exception->getStatusCode())->toBe(422);
-    expect($exception->getErrors())->toBe(['name' => ['Required.']]);
-    expect($exception->hasError('name'))->toBeTrue();
-    expect($exception->hasError('email'))->toBeFalse();
-});
+    expect( $exception->getErrorCode() )->toBe( 'VALIDATION_ERROR' );
+    expect( $exception->getStatusCode() )->toBe( 422 );
+    expect( $exception->getErrors() )->toBe( ['name' => ['Required.']] );
+    expect( $exception->hasError( 'name' ) )->toBeTrue();
+    expect( $exception->hasError( 'email' ) )->toBeFalse();
+} );
 
 // --- Render method returns null for non-JSON requests ---
 
-test('exceptions return null for non-JSON requests to allow default rendering', function (): void {
-    $exception = new CMSFrameworkException('Test error.');
-    $request   = Request::create('/test', 'GET');
+test( 'exceptions return null for non-JSON requests to allow default rendering', function (): void {
+    $exception = new CMSFrameworkException( 'Test error.' );
+    $request   = Request::create( '/test', 'GET' );
 
-    $result = $exception->render($request);
+    $result = $exception->render( $request );
 
-    expect($result)->toBeNull();
-});
+    expect( $result )->toBeNull();
+} );
 
-test('exceptions return JsonResponse for JSON requests', function (): void {
-    $exception = new CMSFrameworkException('Test error.');
-    $request   = Request::create('/test', 'GET', [], [], [], ['HTTP_ACCEPT' => 'application/json']);
+test( 'exceptions return JsonResponse for JSON requests', function (): void {
+    $exception = new CMSFrameworkException( 'Test error.' );
+    $request   = Request::create( '/test', 'GET', [], [], [], ['HTTP_ACCEPT' => 'application/json'] );
 
-    $result = $exception->render($request);
+    $result = $exception->render( $request );
 
-    expect($result)->toBeInstanceOf(JsonResponse::class);
-    expect($result->getStatusCode())->toBe(500);
-});
+    expect( $result )->toBeInstanceOf( JsonResponse::class );
+    expect( $result->getStatusCode() )->toBe( 500 );
+} );
 
 // --- Module-specific exceptions inherit base behavior ---
 
-test('module exceptions that extend CMSFrameworkException inherit JSON rendering', function (): void {
+test( 'module exceptions that extend CMSFrameworkException inherit JSON rendering', function (): void {
     // Create a test route for a generic subclass
-    Route::middleware(['api'])->get('/test/module-error', function (): void {
-        throw new class('Module error occurred.') extends CMSFrameworkException {};
+    Route::middleware( ['api'] )->get( '/test/module-error', function (): void {
+        throw new class( 'Module error occurred.') extends CMSFrameworkException {};
     });
 
-    $response = $this->getJson('/test/module-error');
+    $response = $this->getJson( '/test/module-error');
 
-    $response->assertStatus(500);
-    $response->assertJsonStructure([
+    $response->assertStatus( 500);
+    $response->assertJsonStructure( [
         'error' => [
             'code',
             'message',
         ],
     ]);
-    $response->assertJsonPath('error.code', 'SERVER_ERROR');
-    $response->assertJsonPath('error.message', 'Module error occurred.');
+    $response->assertJsonPath( 'error.code', 'SERVER_ERROR');
+    $response->assertJsonPath( 'error.message', 'Module error occurred.');
 });

--- a/tests/Feature/Exceptions/JsonErrorResponseTest.php
+++ b/tests/Feature/Exceptions/JsonErrorResponseTest.php
@@ -1,0 +1,246 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Tests for standardized JSON error response format.
+ *
+ * Verifies that all CMS Framework exceptions render as a consistent
+ * JSON error format when the request expects JSON.
+ *
+ * @since 1.1.0
+ */
+
+use ArtisanPackUI\CMSFramework\Exceptions\CMSFrameworkException;
+use ArtisanPackUI\CMSFramework\Exceptions\NotFoundException;
+use ArtisanPackUI\CMSFramework\Exceptions\UnauthorizedException;
+use ArtisanPackUI\CMSFramework\Exceptions\ValidationException;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Route;
+
+beforeEach(function (): void {
+    $this->artisan('migrate', ['--database' => 'testing']);
+
+    // Register test routes that throw each exception type.
+    Route::middleware(['api'])->group(function (): void {
+        Route::get('/test/server-error', function (): void {
+            throw new CMSFrameworkException('Something went wrong.');
+        });
+
+        Route::get('/test/not-found', function (): void {
+            throw NotFoundException::resource('Post', 'my-post');
+        });
+
+        Route::get('/test/not-found-model', function (): void {
+            throw NotFoundException::model('App\Models\Post', 42);
+        });
+
+        Route::get('/test/unauthorized-action', function (): void {
+            throw UnauthorizedException::forAction('delete this post');
+        });
+
+        Route::get('/test/unauthorized-resource', function (): void {
+            throw UnauthorizedException::forResource('posts', 'edit');
+        });
+
+        Route::get('/test/unauthorized-permission', function (): void {
+            throw UnauthorizedException::requiresPermission('manage_posts');
+        });
+
+        Route::get('/test/validation-error', function (): void {
+            throw ValidationException::withErrors(
+                'The given data was invalid.',
+                [
+                    'title' => ['The title field is required.'],
+                    'slug'  => ['The slug has already been taken.'],
+                ],
+            );
+        });
+
+        Route::get('/test/validation-error-no-fields', function (): void {
+            throw new ValidationException('Validation failed.');
+        });
+    });
+});
+
+// --- Base CMSFrameworkException ---
+
+test('base exception renders as 500 server error with consistent JSON format', function (): void {
+    $response = $this->getJson('/test/server-error');
+
+    $response->assertStatus(500);
+    $response->assertExactJson([
+        'error' => [
+            'code'    => 'SERVER_ERROR',
+            'message' => 'Something went wrong.',
+        ],
+    ]);
+});
+
+test('base exception has correct error code and status code', function (): void {
+    $exception = new CMSFrameworkException('Test error.');
+
+    expect($exception->getErrorCode())->toBe('SERVER_ERROR');
+    expect($exception->getStatusCode())->toBe(500);
+});
+
+// --- NotFoundException ---
+
+test('not found exception renders as 404 with consistent JSON format', function (): void {
+    $response = $this->getJson('/test/not-found');
+
+    $response->assertStatus(404);
+    $response->assertExactJson([
+        'error' => [
+            'code'    => 'NOT_FOUND',
+            'message' => "Post 'my-post' not found.",
+        ],
+    ]);
+});
+
+test('not found model exception renders as 404 with model details', function (): void {
+    $response = $this->getJson('/test/not-found-model');
+
+    $response->assertStatus(404);
+    $response->assertExactJson([
+        'error' => [
+            'code'    => 'NOT_FOUND',
+            'message' => 'Model App\Models\Post with ID 42 not found.',
+        ],
+    ]);
+});
+
+test('not found exception has correct error code and status code', function (): void {
+    $exception = NotFoundException::resource('Page', 'about');
+
+    expect($exception->getErrorCode())->toBe('NOT_FOUND');
+    expect($exception->getStatusCode())->toBe(404);
+});
+
+// --- UnauthorizedException ---
+
+test('unauthorized action exception renders as 403 with consistent JSON format', function (): void {
+    $response = $this->getJson('/test/unauthorized-action');
+
+    $response->assertStatus(403);
+    $response->assertExactJson([
+        'error' => [
+            'code'    => 'FORBIDDEN',
+            'message' => 'You are not authorized to delete this post.',
+        ],
+    ]);
+});
+
+test('unauthorized resource exception renders as 403', function (): void {
+    $response = $this->getJson('/test/unauthorized-resource');
+
+    $response->assertStatus(403);
+    $response->assertExactJson([
+        'error' => [
+            'code'    => 'FORBIDDEN',
+            'message' => 'You are not authorized to edit posts.',
+        ],
+    ]);
+});
+
+test('unauthorized permission exception renders as 403', function (): void {
+    $response = $this->getJson('/test/unauthorized-permission');
+
+    $response->assertStatus(403);
+    $response->assertExactJson([
+        'error' => [
+            'code'    => 'FORBIDDEN',
+            'message' => "This action requires the 'manage_posts' permission.",
+        ],
+    ]);
+});
+
+test('unauthorized exception has correct error code and status code', function (): void {
+    $exception = UnauthorizedException::forAction('test');
+
+    expect($exception->getErrorCode())->toBe('FORBIDDEN');
+    expect($exception->getStatusCode())->toBe(403);
+});
+
+// --- ValidationException ---
+
+test('validation exception renders as 422 with field-level errors', function (): void {
+    $response = $this->getJson('/test/validation-error');
+
+    $response->assertStatus(422);
+    $response->assertExactJson([
+        'error' => [
+            'code'    => 'VALIDATION_ERROR',
+            'message' => 'The given data was invalid.',
+            'errors'  => [
+                'title' => ['The title field is required.'],
+                'slug'  => ['The slug has already been taken.'],
+            ],
+        ],
+    ]);
+});
+
+test('validation exception without field errors omits errors key', function (): void {
+    $response = $this->getJson('/test/validation-error-no-fields');
+
+    $response->assertStatus(422);
+    $response->assertExactJson([
+        'error' => [
+            'code'    => 'VALIDATION_ERROR',
+            'message' => 'Validation failed.',
+        ],
+    ]);
+});
+
+test('validation exception has correct error code and status code', function (): void {
+    $exception = ValidationException::withErrors('Invalid.', ['name' => ['Required.']]);
+
+    expect($exception->getErrorCode())->toBe('VALIDATION_ERROR');
+    expect($exception->getStatusCode())->toBe(422);
+    expect($exception->getErrors())->toBe(['name' => ['Required.']]);
+    expect($exception->hasError('name'))->toBeTrue();
+    expect($exception->hasError('email'))->toBeFalse();
+});
+
+// --- Render method returns null for non-JSON requests ---
+
+test('exceptions return null for non-JSON requests to allow default rendering', function (): void {
+    $exception = new CMSFrameworkException('Test error.');
+    $request   = Request::create('/test', 'GET');
+
+    $result = $exception->render($request);
+
+    expect($result)->toBeNull();
+});
+
+test('exceptions return JsonResponse for JSON requests', function (): void {
+    $exception = new CMSFrameworkException('Test error.');
+    $request   = Request::create('/test', 'GET', [], [], [], ['HTTP_ACCEPT' => 'application/json']);
+
+    $result = $exception->render($request);
+
+    expect($result)->toBeInstanceOf(JsonResponse::class);
+    expect($result->getStatusCode())->toBe(500);
+});
+
+// --- Module-specific exceptions inherit base behavior ---
+
+test('module exceptions that extend CMSFrameworkException inherit JSON rendering', function (): void {
+    // Create a test route for a generic subclass
+    Route::middleware(['api'])->get('/test/module-error', function (): void {
+        throw new class('Module error occurred.') extends CMSFrameworkException {};
+    });
+
+    $response = $this->getJson('/test/module-error');
+
+    $response->assertStatus(500);
+    $response->assertJsonStructure([
+        'error' => [
+            'code',
+            'message',
+        ],
+    ]);
+    $response->assertJsonPath('error.code', 'SERVER_ERROR');
+    $response->assertJsonPath('error.message', 'Module error occurred.');
+});

--- a/tests/Feature/Exceptions/JsonErrorResponseTest.php
+++ b/tests/Feature/Exceptions/JsonErrorResponseTest.php
@@ -229,18 +229,18 @@ test( 'exceptions return JsonResponse for JSON requests', function (): void {
 test( 'module exceptions that extend CMSFrameworkException inherit JSON rendering', function (): void {
     // Create a test route for a generic subclass
     Route::middleware( ['api'] )->get( '/test/module-error', function (): void {
-        throw new class( 'Module error occurred.') extends CMSFrameworkException {};
-    });
+        throw new class( 'Module error occurred.' ) extends CMSFrameworkException {};
+    } );
 
-    $response = $this->getJson( '/test/module-error');
+    $response = $this->getJson( '/test/module-error' );
 
-    $response->assertStatus( 500);
+    $response->assertStatus( 500 );
     $response->assertJsonStructure( [
         'error' => [
             'code',
             'message',
         ],
-    ]);
-    $response->assertJsonPath( 'error.code', 'SERVER_ERROR');
-    $response->assertJsonPath( 'error.message', 'Module error occurred.');
-});
+    ] );
+    $response->assertJsonPath( 'error.code', 'SERVER_ERROR' );
+    $response->assertJsonPath( 'error.message', 'Module error occurred.' );
+} );

--- a/tests/Feature/IncludableRelationshipsTest.php
+++ b/tests/Feature/IncludableRelationshipsTest.php
@@ -206,14 +206,14 @@ test( 'role update loads requested includes', function (): void {
 
     $response->assertSuccessful();
     expect( $response->json( 'data.permissions' ) )->toHaveCount( 1 );
-});
+} );
 
 test( 'role index ignores invalid include values', function (): void {
     $actor = authenticatedRoleManager();
     Role::factory()->admin()->create();
 
-    $response = $this->actingAs( $actor)->getJson( '/api/v1/roles?include=nonexistent');
+    $response = $this->actingAs( $actor )->getJson( '/api/v1/roles?include=nonexistent' );
 
     $response->assertSuccessful();
-    expect( $response->json( 'data.0'))->not->toHaveKey( 'permissions');
-});
+    expect( $response->json( 'data.0' ) )->not->toHaveKey( 'permissions' );
+} );

--- a/tests/Feature/IncludableRelationshipsTest.php
+++ b/tests/Feature/IncludableRelationshipsTest.php
@@ -15,12 +15,47 @@ function grantRolePermission(string $permission): void
     Gate::define($permission, fn () => true);
 }
 
+/**
+ * Create a test user with an attached role.
+ */
+function createUserWithRole(string $roleState = 'admin'): TestUser
+{
+    $user = TestUser::factory()->create();
+    $role = Role::factory()->{$roleState}()->create();
+    $user->roles()->attach($role);
+
+    return $user;
+}
+
+/**
+ * Create a role with an attached permission.
+ *
+ * @return array{role: Role, permission: Permission}
+ */
+function createRoleWithPermission(): array
+{
+    $role       = Role::factory()->admin()->create();
+    $permission = Permission::create(['name' => 'Edit Posts', 'slug' => 'edit-posts']);
+    $role->permissions()->attach($permission);
+
+    return ['role' => $role, 'permission' => $permission];
+}
+
+/**
+ * Create an authenticated user with role management permission granted.
+ */
+function authenticatedRoleManager(): TestUser
+{
+    $user = TestUser::factory()->create();
+    grantRolePermission('roles.manage');
+
+    return $user;
+}
+
 // --- User Controller: include parameter tests ---
 
 test('user index returns roles by default when no include param', function (): void {
-    $user = TestUser::factory()->create();
-    $role = Role::factory()->admin()->create();
-    $user->roles()->attach($role);
+    $user = createUserWithRole();
 
     $response = $this->getJson('/api/v1/users');
 
@@ -30,9 +65,7 @@ test('user index returns roles by default when no include param', function (): v
 });
 
 test('user index loads only requested includes', function (): void {
-    $user = TestUser::factory()->create();
-    $role = Role::factory()->admin()->create();
-    $user->roles()->attach($role);
+    $user = createUserWithRole();
 
     $response = $this->getJson('/api/v1/users?include=roles');
 
@@ -41,31 +74,25 @@ test('user index loads only requested includes', function (): void {
 });
 
 test('user index returns empty roles when include is empty string', function (): void {
-    $user = TestUser::factory()->create();
-    $role = Role::factory()->admin()->create();
-    $user->roles()->attach($role);
+    $user = createUserWithRole();
 
     $response = $this->getJson('/api/v1/users?include=');
 
     $response->assertSuccessful();
-    // With empty include, no relationships are loaded, so roles won't be in response
     expect($response->json('data.0'))->not->toHaveKey('roles');
 });
 
 test('user index ignores invalid include values', function (): void {
-    $user = TestUser::factory()->create();
+    TestUser::factory()->create();
 
     $response = $this->getJson('/api/v1/users?include=nonexistent,invalid');
 
     $response->assertSuccessful();
-    // Invalid includes are silently ignored, no relationships loaded
     expect($response->json('data.0'))->not->toHaveKey('roles');
 });
 
 test('user index filters out invalid includes but keeps valid ones', function (): void {
-    $user = TestUser::factory()->create();
-    $role = Role::factory()->admin()->create();
-    $user->roles()->attach($role);
+    $user = createUserWithRole();
 
     $response = $this->getJson('/api/v1/users?include=roles,nonexistent');
 
@@ -74,9 +101,7 @@ test('user index filters out invalid includes but keeps valid ones', function ()
 });
 
 test('user show loads requested includes', function (): void {
-    $user = TestUser::factory()->create();
-    $role = Role::factory()->editor()->create();
-    $user->roles()->attach($role);
+    $user = createUserWithRole('editor');
 
     $response = $this->getJson("/api/v1/users/{$user->id}?include=roles");
 
@@ -86,9 +111,7 @@ test('user show loads requested includes', function (): void {
 });
 
 test('user show omits relationships with empty include', function (): void {
-    $user = TestUser::factory()->create();
-    $role = Role::factory()->admin()->create();
-    $user->roles()->attach($role);
+    $user = createUserWithRole();
 
     $response = $this->getJson("/api/v1/users/{$user->id}?include=");
 
@@ -108,9 +131,7 @@ test('user store loads requested includes', function (): void {
 });
 
 test('user update loads requested includes', function (): void {
-    $user = TestUser::factory()->create();
-    $role = Role::factory()->admin()->create();
-    $user->roles()->attach($role);
+    $user = createUserWithRole();
 
     $response = $this->putJson("/api/v1/users/{$user->id}?include=roles", [
         'name' => 'Updated Name',
@@ -123,14 +144,10 @@ test('user update loads requested includes', function (): void {
 // --- Role Controller: include parameter tests ---
 
 test('role index returns permissions by default when no include param', function (): void {
-    $user = TestUser::factory()->create();
-    grantRolePermission('roles.manage');
+    $actor                          = authenticatedRoleManager();
+    ['role' => $role]               = createRoleWithPermission();
 
-    $role       = Role::factory()->admin()->create();
-    $permission = Permission::create(['name' => 'Edit Posts', 'slug' => 'edit-posts']);
-    $role->permissions()->attach($permission);
-
-    $response = $this->actingAs($user)->getJson('/api/v1/roles');
+    $response = $this->actingAs($actor)->getJson('/api/v1/roles');
 
     $response->assertSuccessful();
     expect($response->json('data.0.permissions'))->toHaveCount(1);
@@ -138,52 +155,39 @@ test('role index returns permissions by default when no include param', function
 });
 
 test('role index loads only requested includes', function (): void {
-    $user = TestUser::factory()->create();
-    grantRolePermission('roles.manage');
+    $actor = authenticatedRoleManager();
+    createRoleWithPermission();
 
-    $role       = Role::factory()->admin()->create();
-    $permission = Permission::create(['name' => 'Edit Posts', 'slug' => 'edit-posts']);
-    $role->permissions()->attach($permission);
-
-    $response = $this->actingAs($user)->getJson('/api/v1/roles?include=permissions');
+    $response = $this->actingAs($actor)->getJson('/api/v1/roles?include=permissions');
 
     $response->assertSuccessful();
     expect($response->json('data.0.permissions'))->toHaveCount(1);
 });
 
 test('role index omits permissions with empty include', function (): void {
-    $user = TestUser::factory()->create();
-    grantRolePermission('roles.manage');
+    $actor = authenticatedRoleManager();
+    createRoleWithPermission();
 
-    $role       = Role::factory()->admin()->create();
-    $permission = Permission::create(['name' => 'Edit Posts', 'slug' => 'edit-posts']);
-    $role->permissions()->attach($permission);
-
-    $response = $this->actingAs($user)->getJson('/api/v1/roles?include=');
+    $response = $this->actingAs($actor)->getJson('/api/v1/roles?include=');
 
     $response->assertSuccessful();
     expect($response->json('data.0'))->not->toHaveKey('permissions');
 });
 
 test('role show loads requested includes', function (): void {
-    $user = TestUser::factory()->create();
-    grantRolePermission('roles.manage');
+    $actor                          = authenticatedRoleManager();
+    ['role' => $role]               = createRoleWithPermission();
 
-    $role       = Role::factory()->admin()->create();
-    $permission = Permission::create(['name' => 'Edit Posts', 'slug' => 'edit-posts']);
-    $role->permissions()->attach($permission);
-
-    $response = $this->actingAs($user)->getJson("/api/v1/roles/{$role->id}?include=permissions");
+    $response = $this->actingAs($actor)->getJson("/api/v1/roles/{$role->id}?include=permissions");
 
     $response->assertSuccessful();
     expect($response->json('data.permissions'))->toHaveCount(1);
 });
 
 test('role store loads requested includes', function (): void {
-    $user = TestUser::factory()->create();
-    grantRolePermission('roles.manage');
+    $actor = authenticatedRoleManager();
 
-    $response = $this->actingAs($user)->postJson('/api/v1/roles?include=permissions', [
+    $response = $this->actingAs($actor)->postJson('/api/v1/roles?include=permissions', [
         'name' => 'New Role',
         'slug' => 'new-role',
     ]);
@@ -193,14 +197,10 @@ test('role store loads requested includes', function (): void {
 });
 
 test('role update loads requested includes', function (): void {
-    $user = TestUser::factory()->create();
-    grantRolePermission('roles.manage');
+    $actor                          = authenticatedRoleManager();
+    ['role' => $role]               = createRoleWithPermission();
 
-    $role       = Role::factory()->admin()->create();
-    $permission = Permission::create(['name' => 'Edit Posts', 'slug' => 'edit-posts']);
-    $role->permissions()->attach($permission);
-
-    $response = $this->actingAs($user)->putJson("/api/v1/roles/{$role->id}?include=permissions", [
+    $response = $this->actingAs($actor)->putJson("/api/v1/roles/{$role->id}?include=permissions", [
         'name' => 'Updated Admin',
     ]);
 
@@ -209,12 +209,10 @@ test('role update loads requested includes', function (): void {
 });
 
 test('role index ignores invalid include values', function (): void {
-    $user = TestUser::factory()->create();
-    grantRolePermission('roles.manage');
+    $actor = authenticatedRoleManager();
+    Role::factory()->admin()->create();
 
-    $role = Role::factory()->admin()->create();
-
-    $response = $this->actingAs($user)->getJson('/api/v1/roles?include=nonexistent');
+    $response = $this->actingAs($actor)->getJson('/api/v1/roles?include=nonexistent');
 
     $response->assertSuccessful();
     expect($response->json('data.0'))->not->toHaveKey('permissions');

--- a/tests/Feature/IncludableRelationshipsTest.php
+++ b/tests/Feature/IncludableRelationshipsTest.php
@@ -5,6 +5,15 @@ declare(strict_types=1);
 use ArtisanPackUI\CMSFramework\Modules\Users\Models\Permission;
 use ArtisanPackUI\CMSFramework\Modules\Users\Models\Role;
 use ArtisanPackUI\CMSFramework\Tests\Support\TestUser;
+use Illuminate\Support\Facades\Gate;
+
+/**
+ * Grant a permission capability via Gate for testing authorization.
+ */
+function grantRolePermission(string $permission): void
+{
+    Gate::define($permission, fn () => true);
+}
 
 // --- User Controller: include parameter tests ---
 
@@ -114,11 +123,14 @@ test('user update loads requested includes', function (): void {
 // --- Role Controller: include parameter tests ---
 
 test('role index returns permissions by default when no include param', function (): void {
+    $user = TestUser::factory()->create();
+    grantRolePermission('roles.manage');
+
     $role       = Role::factory()->admin()->create();
     $permission = Permission::create(['name' => 'Edit Posts', 'slug' => 'edit-posts']);
     $role->permissions()->attach($permission);
 
-    $response = $this->getJson('/api/v1/roles');
+    $response = $this->actingAs($user)->getJson('/api/v1/roles');
 
     $response->assertSuccessful();
     expect($response->json('data.0.permissions'))->toHaveCount(1);
@@ -126,40 +138,52 @@ test('role index returns permissions by default when no include param', function
 });
 
 test('role index loads only requested includes', function (): void {
+    $user = TestUser::factory()->create();
+    grantRolePermission('roles.manage');
+
     $role       = Role::factory()->admin()->create();
     $permission = Permission::create(['name' => 'Edit Posts', 'slug' => 'edit-posts']);
     $role->permissions()->attach($permission);
 
-    $response = $this->getJson('/api/v1/roles?include=permissions');
+    $response = $this->actingAs($user)->getJson('/api/v1/roles?include=permissions');
 
     $response->assertSuccessful();
     expect($response->json('data.0.permissions'))->toHaveCount(1);
 });
 
 test('role index omits permissions with empty include', function (): void {
+    $user = TestUser::factory()->create();
+    grantRolePermission('roles.manage');
+
     $role       = Role::factory()->admin()->create();
     $permission = Permission::create(['name' => 'Edit Posts', 'slug' => 'edit-posts']);
     $role->permissions()->attach($permission);
 
-    $response = $this->getJson('/api/v1/roles?include=');
+    $response = $this->actingAs($user)->getJson('/api/v1/roles?include=');
 
     $response->assertSuccessful();
     expect($response->json('data.0'))->not->toHaveKey('permissions');
 });
 
 test('role show loads requested includes', function (): void {
+    $user = TestUser::factory()->create();
+    grantRolePermission('roles.manage');
+
     $role       = Role::factory()->admin()->create();
     $permission = Permission::create(['name' => 'Edit Posts', 'slug' => 'edit-posts']);
     $role->permissions()->attach($permission);
 
-    $response = $this->getJson("/api/v1/roles/{$role->id}?include=permissions");
+    $response = $this->actingAs($user)->getJson("/api/v1/roles/{$role->id}?include=permissions");
 
     $response->assertSuccessful();
     expect($response->json('data.permissions'))->toHaveCount(1);
 });
 
 test('role store loads requested includes', function (): void {
-    $response = $this->postJson('/api/v1/roles?include=permissions', [
+    $user = TestUser::factory()->create();
+    grantRolePermission('roles.manage');
+
+    $response = $this->actingAs($user)->postJson('/api/v1/roles?include=permissions', [
         'name' => 'New Role',
         'slug' => 'new-role',
     ]);
@@ -169,11 +193,14 @@ test('role store loads requested includes', function (): void {
 });
 
 test('role update loads requested includes', function (): void {
+    $user = TestUser::factory()->create();
+    grantRolePermission('roles.manage');
+
     $role       = Role::factory()->admin()->create();
     $permission = Permission::create(['name' => 'Edit Posts', 'slug' => 'edit-posts']);
     $role->permissions()->attach($permission);
 
-    $response = $this->putJson("/api/v1/roles/{$role->id}?include=permissions", [
+    $response = $this->actingAs($user)->putJson("/api/v1/roles/{$role->id}?include=permissions", [
         'name' => 'Updated Admin',
     ]);
 
@@ -182,9 +209,12 @@ test('role update loads requested includes', function (): void {
 });
 
 test('role index ignores invalid include values', function (): void {
+    $user = TestUser::factory()->create();
+    grantRolePermission('roles.manage');
+
     $role = Role::factory()->admin()->create();
 
-    $response = $this->getJson('/api/v1/roles?include=nonexistent');
+    $response = $this->actingAs($user)->getJson('/api/v1/roles?include=nonexistent');
 
     $response->assertSuccessful();
     expect($response->json('data.0'))->not->toHaveKey('permissions');

--- a/tests/Feature/IncludableRelationshipsTest.php
+++ b/tests/Feature/IncludableRelationshipsTest.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare( strict_types=1 );
 
 use ArtisanPackUI\CMSFramework\Modules\Users\Models\Permission;
 use ArtisanPackUI\CMSFramework\Modules\Users\Models\Role;
@@ -10,19 +10,19 @@ use Illuminate\Support\Facades\Gate;
 /**
  * Grant a permission capability via Gate for testing authorization.
  */
-function grantRolePermission(string $permission): void
+function grantRolePermission( string $permission ): void
 {
-    Gate::define($permission, fn () => true);
+    Gate::define( $permission, fn () => true );
 }
 
 /**
  * Create a test user with an attached role.
  */
-function createUserWithRole(string $roleState = 'admin'): TestUser
+function createUserWithRole( string $roleState = 'admin' ): TestUser
 {
     $user = TestUser::factory()->create();
     $role = Role::factory()->{$roleState}()->create();
-    $user->roles()->attach($role);
+    $user->roles()->attach( $role );
 
     return $user;
 }
@@ -35,8 +35,8 @@ function createUserWithRole(string $roleState = 'admin'): TestUser
 function createRoleWithPermission(): array
 {
     $role       = Role::factory()->admin()->create();
-    $permission = Permission::create(['name' => 'Edit Posts', 'slug' => 'edit-posts']);
-    $role->permissions()->attach($permission);
+    $permission = Permission::create( ['name' => 'Edit Posts', 'slug' => 'edit-posts'] );
+    $role->permissions()->attach( $permission );
 
     return ['role' => $role, 'permission' => $permission];
 }
@@ -47,173 +47,173 @@ function createRoleWithPermission(): array
 function authenticatedRoleManager(): TestUser
 {
     $user = TestUser::factory()->create();
-    grantRolePermission('roles.manage');
+    grantRolePermission( 'roles.manage' );
 
     return $user;
 }
 
 // --- User Controller: include parameter tests ---
 
-test('user index returns roles by default when no include param', function (): void {
+test( 'user index returns roles by default when no include param', function (): void {
     $user = createUserWithRole();
 
-    $response = $this->getJson('/api/v1/users');
+    $response = $this->getJson( '/api/v1/users' );
 
     $response->assertSuccessful();
-    expect($response->json('data.0.roles'))->toHaveCount(1);
-    expect($response->json('data.0.roles.0.slug'))->toBe('admin');
-});
+    expect( $response->json( 'data.0.roles' ) )->toHaveCount( 1 );
+    expect( $response->json( 'data.0.roles.0.slug' ) )->toBe( 'admin' );
+} );
 
-test('user index loads only requested includes', function (): void {
+test( 'user index loads only requested includes', function (): void {
     $user = createUserWithRole();
 
-    $response = $this->getJson('/api/v1/users?include=roles');
+    $response = $this->getJson( '/api/v1/users?include=roles' );
 
     $response->assertSuccessful();
-    expect($response->json('data.0.roles'))->toHaveCount(1);
-});
+    expect( $response->json( 'data.0.roles' ) )->toHaveCount( 1 );
+} );
 
-test('user index returns empty roles when include is empty string', function (): void {
+test( 'user index returns empty roles when include is empty string', function (): void {
     $user = createUserWithRole();
 
-    $response = $this->getJson('/api/v1/users?include=');
+    $response = $this->getJson( '/api/v1/users?include=' );
 
     $response->assertSuccessful();
-    expect($response->json('data.0'))->not->toHaveKey('roles');
-});
+    expect( $response->json( 'data.0' ) )->not->toHaveKey( 'roles' );
+} );
 
-test('user index ignores invalid include values', function (): void {
+test( 'user index ignores invalid include values', function (): void {
     TestUser::factory()->create();
 
-    $response = $this->getJson('/api/v1/users?include=nonexistent,invalid');
+    $response = $this->getJson( '/api/v1/users?include=nonexistent,invalid' );
 
     $response->assertSuccessful();
-    expect($response->json('data.0'))->not->toHaveKey('roles');
-});
+    expect( $response->json( 'data.0' ) )->not->toHaveKey( 'roles' );
+} );
 
-test('user index filters out invalid includes but keeps valid ones', function (): void {
+test( 'user index filters out invalid includes but keeps valid ones', function (): void {
     $user = createUserWithRole();
 
-    $response = $this->getJson('/api/v1/users?include=roles,nonexistent');
+    $response = $this->getJson( '/api/v1/users?include=roles,nonexistent' );
 
     $response->assertSuccessful();
-    expect($response->json('data.0.roles'))->toHaveCount(1);
-});
+    expect( $response->json( 'data.0.roles' ) )->toHaveCount( 1 );
+} );
 
-test('user show loads requested includes', function (): void {
-    $user = createUserWithRole('editor');
+test( 'user show loads requested includes', function (): void {
+    $user = createUserWithRole( 'editor' );
 
-    $response = $this->getJson("/api/v1/users/{$user->id}?include=roles");
+    $response = $this->getJson( "/api/v1/users/{$user->id}?include=roles" );
 
     $response->assertSuccessful();
-    expect($response->json('data.roles'))->toHaveCount(1);
-    expect($response->json('data.roles.0.slug'))->toBe('editor');
-});
+    expect( $response->json( 'data.roles' ) )->toHaveCount( 1 );
+    expect( $response->json( 'data.roles.0.slug' ) )->toBe( 'editor' );
+} );
 
-test('user show omits relationships with empty include', function (): void {
+test( 'user show omits relationships with empty include', function (): void {
     $user = createUserWithRole();
 
-    $response = $this->getJson("/api/v1/users/{$user->id}?include=");
+    $response = $this->getJson( "/api/v1/users/{$user->id}?include=" );
 
     $response->assertSuccessful();
-    expect($response->json('data'))->not->toHaveKey('roles');
-});
+    expect( $response->json( 'data' ) )->not->toHaveKey( 'roles' );
+} );
 
-test('user store loads requested includes', function (): void {
-    $response = $this->postJson('/api/v1/users?include=roles', [
+test( 'user store loads requested includes', function (): void {
+    $response = $this->postJson( '/api/v1/users?include=roles', [
         'name'     => 'Test User',
         'email'    => 'test@example.com',
         'password' => 'password123',
-    ]);
+    ] );
 
-    $response->assertStatus(201);
-    expect($response->json('data.roles'))->toBeArray();
-});
+    $response->assertStatus( 201 );
+    expect( $response->json( 'data.roles' ) )->toBeArray();
+} );
 
-test('user update loads requested includes', function (): void {
+test( 'user update loads requested includes', function (): void {
     $user = createUserWithRole();
 
-    $response = $this->putJson("/api/v1/users/{$user->id}?include=roles", [
+    $response = $this->putJson( "/api/v1/users/{$user->id}?include=roles", [
         'name' => 'Updated Name',
-    ]);
+    ] );
 
     $response->assertSuccessful();
-    expect($response->json('data.roles'))->toHaveCount(1);
-});
+    expect( $response->json( 'data.roles' ) )->toHaveCount( 1 );
+} );
 
 // --- Role Controller: include parameter tests ---
 
-test('role index returns permissions by default when no include param', function (): void {
+test( 'role index returns permissions by default when no include param', function (): void {
     $actor                          = authenticatedRoleManager();
     ['role' => $role]               = createRoleWithPermission();
 
-    $response = $this->actingAs($actor)->getJson('/api/v1/roles');
+    $response = $this->actingAs( $actor )->getJson( '/api/v1/roles' );
 
     $response->assertSuccessful();
-    expect($response->json('data.0.permissions'))->toHaveCount(1);
-    expect($response->json('data.0.permissions.0.slug'))->toBe('edit-posts');
-});
+    expect( $response->json( 'data.0.permissions' ) )->toHaveCount( 1 );
+    expect( $response->json( 'data.0.permissions.0.slug' ) )->toBe( 'edit-posts' );
+} );
 
-test('role index loads only requested includes', function (): void {
+test( 'role index loads only requested includes', function (): void {
     $actor = authenticatedRoleManager();
     createRoleWithPermission();
 
-    $response = $this->actingAs($actor)->getJson('/api/v1/roles?include=permissions');
+    $response = $this->actingAs( $actor )->getJson( '/api/v1/roles?include=permissions' );
 
     $response->assertSuccessful();
-    expect($response->json('data.0.permissions'))->toHaveCount(1);
-});
+    expect( $response->json( 'data.0.permissions' ) )->toHaveCount( 1 );
+} );
 
-test('role index omits permissions with empty include', function (): void {
+test( 'role index omits permissions with empty include', function (): void {
     $actor = authenticatedRoleManager();
     createRoleWithPermission();
 
-    $response = $this->actingAs($actor)->getJson('/api/v1/roles?include=');
+    $response = $this->actingAs( $actor )->getJson( '/api/v1/roles?include=' );
 
     $response->assertSuccessful();
-    expect($response->json('data.0'))->not->toHaveKey('permissions');
-});
+    expect( $response->json( 'data.0' ) )->not->toHaveKey( 'permissions' );
+} );
 
-test('role show loads requested includes', function (): void {
+test( 'role show loads requested includes', function (): void {
     $actor                          = authenticatedRoleManager();
     ['role' => $role]               = createRoleWithPermission();
 
-    $response = $this->actingAs($actor)->getJson("/api/v1/roles/{$role->id}?include=permissions");
+    $response = $this->actingAs( $actor )->getJson( "/api/v1/roles/{$role->id}?include=permissions" );
 
     $response->assertSuccessful();
-    expect($response->json('data.permissions'))->toHaveCount(1);
-});
+    expect( $response->json( 'data.permissions' ) )->toHaveCount( 1 );
+} );
 
-test('role store loads requested includes', function (): void {
+test( 'role store loads requested includes', function (): void {
     $actor = authenticatedRoleManager();
 
-    $response = $this->actingAs($actor)->postJson('/api/v1/roles?include=permissions', [
+    $response = $this->actingAs( $actor )->postJson( '/api/v1/roles?include=permissions', [
         'name' => 'New Role',
         'slug' => 'new-role',
-    ]);
+    ] );
 
-    $response->assertStatus(201);
-    expect($response->json('data.permissions'))->toBeArray();
-});
+    $response->assertStatus( 201 );
+    expect( $response->json( 'data.permissions' ) )->toBeArray();
+} );
 
-test('role update loads requested includes', function (): void {
+test( 'role update loads requested includes', function (): void {
     $actor                          = authenticatedRoleManager();
     ['role' => $role]               = createRoleWithPermission();
 
-    $response = $this->actingAs($actor)->putJson("/api/v1/roles/{$role->id}?include=permissions", [
+    $response = $this->actingAs( $actor )->putJson( "/api/v1/roles/{$role->id}?include=permissions", [
         'name' => 'Updated Admin',
-    ]);
+    ] );
 
     $response->assertSuccessful();
-    expect($response->json('data.permissions'))->toHaveCount(1);
+    expect( $response->json( 'data.permissions' ) )->toHaveCount( 1 );
 });
 
-test('role index ignores invalid include values', function (): void {
+test( 'role index ignores invalid include values', function (): void {
     $actor = authenticatedRoleManager();
     Role::factory()->admin()->create();
 
-    $response = $this->actingAs($actor)->getJson('/api/v1/roles?include=nonexistent');
+    $response = $this->actingAs( $actor)->getJson( '/api/v1/roles?include=nonexistent');
 
     $response->assertSuccessful();
-    expect($response->json('data.0'))->not->toHaveKey('permissions');
+    expect( $response->json( 'data.0'))->not->toHaveKey( 'permissions');
 });

--- a/tests/Feature/IncludableRelationshipsTest.php
+++ b/tests/Feature/IncludableRelationshipsTest.php
@@ -1,0 +1,191 @@
+<?php
+
+declare(strict_types=1);
+
+use ArtisanPackUI\CMSFramework\Modules\Users\Models\Permission;
+use ArtisanPackUI\CMSFramework\Modules\Users\Models\Role;
+use ArtisanPackUI\CMSFramework\Tests\Support\TestUser;
+
+// --- User Controller: include parameter tests ---
+
+test('user index returns roles by default when no include param', function (): void {
+    $user = TestUser::factory()->create();
+    $role = Role::factory()->admin()->create();
+    $user->roles()->attach($role);
+
+    $response = $this->getJson('/api/v1/users');
+
+    $response->assertSuccessful();
+    expect($response->json('data.0.roles'))->toHaveCount(1);
+    expect($response->json('data.0.roles.0.slug'))->toBe('admin');
+});
+
+test('user index loads only requested includes', function (): void {
+    $user = TestUser::factory()->create();
+    $role = Role::factory()->admin()->create();
+    $user->roles()->attach($role);
+
+    $response = $this->getJson('/api/v1/users?include=roles');
+
+    $response->assertSuccessful();
+    expect($response->json('data.0.roles'))->toHaveCount(1);
+});
+
+test('user index returns empty roles when include is empty string', function (): void {
+    $user = TestUser::factory()->create();
+    $role = Role::factory()->admin()->create();
+    $user->roles()->attach($role);
+
+    $response = $this->getJson('/api/v1/users?include=');
+
+    $response->assertSuccessful();
+    // With empty include, no relationships are loaded, so roles won't be in response
+    expect($response->json('data.0'))->not->toHaveKey('roles');
+});
+
+test('user index ignores invalid include values', function (): void {
+    $user = TestUser::factory()->create();
+
+    $response = $this->getJson('/api/v1/users?include=nonexistent,invalid');
+
+    $response->assertSuccessful();
+    // Invalid includes are silently ignored, no relationships loaded
+    expect($response->json('data.0'))->not->toHaveKey('roles');
+});
+
+test('user index filters out invalid includes but keeps valid ones', function (): void {
+    $user = TestUser::factory()->create();
+    $role = Role::factory()->admin()->create();
+    $user->roles()->attach($role);
+
+    $response = $this->getJson('/api/v1/users?include=roles,nonexistent');
+
+    $response->assertSuccessful();
+    expect($response->json('data.0.roles'))->toHaveCount(1);
+});
+
+test('user show loads requested includes', function (): void {
+    $user = TestUser::factory()->create();
+    $role = Role::factory()->editor()->create();
+    $user->roles()->attach($role);
+
+    $response = $this->getJson("/api/v1/users/{$user->id}?include=roles");
+
+    $response->assertSuccessful();
+    expect($response->json('data.roles'))->toHaveCount(1);
+    expect($response->json('data.roles.0.slug'))->toBe('editor');
+});
+
+test('user show omits relationships with empty include', function (): void {
+    $user = TestUser::factory()->create();
+    $role = Role::factory()->admin()->create();
+    $user->roles()->attach($role);
+
+    $response = $this->getJson("/api/v1/users/{$user->id}?include=");
+
+    $response->assertSuccessful();
+    expect($response->json('data'))->not->toHaveKey('roles');
+});
+
+test('user store loads requested includes', function (): void {
+    $response = $this->postJson('/api/v1/users?include=roles', [
+        'name'     => 'Test User',
+        'email'    => 'test@example.com',
+        'password' => 'password123',
+    ]);
+
+    $response->assertStatus(201);
+    expect($response->json('data.roles'))->toBeArray();
+});
+
+test('user update loads requested includes', function (): void {
+    $user = TestUser::factory()->create();
+    $role = Role::factory()->admin()->create();
+    $user->roles()->attach($role);
+
+    $response = $this->putJson("/api/v1/users/{$user->id}?include=roles", [
+        'name' => 'Updated Name',
+    ]);
+
+    $response->assertSuccessful();
+    expect($response->json('data.roles'))->toHaveCount(1);
+});
+
+// --- Role Controller: include parameter tests ---
+
+test('role index returns permissions by default when no include param', function (): void {
+    $role       = Role::factory()->admin()->create();
+    $permission = Permission::create(['name' => 'Edit Posts', 'slug' => 'edit-posts']);
+    $role->permissions()->attach($permission);
+
+    $response = $this->getJson('/api/v1/roles');
+
+    $response->assertSuccessful();
+    expect($response->json('data.0.permissions'))->toHaveCount(1);
+    expect($response->json('data.0.permissions.0.slug'))->toBe('edit-posts');
+});
+
+test('role index loads only requested includes', function (): void {
+    $role       = Role::factory()->admin()->create();
+    $permission = Permission::create(['name' => 'Edit Posts', 'slug' => 'edit-posts']);
+    $role->permissions()->attach($permission);
+
+    $response = $this->getJson('/api/v1/roles?include=permissions');
+
+    $response->assertSuccessful();
+    expect($response->json('data.0.permissions'))->toHaveCount(1);
+});
+
+test('role index omits permissions with empty include', function (): void {
+    $role       = Role::factory()->admin()->create();
+    $permission = Permission::create(['name' => 'Edit Posts', 'slug' => 'edit-posts']);
+    $role->permissions()->attach($permission);
+
+    $response = $this->getJson('/api/v1/roles?include=');
+
+    $response->assertSuccessful();
+    expect($response->json('data.0'))->not->toHaveKey('permissions');
+});
+
+test('role show loads requested includes', function (): void {
+    $role       = Role::factory()->admin()->create();
+    $permission = Permission::create(['name' => 'Edit Posts', 'slug' => 'edit-posts']);
+    $role->permissions()->attach($permission);
+
+    $response = $this->getJson("/api/v1/roles/{$role->id}?include=permissions");
+
+    $response->assertSuccessful();
+    expect($response->json('data.permissions'))->toHaveCount(1);
+});
+
+test('role store loads requested includes', function (): void {
+    $response = $this->postJson('/api/v1/roles?include=permissions', [
+        'name' => 'New Role',
+        'slug' => 'new-role',
+    ]);
+
+    $response->assertStatus(201);
+    expect($response->json('data.permissions'))->toBeArray();
+});
+
+test('role update loads requested includes', function (): void {
+    $role       = Role::factory()->admin()->create();
+    $permission = Permission::create(['name' => 'Edit Posts', 'slug' => 'edit-posts']);
+    $role->permissions()->attach($permission);
+
+    $response = $this->putJson("/api/v1/roles/{$role->id}?include=permissions", [
+        'name' => 'Updated Admin',
+    ]);
+
+    $response->assertSuccessful();
+    expect($response->json('data.permissions'))->toHaveCount(1);
+});
+
+test('role index ignores invalid include values', function (): void {
+    $role = Role::factory()->admin()->create();
+
+    $response = $this->getJson('/api/v1/roles?include=nonexistent');
+
+    $response->assertSuccessful();
+    expect($response->json('data.0'))->not->toHaveKey('permissions');
+});

--- a/tests/Feature/Notifications/HasNotificationsTraitTest.php
+++ b/tests/Feature/Notifications/HasNotificationsTraitTest.php
@@ -149,4 +149,4 @@ test( 'user can get unread notifications count', function (): void {
     $count = $user->unreadSystemNotificationsCount();
 
     expect( $count )->toBe( 2 );
-});
+} );

--- a/tests/Feature/Notifications/HasNotificationsTraitTest.php
+++ b/tests/Feature/Notifications/HasNotificationsTraitTest.php
@@ -143,10 +143,10 @@ test( 'user can get unread notifications count', function (): void {
     $notification1 = Notification::factory()->create();
     $notification2 = Notification::factory()->create();
 
-    $notification1->users()->attach( $user->id, ['is_read' => false, 'is_dismissed' => false]);
-    $notification2->users()->attach( $user->id, ['is_read' => false, 'is_dismissed' => false]);
+    $notification1->users()->attach( $user->id, ['is_read' => false, 'is_dismissed' => false] );
+    $notification2->users()->attach( $user->id, ['is_read' => false, 'is_dismissed' => false] );
 
     $count = $user->unreadSystemNotificationsCount();
 
-    expect( $count)->toBe( 2);
+    expect( $count )->toBe( 2 );
 });

--- a/tests/Feature/Notifications/NotificationHelpersTest.php
+++ b/tests/Feature/Notifications/NotificationHelpersTest.php
@@ -33,7 +33,7 @@ test( 'apSendNotification helper sends notification to users', function (): void
 } );
 
 test( 'apSendNotificationByRole helper sends by role', function (): void {
-    $role   = \ArtisanPackUI\CMSFramework\Modules\Users\Models\Role::factory()->create( ['name' => 'Admin'] );
+    $role   = ArtisanPackUI\CMSFramework\Modules\Users\Models\Role::factory()->create( ['name' => 'Admin'] );
     $user1  = User::factory()->create();
     $user2  = User::factory()->create();
     $user3  = User::factory()->create();
@@ -139,11 +139,11 @@ test( 'apGetUnreadNotificationCount helper returns unread count', function (): v
 } );
 
 test( 'apGetRegisteredNotifications helper returns all registered notifications', function (): void {
-    apRegisterNotification( 'test.one', 'Test One', 'Content One');
-    apRegisterNotification( 'test.two', 'Test Two', 'Content Two');
+    apRegisterNotification( 'test.one', 'Test One', 'Content One' );
+    apRegisterNotification( 'test.two', 'Test Two', 'Content Two' );
 
     $registered = apGetRegisteredNotifications();
 
-    expect( $registered)->toHaveKey( 'test.one')
-        ->and( $registered)->toHaveKey( 'test.two');
+    expect( $registered )->toHaveKey( 'test.one' )
+        ->and( $registered )->toHaveKey( 'test.two' );
 });

--- a/tests/Feature/Notifications/NotificationHelpersTest.php
+++ b/tests/Feature/Notifications/NotificationHelpersTest.php
@@ -146,4 +146,4 @@ test( 'apGetRegisteredNotifications helper returns all registered notifications'
 
     expect( $registered )->toHaveKey( 'test.one' )
         ->and( $registered )->toHaveKey( 'test.two' );
-});
+} );

--- a/tests/Feature/Notifications/NotificationManagerTest.php
+++ b/tests/Feature/Notifications/NotificationManagerTest.php
@@ -177,7 +177,7 @@ test( 'sendNotification respects email preferences', function (): void {
 test( 'sendNotificationByRole sends to users with specific role', function (): void {
     $manager = app( NotificationManager::class );
 
-    $role   = \ArtisanPackUI\CMSFramework\Modules\Users\Models\Role::factory()->create( ['name' => 'Editor'] );
+    $role   = ArtisanPackUI\CMSFramework\Modules\Users\Models\Role::factory()->create( ['name' => 'Editor'] );
     $user1  = User::factory()->create();
     $user2  = User::factory()->create();
     $user3  = User::factory()->create();
@@ -358,11 +358,11 @@ test( 'getUnreadCount returns correct unread count', function (): void {
     $notification2 = Notification::factory()->create();
     $notification3 = Notification::factory()->create();
 
-    $notification1->users()->attach( $user->id, ['is_read' => false, 'is_dismissed' => false]);
-    $notification2->users()->attach( $user->id, ['is_read' => false, 'is_dismissed' => false]);
-    $notification3->users()->attach( $user->id, ['is_read' => true, 'is_dismissed' => false]);
+    $notification1->users()->attach( $user->id, ['is_read' => false, 'is_dismissed' => false] );
+    $notification2->users()->attach( $user->id, ['is_read' => false, 'is_dismissed' => false] );
+    $notification3->users()->attach( $user->id, ['is_read' => true, 'is_dismissed' => false] );
 
-    $count = $manager->getUnreadCount( $user->id);
+    $count = $manager->getUnreadCount( $user->id );
 
-    expect( $count)->toBe( 2);
+    expect( $count )->toBe( 2 );
 });

--- a/tests/Feature/Notifications/NotificationManagerTest.php
+++ b/tests/Feature/Notifications/NotificationManagerTest.php
@@ -365,4 +365,4 @@ test( 'getUnreadCount returns correct unread count', function (): void {
     $count = $manager->getUnreadCount( $user->id );
 
     expect( $count )->toBe( 2 );
-});
+} );

--- a/tests/Feature/Notifications/SendNotificationEmailJobTest.php
+++ b/tests/Feature/Notifications/SendNotificationEmailJobTest.php
@@ -48,5 +48,5 @@ test( 'job only sends to existing users', function (): void {
     $job = new SendNotificationEmail( $notification, [$user->id, 9999] );
     $job->handle();
 
-    Mail::assertSent( NotificationMail::class, 1);
+    Mail::assertSent( NotificationMail::class, 1 );
 });

--- a/tests/Feature/OpenApi/OpenApiSpecTest.php
+++ b/tests/Feature/OpenApi/OpenApiSpecTest.php
@@ -1,0 +1,152 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Feature Tests for the OpenAPI Specification Generation.
+ *
+ * Verifies that the OpenAPI specification is generated correctly with
+ * all expected endpoints, groups, and schemas.
+ *
+ * @since 1.1.0
+ */
+
+use Dedoc\Scramble\Generator;
+use Dedoc\Scramble\Scramble;
+
+/**
+ * Helper to generate the OpenAPI spec array for the CMS API.
+ */
+function generateSpec(): array
+{
+    $config    = Scramble::getGeneratorConfig('cms');
+    $generator = app(Generator::class);
+
+    return $generator($config);
+}
+
+test('openapi spec is generated with correct info', function (): void {
+    $spec = generateSpec();
+
+    expect($spec)->toHaveKey('info');
+    expect($spec['info']['title'])->toBe('ArtisanPack CMS Framework API');
+    expect($spec['info']['version'])->toBe('1.1.0');
+});
+
+test('openapi spec contains paths', function (): void {
+    $spec = generateSpec();
+
+    expect($spec)->toHaveKey('paths');
+    expect($spec['paths'])->not->toBeEmpty();
+});
+
+test('openapi spec includes security scheme', function (): void {
+    $spec = generateSpec();
+
+    expect($spec)->toHaveKey('components');
+    expect($spec['components'])->toHaveKey('securitySchemes');
+});
+
+test('openapi spec includes post endpoints', function (): void {
+    $spec  = generateSpec();
+    $paths = array_keys($spec['paths'] ?? []);
+
+    expect($paths)->toContain('/posts');
+    expect($paths)->toContain('/posts/{id}');
+});
+
+test('openapi spec includes page endpoints', function (): void {
+    $spec  = generateSpec();
+    $paths = array_keys($spec['paths'] ?? []);
+
+    expect($paths)->toContain('/pages');
+    expect($paths)->toContain('/pages/{id}');
+});
+
+test('openapi spec includes settings endpoints', function (): void {
+    $spec  = generateSpec();
+    $paths = array_keys($spec['paths'] ?? []);
+
+    expect($paths)->toContain('/settings');
+});
+
+test('openapi spec includes notification endpoints', function (): void {
+    $spec  = generateSpec();
+    $paths = array_keys($spec['paths'] ?? []);
+
+    expect($paths)->toContain('/notifications');
+});
+
+test('openapi spec includes content type endpoints', function (): void {
+    $spec  = generateSpec();
+    $paths = array_keys($spec['paths'] ?? []);
+
+    expect($paths)->toContain('/content-types');
+});
+
+test('openapi spec includes user management endpoints', function (): void {
+    $spec  = generateSpec();
+    $paths = array_keys($spec['paths'] ?? []);
+
+    expect($paths)->toContain('/users');
+    expect($paths)->toContain('/roles');
+    expect($paths)->toContain('/permissions');
+});
+
+test('openapi spec uses tags for grouping', function (): void {
+    $spec = generateSpec();
+
+    expect($spec)->toHaveKey('tags');
+
+    $tagNames = array_column($spec['tags'] ?? [], 'name');
+
+    expect($tagNames)->toContain('Posts');
+    expect($tagNames)->toContain('Pages');
+    expect($tagNames)->toContain('Settings');
+});
+
+test('openapi disabled when config is false', function (): void {
+    config(['artisanpack.cms-framework.openapi.enabled' => false]);
+
+    $provider = new ArtisanPackUI\CMSFramework\Modules\OpenApi\Providers\OpenApiServiceProvider(app());
+    $provider->boot();
+
+    // The provider should skip registration — no error thrown
+    expect(true)->toBeTrue();
+});
+
+test('export command writes openapi spec to file', function (): void {
+    $outputPath = sys_get_temp_dir().'/cms-openapi-test-'.uniqid().'.json';
+
+    $this->artisan('cms:openapi:export', [
+        'path' => $outputPath,
+    ])->assertSuccessful();
+
+    expect(file_exists($outputPath))->toBeTrue();
+
+    $content = file_get_contents($outputPath);
+    $spec    = json_decode($content, true);
+
+    expect($spec)->toBeArray();
+    expect($spec)->toHaveKey('openapi');
+    expect($spec)->toHaveKey('info');
+    expect($spec)->toHaveKey('paths');
+
+    unlink($outputPath);
+});
+
+test('export command supports pretty print', function (): void {
+    $outputPath = sys_get_temp_dir().'/cms-openapi-pretty-test-'.uniqid().'.json';
+
+    $this->artisan('cms:openapi:export', [
+        'path'     => $outputPath,
+        '--pretty' => true,
+    ])->assertSuccessful();
+
+    $content = file_get_contents($outputPath);
+
+    // Pretty-printed JSON contains newlines
+    expect($content)->toContain("\n");
+
+    unlink($outputPath);
+});

--- a/tests/Feature/OpenApi/OpenApiSpecTest.php
+++ b/tests/Feature/OpenApi/OpenApiSpecTest.php
@@ -14,6 +14,18 @@ declare(strict_types=1);
 use Dedoc\Scramble\Generator;
 use Dedoc\Scramble\Scramble;
 
+beforeEach(function (): void {
+    $this->tempFiles = [];
+});
+
+afterEach(function (): void {
+    foreach ($this->tempFiles as $file) {
+        if (file_exists($file)) {
+            unlink($file);
+        }
+    }
+});
+
 /**
  * Helper to generate the OpenAPI spec array for the CMS API.
  */
@@ -119,7 +131,8 @@ test('openapi provider skips registration when disabled', function (): void {
 });
 
 test('export command writes openapi spec to file', function (): void {
-    $outputPath = sys_get_temp_dir().'/cms-openapi-test-'.uniqid().'.json';
+    $outputPath          = sys_get_temp_dir().'/cms-openapi-test-'.uniqid().'.json';
+    $this->tempFiles[]   = $outputPath;
 
     $this->artisan('cms:openapi:export', [
         'path' => $outputPath,
@@ -134,12 +147,11 @@ test('export command writes openapi spec to file', function (): void {
     expect($spec)->toHaveKey('openapi');
     expect($spec)->toHaveKey('info');
     expect($spec)->toHaveKey('paths');
-
-    unlink($outputPath);
 });
 
 test('export command supports pretty print', function (): void {
-    $outputPath = sys_get_temp_dir().'/cms-openapi-pretty-test-'.uniqid().'.json';
+    $outputPath          = sys_get_temp_dir().'/cms-openapi-pretty-test-'.uniqid().'.json';
+    $this->tempFiles[]   = $outputPath;
 
     $this->artisan('cms:openapi:export', [
         'path'     => $outputPath,
@@ -150,6 +162,4 @@ test('export command supports pretty print', function (): void {
 
     // Pretty-printed JSON contains newlines
     expect($content)->toContain("\n");
-
-    unlink($outputPath);
 });

--- a/tests/Feature/OpenApi/OpenApiSpecTest.php
+++ b/tests/Feature/OpenApi/OpenApiSpecTest.php
@@ -26,11 +26,13 @@ function generateSpec(): array
 }
 
 test('openapi spec is generated with correct info', function (): void {
-    $spec = generateSpec();
+    $spec          = generateSpec();
+    $expectedTitle = config('artisanpack.cms-framework.openapi.info.title', 'ArtisanPack CMS Framework API');
+    $expectedVer   = config('artisanpack.cms-framework.openapi.info.version', '1.1.0');
 
     expect($spec)->toHaveKey('info');
-    expect($spec['info']['title'])->toBe('ArtisanPack CMS Framework API');
-    expect($spec['info']['version'])->toBe('1.1.0');
+    expect($spec['info']['title'])->toBe($expectedTitle);
+    expect($spec['info']['version'])->toBe($expectedVer);
 });
 
 test('openapi spec contains paths', function (): void {
@@ -105,14 +107,15 @@ test('openapi spec uses tags for grouping', function (): void {
     expect($tagNames)->toContain('Settings');
 });
 
-test('openapi disabled when config is false', function (): void {
+test('openapi provider skips registration when disabled', function (): void {
     config(['artisanpack.cms-framework.openapi.enabled' => false]);
 
     $provider = new ArtisanPackUI\CMSFramework\Modules\OpenApi\Providers\OpenApiServiceProvider(app());
+
+    // Should not throw — registerCmsApi is skipped when disabled
     $provider->boot();
 
-    // The provider should skip registration — no error thrown
-    expect(true)->toBeTrue();
+    expect(config('artisanpack.cms-framework.openapi.enabled'))->toBeFalse();
 });
 
 test('export command writes openapi spec to file', function (): void {

--- a/tests/Feature/OpenApi/OpenApiSpecTest.php
+++ b/tests/Feature/OpenApi/OpenApiSpecTest.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare( strict_types=1 );
 
 /**
  * Feature Tests for the OpenAPI Specification Generation.
@@ -14,160 +14,160 @@ declare(strict_types=1);
 use Dedoc\Scramble\Generator;
 use Dedoc\Scramble\Scramble;
 
-beforeEach(function (): void {
+beforeEach( function (): void {
     $this->tempFiles = [];
-});
+} );
 
-afterEach(function (): void {
-    foreach ($this->tempFiles as $file) {
-        if (file_exists($file)) {
-            unlink($file);
+afterEach( function (): void {
+    foreach ( $this->tempFiles as $file ) {
+        if ( file_exists( $file ) ) {
+            unlink( $file );
         }
     }
-});
+} );
 
 /**
  * Helper to generate the OpenAPI spec array for the CMS API.
  */
 function generateSpec(): array
 {
-    $config    = Scramble::getGeneratorConfig('cms');
-    $generator = app(Generator::class);
+    $config    = Scramble::getGeneratorConfig( 'cms' );
+    $generator = app( Generator::class );
 
-    return $generator($config);
+    return $generator( $config );
 }
 
-test('openapi spec is generated with correct info', function (): void {
+test( 'openapi spec is generated with correct info', function (): void {
     $spec          = generateSpec();
-    $expectedTitle = config('artisanpack.cms-framework.openapi.info.title', 'ArtisanPack CMS Framework API');
-    $expectedVer   = config('artisanpack.cms-framework.openapi.info.version', '1.1.0');
+    $expectedTitle = config( 'artisanpack.cms-framework.openapi.info.title', 'ArtisanPack CMS Framework API' );
+    $expectedVer   = config( 'artisanpack.cms-framework.openapi.info.version', '1.1.0' );
 
-    expect($spec)->toHaveKey('info');
-    expect($spec['info']['title'])->toBe($expectedTitle);
-    expect($spec['info']['version'])->toBe($expectedVer);
-});
+    expect( $spec )->toHaveKey( 'info' );
+    expect( $spec['info']['title'] )->toBe( $expectedTitle );
+    expect( $spec['info']['version'] )->toBe( $expectedVer );
+} );
 
-test('openapi spec contains paths', function (): void {
+test( 'openapi spec contains paths', function (): void {
     $spec = generateSpec();
 
-    expect($spec)->toHaveKey('paths');
-    expect($spec['paths'])->not->toBeEmpty();
-});
+    expect( $spec )->toHaveKey( 'paths' );
+    expect( $spec['paths'] )->not->toBeEmpty();
+} );
 
-test('openapi spec includes security scheme', function (): void {
+test( 'openapi spec includes security scheme', function (): void {
     $spec = generateSpec();
 
-    expect($spec)->toHaveKey('components');
-    expect($spec['components'])->toHaveKey('securitySchemes');
-});
+    expect( $spec )->toHaveKey( 'components' );
+    expect( $spec['components'] )->toHaveKey( 'securitySchemes' );
+} );
 
-test('openapi spec includes post endpoints', function (): void {
+test( 'openapi spec includes post endpoints', function (): void {
     $spec  = generateSpec();
-    $paths = array_keys($spec['paths'] ?? []);
+    $paths = array_keys( $spec['paths'] ?? [] );
 
-    expect($paths)->toContain('/posts');
-    expect($paths)->toContain('/posts/{id}');
-});
+    expect( $paths )->toContain( '/posts' );
+    expect( $paths )->toContain( '/posts/{id}' );
+} );
 
-test('openapi spec includes page endpoints', function (): void {
+test( 'openapi spec includes page endpoints', function (): void {
     $spec  = generateSpec();
-    $paths = array_keys($spec['paths'] ?? []);
+    $paths = array_keys( $spec['paths'] ?? [] );
 
-    expect($paths)->toContain('/pages');
-    expect($paths)->toContain('/pages/{id}');
-});
+    expect( $paths )->toContain( '/pages' );
+    expect( $paths )->toContain( '/pages/{id}' );
+} );
 
-test('openapi spec includes settings endpoints', function (): void {
+test( 'openapi spec includes settings endpoints', function (): void {
     $spec  = generateSpec();
-    $paths = array_keys($spec['paths'] ?? []);
+    $paths = array_keys( $spec['paths'] ?? [] );
 
-    expect($paths)->toContain('/settings');
-});
+    expect( $paths )->toContain( '/settings' );
+} );
 
-test('openapi spec includes notification endpoints', function (): void {
+test( 'openapi spec includes notification endpoints', function (): void {
     $spec  = generateSpec();
-    $paths = array_keys($spec['paths'] ?? []);
+    $paths = array_keys( $spec['paths'] ?? [] );
 
-    expect($paths)->toContain('/notifications');
-});
+    expect( $paths )->toContain( '/notifications' );
+} );
 
-test('openapi spec includes content type endpoints', function (): void {
+test( 'openapi spec includes content type endpoints', function (): void {
     $spec  = generateSpec();
-    $paths = array_keys($spec['paths'] ?? []);
+    $paths = array_keys( $spec['paths'] ?? [] );
 
-    expect($paths)->toContain('/content-types');
-});
+    expect( $paths )->toContain( '/content-types' );
+} );
 
-test('openapi spec includes user management endpoints', function (): void {
+test( 'openapi spec includes user management endpoints', function (): void {
     $spec  = generateSpec();
-    $paths = array_keys($spec['paths'] ?? []);
+    $paths = array_keys( $spec['paths'] ?? [] );
 
-    expect($paths)->toContain('/users');
-    expect($paths)->toContain('/roles');
-    expect($paths)->toContain('/permissions');
-});
+    expect( $paths )->toContain( '/users' );
+    expect( $paths )->toContain( '/roles' );
+    expect( $paths )->toContain( '/permissions' );
+} );
 
-test('openapi spec uses tags for grouping', function (): void {
+test( 'openapi spec uses tags for grouping', function (): void {
     $spec = generateSpec();
 
-    expect($spec)->toHaveKey('tags');
+    expect( $spec )->toHaveKey( 'tags' );
 
-    $tagNames = array_column($spec['tags'] ?? [], 'name');
+    $tagNames = array_column( $spec['tags'] ?? [], 'name' );
 
-    expect($tagNames)->toContain('Posts');
-    expect($tagNames)->toContain('Pages');
-    expect($tagNames)->toContain('Settings');
-});
+    expect( $tagNames )->toContain( 'Posts' );
+    expect( $tagNames )->toContain( 'Pages' );
+    expect( $tagNames )->toContain( 'Settings' );
+} );
 
-test('openapi provider skips registration when disabled', function (): void {
-    config(['artisanpack.cms-framework.openapi.enabled' => false]);
+test( 'openapi provider skips registration when disabled', function (): void {
+    config( ['artisanpack.cms-framework.openapi.enabled' => false] );
 
-    $provider = new ArtisanPackUI\CMSFramework\Modules\OpenApi\Providers\OpenApiServiceProvider(app());
+    $provider = new ArtisanPackUI\CMSFramework\Modules\OpenApi\Providers\OpenApiServiceProvider( app() );
 
     // Should not throw — registerCmsApi is skipped when disabled
     $provider->boot();
 
-    expect(config('artisanpack.cms-framework.openapi.enabled'))->toBeFalse();
-});
+    expect( config( 'artisanpack.cms-framework.openapi.enabled' ) )->toBeFalse();
+} );
 
-test('export command writes openapi spec to file', function (): void {
-    $outputPath          = sys_get_temp_dir().'/cms-openapi-test-'.uniqid().'.json';
+test( 'export command writes openapi spec to file', function (): void {
+    $outputPath          = sys_get_temp_dir() . '/cms-openapi-test-' . uniqid() . '.json';
     $this->tempFiles[]   = $outputPath;
 
-    $this->artisan('cms:openapi:export', [
+    $this->artisan( 'cms:openapi:export', [
         'path' => $outputPath,
-    ])->assertSuccessful();
+    ] )->assertSuccessful();
 
-    expect(file_exists($outputPath))->toBeTrue();
+    expect( file_exists( $outputPath ) )->toBeTrue();
 
-    $content = file_get_contents($outputPath);
-    $spec    = json_decode($content, true);
+    $content = file_get_contents( $outputPath );
+    $spec    = json_decode( $content, true );
 
-    expect($spec)->toBeArray();
-    expect($spec)->toHaveKey('openapi');
-    expect($spec)->toHaveKey('info');
-    expect($spec)->toHaveKey('paths');
-});
+    expect( $spec )->toBeArray();
+    expect( $spec )->toHaveKey( 'openapi' );
+    expect( $spec )->toHaveKey( 'info' );
+    expect( $spec )->toHaveKey( 'paths' );
+} );
 
-test('export command supports pretty print', function (): void {
-    $compactPath         = sys_get_temp_dir().'/cms-openapi-compact-test-'.uniqid().'.json';
-    $prettyPath          = sys_get_temp_dir().'/cms-openapi-pretty-test-'.uniqid().'.json';
+test( 'export command supports pretty print', function (): void {
+    $compactPath         = sys_get_temp_dir() . '/cms-openapi-compact-test-' . uniqid() . '.json';
+    $prettyPath          = sys_get_temp_dir() . '/cms-openapi-pretty-test-' . uniqid() . '.json';
     $this->tempFiles[]   = $compactPath;
     $this->tempFiles[]   = $prettyPath;
 
-    $this->artisan('cms:openapi:export', [
+    $this->artisan( 'cms:openapi:export', [
         'path' => $compactPath,
-    ])->assertSuccessful();
+    ] )->assertSuccessful();
 
-    $this->artisan('cms:openapi:export', [
+    $this->artisan( 'cms:openapi:export', [
         'path'     => $prettyPath,
         '--pretty' => true,
     ])->assertSuccessful();
 
-    $compactContent = file_get_contents($compactPath);
-    $prettyContent  = file_get_contents($prettyPath);
+    $compactContent = file_get_contents( $compactPath);
+    $prettyContent  = file_get_contents( $prettyPath);
 
     // Pretty-printed JSON is longer and contains indentation
-    expect(strlen($prettyContent))->toBeGreaterThan(strlen($compactContent));
-    expect($prettyContent)->toContain("\n    ");
+    expect( strlen( $prettyContent))->toBeGreaterThan( strlen( $compactContent));
+    expect( $prettyContent)->toContain( "\n    ");
 });

--- a/tests/Feature/OpenApi/OpenApiSpecTest.php
+++ b/tests/Feature/OpenApi/OpenApiSpecTest.php
@@ -150,16 +150,24 @@ test('export command writes openapi spec to file', function (): void {
 });
 
 test('export command supports pretty print', function (): void {
-    $outputPath          = sys_get_temp_dir().'/cms-openapi-pretty-test-'.uniqid().'.json';
-    $this->tempFiles[]   = $outputPath;
+    $compactPath         = sys_get_temp_dir().'/cms-openapi-compact-test-'.uniqid().'.json';
+    $prettyPath          = sys_get_temp_dir().'/cms-openapi-pretty-test-'.uniqid().'.json';
+    $this->tempFiles[]   = $compactPath;
+    $this->tempFiles[]   = $prettyPath;
 
     $this->artisan('cms:openapi:export', [
-        'path'     => $outputPath,
+        'path' => $compactPath,
+    ])->assertSuccessful();
+
+    $this->artisan('cms:openapi:export', [
+        'path'     => $prettyPath,
         '--pretty' => true,
     ])->assertSuccessful();
 
-    $content = file_get_contents($outputPath);
+    $compactContent = file_get_contents($compactPath);
+    $prettyContent  = file_get_contents($prettyPath);
 
-    // Pretty-printed JSON contains newlines
-    expect($content)->toContain("\n");
+    // Pretty-printed JSON is longer and contains indentation
+    expect(strlen($prettyContent))->toBeGreaterThan(strlen($compactContent));
+    expect($prettyContent)->toContain("\n    ");
 });

--- a/tests/Feature/OpenApi/OpenApiSpecTest.php
+++ b/tests/Feature/OpenApi/OpenApiSpecTest.php
@@ -162,12 +162,12 @@ test( 'export command supports pretty print', function (): void {
     $this->artisan( 'cms:openapi:export', [
         'path'     => $prettyPath,
         '--pretty' => true,
-    ])->assertSuccessful();
+    ] )->assertSuccessful();
 
-    $compactContent = file_get_contents( $compactPath);
-    $prettyContent  = file_get_contents( $prettyPath);
+    $compactContent = file_get_contents( $compactPath );
+    $prettyContent  = file_get_contents( $prettyPath );
 
     // Pretty-printed JSON is longer and contains indentation
-    expect( strlen( $prettyContent))->toBeGreaterThan( strlen( $compactContent));
-    expect( $prettyContent)->toContain( "\n    ");
-});
+    expect( strlen( $prettyContent ) )->toBeGreaterThan( strlen( $compactContent ) );
+    expect( $prettyContent )->toContain( "\n    " );
+} );

--- a/tests/Feature/Plugins/PluginApiTest.php
+++ b/tests/Feature/Plugins/PluginApiTest.php
@@ -230,4 +230,4 @@ describe( 'Plugin API - Permission Checks', function (): void {
             $response->assertStatus( 401 );
         }
     } );
-});
+} );

--- a/tests/Feature/Plugins/PluginLifecycleTest.php
+++ b/tests/Feature/Plugins/PluginLifecycleTest.php
@@ -267,4 +267,4 @@ describe( 'Active Plugins Loading', function (): void {
         expect( fn () => $this->manager->loadActivePlugins() )
             ->not->toThrow( Exception::class );
     } );
-});
+} );

--- a/tests/Feature/Plugins/PluginPerformanceTest.php
+++ b/tests/Feature/Plugins/PluginPerformanceTest.php
@@ -333,4 +333,4 @@ describe( 'Scalability Tests', function (): void {
         // Last insertion should not be more than 5x slower than first
         expect( $lastTime )->toBeLessThan( $firstTime * 5 );
     } );
-});
+} );

--- a/tests/Feature/Plugins/PluginSecurityTest.php
+++ b/tests/Feature/Plugins/PluginSecurityTest.php
@@ -303,4 +303,4 @@ describe( 'File System Security', function (): void {
         // This is tested implicitly through the ZIP extraction process
         expect( true )->toBeTrue();
     } );
-});
+} );

--- a/tests/Feature/Plugins/PluginSecurityTest.php
+++ b/tests/Feature/Plugins/PluginSecurityTest.php
@@ -302,5 +302,5 @@ describe( 'File System Security', function (): void {
         // When extracting, paths should be validated
         // This is tested implicitly through the ZIP extraction process
         expect( true )->toBeTrue();
-    });
+    } );
 });

--- a/tests/Feature/Settings/SettingsApiTest.php
+++ b/tests/Feature/Settings/SettingsApiTest.php
@@ -146,9 +146,9 @@ test( 'user can delete setting', function (): void {
 
     $setting = Setting::create( ['key' => 'delete-key', 'value' => 'old'] );
 
-    actingAs( $this->user)
-        ->deleteJson( '/api/v1/settings/' . $setting->key) // Use key in URL
+    actingAs( $this->user )
+        ->deleteJson( '/api/v1/settings/' . $setting->key ) // Use key in URL
         ->assertNoContent(); // 204 No Content
 
-    $this->assertDatabaseMissing( 'settings', ['key' => 'delete-key']);
+    $this->assertDatabaseMissing( 'settings', ['key' => 'delete-key'] );
 });

--- a/tests/Feature/TypeScriptTypesPublishTest.php
+++ b/tests/Feature/TypeScriptTypesPublishTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+test('cms-types publish tag is registered', function (): void {
+    $tags = Illuminate\Support\ServiceProvider::$publishGroups;
+
+    expect($tags)->toHaveKey('cms-types');
+});
+
+test('type definition source files exist', function (string $file): void {
+    $path = realpath(__DIR__.'/../../resources/types/'.$file);
+
+    expect($path)->not()->toBeFalse()
+        ->and(file_exists($path))->toBeTrue();
+})->with([
+    'index.d.ts',
+    'common.d.ts',
+    'blog.d.ts',
+    'pages.d.ts',
+    'content-types.d.ts',
+    'users.d.ts',
+    'settings.d.ts',
+    'notifications.d.ts',
+    'plugins.d.ts',
+]);
+
+test('type definition files are publishable to resource path', function (): void {
+    $tags = Illuminate\Support\ServiceProvider::$publishGroups;
+
+    $sourceKeys  = array_keys($tags['cms-types']);
+    $sourcePath  = $sourceKeys[0];
+    $destination = $tags['cms-types'][$sourcePath];
+
+    expect($sourcePath)->toContain('resources/types')
+        ->and($destination)->toContain('types/cms-framework');
+});

--- a/tests/Feature/TypeScriptTypesPublishTest.php
+++ b/tests/Feature/TypeScriptTypesPublishTest.php
@@ -11,8 +11,8 @@ test('cms-types publish tag is registered', function (): void {
 test('type definition source files exist', function (string $file): void {
     $path = realpath(__DIR__.'/../../resources/types/'.$file);
 
-    expect($path)->not()->toBeFalse()
-        ->and(file_exists($path))->toBeTrue();
+    expect($path)->not()->toBeFalse();
+    expect(file_exists((string) $path))->toBeTrue();
 })->with([
     'index.d.ts',
     'common.d.ts',
@@ -26,12 +26,21 @@ test('type definition source files exist', function (string $file): void {
 ]);
 
 test('type definition files are publishable to resource path', function (): void {
-    $tags = Illuminate\Support\ServiceProvider::$publishGroups;
+    $tags     = Illuminate\Support\ServiceProvider::$publishGroups;
+    $mappings = $tags['cms-types'];
 
-    $sourceKeys  = array_keys($tags['cms-types']);
-    $sourcePath  = $sourceKeys[0];
-    $destination = $tags['cms-types'][$sourcePath];
+    $hasSourcePath      = false;
+    $hasDestinationPath = false;
 
-    expect($sourcePath)->toContain('resources/types')
-        ->and($destination)->toContain('types/cms-framework');
+    foreach ($mappings as $source => $destination) {
+        if (str_contains($source, 'resources/types')) {
+            $hasSourcePath = true;
+        }
+        if (str_contains($destination, 'types/cms-framework')) {
+            $hasDestinationPath = true;
+        }
+    }
+
+    expect($hasSourcePath)->toBeTrue()
+        ->and($hasDestinationPath)->toBeTrue();
 });

--- a/tests/Feature/TypeScriptTypesPublishTest.php
+++ b/tests/Feature/TypeScriptTypesPublishTest.php
@@ -1,19 +1,19 @@
 <?php
 
-declare(strict_types=1);
+declare( strict_types=1 );
 
-test('cms-types publish tag is registered', function (): void {
+test( 'cms-types publish tag is registered', function (): void {
     $tags = Illuminate\Support\ServiceProvider::$publishGroups;
 
-    expect($tags)->toHaveKey('cms-types');
-});
+    expect( $tags )->toHaveKey( 'cms-types' );
+} );
 
-test('type definition source files exist', function (string $file): void {
-    $path = realpath(__DIR__.'/../../resources/types/'.$file);
+test( 'type definition source files exist', function ( string $file ): void {
+    $path = realpath( __DIR__ . '/../../resources/types/' . $file );
 
-    expect($path)->not()->toBeFalse();
-    expect(file_exists((string) $path))->toBeTrue();
-})->with([
+    expect( $path )->not()->toBeFalse();
+    expect( file_exists( (string) $path ) )->toBeTrue();
+} )->with( [
     'index.d.ts',
     'common.d.ts',
     'blog.d.ts',
@@ -23,24 +23,24 @@ test('type definition source files exist', function (string $file): void {
     'settings.d.ts',
     'notifications.d.ts',
     'plugins.d.ts',
-]);
+] );
 
-test('type definition files are publishable to resource path', function (): void {
+test( 'type definition files are publishable to resource path', function (): void {
     $tags     = Illuminate\Support\ServiceProvider::$publishGroups;
     $mappings = $tags['cms-types'];
 
     $hasSourcePath      = false;
     $hasDestinationPath = false;
 
-    foreach ($mappings as $source => $destination) {
-        if (str_contains($source, 'resources/types')) {
+    foreach ( $mappings as $source => $destination ) {
+        if ( str_contains( $source, 'resources/types' ) ) {
             $hasSourcePath = true;
         }
-        if (str_contains($destination, 'types/cms-framework')) {
+        if ( str_contains( $destination, 'types/cms-framework' ) ) {
             $hasDestinationPath = true;
         }
     }
 
-    expect($hasSourcePath)->toBeTrue()
-        ->and($hasDestinationPath)->toBeTrue();
+    expect( $hasSourcePath )->toBeTrue()
+        ->and( $hasDestinationPath)->toBeTrue();
 });

--- a/tests/Feature/TypeScriptTypesPublishTest.php
+++ b/tests/Feature/TypeScriptTypesPublishTest.php
@@ -42,5 +42,5 @@ test( 'type definition files are publishable to resource path', function (): voi
     }
 
     expect( $hasSourcePath )->toBeTrue()
-        ->and( $hasDestinationPath)->toBeTrue();
-});
+        ->and( $hasDestinationPath )->toBeTrue();
+} );

--- a/tests/Feature/Updates/UpdateFlowTest.php
+++ b/tests/Feature/Updates/UpdateFlowTest.php
@@ -1,6 +1,6 @@
 <?php
 
-declare( strict_types = 1 );
+declare(strict_types=1);
 
 namespace ArtisanPackUI\CMSFramework\Tests\Feature\Updates;
 
@@ -36,20 +36,19 @@ class UpdateFlowTest extends TestCase
         $updateInfo = new UpdateInfo(
             currentVersion: '1.0.0',
             latestVersion: '2.0.0',
-            hasUpdate: true,
             downloadUrl: 'https://example.com/update.zip',
         );
 
-        $checker = $this->createMock( UpdateChecker::class );
-        $checker->method( 'checkForUpdate' )->willReturn( $updateInfo );
+        $checker = $this->createMock(UpdateChecker::class);
+        $checker->method('checkForUpdate')->willReturn($updateInfo);
 
-        $manager->setUpdateChecker( $checker );
+        $manager->setUpdateChecker($checker);
 
         $result = $manager->checkForUpdate();
 
-        $this->assertTrue( $result->hasUpdate );
-        $this->assertEquals( '2.0.0', $result->latestVersion );
-        $this->assertEquals( '1.0.0', $result->currentVersion );
+        $this->assertTrue($result->hasUpdate());
+        $this->assertEquals('2.0.0', $result->latestVersion);
+        $this->assertEquals('1.0.0', $result->currentVersion);
     }
 
     /**
@@ -59,12 +58,12 @@ class UpdateFlowTest extends TestCase
      */
     public function test_update_check_command(): void
     {
-        Config::set( 'cms.updates.update_source_url', 'https://github.com/test/repo' );
+        Config::set('cms.updates.update_source_url', 'https://github.com/test/repo');
 
-        $exitCode = Artisan::call( 'update:check', ['--clear-cache' => true] );
+        $exitCode = Artisan::call('update:check', ['--clear-cache' => true]);
 
         // Command may fail due to no real repository, but it should execute
-        $this->assertContains( $exitCode, [0, 1] );
+        $this->assertContains($exitCode, [0, 1]);
     }
 
     /**
@@ -74,13 +73,13 @@ class UpdateFlowTest extends TestCase
      */
     public function test_scheduled_update_check_command(): void
     {
-        Config::set( 'cms.updates.update_source_url', 'https://github.com/test/repo' );
-        Config::set( 'cms.updates.auto_update_enabled', false );
+        Config::set('cms.updates.update_source_url', 'https://github.com/test/repo');
+        Config::set('cms.updates.auto_update_enabled', false);
 
-        $exitCode = Artisan::call( 'update:check-scheduled' );
+        $exitCode = Artisan::call('update:check-scheduled');
 
         // Command may fail due to no real repository, but it should execute
-        $this->assertContains( $exitCode, [0, 1] );
+        $this->assertContains($exitCode, [0, 1]);
     }
 
     /**
@@ -90,12 +89,12 @@ class UpdateFlowTest extends TestCase
      */
     public function test_rollback_command_with_no_backups(): void
     {
-        $exitCode = Artisan::call( 'update:rollback', ['--force' => true] );
+        $exitCode = Artisan::call('update:rollback', ['--force' => true]);
 
-        $this->assertEquals( 1, $exitCode );
+        $this->assertEquals(1, $exitCode);
 
         $output = Artisan::output();
-        $this->assertStringContainsString( 'No backups found', $output );
+        $this->assertStringContainsString('No backups found', $output);
     }
 
     /**
@@ -107,10 +106,10 @@ class UpdateFlowTest extends TestCase
     {
         $commands = Artisan::all();
 
-        $this->assertArrayHasKey( 'update:check', $commands );
-        $this->assertArrayHasKey( 'update:perform', $commands );
-        $this->assertArrayHasKey( 'update:rollback', $commands );
-        $this->assertArrayHasKey( 'update:check-scheduled', $commands );
+        $this->assertArrayHasKey('update:check', $commands);
+        $this->assertArrayHasKey('update:perform', $commands);
+        $this->assertArrayHasKey('update:rollback', $commands);
+        $this->assertArrayHasKey('update:check-scheduled', $commands);
     }
 
     /**
@@ -125,17 +124,16 @@ class UpdateFlowTest extends TestCase
         $updateInfo = new UpdateInfo(
             currentVersion: '1.0.0',
             latestVersion: '1.0.0',
-            hasUpdate: false,
             downloadUrl: 'https://example.com/update.zip',
         );
 
-        $checker = $this->createMock( UpdateChecker::class );
-        $checker->expects( $this->once() )->method( 'clearCache' );
+        $checker = $this->createMock(UpdateChecker::class);
+        $checker->expects($this->once())->method('clearCache');
 
-        $manager->setUpdateChecker( $checker );
+        $manager->setUpdateChecker($checker);
         $manager->clearCache();
 
-        $this->assertTrue( true ); // If we get here, test passed
+        $this->assertTrue(true); // If we get here, test passed
     }
 
     /**
@@ -145,10 +143,10 @@ class UpdateFlowTest extends TestCase
      */
     public function test_configuration_is_loaded(): void
     {
-        $this->assertIsInt( config( 'cms.updates.cache_ttl' ) );
-        $this->assertIsBool( config( 'cms.updates.backup_enabled' ) );
-        $this->assertIsArray( config( 'cms.updates.exclude_from_update' ) );
-        $this->assertIsString( config( 'cms.updates.composer_install_command' ) );
+        $this->assertIsInt(config('cms.updates.cache_ttl'));
+        $this->assertIsBool(config('cms.updates.backup_enabled'));
+        $this->assertIsArray(config('cms.updates.exclude_from_update'));
+        $this->assertIsString(config('cms.updates.composer_install_command'));
     }
 
     /**
@@ -160,7 +158,7 @@ class UpdateFlowTest extends TestCase
      *
      * @return array<int, class-string>
      */
-    protected function getPackageProviders( $app ): array
+    protected function getPackageProviders($app): array
     {
         return [
             CoreServiceProvider::class,
@@ -174,10 +172,10 @@ class UpdateFlowTest extends TestCase
      *
      * @param  \Illuminate\Foundation\Application  $app
      */
-    protected function defineEnvironment( $app ): void
+    protected function defineEnvironment($app): void
     {
-        $app['config']->set( 'cms.updates.update_source_url', 'https://github.com/test/repo' );
-        $app['config']->set( 'cms.updates.backup_enabled', false ); // Disable for tests
-        $app['config']->set( 'cms.updates.verify_checksum', false );
+        $app['config']->set('cms.updates.update_source_url', 'https://github.com/test/repo');
+        $app['config']->set('cms.updates.backup_enabled', false); // Disable for tests
+        $app['config']->set('cms.updates.verify_checksum', false);
     }
 }

--- a/tests/Feature/Updates/UpdateFlowTest.php
+++ b/tests/Feature/Updates/UpdateFlowTest.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare( strict_types=1 );
 
 namespace ArtisanPackUI\CMSFramework\Tests\Feature\Updates;
 
@@ -39,16 +39,16 @@ class UpdateFlowTest extends TestCase
             downloadUrl: 'https://example.com/update.zip',
         );
 
-        $checker = $this->createMock(UpdateChecker::class);
-        $checker->method('checkForUpdate')->willReturn($updateInfo);
+        $checker = $this->createMock( UpdateChecker::class );
+        $checker->method( 'checkForUpdate' )->willReturn( $updateInfo );
 
-        $manager->setUpdateChecker($checker);
+        $manager->setUpdateChecker( $checker );
 
         $result = $manager->checkForUpdate();
 
-        $this->assertTrue($result->hasUpdate());
-        $this->assertEquals('2.0.0', $result->latestVersion);
-        $this->assertEquals('1.0.0', $result->currentVersion);
+        $this->assertTrue( $result->hasUpdate() );
+        $this->assertEquals( '2.0.0', $result->latestVersion );
+        $this->assertEquals( '1.0.0', $result->currentVersion );
     }
 
     /**
@@ -58,12 +58,12 @@ class UpdateFlowTest extends TestCase
      */
     public function test_update_check_command(): void
     {
-        Config::set('cms.updates.update_source_url', 'https://github.com/test/repo');
+        Config::set( 'cms.updates.update_source_url', 'https://github.com/test/repo' );
 
-        $exitCode = Artisan::call('update:check', ['--clear-cache' => true]);
+        $exitCode = Artisan::call( 'update:check', ['--clear-cache' => true] );
 
         // Command may fail due to no real repository, but it should execute
-        $this->assertContains($exitCode, [0, 1]);
+        $this->assertContains( $exitCode, [0, 1] );
     }
 
     /**
@@ -73,13 +73,13 @@ class UpdateFlowTest extends TestCase
      */
     public function test_scheduled_update_check_command(): void
     {
-        Config::set('cms.updates.update_source_url', 'https://github.com/test/repo');
-        Config::set('cms.updates.auto_update_enabled', false);
+        Config::set( 'cms.updates.update_source_url', 'https://github.com/test/repo' );
+        Config::set( 'cms.updates.auto_update_enabled', false );
 
-        $exitCode = Artisan::call('update:check-scheduled');
+        $exitCode = Artisan::call( 'update:check-scheduled' );
 
         // Command may fail due to no real repository, but it should execute
-        $this->assertContains($exitCode, [0, 1]);
+        $this->assertContains( $exitCode, [0, 1] );
     }
 
     /**
@@ -89,12 +89,12 @@ class UpdateFlowTest extends TestCase
      */
     public function test_rollback_command_with_no_backups(): void
     {
-        $exitCode = Artisan::call('update:rollback', ['--force' => true]);
+        $exitCode = Artisan::call( 'update:rollback', ['--force' => true] );
 
-        $this->assertEquals(1, $exitCode);
+        $this->assertEquals( 1, $exitCode );
 
         $output = Artisan::output();
-        $this->assertStringContainsString('No backups found', $output);
+        $this->assertStringContainsString( 'No backups found', $output );
     }
 
     /**
@@ -106,10 +106,10 @@ class UpdateFlowTest extends TestCase
     {
         $commands = Artisan::all();
 
-        $this->assertArrayHasKey('update:check', $commands);
-        $this->assertArrayHasKey('update:perform', $commands);
-        $this->assertArrayHasKey('update:rollback', $commands);
-        $this->assertArrayHasKey('update:check-scheduled', $commands);
+        $this->assertArrayHasKey( 'update:check', $commands );
+        $this->assertArrayHasKey( 'update:perform', $commands );
+        $this->assertArrayHasKey( 'update:rollback', $commands );
+        $this->assertArrayHasKey( 'update:check-scheduled', $commands );
     }
 
     /**
@@ -127,13 +127,13 @@ class UpdateFlowTest extends TestCase
             downloadUrl: 'https://example.com/update.zip',
         );
 
-        $checker = $this->createMock(UpdateChecker::class);
-        $checker->expects($this->once())->method('clearCache');
+        $checker = $this->createMock( UpdateChecker::class );
+        $checker->expects( $this->once() )->method( 'clearCache' );
 
-        $manager->setUpdateChecker($checker);
+        $manager->setUpdateChecker( $checker );
         $manager->clearCache();
 
-        $this->assertTrue(true); // If we get here, test passed
+        $this->assertTrue( true ); // If we get here, test passed
     }
 
     /**
@@ -143,10 +143,10 @@ class UpdateFlowTest extends TestCase
      */
     public function test_configuration_is_loaded(): void
     {
-        $this->assertIsInt(config('cms.updates.cache_ttl'));
-        $this->assertIsBool(config('cms.updates.backup_enabled'));
-        $this->assertIsArray(config('cms.updates.exclude_from_update'));
-        $this->assertIsString(config('cms.updates.composer_install_command'));
+        $this->assertIsInt( config( 'cms.updates.cache_ttl' ) );
+        $this->assertIsBool( config( 'cms.updates.backup_enabled' ) );
+        $this->assertIsArray( config( 'cms.updates.exclude_from_update' ) );
+        $this->assertIsString( config( 'cms.updates.composer_install_command' ) );
     }
 
     /**
@@ -158,7 +158,7 @@ class UpdateFlowTest extends TestCase
      *
      * @return array<int, class-string>
      */
-    protected function getPackageProviders($app): array
+    protected function getPackageProviders( $app ): array
     {
         return [
             CoreServiceProvider::class,
@@ -172,10 +172,10 @@ class UpdateFlowTest extends TestCase
      *
      * @param  \Illuminate\Foundation\Application  $app
      */
-    protected function defineEnvironment($app): void
+    protected function defineEnvironment( $app ): void
     {
-        $app['config']->set('cms.updates.update_source_url', 'https://github.com/test/repo');
-        $app['config']->set('cms.updates.backup_enabled', false); // Disable for tests
-        $app['config']->set('cms.updates.verify_checksum', false);
+        $app['config']->set( 'cms.updates.update_source_url', 'https://github.com/test/repo' );
+        $app['config']->set( 'cms.updates.backup_enabled', false); // Disable for tests
+        $app['config']->set( 'cms.updates.verify_checksum', false);
     }
 }

--- a/tests/Feature/Updates/UpdateFlowTest.php
+++ b/tests/Feature/Updates/UpdateFlowTest.php
@@ -175,7 +175,7 @@ class UpdateFlowTest extends TestCase
     protected function defineEnvironment( $app ): void
     {
         $app['config']->set( 'cms.updates.update_source_url', 'https://github.com/test/repo' );
-        $app['config']->set( 'cms.updates.backup_enabled', false); // Disable for tests
-        $app['config']->set( 'cms.updates.verify_checksum', false);
+        $app['config']->set( 'cms.updates.backup_enabled', false ); // Disable for tests
+        $app['config']->set( 'cms.updates.verify_checksum', false );
     }
 }

--- a/tests/Feature/Updates/UpdateFlowTest.php
+++ b/tests/Feature/Updates/UpdateFlowTest.php
@@ -18,7 +18,7 @@ use Orchestra\Testbench\TestCase;
  *
  * Tests the complete update workflow.
  *
- * @since 2.0.0
+ * @since 1.0.0
  */
 class UpdateFlowTest extends TestCase
 {
@@ -27,7 +27,7 @@ class UpdateFlowTest extends TestCase
     /**
      * Test complete update check flow.
      *
-     * @since 2.0.0
+     * @since 1.0.0
      */
     public function test_complete_update_check_flow(): void
     {
@@ -54,7 +54,7 @@ class UpdateFlowTest extends TestCase
     /**
      * Test update check command.
      *
-     * @since 2.0.0
+     * @since 1.0.0
      */
     public function test_update_check_command(): void
     {
@@ -69,7 +69,7 @@ class UpdateFlowTest extends TestCase
     /**
      * Test scheduled update check command.
      *
-     * @since 2.0.0
+     * @since 1.0.0
      */
     public function test_scheduled_update_check_command(): void
     {
@@ -85,7 +85,7 @@ class UpdateFlowTest extends TestCase
     /**
      * Test rollback command with no backups.
      *
-     * @since 2.0.0
+     * @since 1.0.0
      */
     public function test_rollback_command_with_no_backups(): void
     {
@@ -100,7 +100,7 @@ class UpdateFlowTest extends TestCase
     /**
      * Test that update commands are registered.
      *
-     * @since 2.0.0
+     * @since 1.0.0
      */
     public function test_update_commands_are_registered(): void
     {
@@ -115,7 +115,7 @@ class UpdateFlowTest extends TestCase
     /**
      * Test cache clearing.
      *
-     * @since 2.0.0
+     * @since 1.0.0
      */
     public function test_cache_clearing(): void
     {
@@ -139,7 +139,7 @@ class UpdateFlowTest extends TestCase
     /**
      * Test configuration loading.
      *
-     * @since 2.0.0
+     * @since 1.0.0
      */
     public function test_configuration_is_loaded(): void
     {
@@ -152,7 +152,7 @@ class UpdateFlowTest extends TestCase
     /**
      * Get package providers.
      *
-     * @since 2.0.0
+     * @since 1.0.0
      *
      * @param  \Illuminate\Foundation\Application  $app
      *
@@ -168,7 +168,7 @@ class UpdateFlowTest extends TestCase
     /**
      * Define environment setup.
      *
-     * @since 2.0.0
+     * @since 1.0.0
      *
      * @param  \Illuminate\Foundation\Application  $app
      */

--- a/tests/Feature/UserControllerTest.php
+++ b/tests/Feature/UserControllerTest.php
@@ -284,5 +284,5 @@ test( 'user controller destroy deletes user', function (): void {
 test( 'user controller destroy returns 404 for non-existent user', function (): void {
     $response = $this->deleteJson( '/api/v1/users/999' );
 
-    $response->assertStatus( 404);
-});
+    $response->assertStatus( 404 );
+} );

--- a/tests/Feature/UserControllerTest.php
+++ b/tests/Feature/UserControllerTest.php
@@ -270,19 +270,19 @@ test( 'user controller destroy deletes user', function (): void {
     $user = $userModel::create( [
         'name'     => 'To Delete',
         'email'    => 'delete@example.com',
-        'password' => Hash::make( 'password'),
-    ]);
+        'password' => Hash::make( 'password' ),
+    ] );
 
-    $response = $this->deleteJson( "/api/v1/users/{$user->id}");
+    $response = $this->deleteJson( "/api/v1/users/{$user->id}" );
 
-    $response->assertStatus( 204);
+    $response->assertStatus( 204 );
 
     // Verify user was deleted
-    expect( $userModel::find( $user->id))->toBeNull();
-});
+    expect( $userModel::find( $user->id ) )->toBeNull();
+} );
 
 test( 'user controller destroy returns 404 for non-existent user', function (): void {
-    $response = $this->deleteJson( '/api/v1/users/999');
+    $response = $this->deleteJson( '/api/v1/users/999' );
 
     $response->assertStatus( 404);
 });

--- a/tests/Helpers/TestHelpers.php
+++ b/tests/Helpers/TestHelpers.php
@@ -12,7 +12,7 @@ if ( ! function_exists( 'invokeMethod' ) ) {
      *
      * @return mixed The method's return value
      */
-    function invokeMethod( $object, string $methodName, array $parameters = [] ): mixed
+    function invokeMethod( object $object, string $methodName, array $parameters = [] ): mixed
     {
         $reflection = new ReflectionClass( get_class( $object ) );
         $method     = $reflection->getMethod( $methodName );

--- a/tests/Support/TestUser.php
+++ b/tests/Support/TestUser.php
@@ -10,7 +10,10 @@ use Illuminate\Notifications\Notifiable;
 
 class TestUser extends Authenticatable
 {
-    use HasFactory;use HasNotifications;use HasRolesAndPermissions;use Notifiable;
+    use HasFactory;
+use HasNotifications;
+use HasRolesAndPermissions;
+use Notifiable;
 
     protected $table = 'users';
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Base test case for the CMS Framework.
  *
@@ -12,6 +14,7 @@ use ArtisanPackUI\CMSFramework\CMSFrameworkServiceProvider;
 use ArtisanPackUI\CMSFramework\Tests\Support\TestUser;
 use ArtisanPackUI\Hooks\Providers\HooksServiceProvider;
 use ArtisanPackUI\Security\SecurityServiceProvider;
+use Dedoc\Scramble\ScrambleServiceProvider;
 use Illuminate\Foundation\Application;
 
 /**
@@ -26,7 +29,7 @@ class TestCase extends \Orchestra\Testbench\TestCase
         parent::setUp();
 
         // Load the package's migrations (includes users, roles, permissions, settings, etc.)
-        $this->loadMigrationsFrom( __DIR__ . '/../database/migrations' );
+        $this->loadMigrationsFrom(__DIR__.'/../database/migrations');
     }
 
     /**
@@ -36,10 +39,11 @@ class TestCase extends \Orchestra\Testbench\TestCase
      *
      * @return array<int, class-string>
      */
-    protected function getPackageProviders( $app ): array
+    protected function getPackageProviders($app): array
     {
         return [
             SecurityServiceProvider::class,
+            ScrambleServiceProvider::class,
             CMSFrameworkServiceProvider::class,
             HooksServiceProvider::class,
         ];
@@ -50,16 +54,16 @@ class TestCase extends \Orchestra\Testbench\TestCase
      *
      * @param  Application  $app
      */
-    protected function getEnvironmentSetUp( $app ): void
+    protected function getEnvironmentSetUp($app): void
     {
         // 1. Set the configurable user model to our test user model.
-        $app['config']->set( 'artisanpack.cms-framework.user_model', TestUser::class );
-        $app['config']->set( 'auth.providers.users.model', TestUser::class );
+        $app['config']->set('artisanpack.cms-framework.user_model', TestUser::class);
+        $app['config']->set('auth.providers.users.model', TestUser::class);
 
         // 2. Set up database configuration
-        $app['config']->set( 'app.key', 'base64:' . base64_encode( random_bytes( 32 ) ) );
-        $app['config']->set( 'database.default', 'testing' );
-        $app['config']->set( 'database.connections.testing', [
+        $app['config']->set('app.key', 'base64:'.base64_encode(random_bytes(32)));
+        $app['config']->set('database.default', 'testing');
+        $app['config']->set('database.connections.testing', [
             'driver'   => 'sqlite',
             'database' => ':memory:',
             'prefix'   => '',

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -68,6 +68,6 @@ class TestCase extends \Orchestra\Testbench\TestCase
             'driver'   => 'sqlite',
             'database' => ':memory:',
             'prefix'   => '',
-        ]);
+        ] );
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -56,8 +56,9 @@ class TestCase extends \Orchestra\Testbench\TestCase
      */
     protected function getEnvironmentSetUp($app): void
     {
-        // 1. Set the configurable user model to our test user model.
+        // 1. Set the configurable user model and enable OpenAPI for testing.
         $app['config']->set('artisanpack.cms-framework.user_model', TestUser::class);
+        $app['config']->set('artisanpack.cms-framework.openapi.enabled', true);
         $app['config']->set('auth.providers.users.model', TestUser::class);
 
         // 2. Set up database configuration

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare( strict_types=1 );
 
 /**
  * Base test case for the CMS Framework.
@@ -29,7 +29,7 @@ class TestCase extends \Orchestra\Testbench\TestCase
         parent::setUp();
 
         // Load the package's migrations (includes users, roles, permissions, settings, etc.)
-        $this->loadMigrationsFrom(__DIR__.'/../database/migrations');
+        $this->loadMigrationsFrom( __DIR__ . '/../database/migrations' );
     }
 
     /**
@@ -39,7 +39,7 @@ class TestCase extends \Orchestra\Testbench\TestCase
      *
      * @return array<int, class-string>
      */
-    protected function getPackageProviders($app): array
+    protected function getPackageProviders( $app ): array
     {
         return [
             SecurityServiceProvider::class,
@@ -54,17 +54,17 @@ class TestCase extends \Orchestra\Testbench\TestCase
      *
      * @param  Application  $app
      */
-    protected function getEnvironmentSetUp($app): void
+    protected function getEnvironmentSetUp( $app ): void
     {
         // 1. Set the configurable user model and enable OpenAPI for testing.
-        $app['config']->set('artisanpack.cms-framework.user_model', TestUser::class);
-        $app['config']->set('artisanpack.cms-framework.openapi.enabled', true);
-        $app['config']->set('auth.providers.users.model', TestUser::class);
+        $app['config']->set( 'artisanpack.cms-framework.user_model', TestUser::class );
+        $app['config']->set( 'artisanpack.cms-framework.openapi.enabled', true );
+        $app['config']->set( 'auth.providers.users.model', TestUser::class );
 
         // 2. Set up database configuration
-        $app['config']->set('app.key', 'base64:'.base64_encode(random_bytes(32)));
-        $app['config']->set('database.default', 'testing');
-        $app['config']->set('database.connections.testing', [
+        $app['config']->set( 'app.key', 'base64:' . base64_encode( random_bytes( 32 ) ) );
+        $app['config']->set( 'database.default', 'testing' );
+        $app['config']->set( 'database.connections.testing', [
             'driver'   => 'sqlite',
             'database' => ':memory:',
             'prefix'   => '',

--- a/tests/Unit/Blog/PostModelTest.php
+++ b/tests/Unit/Blog/PostModelTest.php
@@ -472,19 +472,19 @@ test( 'post uses soft deletes', function (): void {
         'name'     => 'Test Author',
         'email'    => 'author@example.com',
         'password' => 'password',
-    ]);
+    ] );
 
     $post = Post::create( [
         'title'     => 'Test Post',
         'slug'      => 'test-post',
         'author_id' => $user->id,
         'status'    => 'draft',
-    ]);
+    ] );
 
     $postId = $post->id;
 
     $post->delete();
 
-    expect( Post::find( $postId))->toBeNull();
-    expect( Post::withTrashed()->find( $postId))->not->toBeNull();
+    expect( Post::find( $postId ) )->toBeNull();
+    expect( Post::withTrashed()->find( $postId ) )->not->toBeNull();
 });

--- a/tests/Unit/Blog/PostModelTest.php
+++ b/tests/Unit/Blog/PostModelTest.php
@@ -3,6 +3,7 @@
 use ArtisanPackUI\CMSFramework\Modules\Blog\Models\Post;
 use ArtisanPackUI\CMSFramework\Modules\Blog\Models\PostCategory;
 use ArtisanPackUI\CMSFramework\Modules\Blog\Models\PostTag;
+use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Enums\ContentStatus;
 use ArtisanPackUI\CMSFramework\Tests\Support\TestUser;
 use Carbon\Carbon;
 
@@ -29,7 +30,7 @@ test( 'post can be created with required attributes', function (): void {
     expect( $post )->toBeInstanceOf( Post::class );
     expect( $post->title )->toBe( 'Test Post' );
     expect( $post->slug )->toBe( 'test-post' );
-    expect( $post->status )->toBe( 'draft' );
+    expect( $post->status )->toBe( ContentStatus::Draft );
     expect( $post->author_id )->toBe( $user->id );
 } );
 

--- a/tests/Unit/Blog/PostModelTest.php
+++ b/tests/Unit/Blog/PostModelTest.php
@@ -487,4 +487,4 @@ test( 'post uses soft deletes', function (): void {
 
     expect( Post::find( $postId ) )->toBeNull();
     expect( Post::withTrashed()->find( $postId ) )->not->toBeNull();
-});
+} );

--- a/tests/Unit/ContentTypes/ColumnTypeEnumTest.php
+++ b/tests/Unit/ContentTypes/ColumnTypeEnumTest.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Enums\ColumnType;
+use Illuminate\Validation\Rules\Enum;
+
+test('column type enum has expected cases', function (): void {
+    $cases = ColumnType::cases();
+
+    expect($cases)->toHaveCount(13);
+    expect(ColumnType::String->value)->toBe('string');
+    expect(ColumnType::Text->value)->toBe('text');
+    expect(ColumnType::Integer->value)->toBe('integer');
+    expect(ColumnType::BigInteger->value)->toBe('bigInteger');
+    expect(ColumnType::Decimal->value)->toBe('decimal');
+    expect(ColumnType::Float->value)->toBe('float');
+    expect(ColumnType::Double->value)->toBe('double');
+    expect(ColumnType::Boolean->value)->toBe('boolean');
+    expect(ColumnType::Date->value)->toBe('date');
+    expect(ColumnType::DateTime->value)->toBe('dateTime');
+    expect(ColumnType::Time->value)->toBe('time');
+    expect(ColumnType::Json->value)->toBe('json');
+    expect(ColumnType::Binary->value)->toBe('binary');
+});
+
+test('column type enum can be created from string values', function (): void {
+    expect(ColumnType::from('string'))->toBe(ColumnType::String);
+    expect(ColumnType::from('text'))->toBe(ColumnType::Text);
+    expect(ColumnType::from('integer'))->toBe(ColumnType::Integer);
+    expect(ColumnType::from('bigInteger'))->toBe(ColumnType::BigInteger);
+    expect(ColumnType::from('decimal'))->toBe(ColumnType::Decimal);
+    expect(ColumnType::from('float'))->toBe(ColumnType::Float);
+    expect(ColumnType::from('double'))->toBe(ColumnType::Double);
+    expect(ColumnType::from('boolean'))->toBe(ColumnType::Boolean);
+    expect(ColumnType::from('date'))->toBe(ColumnType::Date);
+    expect(ColumnType::from('dateTime'))->toBe(ColumnType::DateTime);
+    expect(ColumnType::from('time'))->toBe(ColumnType::Time);
+    expect(ColumnType::from('json'))->toBe(ColumnType::Json);
+    expect(ColumnType::from('binary'))->toBe(ColumnType::Binary);
+});
+
+test('column type enum tryFrom returns null for invalid value', function (): void {
+    expect(ColumnType::tryFrom('invalid'))->toBeNull();
+});
+
+test('column type enum label returns translatable string', function (): void {
+    app()->setLocale('en');
+
+    expect(ColumnType::String->label())->toBe(__('String'));
+    expect(ColumnType::Text->label())->toBe(__('Text'));
+    expect(ColumnType::Integer->label())->toBe(__('Integer'));
+    expect(ColumnType::BigInteger->label())->toBe(__('Big Integer'));
+    expect(ColumnType::Decimal->label())->toBe(__('Decimal'));
+    expect(ColumnType::Float->label())->toBe(__('Float'));
+    expect(ColumnType::Double->label())->toBe(__('Double'));
+    expect(ColumnType::Boolean->label())->toBe(__('Boolean'));
+    expect(ColumnType::Date->label())->toBe(__('Date'));
+    expect(ColumnType::DateTime->label())->toBe(__('DateTime'));
+    expect(ColumnType::Time->label())->toBe(__('Time'));
+    expect(ColumnType::Json->label())->toBe(__('JSON'));
+    expect(ColumnType::Binary->label())->toBe(__('Binary'));
+});
+
+test('column type enum validationRule returns enum rule', function (): void {
+    $rule = ColumnType::validationRule();
+
+    expect($rule)->toBeInstanceOf(Enum::class);
+});

--- a/tests/Unit/ContentTypes/ColumnTypeEnumTest.php
+++ b/tests/Unit/ContentTypes/ColumnTypeEnumTest.php
@@ -1,69 +1,69 @@
 <?php
 
-declare(strict_types=1);
+declare( strict_types=1 );
 
 use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Enums\ColumnType;
 use Illuminate\Validation\Rules\Enum;
 
-test('column type enum has expected cases', function (): void {
+test( 'column type enum has expected cases', function (): void {
     $cases = ColumnType::cases();
 
-    expect($cases)->toHaveCount(13);
-    expect(ColumnType::String->value)->toBe('string');
-    expect(ColumnType::Text->value)->toBe('text');
-    expect(ColumnType::Integer->value)->toBe('integer');
-    expect(ColumnType::BigInteger->value)->toBe('bigInteger');
-    expect(ColumnType::Decimal->value)->toBe('decimal');
-    expect(ColumnType::Float->value)->toBe('float');
-    expect(ColumnType::Double->value)->toBe('double');
-    expect(ColumnType::Boolean->value)->toBe('boolean');
-    expect(ColumnType::Date->value)->toBe('date');
-    expect(ColumnType::DateTime->value)->toBe('dateTime');
-    expect(ColumnType::Time->value)->toBe('time');
-    expect(ColumnType::Json->value)->toBe('json');
-    expect(ColumnType::Binary->value)->toBe('binary');
+    expect( $cases )->toHaveCount( 13 );
+    expect( ColumnType::String->value )->toBe( 'string' );
+    expect( ColumnType::Text->value )->toBe( 'text' );
+    expect( ColumnType::Integer->value )->toBe( 'integer' );
+    expect( ColumnType::BigInteger->value )->toBe( 'bigInteger' );
+    expect( ColumnType::Decimal->value )->toBe( 'decimal' );
+    expect( ColumnType::Float->value )->toBe( 'float' );
+    expect( ColumnType::Double->value )->toBe( 'double' );
+    expect( ColumnType::Boolean->value )->toBe( 'boolean' );
+    expect( ColumnType::Date->value )->toBe( 'date' );
+    expect( ColumnType::DateTime->value )->toBe( 'dateTime' );
+    expect( ColumnType::Time->value )->toBe( 'time' );
+    expect( ColumnType::Json->value )->toBe( 'json' );
+    expect( ColumnType::Binary->value )->toBe( 'binary' );
+} );
+
+test( 'column type enum can be created from string values', function (): void {
+    expect( ColumnType::from( 'string' ) )->toBe( ColumnType::String );
+    expect( ColumnType::from( 'text' ) )->toBe( ColumnType::Text );
+    expect( ColumnType::from( 'integer' ) )->toBe( ColumnType::Integer );
+    expect( ColumnType::from( 'bigInteger' ) )->toBe( ColumnType::BigInteger );
+    expect( ColumnType::from( 'decimal' ) )->toBe( ColumnType::Decimal );
+    expect( ColumnType::from( 'float' ) )->toBe( ColumnType::Float );
+    expect( ColumnType::from( 'double' ) )->toBe( ColumnType::Double );
+    expect( ColumnType::from( 'boolean' ) )->toBe( ColumnType::Boolean );
+    expect( ColumnType::from( 'date' ) )->toBe( ColumnType::Date );
+    expect( ColumnType::from( 'dateTime' ) )->toBe( ColumnType::DateTime );
+    expect( ColumnType::from( 'time' ) )->toBe( ColumnType::Time );
+    expect( ColumnType::from( 'json' ) )->toBe( ColumnType::Json );
+    expect( ColumnType::from( 'binary' ) )->toBe( ColumnType::Binary );
+} );
+
+test( 'column type enum tryFrom returns null for invalid value', function (): void {
+    expect( ColumnType::tryFrom( 'invalid' ) )->toBeNull();
+} );
+
+test( 'column type enum label returns translatable string', function (): void {
+    app()->setLocale( 'en' );
+
+    expect( ColumnType::String->label() )->toBe( __( 'String' ) );
+    expect( ColumnType::Text->label() )->toBe( __( 'Text' ) );
+    expect( ColumnType::Integer->label() )->toBe( __( 'Integer' ) );
+    expect( ColumnType::BigInteger->label() )->toBe( __( 'Big Integer' ) );
+    expect( ColumnType::Decimal->label() )->toBe( __( 'Decimal' ) );
+    expect( ColumnType::Float->label() )->toBe( __( 'Float' ) );
+    expect( ColumnType::Double->label() )->toBe( __( 'Double' ) );
+    expect( ColumnType::Boolean->label() )->toBe( __( 'Boolean' ) );
+    expect( ColumnType::Date->label() )->toBe( __( 'Date' ) );
+    expect( ColumnType::DateTime->label() )->toBe( __( 'DateTime' ) );
+    expect( ColumnType::Time->label() )->toBe( __( 'Time'));
+    expect( ColumnType::Json->label())->toBe( __( 'JSON'));
+    expect( ColumnType::Binary->label())->toBe( __( 'Binary'));
 });
 
-test('column type enum can be created from string values', function (): void {
-    expect(ColumnType::from('string'))->toBe(ColumnType::String);
-    expect(ColumnType::from('text'))->toBe(ColumnType::Text);
-    expect(ColumnType::from('integer'))->toBe(ColumnType::Integer);
-    expect(ColumnType::from('bigInteger'))->toBe(ColumnType::BigInteger);
-    expect(ColumnType::from('decimal'))->toBe(ColumnType::Decimal);
-    expect(ColumnType::from('float'))->toBe(ColumnType::Float);
-    expect(ColumnType::from('double'))->toBe(ColumnType::Double);
-    expect(ColumnType::from('boolean'))->toBe(ColumnType::Boolean);
-    expect(ColumnType::from('date'))->toBe(ColumnType::Date);
-    expect(ColumnType::from('dateTime'))->toBe(ColumnType::DateTime);
-    expect(ColumnType::from('time'))->toBe(ColumnType::Time);
-    expect(ColumnType::from('json'))->toBe(ColumnType::Json);
-    expect(ColumnType::from('binary'))->toBe(ColumnType::Binary);
-});
-
-test('column type enum tryFrom returns null for invalid value', function (): void {
-    expect(ColumnType::tryFrom('invalid'))->toBeNull();
-});
-
-test('column type enum label returns translatable string', function (): void {
-    app()->setLocale('en');
-
-    expect(ColumnType::String->label())->toBe(__('String'));
-    expect(ColumnType::Text->label())->toBe(__('Text'));
-    expect(ColumnType::Integer->label())->toBe(__('Integer'));
-    expect(ColumnType::BigInteger->label())->toBe(__('Big Integer'));
-    expect(ColumnType::Decimal->label())->toBe(__('Decimal'));
-    expect(ColumnType::Float->label())->toBe(__('Float'));
-    expect(ColumnType::Double->label())->toBe(__('Double'));
-    expect(ColumnType::Boolean->label())->toBe(__('Boolean'));
-    expect(ColumnType::Date->label())->toBe(__('Date'));
-    expect(ColumnType::DateTime->label())->toBe(__('DateTime'));
-    expect(ColumnType::Time->label())->toBe(__('Time'));
-    expect(ColumnType::Json->label())->toBe(__('JSON'));
-    expect(ColumnType::Binary->label())->toBe(__('Binary'));
-});
-
-test('column type enum validationRule returns enum rule', function (): void {
+test( 'column type enum validationRule returns enum rule', function (): void {
     $rule = ColumnType::validationRule();
 
-    expect($rule)->toBeInstanceOf(Enum::class);
+    expect( $rule)->toBeInstanceOf( Enum::class);
 });

--- a/tests/Unit/ContentTypes/ColumnTypeEnumTest.php
+++ b/tests/Unit/ContentTypes/ColumnTypeEnumTest.php
@@ -57,13 +57,13 @@ test( 'column type enum label returns translatable string', function (): void {
     expect( ColumnType::Boolean->label() )->toBe( __( 'Boolean' ) );
     expect( ColumnType::Date->label() )->toBe( __( 'Date' ) );
     expect( ColumnType::DateTime->label() )->toBe( __( 'DateTime' ) );
-    expect( ColumnType::Time->label() )->toBe( __( 'Time'));
-    expect( ColumnType::Json->label())->toBe( __( 'JSON'));
-    expect( ColumnType::Binary->label())->toBe( __( 'Binary'));
-});
+    expect( ColumnType::Time->label() )->toBe( __( 'Time' ) );
+    expect( ColumnType::Json->label() )->toBe( __( 'JSON' ) );
+    expect( ColumnType::Binary->label() )->toBe( __( 'Binary' ) );
+} );
 
 test( 'column type enum validationRule returns enum rule', function (): void {
     $rule = ColumnType::validationRule();
 
-    expect( $rule)->toBeInstanceOf( Enum::class);
-});
+    expect( $rule )->toBeInstanceOf( Enum::class );
+} );

--- a/tests/Unit/ContentTypes/ContentStatusEnumTest.php
+++ b/tests/Unit/ContentTypes/ContentStatusEnumTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Enums\ContentStatus;
+use Illuminate\Validation\Rules\Enum;
 
 test('content status enum has expected cases', function (): void {
     $cases = ContentStatus::cases();
@@ -32,4 +33,10 @@ test('content status enum label returns translatable string', function (): void 
     expect(ContentStatus::Published->label())->toBe(__('Published'));
     expect(ContentStatus::Scheduled->label())->toBe(__('Scheduled'));
     expect(ContentStatus::Private->label())->toBe(__('Private'));
+});
+
+test('content status enum validationRule returns enum rule', function (): void {
+    $rule = ContentStatus::validationRule();
+
+    expect($rule)->toBeInstanceOf(Enum::class);
 });

--- a/tests/Unit/ContentTypes/ContentStatusEnumTest.php
+++ b/tests/Unit/ContentTypes/ContentStatusEnumTest.php
@@ -1,42 +1,42 @@
 <?php
 
-declare(strict_types=1);
+declare( strict_types=1 );
 
 use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Enums\ContentStatus;
 use Illuminate\Validation\Rules\Enum;
 
-test('content status enum has expected cases', function (): void {
+test( 'content status enum has expected cases', function (): void {
     $cases = ContentStatus::cases();
 
-    expect($cases)->toHaveCount(4);
-    expect(ContentStatus::Draft->value)->toBe('draft');
-    expect(ContentStatus::Published->value)->toBe('published');
-    expect(ContentStatus::Scheduled->value)->toBe('scheduled');
-    expect(ContentStatus::Private->value)->toBe('private');
-});
+    expect( $cases )->toHaveCount( 4 );
+    expect( ContentStatus::Draft->value )->toBe( 'draft' );
+    expect( ContentStatus::Published->value )->toBe( 'published' );
+    expect( ContentStatus::Scheduled->value )->toBe( 'scheduled' );
+    expect( ContentStatus::Private->value )->toBe( 'private' );
+} );
 
-test('content status enum can be created from string values', function (): void {
-    expect(ContentStatus::from('draft'))->toBe(ContentStatus::Draft);
-    expect(ContentStatus::from('published'))->toBe(ContentStatus::Published);
-    expect(ContentStatus::from('scheduled'))->toBe(ContentStatus::Scheduled);
-    expect(ContentStatus::from('private'))->toBe(ContentStatus::Private);
-});
+test( 'content status enum can be created from string values', function (): void {
+    expect( ContentStatus::from( 'draft' ) )->toBe( ContentStatus::Draft );
+    expect( ContentStatus::from( 'published' ) )->toBe( ContentStatus::Published );
+    expect( ContentStatus::from( 'scheduled' ) )->toBe( ContentStatus::Scheduled );
+    expect( ContentStatus::from( 'private' ) )->toBe( ContentStatus::Private );
+} );
 
-test('content status enum tryFrom returns null for invalid value', function (): void {
-    expect(ContentStatus::tryFrom('invalid'))->toBeNull();
-});
+test( 'content status enum tryFrom returns null for invalid value', function (): void {
+    expect( ContentStatus::tryFrom( 'invalid' ) )->toBeNull();
+} );
 
-test('content status enum label returns translatable string', function (): void {
-    app()->setLocale('en');
+test( 'content status enum label returns translatable string', function (): void {
+    app()->setLocale( 'en' );
 
-    expect(ContentStatus::Draft->label())->toBe(__('Draft'));
-    expect(ContentStatus::Published->label())->toBe(__('Published'));
-    expect(ContentStatus::Scheduled->label())->toBe(__('Scheduled'));
-    expect(ContentStatus::Private->label())->toBe(__('Private'));
-});
+    expect( ContentStatus::Draft->label() )->toBe( __( 'Draft' ) );
+    expect( ContentStatus::Published->label() )->toBe( __( 'Published' ) );
+    expect( ContentStatus::Scheduled->label() )->toBe( __( 'Scheduled' ) );
+    expect( ContentStatus::Private->label() )->toBe( __( 'Private' ) );
+} );
 
-test('content status enum validationRule returns enum rule', function (): void {
+test( 'content status enum validationRule returns enum rule', function (): void {
     $rule = ContentStatus::validationRule();
 
-    expect($rule)->toBeInstanceOf(Enum::class);
+    expect( $rule)->toBeInstanceOf( Enum::class);
 });

--- a/tests/Unit/ContentTypes/ContentStatusEnumTest.php
+++ b/tests/Unit/ContentTypes/ContentStatusEnumTest.php
@@ -26,8 +26,10 @@ test('content status enum tryFrom returns null for invalid value', function (): 
 });
 
 test('content status enum label returns translatable string', function (): void {
-    expect(ContentStatus::Draft->label())->toBe('Draft');
-    expect(ContentStatus::Published->label())->toBe('Published');
-    expect(ContentStatus::Scheduled->label())->toBe('Scheduled');
-    expect(ContentStatus::Private->label())->toBe('Private');
+    app()->setLocale('en');
+
+    expect(ContentStatus::Draft->label())->toBe(__('Draft'));
+    expect(ContentStatus::Published->label())->toBe(__('Published'));
+    expect(ContentStatus::Scheduled->label())->toBe(__('Scheduled'));
+    expect(ContentStatus::Private->label())->toBe(__('Private'));
 });

--- a/tests/Unit/ContentTypes/ContentStatusEnumTest.php
+++ b/tests/Unit/ContentTypes/ContentStatusEnumTest.php
@@ -38,5 +38,5 @@ test( 'content status enum label returns translatable string', function (): void
 test( 'content status enum validationRule returns enum rule', function (): void {
     $rule = ContentStatus::validationRule();
 
-    expect( $rule)->toBeInstanceOf( Enum::class);
-});
+    expect( $rule )->toBeInstanceOf( Enum::class );
+} );

--- a/tests/Unit/ContentTypes/ContentStatusEnumTest.php
+++ b/tests/Unit/ContentTypes/ContentStatusEnumTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Enums\ContentStatus;
+
+test('content status enum has expected cases', function (): void {
+    $cases = ContentStatus::cases();
+
+    expect($cases)->toHaveCount(4);
+    expect(ContentStatus::Draft->value)->toBe('draft');
+    expect(ContentStatus::Published->value)->toBe('published');
+    expect(ContentStatus::Scheduled->value)->toBe('scheduled');
+    expect(ContentStatus::Private->value)->toBe('private');
+});
+
+test('content status enum can be created from string values', function (): void {
+    expect(ContentStatus::from('draft'))->toBe(ContentStatus::Draft);
+    expect(ContentStatus::from('published'))->toBe(ContentStatus::Published);
+    expect(ContentStatus::from('scheduled'))->toBe(ContentStatus::Scheduled);
+    expect(ContentStatus::from('private'))->toBe(ContentStatus::Private);
+});
+
+test('content status enum tryFrom returns null for invalid value', function (): void {
+    expect(ContentStatus::tryFrom('invalid'))->toBeNull();
+});
+
+test('content status enum label returns translatable string', function (): void {
+    expect(ContentStatus::Draft->label())->toBe('Draft');
+    expect(ContentStatus::Published->label())->toBe('Published');
+    expect(ContentStatus::Scheduled->label())->toBe('Scheduled');
+    expect(ContentStatus::Private->label())->toBe('Private');
+});

--- a/tests/Unit/ContentTypes/ContentTypeManagerTest.php
+++ b/tests/Unit/ContentTypes/ContentTypeManagerTest.php
@@ -225,10 +225,10 @@ test( 'registered content types merges database and filtered content types', fun
         'slug'        => 'custom',
         'table_name'  => 'custom',
         'model_class' => 'App\\Models\\Custom',
-    ]);
+    ] );
 
     $registeredTypes = $manager->getRegisteredContentTypes();
 
-    expect( $registeredTypes)->toHaveKey( 'posts');
-    expect( $registeredTypes)->toHaveKey( 'custom');
+    expect( $registeredTypes )->toHaveKey( 'posts' );
+    expect( $registeredTypes )->toHaveKey( 'custom' );
 });

--- a/tests/Unit/ContentTypes/ContentTypeManagerTest.php
+++ b/tests/Unit/ContentTypes/ContentTypeManagerTest.php
@@ -231,4 +231,4 @@ test( 'registered content types merges database and filtered content types', fun
 
     expect( $registeredTypes )->toHaveKey( 'posts' );
     expect( $registeredTypes )->toHaveKey( 'custom' );
-});
+} );

--- a/tests/Unit/ContentTypes/CustomFieldManagerTest.php
+++ b/tests/Unit/ContentTypes/CustomFieldManagerTest.php
@@ -422,6 +422,6 @@ test( 'update field handles content type changes', function (): void {
     expect( Schema::hasColumn( 'test_posts_ct', 'custom_field' ) )->toBeTrue();
     expect( Schema::hasColumn( 'test_pages_ct', 'custom_field' ) )->toBeTrue();
 
-    Schema::dropIfExists( 'test_posts_ct');
+    Schema::dropIfExists( 'test_posts_ct' );
     Schema::dropIfExists( 'test_pages_ct');
 });

--- a/tests/Unit/ContentTypes/CustomFieldManagerTest.php
+++ b/tests/Unit/ContentTypes/CustomFieldManagerTest.php
@@ -410,17 +410,17 @@ test( 'update field handles content type changes', function (): void {
         'content_types' => ['posts'],
         'order'         => 1,
         'required'      => false,
-    ]);
+    ] );
 
-    $manager->addColumnToTable( $field, 'test_posts_ct');
+    $manager->addColumnToTable( $field, 'test_posts_ct' );
 
     // Update to also include pages
     $manager->updateField( $field->id, [
         'content_types' => ['posts', 'pages'],
-    ]);
+    ] );
 
-    expect( Schema::hasColumn( 'test_posts_ct', 'custom_field'))->toBeTrue();
-    expect( Schema::hasColumn( 'test_pages_ct', 'custom_field'))->toBeTrue();
+    expect( Schema::hasColumn( 'test_posts_ct', 'custom_field' ) )->toBeTrue();
+    expect( Schema::hasColumn( 'test_pages_ct', 'custom_field' ) )->toBeTrue();
 
     Schema::dropIfExists( 'test_posts_ct');
     Schema::dropIfExists( 'test_pages_ct');

--- a/tests/Unit/ContentTypes/FieldTypeEnumTest.php
+++ b/tests/Unit/ContentTypes/FieldTypeEnumTest.php
@@ -1,78 +1,78 @@
 <?php
 
-declare(strict_types=1);
+declare( strict_types=1 );
 
 use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Enums\FieldType;
 use Illuminate\Validation\Rules\Enum;
 
-test('field type enum has expected cases', function (): void {
+test( 'field type enum has expected cases', function (): void {
     $cases = FieldType::cases();
 
-    expect($cases)->toHaveCount(16);
-    expect(FieldType::Text->value)->toBe('text');
-    expect(FieldType::Textarea->value)->toBe('textarea');
-    expect(FieldType::Number->value)->toBe('number');
-    expect(FieldType::Select->value)->toBe('select');
-    expect(FieldType::Checkbox->value)->toBe('checkbox');
-    expect(FieldType::Radio->value)->toBe('radio');
-    expect(FieldType::Boolean->value)->toBe('boolean');
-    expect(FieldType::Date->value)->toBe('date');
-    expect(FieldType::Datetime->value)->toBe('datetime');
-    expect(FieldType::Time->value)->toBe('time');
-    expect(FieldType::Email->value)->toBe('email');
-    expect(FieldType::Url->value)->toBe('url');
-    expect(FieldType::Tel->value)->toBe('tel');
-    expect(FieldType::Color->value)->toBe('color');
-    expect(FieldType::File->value)->toBe('file');
-    expect(FieldType::Image->value)->toBe('image');
+    expect( $cases )->toHaveCount( 16 );
+    expect( FieldType::Text->value )->toBe( 'text' );
+    expect( FieldType::Textarea->value )->toBe( 'textarea' );
+    expect( FieldType::Number->value )->toBe( 'number' );
+    expect( FieldType::Select->value )->toBe( 'select' );
+    expect( FieldType::Checkbox->value )->toBe( 'checkbox' );
+    expect( FieldType::Radio->value )->toBe( 'radio' );
+    expect( FieldType::Boolean->value )->toBe( 'boolean' );
+    expect( FieldType::Date->value )->toBe( 'date' );
+    expect( FieldType::Datetime->value )->toBe( 'datetime' );
+    expect( FieldType::Time->value )->toBe( 'time' );
+    expect( FieldType::Email->value )->toBe( 'email' );
+    expect( FieldType::Url->value )->toBe( 'url' );
+    expect( FieldType::Tel->value )->toBe( 'tel' );
+    expect( FieldType::Color->value )->toBe( 'color' );
+    expect( FieldType::File->value )->toBe( 'file' );
+    expect( FieldType::Image->value )->toBe( 'image' );
+} );
+
+test( 'field type enum can be created from string values', function (): void {
+    expect( FieldType::from( 'text' ) )->toBe( FieldType::Text );
+    expect( FieldType::from( 'textarea' ) )->toBe( FieldType::Textarea );
+    expect( FieldType::from( 'number' ) )->toBe( FieldType::Number );
+    expect( FieldType::from( 'select' ) )->toBe( FieldType::Select );
+    expect( FieldType::from( 'checkbox' ) )->toBe( FieldType::Checkbox );
+    expect( FieldType::from( 'radio' ) )->toBe( FieldType::Radio );
+    expect( FieldType::from( 'boolean' ) )->toBe( FieldType::Boolean );
+    expect( FieldType::from( 'date' ) )->toBe( FieldType::Date );
+    expect( FieldType::from( 'datetime' ) )->toBe( FieldType::Datetime );
+    expect( FieldType::from( 'time' ) )->toBe( FieldType::Time );
+    expect( FieldType::from( 'email' ) )->toBe( FieldType::Email );
+    expect( FieldType::from( 'url' ) )->toBe( FieldType::Url );
+    expect( FieldType::from( 'tel' ) )->toBe( FieldType::Tel );
+    expect( FieldType::from( 'color' ) )->toBe( FieldType::Color );
+    expect( FieldType::from( 'file' ) )->toBe( FieldType::File );
+    expect( FieldType::from( 'image' ) )->toBe( FieldType::Image );
+} );
+
+test( 'field type enum tryFrom returns null for invalid value', function (): void {
+    expect( FieldType::tryFrom( 'invalid' ) )->toBeNull();
+} );
+
+test( 'field type enum label returns translatable string', function (): void {
+    app()->setLocale( 'en' );
+
+    expect( FieldType::Text->label() )->toBe( __( 'Text' ) );
+    expect( FieldType::Textarea->label() )->toBe( __( 'Textarea' ) );
+    expect( FieldType::Number->label() )->toBe( __( 'Number' ) );
+    expect( FieldType::Select->label() )->toBe( __( 'Select' ) );
+    expect( FieldType::Checkbox->label() )->toBe( __( 'Checkbox' ) );
+    expect( FieldType::Radio->label() )->toBe( __( 'Radio' ) );
+    expect( FieldType::Boolean->label() )->toBe( __( 'Boolean' ) );
+    expect( FieldType::Date->label() )->toBe( __( 'Date' ) );
+    expect( FieldType::Datetime->label() )->toBe( __( 'Datetime' ) );
+    expect( FieldType::Time->label() )->toBe( __( 'Time' ) );
+    expect( FieldType::Email->label() )->toBe( __( 'Email' ) );
+    expect( FieldType::Url->label() )->toBe( __( 'URL' ) );
+    expect( FieldType::Tel->label() )->toBe( __( 'Telephone'));
+    expect( FieldType::Color->label())->toBe( __( 'Color'));
+    expect( FieldType::File->label())->toBe( __( 'File'));
+    expect( FieldType::Image->label())->toBe( __( 'Image'));
 });
 
-test('field type enum can be created from string values', function (): void {
-    expect(FieldType::from('text'))->toBe(FieldType::Text);
-    expect(FieldType::from('textarea'))->toBe(FieldType::Textarea);
-    expect(FieldType::from('number'))->toBe(FieldType::Number);
-    expect(FieldType::from('select'))->toBe(FieldType::Select);
-    expect(FieldType::from('checkbox'))->toBe(FieldType::Checkbox);
-    expect(FieldType::from('radio'))->toBe(FieldType::Radio);
-    expect(FieldType::from('boolean'))->toBe(FieldType::Boolean);
-    expect(FieldType::from('date'))->toBe(FieldType::Date);
-    expect(FieldType::from('datetime'))->toBe(FieldType::Datetime);
-    expect(FieldType::from('time'))->toBe(FieldType::Time);
-    expect(FieldType::from('email'))->toBe(FieldType::Email);
-    expect(FieldType::from('url'))->toBe(FieldType::Url);
-    expect(FieldType::from('tel'))->toBe(FieldType::Tel);
-    expect(FieldType::from('color'))->toBe(FieldType::Color);
-    expect(FieldType::from('file'))->toBe(FieldType::File);
-    expect(FieldType::from('image'))->toBe(FieldType::Image);
-});
-
-test('field type enum tryFrom returns null for invalid value', function (): void {
-    expect(FieldType::tryFrom('invalid'))->toBeNull();
-});
-
-test('field type enum label returns translatable string', function (): void {
-    app()->setLocale('en');
-
-    expect(FieldType::Text->label())->toBe(__('Text'));
-    expect(FieldType::Textarea->label())->toBe(__('Textarea'));
-    expect(FieldType::Number->label())->toBe(__('Number'));
-    expect(FieldType::Select->label())->toBe(__('Select'));
-    expect(FieldType::Checkbox->label())->toBe(__('Checkbox'));
-    expect(FieldType::Radio->label())->toBe(__('Radio'));
-    expect(FieldType::Boolean->label())->toBe(__('Boolean'));
-    expect(FieldType::Date->label())->toBe(__('Date'));
-    expect(FieldType::Datetime->label())->toBe(__('Datetime'));
-    expect(FieldType::Time->label())->toBe(__('Time'));
-    expect(FieldType::Email->label())->toBe(__('Email'));
-    expect(FieldType::Url->label())->toBe(__('URL'));
-    expect(FieldType::Tel->label())->toBe(__('Telephone'));
-    expect(FieldType::Color->label())->toBe(__('Color'));
-    expect(FieldType::File->label())->toBe(__('File'));
-    expect(FieldType::Image->label())->toBe(__('Image'));
-});
-
-test('field type enum validationRule returns enum rule', function (): void {
+test( 'field type enum validationRule returns enum rule', function (): void {
     $rule = FieldType::validationRule();
 
-    expect($rule)->toBeInstanceOf(Enum::class);
+    expect( $rule)->toBeInstanceOf( Enum::class);
 });

--- a/tests/Unit/ContentTypes/FieldTypeEnumTest.php
+++ b/tests/Unit/ContentTypes/FieldTypeEnumTest.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Enums\FieldType;
+use Illuminate\Validation\Rules\Enum;
+
+test('field type enum has expected cases', function (): void {
+    $cases = FieldType::cases();
+
+    expect($cases)->toHaveCount(16);
+    expect(FieldType::Text->value)->toBe('text');
+    expect(FieldType::Textarea->value)->toBe('textarea');
+    expect(FieldType::Number->value)->toBe('number');
+    expect(FieldType::Select->value)->toBe('select');
+    expect(FieldType::Checkbox->value)->toBe('checkbox');
+    expect(FieldType::Radio->value)->toBe('radio');
+    expect(FieldType::Boolean->value)->toBe('boolean');
+    expect(FieldType::Date->value)->toBe('date');
+    expect(FieldType::Datetime->value)->toBe('datetime');
+    expect(FieldType::Time->value)->toBe('time');
+    expect(FieldType::Email->value)->toBe('email');
+    expect(FieldType::Url->value)->toBe('url');
+    expect(FieldType::Tel->value)->toBe('tel');
+    expect(FieldType::Color->value)->toBe('color');
+    expect(FieldType::File->value)->toBe('file');
+    expect(FieldType::Image->value)->toBe('image');
+});
+
+test('field type enum can be created from string values', function (): void {
+    expect(FieldType::from('text'))->toBe(FieldType::Text);
+    expect(FieldType::from('textarea'))->toBe(FieldType::Textarea);
+    expect(FieldType::from('number'))->toBe(FieldType::Number);
+    expect(FieldType::from('select'))->toBe(FieldType::Select);
+    expect(FieldType::from('checkbox'))->toBe(FieldType::Checkbox);
+    expect(FieldType::from('radio'))->toBe(FieldType::Radio);
+    expect(FieldType::from('boolean'))->toBe(FieldType::Boolean);
+    expect(FieldType::from('date'))->toBe(FieldType::Date);
+    expect(FieldType::from('datetime'))->toBe(FieldType::Datetime);
+    expect(FieldType::from('time'))->toBe(FieldType::Time);
+    expect(FieldType::from('email'))->toBe(FieldType::Email);
+    expect(FieldType::from('url'))->toBe(FieldType::Url);
+    expect(FieldType::from('tel'))->toBe(FieldType::Tel);
+    expect(FieldType::from('color'))->toBe(FieldType::Color);
+    expect(FieldType::from('file'))->toBe(FieldType::File);
+    expect(FieldType::from('image'))->toBe(FieldType::Image);
+});
+
+test('field type enum tryFrom returns null for invalid value', function (): void {
+    expect(FieldType::tryFrom('invalid'))->toBeNull();
+});
+
+test('field type enum label returns translatable string', function (): void {
+    app()->setLocale('en');
+
+    expect(FieldType::Text->label())->toBe(__('Text'));
+    expect(FieldType::Textarea->label())->toBe(__('Textarea'));
+    expect(FieldType::Number->label())->toBe(__('Number'));
+    expect(FieldType::Select->label())->toBe(__('Select'));
+    expect(FieldType::Checkbox->label())->toBe(__('Checkbox'));
+    expect(FieldType::Radio->label())->toBe(__('Radio'));
+    expect(FieldType::Boolean->label())->toBe(__('Boolean'));
+    expect(FieldType::Date->label())->toBe(__('Date'));
+    expect(FieldType::Datetime->label())->toBe(__('Datetime'));
+    expect(FieldType::Time->label())->toBe(__('Time'));
+    expect(FieldType::Email->label())->toBe(__('Email'));
+    expect(FieldType::Url->label())->toBe(__('URL'));
+    expect(FieldType::Tel->label())->toBe(__('Telephone'));
+    expect(FieldType::Color->label())->toBe(__('Color'));
+    expect(FieldType::File->label())->toBe(__('File'));
+    expect(FieldType::Image->label())->toBe(__('Image'));
+});
+
+test('field type enum validationRule returns enum rule', function (): void {
+    $rule = FieldType::validationRule();
+
+    expect($rule)->toBeInstanceOf(Enum::class);
+});

--- a/tests/Unit/ContentTypes/FieldTypeEnumTest.php
+++ b/tests/Unit/ContentTypes/FieldTypeEnumTest.php
@@ -65,14 +65,14 @@ test( 'field type enum label returns translatable string', function (): void {
     expect( FieldType::Time->label() )->toBe( __( 'Time' ) );
     expect( FieldType::Email->label() )->toBe( __( 'Email' ) );
     expect( FieldType::Url->label() )->toBe( __( 'URL' ) );
-    expect( FieldType::Tel->label() )->toBe( __( 'Telephone'));
-    expect( FieldType::Color->label())->toBe( __( 'Color'));
-    expect( FieldType::File->label())->toBe( __( 'File'));
-    expect( FieldType::Image->label())->toBe( __( 'Image'));
-});
+    expect( FieldType::Tel->label() )->toBe( __( 'Telephone' ) );
+    expect( FieldType::Color->label() )->toBe( __( 'Color' ) );
+    expect( FieldType::File->label() )->toBe( __( 'File' ) );
+    expect( FieldType::Image->label() )->toBe( __( 'Image' ) );
+} );
 
 test( 'field type enum validationRule returns enum rule', function (): void {
     $rule = FieldType::validationRule();
 
-    expect( $rule)->toBeInstanceOf( Enum::class);
-});
+    expect( $rule )->toBeInstanceOf( Enum::class );
+} );

--- a/tests/Unit/ContentTypes/HasContentFiltersTest.php
+++ b/tests/Unit/ContentTypes/HasContentFiltersTest.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare( strict_types=1 );
 
 use ArtisanPackUI\CMSFramework\Modules\Blog\Managers\BlogManager;
 use ArtisanPackUI\CMSFramework\Modules\Blog\Models\Post;
@@ -10,311 +10,311 @@ use ArtisanPackUI\CMSFramework\Modules\Pages\Managers\PageManager;
 use ArtisanPackUI\CMSFramework\Modules\Pages\Models\Page;
 use ArtisanPackUI\CMSFramework\Tests\Support\TestUser;
 
-beforeEach(function (): void {
-    $this->artisan('migrate', ['--database' => 'testing']);
-});
+beforeEach( function (): void {
+    $this->artisan( 'migrate', ['--database' => 'testing'] );
+} );
 
-test('BlogManager uses HasContentFilters trait', function (): void {
-    expect(in_array(HasContentFilters::class, class_uses_recursive(BlogManager::class)))->toBeTrue();
-});
+test( 'BlogManager uses HasContentFilters trait', function (): void {
+    expect( in_array( HasContentFilters::class, class_uses_recursive( BlogManager::class ) ) )->toBeTrue();
+} );
 
-test('PageManager uses HasContentFilters trait', function (): void {
-    expect(in_array(HasContentFilters::class, class_uses_recursive(PageManager::class)))->toBeTrue();
-});
+test( 'PageManager uses HasContentFilters trait', function (): void {
+    expect( in_array( HasContentFilters::class, class_uses_recursive( PageManager::class ) ) )->toBeTrue();
+} );
 
-test('blog manager status filter defaults to published', function (): void {
-    $user = TestUser::create([
+test( 'blog manager status filter defaults to published', function (): void {
+    $user = TestUser::create( [
         'name'     => 'Test Author',
         'email'    => 'author@example.com',
         'password' => 'password',
-    ]);
+    ] );
 
-    Post::create([
+    Post::create( [
         'title'        => 'Published Post',
         'slug'         => 'published-post',
         'author_id'    => $user->id,
         'status'       => 'published',
         'published_at' => now()->subDay(),
-    ]);
+    ] );
 
-    Post::create([
+    Post::create( [
         'title'     => 'Draft Post',
         'slug'      => 'draft-post',
         'author_id' => $user->id,
         'status'    => 'draft',
-    ]);
+    ] );
 
     $manager = new BlogManager;
     $results = $manager->getArchiveQuery()->get();
 
-    expect($results)->toHaveCount(1);
-    expect($results->first()->title)->toBe('Published Post');
-});
+    expect( $results )->toHaveCount( 1 );
+    expect( $results->first()->title )->toBe( 'Published Post' );
+} );
 
-test('blog manager status filter with draft status', function (): void {
-    $user = TestUser::create([
+test( 'blog manager status filter with draft status', function (): void {
+    $user = TestUser::create( [
         'name'     => 'Test Author',
         'email'    => 'author@example.com',
         'password' => 'password',
-    ]);
+    ] );
 
-    Post::create([
+    Post::create( [
         'title'        => 'Published Post',
         'slug'         => 'published-post',
         'author_id'    => $user->id,
         'status'       => 'published',
         'published_at' => now()->subDay(),
-    ]);
+    ] );
 
-    Post::create([
+    Post::create( [
         'title'     => 'Draft Post',
         'slug'      => 'draft-post',
         'author_id' => $user->id,
         'status'    => 'draft',
-    ]);
+    ] );
 
     $manager = new BlogManager;
-    $results = $manager->getArchiveQuery(['status' => 'draft'])->get();
+    $results = $manager->getArchiveQuery( ['status' => 'draft'] )->get();
 
-    expect($results)->toHaveCount(1);
-    expect($results->first()->title)->toBe('Draft Post');
-});
+    expect( $results )->toHaveCount( 1 );
+    expect( $results->first()->title )->toBe( 'Draft Post' );
+} );
 
-test('blog manager status filter with ContentStatus enum', function (): void {
-    $user = TestUser::create([
+test( 'blog manager status filter with ContentStatus enum', function (): void {
+    $user = TestUser::create( [
         'name'     => 'Test Author',
         'email'    => 'author@example.com',
         'password' => 'password',
-    ]);
+    ] );
 
-    Post::create([
+    Post::create( [
         'title'     => 'Draft Post',
         'slug'      => 'draft-post',
         'author_id' => $user->id,
         'status'    => 'draft',
-    ]);
+    ] );
 
-    Post::create([
+    Post::create( [
         'title'        => 'Published Post',
         'slug'         => 'published-post',
         'author_id'    => $user->id,
         'status'       => 'published',
         'published_at' => now()->subDay(),
-    ]);
+    ] );
 
     $manager = new BlogManager;
-    $results = $manager->getArchiveQuery(['status' => ContentStatus::Draft])->get();
+    $results = $manager->getArchiveQuery( ['status' => ContentStatus::Draft] )->get();
 
-    expect($results)->toHaveCount(1);
-    expect($results->first()->title)->toBe('Draft Post');
-});
+    expect( $results )->toHaveCount( 1 );
+    expect( $results->first()->title )->toBe( 'Draft Post' );
+} );
 
-test('blog manager search filter searches title content and excerpt', function (): void {
-    $user = TestUser::create([
+test( 'blog manager search filter searches title content and excerpt', function (): void {
+    $user = TestUser::create( [
         'name'     => 'Test Author',
         'email'    => 'author@example.com',
         'password' => 'password',
-    ]);
+    ] );
 
-    Post::create([
+    Post::create( [
         'title'        => 'Laravel Tutorial',
         'slug'         => 'laravel-tutorial',
         'content'      => 'Learn about PHP frameworks',
         'author_id'    => $user->id,
         'status'       => 'published',
         'published_at' => now()->subDay(),
-    ]);
+    ] );
 
-    Post::create([
+    Post::create( [
         'title'        => 'Vue Guide',
         'slug'         => 'vue-guide',
         'content'      => 'Frontend framework guide',
         'author_id'    => $user->id,
         'status'       => 'published',
         'published_at' => now()->subDay(),
-    ]);
+    ] );
 
     $manager = new BlogManager;
-    $results = $manager->getArchiveQuery(['search' => 'Laravel'])->get();
+    $results = $manager->getArchiveQuery( ['search' => 'Laravel'] )->get();
 
-    expect($results)->toHaveCount(1);
-    expect($results->first()->title)->toBe('Laravel Tutorial');
-});
+    expect( $results )->toHaveCount( 1 );
+    expect( $results->first()->title )->toBe( 'Laravel Tutorial' );
+} );
 
-test('blog manager author filter filters by author', function (): void {
-    $author1 = TestUser::create([
+test( 'blog manager author filter filters by author', function (): void {
+    $author1 = TestUser::create( [
         'name'     => 'Author 1',
         'email'    => 'author1@example.com',
         'password' => 'password',
-    ]);
+    ] );
 
-    $author2 = TestUser::create([
+    $author2 = TestUser::create( [
         'name'     => 'Author 2',
         'email'    => 'author2@example.com',
         'password' => 'password',
-    ]);
+    ] );
 
-    Post::create([
+    Post::create( [
         'title'        => 'Post by Author 1',
         'slug'         => 'post-author-1',
         'author_id'    => $author1->id,
         'status'       => 'published',
         'published_at' => now()->subDay(),
-    ]);
+    ] );
 
-    Post::create([
+    Post::create( [
         'title'        => 'Post by Author 2',
         'slug'         => 'post-author-2',
         'author_id'    => $author2->id,
         'status'       => 'published',
         'published_at' => now()->subDay(),
-    ]);
+    ] );
 
     $manager = new BlogManager;
-    $results = $manager->getArchiveQuery(['author' => $author1->id])->get();
+    $results = $manager->getArchiveQuery( ['author' => $author1->id] )->get();
 
-    expect($results)->toHaveCount(1);
-    expect($results->first()->title)->toBe('Post by Author 1');
-});
+    expect( $results )->toHaveCount( 1 );
+    expect( $results->first()->title )->toBe( 'Post by Author 1' );
+} );
 
-test('page manager status filter with draft status', function (): void {
-    $user = TestUser::create([
+test( 'page manager status filter with draft status', function (): void {
+    $user = TestUser::create( [
         'name'     => 'Test Author',
         'email'    => 'author@example.com',
         'password' => 'password',
-    ]);
+    ] );
 
-    Page::create([
+    Page::create( [
         'title'        => 'Published Page',
         'slug'         => 'published-page',
         'author_id'    => $user->id,
         'status'       => 'published',
         'published_at' => now()->subDay(),
         'order'        => 1,
-    ]);
+    ] );
 
-    Page::create([
+    Page::create( [
         'title'     => 'Draft Page',
         'slug'      => 'draft-page',
         'author_id' => $user->id,
         'status'    => 'draft',
         'order'     => 2,
-    ]);
+    ] );
 
     $manager = new PageManager;
-    $results = $manager->getPageQuery(['status' => 'draft'])->get();
+    $results = $manager->getPageQuery( ['status' => 'draft'] )->get();
 
-    expect($results)->toHaveCount(1);
-    expect($results->first()->title)->toBe('Draft Page');
-});
+    expect( $results )->toHaveCount( 1 );
+    expect( $results->first()->title )->toBe( 'Draft Page' );
+} );
 
-test('page manager search filter searches title content and excerpt', function (): void {
-    $user = TestUser::create([
+test( 'page manager search filter searches title content and excerpt', function (): void {
+    $user = TestUser::create( [
         'name'     => 'Test Author',
         'email'    => 'author@example.com',
         'password' => 'password',
-    ]);
+    ] );
 
-    Page::create([
+    Page::create( [
         'title'     => 'About Us',
         'slug'      => 'about-us',
         'content'   => 'Learn about our company',
         'author_id' => $user->id,
         'status'    => 'draft',
         'order'     => 1,
-    ]);
+    ] );
 
-    Page::create([
+    Page::create( [
         'title'     => 'Contact',
         'slug'      => 'contact',
         'content'   => 'Get in touch',
         'author_id' => $user->id,
         'status'    => 'draft',
         'order'     => 2,
-    ]);
+    ] );
 
     $manager = new PageManager;
-    $results = $manager->getPageQuery(['status' => 'draft', 'search' => 'About'])->get();
+    $results = $manager->getPageQuery( ['status' => 'draft', 'search' => 'About'] )->get();
 
-    expect($results)->toHaveCount(1);
-    expect($results->first()->title)->toBe('About Us');
-});
+    expect( $results )->toHaveCount( 1 );
+    expect( $results->first()->title )->toBe( 'About Us' );
+} );
 
-test('page manager does not default to published when no status filter', function (): void {
-    $user = TestUser::create([
+test( 'page manager does not default to published when no status filter', function (): void {
+    $user = TestUser::create( [
         'name'     => 'Test Author',
         'email'    => 'author@example.com',
         'password' => 'password',
-    ]);
+    ] );
 
-    Page::create([
+    Page::create( [
         'title'     => 'Published Page',
         'slug'      => 'published-page',
         'author_id' => $user->id,
         'status'    => 'published',
         'order'     => 1,
-    ]);
+    ] );
 
-    Page::create([
+    Page::create( [
         'title'     => 'Draft Page',
         'slug'      => 'draft-page',
         'author_id' => $user->id,
         'status'    => 'draft',
         'order'     => 2,
-    ]);
+    ] );
 
     $manager = new PageManager;
     $results = $manager->getPageQuery()->get();
 
-    expect($results)->toHaveCount(2);
-});
+    expect( $results )->toHaveCount( 2 );
+} );
 
-test('blog manager status filter falls back to published for invalid status', function (): void {
-    $user = TestUser::create([
+test( 'blog manager status filter falls back to published for invalid status', function (): void {
+    $user = TestUser::create( [
         'name'     => 'Test Author',
         'email'    => 'author@example.com',
         'password' => 'password',
-    ]);
+    ] );
 
-    Post::create([
+    Post::create( [
         'title'        => 'Published Post',
         'slug'         => 'published-post',
         'author_id'    => $user->id,
         'status'       => 'published',
         'published_at' => now()->subDay(),
-    ]);
+    ] );
 
-    Post::create([
+    Post::create( [
         'title'     => 'Draft Post',
         'slug'      => 'draft-post',
         'author_id' => $user->id,
         'status'    => 'draft',
-    ]);
+    ] );
 
     $manager = new BlogManager;
-    $results = $manager->getArchiveQuery(['status' => 'nonexistent'])->get();
+    $results = $manager->getArchiveQuery( ['status' => 'nonexistent'] )->get();
 
-    expect($results)->toHaveCount(1);
-    expect($results->first()->title)->toBe('Published Post');
-});
+    expect( $results )->toHaveCount( 1 );
+    expect( $results->first()->title )->toBe( 'Published Post' );
+} );
 
-test('blog manager search filter escapes LIKE wildcards', function (): void {
-    $user = TestUser::create([
+test( 'blog manager search filter escapes LIKE wildcards', function (): void {
+    $user = TestUser::create( [
         'name'     => 'Test Author',
         'email'    => 'author@example.com',
         'password' => 'password',
-    ]);
+    ] );
 
-    Post::create([
+    Post::create( [
         'title'        => 'Sale: 50% off everything',
         'slug'         => 'sale-50-percent',
         'content'      => 'Big sale',
         'author_id'    => $user->id,
         'status'       => 'published',
         'published_at' => now()->subDay(),
-    ]);
+    ] );
 
-    Post::create([
+    Post::create( [
         'title'        => 'Top 50 items for your home',
         'slug'         => 'top-50-items',
         'content'      => 'Home decor list',
@@ -326,8 +326,8 @@ test('blog manager search filter escapes LIKE wildcards', function (): void {
     $manager = new BlogManager;
 
     // Searching for literal "50%" should only match the post with "50%" in the title
-    $results = $manager->getArchiveQuery(['search' => '50%'])->get();
+    $results = $manager->getArchiveQuery( ['search' => '50%'])->get();
 
-    expect($results)->toHaveCount(1);
-    expect($results->first()->title)->toBe('Sale: 50% off everything');
+    expect( $results)->toHaveCount( 1);
+    expect( $results->first()->title)->toBe( 'Sale: 50% off everything');
 });

--- a/tests/Unit/ContentTypes/HasContentFiltersTest.php
+++ b/tests/Unit/ContentTypes/HasContentFiltersTest.php
@@ -321,13 +321,13 @@ test( 'blog manager search filter escapes LIKE wildcards', function (): void {
         'author_id'    => $user->id,
         'status'       => 'published',
         'published_at' => now()->subDay(),
-    ]);
+    ] );
 
     $manager = new BlogManager;
 
     // Searching for literal "50%" should only match the post with "50%" in the title
-    $results = $manager->getArchiveQuery( ['search' => '50%'])->get();
+    $results = $manager->getArchiveQuery( ['search' => '50%'] )->get();
 
-    expect( $results)->toHaveCount( 1);
-    expect( $results->first()->title)->toBe( 'Sale: 50% off everything');
-});
+    expect( $results )->toHaveCount( 1 );
+    expect( $results->first()->title )->toBe( 'Sale: 50% off everything' );
+} );

--- a/tests/Unit/ContentTypes/HasContentFiltersTest.php
+++ b/tests/Unit/ContentTypes/HasContentFiltersTest.php
@@ -1,0 +1,299 @@
+<?php
+
+declare(strict_types=1);
+
+use ArtisanPackUI\CMSFramework\Modules\Blog\Managers\BlogManager;
+use ArtisanPackUI\CMSFramework\Modules\Blog\Models\Post;
+use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Enums\ContentStatus;
+use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Managers\Concerns\HasContentFilters;
+use ArtisanPackUI\CMSFramework\Modules\Pages\Managers\PageManager;
+use ArtisanPackUI\CMSFramework\Modules\Pages\Models\Page;
+use ArtisanPackUI\CMSFramework\Tests\Support\TestUser;
+
+beforeEach(function (): void {
+    $this->artisan('migrate', ['--database' => 'testing']);
+});
+
+test('BlogManager uses HasContentFilters trait', function (): void {
+    expect(in_array(HasContentFilters::class, class_uses_recursive(BlogManager::class)))->toBeTrue();
+});
+
+test('PageManager uses HasContentFilters trait', function (): void {
+    expect(in_array(HasContentFilters::class, class_uses_recursive(PageManager::class)))->toBeTrue();
+});
+
+test('blog manager status filter defaults to published', function (): void {
+    $user = TestUser::create([
+        'name'     => 'Test Author',
+        'email'    => 'author@example.com',
+        'password' => 'password',
+    ]);
+
+    Post::create([
+        'title'        => 'Published Post',
+        'slug'         => 'published-post',
+        'author_id'    => $user->id,
+        'status'       => 'published',
+        'published_at' => now()->subDay(),
+    ]);
+
+    Post::create([
+        'title'     => 'Draft Post',
+        'slug'      => 'draft-post',
+        'author_id' => $user->id,
+        'status'    => 'draft',
+    ]);
+
+    $manager = new BlogManager;
+    $results = $manager->getArchiveQuery()->get();
+
+    expect($results)->toHaveCount(1);
+    expect($results->first()->title)->toBe('Published Post');
+});
+
+test('blog manager status filter with draft status', function (): void {
+    $user = TestUser::create([
+        'name'     => 'Test Author',
+        'email'    => 'author@example.com',
+        'password' => 'password',
+    ]);
+
+    Post::create([
+        'title'        => 'Published Post',
+        'slug'         => 'published-post',
+        'author_id'    => $user->id,
+        'status'       => 'published',
+        'published_at' => now()->subDay(),
+    ]);
+
+    Post::create([
+        'title'     => 'Draft Post',
+        'slug'      => 'draft-post',
+        'author_id' => $user->id,
+        'status'    => 'draft',
+    ]);
+
+    $manager = new BlogManager;
+    $results = $manager->getArchiveQuery(['status' => 'draft'])->get();
+
+    expect($results)->toHaveCount(1);
+    expect($results->first()->title)->toBe('Draft Post');
+});
+
+test('blog manager status filter with ContentStatus enum', function (): void {
+    $user = TestUser::create([
+        'name'     => 'Test Author',
+        'email'    => 'author@example.com',
+        'password' => 'password',
+    ]);
+
+    Post::create([
+        'title'     => 'Draft Post',
+        'slug'      => 'draft-post',
+        'author_id' => $user->id,
+        'status'    => 'draft',
+    ]);
+
+    Post::create([
+        'title'        => 'Published Post',
+        'slug'         => 'published-post',
+        'author_id'    => $user->id,
+        'status'       => 'published',
+        'published_at' => now()->subDay(),
+    ]);
+
+    $manager = new BlogManager;
+    $results = $manager->getArchiveQuery(['status' => ContentStatus::Draft])->get();
+
+    expect($results)->toHaveCount(1);
+    expect($results->first()->title)->toBe('Draft Post');
+});
+
+test('blog manager search filter searches title content and excerpt', function (): void {
+    $user = TestUser::create([
+        'name'     => 'Test Author',
+        'email'    => 'author@example.com',
+        'password' => 'password',
+    ]);
+
+    Post::create([
+        'title'        => 'Laravel Tutorial',
+        'slug'         => 'laravel-tutorial',
+        'content'      => 'Learn about PHP frameworks',
+        'author_id'    => $user->id,
+        'status'       => 'published',
+        'published_at' => now()->subDay(),
+    ]);
+
+    Post::create([
+        'title'        => 'Vue Guide',
+        'slug'         => 'vue-guide',
+        'content'      => 'Frontend framework guide',
+        'author_id'    => $user->id,
+        'status'       => 'published',
+        'published_at' => now()->subDay(),
+    ]);
+
+    $manager = new BlogManager;
+    $results = $manager->getArchiveQuery(['search' => 'Laravel'])->get();
+
+    expect($results)->toHaveCount(1);
+    expect($results->first()->title)->toBe('Laravel Tutorial');
+});
+
+test('blog manager author filter filters by author', function (): void {
+    $author1 = TestUser::create([
+        'name'     => 'Author 1',
+        'email'    => 'author1@example.com',
+        'password' => 'password',
+    ]);
+
+    $author2 = TestUser::create([
+        'name'     => 'Author 2',
+        'email'    => 'author2@example.com',
+        'password' => 'password',
+    ]);
+
+    Post::create([
+        'title'        => 'Post by Author 1',
+        'slug'         => 'post-author-1',
+        'author_id'    => $author1->id,
+        'status'       => 'published',
+        'published_at' => now()->subDay(),
+    ]);
+
+    Post::create([
+        'title'        => 'Post by Author 2',
+        'slug'         => 'post-author-2',
+        'author_id'    => $author2->id,
+        'status'       => 'published',
+        'published_at' => now()->subDay(),
+    ]);
+
+    $manager = new BlogManager;
+    $results = $manager->getArchiveQuery(['author' => $author1->id])->get();
+
+    expect($results)->toHaveCount(1);
+    expect($results->first()->title)->toBe('Post by Author 1');
+});
+
+test('page manager status filter with draft status', function (): void {
+    $user = TestUser::create([
+        'name'     => 'Test Author',
+        'email'    => 'author@example.com',
+        'password' => 'password',
+    ]);
+
+    Page::create([
+        'title'        => 'Published Page',
+        'slug'         => 'published-page',
+        'author_id'    => $user->id,
+        'status'       => 'published',
+        'published_at' => now()->subDay(),
+        'order'        => 1,
+    ]);
+
+    Page::create([
+        'title'     => 'Draft Page',
+        'slug'      => 'draft-page',
+        'author_id' => $user->id,
+        'status'    => 'draft',
+        'order'     => 2,
+    ]);
+
+    $manager = new PageManager;
+    $results = $manager->getPageQuery(['status' => 'draft'])->get();
+
+    expect($results)->toHaveCount(1);
+    expect($results->first()->title)->toBe('Draft Page');
+});
+
+test('page manager search filter searches title content and excerpt', function (): void {
+    $user = TestUser::create([
+        'name'     => 'Test Author',
+        'email'    => 'author@example.com',
+        'password' => 'password',
+    ]);
+
+    Page::create([
+        'title'     => 'About Us',
+        'slug'      => 'about-us',
+        'content'   => 'Learn about our company',
+        'author_id' => $user->id,
+        'status'    => 'draft',
+        'order'     => 1,
+    ]);
+
+    Page::create([
+        'title'     => 'Contact',
+        'slug'      => 'contact',
+        'content'   => 'Get in touch',
+        'author_id' => $user->id,
+        'status'    => 'draft',
+        'order'     => 2,
+    ]);
+
+    $manager = new PageManager;
+    $results = $manager->getPageQuery(['status' => 'draft', 'search' => 'About'])->get();
+
+    expect($results)->toHaveCount(1);
+    expect($results->first()->title)->toBe('About Us');
+});
+
+test('page manager does not default to published when no status filter', function (): void {
+    $user = TestUser::create([
+        'name'     => 'Test Author',
+        'email'    => 'author@example.com',
+        'password' => 'password',
+    ]);
+
+    Page::create([
+        'title'     => 'Published Page',
+        'slug'      => 'published-page',
+        'author_id' => $user->id,
+        'status'    => 'published',
+        'order'     => 1,
+    ]);
+
+    Page::create([
+        'title'     => 'Draft Page',
+        'slug'      => 'draft-page',
+        'author_id' => $user->id,
+        'status'    => 'draft',
+        'order'     => 2,
+    ]);
+
+    $manager = new PageManager;
+    $results = $manager->getPageQuery()->get();
+
+    expect($results)->toHaveCount(2);
+});
+
+test('blog manager status filter falls back to published for invalid status', function (): void {
+    $user = TestUser::create([
+        'name'     => 'Test Author',
+        'email'    => 'author@example.com',
+        'password' => 'password',
+    ]);
+
+    Post::create([
+        'title'        => 'Published Post',
+        'slug'         => 'published-post',
+        'author_id'    => $user->id,
+        'status'       => 'published',
+        'published_at' => now()->subDay(),
+    ]);
+
+    Post::create([
+        'title'     => 'Draft Post',
+        'slug'      => 'draft-post',
+        'author_id' => $user->id,
+        'status'    => 'draft',
+    ]);
+
+    $manager = new BlogManager;
+    $results = $manager->getArchiveQuery(['status' => 'nonexistent'])->get();
+
+    expect($results)->toHaveCount(1);
+    expect($results->first()->title)->toBe('Published Post');
+});

--- a/tests/Unit/ContentTypes/HasContentFiltersTest.php
+++ b/tests/Unit/ContentTypes/HasContentFiltersTest.php
@@ -297,3 +297,37 @@ test('blog manager status filter falls back to published for invalid status', fu
     expect($results)->toHaveCount(1);
     expect($results->first()->title)->toBe('Published Post');
 });
+
+test('blog manager search filter escapes LIKE wildcards', function (): void {
+    $user = TestUser::create([
+        'name'     => 'Test Author',
+        'email'    => 'author@example.com',
+        'password' => 'password',
+    ]);
+
+    Post::create([
+        'title'        => 'Sale: 50% off everything',
+        'slug'         => 'sale-50-percent',
+        'content'      => 'Big sale',
+        'author_id'    => $user->id,
+        'status'       => 'published',
+        'published_at' => now()->subDay(),
+    ]);
+
+    Post::create([
+        'title'        => 'Top 50 items for your home',
+        'slug'         => 'top-50-items',
+        'content'      => 'Home decor list',
+        'author_id'    => $user->id,
+        'status'       => 'published',
+        'published_at' => now()->subDay(),
+    ]);
+
+    $manager = new BlogManager;
+
+    // Searching for literal "50%" should only match the post with "50%" in the title
+    $results = $manager->getArchiveQuery(['search' => '50%'])->get();
+
+    expect($results)->toHaveCount(1);
+    expect($results->first()->title)->toBe('Sale: 50% off everything');
+});

--- a/tests/Unit/ContentTypes/HasContentStatusTest.php
+++ b/tests/Unit/ContentTypes/HasContentStatusTest.php
@@ -1,0 +1,205 @@
+<?php
+
+declare(strict_types=1);
+
+use ArtisanPackUI\CMSFramework\Modules\Blog\Models\Post;
+use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Models\Concerns\HasContentStatus;
+use ArtisanPackUI\CMSFramework\Modules\Pages\Models\Page;
+use ArtisanPackUI\CMSFramework\Tests\Support\TestUser;
+
+beforeEach(function (): void {
+    $this->artisan('migrate', ['--database' => 'testing']);
+});
+
+test('post model uses HasContentStatus trait', function (): void {
+    expect(in_array(HasContentStatus::class, class_uses_recursive(Post::class)))->toBeTrue();
+});
+
+test('page model uses HasContentStatus trait', function (): void {
+    expect(in_array(HasContentStatus::class, class_uses_recursive(Page::class)))->toBeTrue();
+});
+
+test('scopePublished filters published posts via trait', function (): void {
+    $user = TestUser::create([
+        'name'     => 'Test Author',
+        'email'    => 'author@example.com',
+        'password' => 'password',
+    ]);
+
+    Post::create([
+        'title'        => 'Published Post',
+        'slug'         => 'published-post',
+        'author_id'    => $user->id,
+        'status'       => 'published',
+        'published_at' => now()->subDay(),
+    ]);
+
+    Post::create([
+        'title'     => 'Draft Post',
+        'slug'      => 'draft-post',
+        'author_id' => $user->id,
+        'status'    => 'draft',
+    ]);
+
+    Post::create([
+        'title'        => 'Future Post',
+        'slug'         => 'future-post',
+        'author_id'    => $user->id,
+        'status'       => 'published',
+        'published_at' => now()->addDay(),
+    ]);
+
+    $published = Post::published()->get();
+
+    expect($published)->toHaveCount(1);
+    expect($published->first()->title)->toBe('Published Post');
+});
+
+test('scopePublished filters published pages via trait', function (): void {
+    $user = TestUser::create([
+        'name'     => 'Test Author',
+        'email'    => 'author@example.com',
+        'password' => 'password',
+    ]);
+
+    Page::create([
+        'title'        => 'Published Page',
+        'slug'         => 'published-page',
+        'author_id'    => $user->id,
+        'status'       => 'published',
+        'published_at' => now()->subDay(),
+        'order'        => 1,
+    ]);
+
+    Page::create([
+        'title'     => 'Draft Page',
+        'slug'      => 'draft-page',
+        'author_id' => $user->id,
+        'status'    => 'draft',
+        'order'     => 2,
+    ]);
+
+    $published = Page::published()->get();
+
+    expect($published)->toHaveCount(1);
+    expect($published->first()->title)->toBe('Published Page');
+});
+
+test('scopeDraft filters draft content via trait', function (): void {
+    $user = TestUser::create([
+        'name'     => 'Test Author',
+        'email'    => 'author@example.com',
+        'password' => 'password',
+    ]);
+
+    Post::create([
+        'title'     => 'Published Post',
+        'slug'      => 'published-post',
+        'author_id' => $user->id,
+        'status'    => 'published',
+    ]);
+
+    Post::create([
+        'title'     => 'Draft Post',
+        'slug'      => 'draft-post',
+        'author_id' => $user->id,
+        'status'    => 'draft',
+    ]);
+
+    $drafts = Post::draft()->get();
+
+    expect($drafts)->toHaveCount(1);
+    expect($drafts->first()->title)->toBe('Draft Post');
+});
+
+test('isPublished returns true for published content via trait', function (): void {
+    $user = TestUser::create([
+        'name'     => 'Test Author',
+        'email'    => 'author@example.com',
+        'password' => 'password',
+    ]);
+
+    $post = Post::create([
+        'title'        => 'Published Post',
+        'slug'         => 'published-post',
+        'author_id'    => $user->id,
+        'status'       => 'published',
+        'published_at' => now()->subDay(),
+    ]);
+
+    expect($post->isPublished())->toBeTrue();
+});
+
+test('isPublished returns false for draft content via trait', function (): void {
+    $user = TestUser::create([
+        'name'     => 'Test Author',
+        'email'    => 'author@example.com',
+        'password' => 'password',
+    ]);
+
+    $post = Post::create([
+        'title'     => 'Draft Post',
+        'slug'      => 'draft-post',
+        'author_id' => $user->id,
+        'status'    => 'draft',
+    ]);
+
+    expect($post->isPublished())->toBeFalse();
+});
+
+test('isPublished returns false for future published content via trait', function (): void {
+    $user = TestUser::create([
+        'name'     => 'Test Author',
+        'email'    => 'author@example.com',
+        'password' => 'password',
+    ]);
+
+    $post = Post::create([
+        'title'        => 'Future Post',
+        'slug'         => 'future-post',
+        'author_id'    => $user->id,
+        'status'       => 'published',
+        'published_at' => now()->addDay(),
+    ]);
+
+    expect($post->isPublished())->toBeFalse();
+});
+
+test('isPublished returns true for published content with null published_at via trait', function (): void {
+    $user = TestUser::create([
+        'name'     => 'Test Author',
+        'email'    => 'author@example.com',
+        'password' => 'password',
+    ]);
+
+    $post = Post::create([
+        'title'        => 'Published Post',
+        'slug'         => 'published-post',
+        'author_id'    => $user->id,
+        'status'       => 'published',
+        'published_at' => null,
+    ]);
+
+    expect($post->isPublished())->toBeTrue();
+});
+
+test('scopePublished includes content with null published_at via trait', function (): void {
+    $user = TestUser::create([
+        'name'     => 'Test Author',
+        'email'    => 'author@example.com',
+        'password' => 'password',
+    ]);
+
+    Post::create([
+        'title'        => 'Published No Date',
+        'slug'         => 'published-no-date',
+        'author_id'    => $user->id,
+        'status'       => 'published',
+        'published_at' => null,
+    ]);
+
+    $published = Post::published()->get();
+
+    expect($published)->toHaveCount(1);
+    expect($published->first()->title)->toBe('Published No Date');
+});

--- a/tests/Unit/ContentTypes/HasContentStatusTest.php
+++ b/tests/Unit/ContentTypes/HasContentStatusTest.php
@@ -1,205 +1,205 @@
 <?php
 
-declare(strict_types=1);
+declare( strict_types=1 );
 
 use ArtisanPackUI\CMSFramework\Modules\Blog\Models\Post;
 use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Models\Concerns\HasContentStatus;
 use ArtisanPackUI\CMSFramework\Modules\Pages\Models\Page;
 use ArtisanPackUI\CMSFramework\Tests\Support\TestUser;
 
-beforeEach(function (): void {
-    $this->artisan('migrate', ['--database' => 'testing']);
-});
+beforeEach( function (): void {
+    $this->artisan( 'migrate', ['--database' => 'testing'] );
+} );
 
-test('post model uses HasContentStatus trait', function (): void {
-    expect(in_array(HasContentStatus::class, class_uses_recursive(Post::class)))->toBeTrue();
-});
+test( 'post model uses HasContentStatus trait', function (): void {
+    expect( in_array( HasContentStatus::class, class_uses_recursive( Post::class ) ) )->toBeTrue();
+} );
 
-test('page model uses HasContentStatus trait', function (): void {
-    expect(in_array(HasContentStatus::class, class_uses_recursive(Page::class)))->toBeTrue();
-});
+test( 'page model uses HasContentStatus trait', function (): void {
+    expect( in_array( HasContentStatus::class, class_uses_recursive( Page::class ) ) )->toBeTrue();
+} );
 
-test('scopePublished filters published posts via trait', function (): void {
-    $user = TestUser::create([
+test( 'scopePublished filters published posts via trait', function (): void {
+    $user = TestUser::create( [
         'name'     => 'Test Author',
         'email'    => 'author@example.com',
         'password' => 'password',
-    ]);
+    ] );
 
-    Post::create([
+    Post::create( [
         'title'        => 'Published Post',
         'slug'         => 'published-post',
         'author_id'    => $user->id,
         'status'       => 'published',
         'published_at' => now()->subDay(),
-    ]);
+    ] );
 
-    Post::create([
+    Post::create( [
         'title'     => 'Draft Post',
         'slug'      => 'draft-post',
         'author_id' => $user->id,
         'status'    => 'draft',
-    ]);
+    ] );
 
-    Post::create([
+    Post::create( [
         'title'        => 'Future Post',
         'slug'         => 'future-post',
         'author_id'    => $user->id,
         'status'       => 'published',
         'published_at' => now()->addDay(),
-    ]);
+    ] );
 
     $published = Post::published()->get();
 
-    expect($published)->toHaveCount(1);
-    expect($published->first()->title)->toBe('Published Post');
-});
+    expect( $published )->toHaveCount( 1 );
+    expect( $published->first()->title )->toBe( 'Published Post' );
+} );
 
-test('scopePublished filters published pages via trait', function (): void {
-    $user = TestUser::create([
+test( 'scopePublished filters published pages via trait', function (): void {
+    $user = TestUser::create( [
         'name'     => 'Test Author',
         'email'    => 'author@example.com',
         'password' => 'password',
-    ]);
+    ] );
 
-    Page::create([
+    Page::create( [
         'title'        => 'Published Page',
         'slug'         => 'published-page',
         'author_id'    => $user->id,
         'status'       => 'published',
         'published_at' => now()->subDay(),
         'order'        => 1,
-    ]);
+    ] );
 
-    Page::create([
+    Page::create( [
         'title'     => 'Draft Page',
         'slug'      => 'draft-page',
         'author_id' => $user->id,
         'status'    => 'draft',
         'order'     => 2,
-    ]);
+    ] );
 
     $published = Page::published()->get();
 
-    expect($published)->toHaveCount(1);
-    expect($published->first()->title)->toBe('Published Page');
-});
+    expect( $published )->toHaveCount( 1 );
+    expect( $published->first()->title )->toBe( 'Published Page' );
+} );
 
-test('scopeDraft filters draft content via trait', function (): void {
-    $user = TestUser::create([
+test( 'scopeDraft filters draft content via trait', function (): void {
+    $user = TestUser::create( [
         'name'     => 'Test Author',
         'email'    => 'author@example.com',
         'password' => 'password',
-    ]);
+    ] );
 
-    Post::create([
+    Post::create( [
         'title'     => 'Published Post',
         'slug'      => 'published-post',
         'author_id' => $user->id,
         'status'    => 'published',
-    ]);
+    ] );
 
-    Post::create([
+    Post::create( [
         'title'     => 'Draft Post',
         'slug'      => 'draft-post',
         'author_id' => $user->id,
         'status'    => 'draft',
-    ]);
+    ] );
 
     $drafts = Post::draft()->get();
 
-    expect($drafts)->toHaveCount(1);
-    expect($drafts->first()->title)->toBe('Draft Post');
-});
+    expect( $drafts )->toHaveCount( 1 );
+    expect( $drafts->first()->title )->toBe( 'Draft Post' );
+} );
 
-test('isPublished returns true for published content via trait', function (): void {
-    $user = TestUser::create([
+test( 'isPublished returns true for published content via trait', function (): void {
+    $user = TestUser::create( [
         'name'     => 'Test Author',
         'email'    => 'author@example.com',
         'password' => 'password',
-    ]);
+    ] );
 
-    $post = Post::create([
+    $post = Post::create( [
         'title'        => 'Published Post',
         'slug'         => 'published-post',
         'author_id'    => $user->id,
         'status'       => 'published',
         'published_at' => now()->subDay(),
-    ]);
+    ] );
 
-    expect($post->isPublished())->toBeTrue();
-});
+    expect( $post->isPublished() )->toBeTrue();
+} );
 
-test('isPublished returns false for draft content via trait', function (): void {
-    $user = TestUser::create([
+test( 'isPublished returns false for draft content via trait', function (): void {
+    $user = TestUser::create( [
         'name'     => 'Test Author',
         'email'    => 'author@example.com',
         'password' => 'password',
-    ]);
+    ] );
 
-    $post = Post::create([
+    $post = Post::create( [
         'title'     => 'Draft Post',
         'slug'      => 'draft-post',
         'author_id' => $user->id,
         'status'    => 'draft',
-    ]);
+    ] );
 
-    expect($post->isPublished())->toBeFalse();
-});
+    expect( $post->isPublished() )->toBeFalse();
+} );
 
-test('isPublished returns false for future published content via trait', function (): void {
-    $user = TestUser::create([
+test( 'isPublished returns false for future published content via trait', function (): void {
+    $user = TestUser::create( [
         'name'     => 'Test Author',
         'email'    => 'author@example.com',
         'password' => 'password',
-    ]);
+    ] );
 
-    $post = Post::create([
+    $post = Post::create( [
         'title'        => 'Future Post',
         'slug'         => 'future-post',
         'author_id'    => $user->id,
         'status'       => 'published',
         'published_at' => now()->addDay(),
-    ]);
+    ] );
 
-    expect($post->isPublished())->toBeFalse();
-});
+    expect( $post->isPublished() )->toBeFalse();
+} );
 
-test('isPublished returns true for published content with null published_at via trait', function (): void {
-    $user = TestUser::create([
+test( 'isPublished returns true for published content with null published_at via trait', function (): void {
+    $user = TestUser::create( [
         'name'     => 'Test Author',
         'email'    => 'author@example.com',
         'password' => 'password',
-    ]);
+    ] );
 
-    $post = Post::create([
+    $post = Post::create( [
         'title'        => 'Published Post',
         'slug'         => 'published-post',
         'author_id'    => $user->id,
         'status'       => 'published',
         'published_at' => null,
-    ]);
+    ] );
 
-    expect($post->isPublished())->toBeTrue();
-});
+    expect( $post->isPublished() )->toBeTrue();
+} );
 
-test('scopePublished includes content with null published_at via trait', function (): void {
-    $user = TestUser::create([
+test( 'scopePublished includes content with null published_at via trait', function (): void {
+    $user = TestUser::create( [
         'name'     => 'Test Author',
         'email'    => 'author@example.com',
         'password' => 'password',
-    ]);
+    ] );
 
-    Post::create([
+    Post::create( [
         'title'        => 'Published No Date',
         'slug'         => 'published-no-date',
         'author_id'    => $user->id,
         'status'       => 'published',
         'published_at' => null,
-    ]);
+    ] );
 
     $published = Post::published()->get();
 
-    expect($published)->toHaveCount(1);
-    expect($published->first()->title)->toBe('Published No Date');
+    expect( $published)->toHaveCount( 1);
+    expect( $published->first()->title)->toBe( 'Published No Date');
 });

--- a/tests/Unit/ContentTypes/HasContentStatusTest.php
+++ b/tests/Unit/ContentTypes/HasContentStatusTest.php
@@ -200,6 +200,6 @@ test( 'scopePublished includes content with null published_at via trait', functi
 
     $published = Post::published()->get();
 
-    expect( $published)->toHaveCount( 1);
-    expect( $published->first()->title)->toBe( 'Published No Date');
-});
+    expect( $published )->toHaveCount( 1 );
+    expect( $published->first()->title )->toBe( 'Published No Date' );
+} );

--- a/tests/Unit/Core/AssetManagerTest.php
+++ b/tests/Unit/Core/AssetManagerTest.php
@@ -92,4 +92,4 @@ test( 'auth: enqueuing assets registers and lists them', function (): void {
             'path'     => '/auth/app.js',
             'inFooter' => true,
         ] );
-});
+} );

--- a/tests/Unit/Core/AssetManagerTest.php
+++ b/tests/Unit/Core/AssetManagerTest.php
@@ -86,10 +86,10 @@ test( 'auth: enqueuing assets registers and lists them', function (): void {
     $result = $assets->authAssets();
 
     expect( $result )->toBeArray();
-    expect( $result)->toHaveKey( 'auth-js');
-    expect( $result['auth-js'])
+    expect( $result )->toHaveKey( 'auth-js' );
+    expect( $result['auth-js'] )
         ->toMatchArray( [
             'path'     => '/auth/app.js',
             'inFooter' => true,
-        ]);
+        ] );
 });

--- a/tests/Unit/Core/CoreAssetHelpersTest.php
+++ b/tests/Unit/Core/CoreAssetHelpersTest.php
@@ -55,5 +55,5 @@ test( 'auth helpers: enqueue and retrieve assets via helpers', function (): void
         ->toMatchArray( [
             'path'     => '/auth/app.js',
             'inFooter' => true,
-        ]);
-});
+        ] );
+} );

--- a/tests/Unit/Core/HasManifestParsingTest.php
+++ b/tests/Unit/Core/HasManifestParsingTest.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare( strict_types=1 );
 
 use ArtisanPackUI\CMSFramework\Modules\Core\Managers\Concerns\HasManifestParsing;
 use Illuminate\Support\Facades\File;
@@ -8,7 +8,7 @@ use Illuminate\Support\Facades\File;
 /**
  * Anonymous class that uses the trait so we can test the trait methods directly.
  */
-beforeEach(function (): void {
+beforeEach( function (): void {
     $this->parser = new class {
         use HasManifestParsing {
             parseManifest as public;
@@ -16,58 +16,58 @@ beforeEach(function (): void {
             resolveSecurePath as public;
         }
     };
-});
+} );
 
-describe('parseManifest', function (): void {
-    it('parses valid JSON manifest', function (): void {
-        $tempFile = storage_path('app/test-manifest.json');
-        File::put($tempFile, json_encode([
+describe( 'parseManifest', function (): void {
+    it( 'parses valid JSON manifest', function (): void {
+        $tempFile = storage_path( 'app/test-manifest.json' );
+        File::put( $tempFile, json_encode( [
             'slug'    => 'test-package',
             'name'    => 'Test Package',
             'version' => '1.0.0',
-        ]));
+        ] ) );
 
-        $manifest = $this->parser->parseManifest($tempFile);
+        $manifest = $this->parser->parseManifest( $tempFile );
 
-        expect($manifest)->toBeArray()
-            ->and($manifest['slug'])->toBe('test-package')
-            ->and($manifest['name'])->toBe('Test Package')
-            ->and($manifest['version'])->toBe('1.0.0');
+        expect( $manifest )->toBeArray()
+            ->and( $manifest['slug'] )->toBe( 'test-package' )
+            ->and( $manifest['name'] )->toBe( 'Test Package' )
+            ->and( $manifest['version'] )->toBe( '1.0.0' );
 
-        File::delete($tempFile);
-    });
+        File::delete( $tempFile );
+    } );
 
-    it('returns null for non-existent manifest', function (): void {
-        $manifest = $this->parser->parseManifest('/non/existent/path/manifest.json');
+    it( 'returns null for non-existent manifest', function (): void {
+        $manifest = $this->parser->parseManifest( '/non/existent/path/manifest.json' );
 
-        expect($manifest)->toBeNull();
-    });
+        expect( $manifest )->toBeNull();
+    } );
 
-    it('returns null for invalid JSON', function (): void {
-        $tempFile = storage_path('app/invalid-manifest.json');
-        File::put($tempFile, '{invalid json content}');
+    it( 'returns null for invalid JSON', function (): void {
+        $tempFile = storage_path( 'app/invalid-manifest.json' );
+        File::put( $tempFile, '{invalid json content}' );
 
-        $manifest = $this->parser->parseManifest($tempFile);
+        $manifest = $this->parser->parseManifest( $tempFile );
 
-        expect($manifest)->toBeNull();
+        expect( $manifest )->toBeNull();
 
-        File::delete($tempFile);
-    });
+        File::delete( $tempFile );
+    } );
 
-    it('returns null for empty file', function (): void {
-        $tempFile = storage_path('app/empty-manifest.json');
-        File::put($tempFile, '');
+    it( 'returns null for empty file', function (): void {
+        $tempFile = storage_path( 'app/empty-manifest.json' );
+        File::put( $tempFile, '' );
 
-        $manifest = $this->parser->parseManifest($tempFile);
+        $manifest = $this->parser->parseManifest( $tempFile );
 
-        expect($manifest)->toBeNull();
+        expect( $manifest )->toBeNull();
 
-        File::delete($tempFile);
-    });
+        File::delete( $tempFile );
+    } );
 
-    it('handles nested JSON structures', function (): void {
-        $tempFile = storage_path('app/nested-manifest.json');
-        File::put($tempFile, json_encode([
+    it( 'handles nested JSON structures', function (): void {
+        $tempFile = storage_path( 'app/nested-manifest.json' );
+        File::put( $tempFile, json_encode( [
             'slug'     => 'nested-package',
             'name'     => 'Nested Package',
             'version'  => '2.0.0',
@@ -76,22 +76,22 @@ describe('parseManifest', function (): void {
                     'NestedPackage\\' => 'src/',
                 ],
             ],
-        ]));
+        ] ) );
 
-        $manifest = $this->parser->parseManifest($tempFile);
+        $manifest = $this->parser->parseManifest( $tempFile );
 
-        expect($manifest)->toBeArray()
-            ->and($manifest['autoload']['psr-4'])->toBeArray()
-            ->and($manifest['autoload']['psr-4']['NestedPackage\\'])->toBe('src/');
+        expect( $manifest )->toBeArray()
+            ->and( $manifest['autoload']['psr-4'] )->toBeArray()
+            ->and( $manifest['autoload']['psr-4']['NestedPackage\\'] )->toBe( 'src/' );
 
-        File::delete($tempFile);
-    });
-});
+        File::delete( $tempFile );
+    } );
+} );
 
-describe('validateSlug', function (): void {
-    it('accepts valid slugs', function (string $slug): void {
-        expect($this->parser->validateSlug($slug))->toBeTrue();
-    })->with([
+describe( 'validateSlug', function (): void {
+    it( 'accepts valid slugs', function ( string $slug ): void {
+        expect( $this->parser->validateSlug( $slug ) )->toBeTrue();
+    } )->with( [
         'lowercase'          => 'my-plugin',
         'uppercase'          => 'MyPlugin',
         'mixed case'         => 'My-Plugin',
@@ -101,11 +101,11 @@ describe('validateSlug', function (): void {
         'mixed'              => 'my-Plugin_123',
         'single character'   => 'a',
         'all numbers'        => '123',
-    ]);
+    ] );
 
-    it('rejects invalid slugs', function (string $slug): void {
-        expect($this->parser->validateSlug($slug))->toBeFalse();
-    })->with([
+    it( 'rejects invalid slugs', function ( string $slug ): void {
+        expect( $this->parser->validateSlug( $slug ) )->toBeFalse();
+    } )->with( [
         'path traversal'     => '../../../etc/passwd',
         'slashes'            => 'plugin/with/slashes',
         'spaces'             => 'plugin with spaces',
@@ -116,54 +116,54 @@ describe('validateSlug', function (): void {
         'backslash'          => 'plugin\\name',
         'semicolon'          => 'plugin;name',
         'pipe'               => 'plugin|name',
-    ]);
-});
+    ] );
+} );
 
-describe('resolveSecurePath', function (): void {
-    it('resolves a valid path within base directory', function (): void {
-        $basePath = storage_path('app');
-        $itemPath = $basePath.'/test-item';
+describe( 'resolveSecurePath', function (): void {
+    it( 'resolves a valid path within base directory', function (): void {
+        $basePath = storage_path( 'app' );
+        $itemPath = $basePath . '/test-item';
 
         // Create the directory so realpath works
-        File::ensureDirectoryExists($itemPath);
+        File::ensureDirectoryExists( $itemPath );
 
-        $result = $this->parser->resolveSecurePath($itemPath, $basePath);
+        $result = $this->parser->resolveSecurePath( $itemPath, $basePath );
 
-        expect($result)->not->toBeNull()
-            ->and($result)->toContain('test-item');
+        expect( $result )->not->toBeNull()
+            ->and( $result )->toContain( 'test-item' );
 
-        File::deleteDirectory($itemPath);
-    });
+        File::deleteDirectory( $itemPath );
+    } );
 
-    it('returns null for non-existent path', function (): void {
-        $basePath = storage_path('app');
-        $itemPath = $basePath.'/non-existent-directory';
+    it( 'returns null for non-existent path', function (): void {
+        $basePath = storage_path( 'app' );
+        $itemPath = $basePath . '/non-existent-directory';
 
-        $result = $this->parser->resolveSecurePath($itemPath, $basePath);
+        $result = $this->parser->resolveSecurePath( $itemPath, $basePath );
 
-        expect($result)->toBeNull();
-    });
+        expect( $result )->toBeNull();
+    } );
 
-    it('returns null for path traversal attempt', function (): void {
-        $basePath = storage_path('app/plugins');
-        File::ensureDirectoryExists($basePath);
+    it( 'returns null for path traversal attempt', function (): void {
+        $basePath = storage_path( 'app/plugins' );
+        File::ensureDirectoryExists( $basePath );
 
         // Try to escape the base directory
-        $itemPath = $basePath.'/../../';
+        $itemPath = $basePath . '/../../';
 
-        $result = $this->parser->resolveSecurePath($itemPath, $basePath);
+        $result = $this->parser->resolveSecurePath( $itemPath, $basePath );
 
-        expect($result)->toBeNull();
+        expect( $result )->toBeNull();
 
-        File::deleteDirectory($basePath);
-    });
+        File::deleteDirectory( $basePath );
+    } );
 
-    it('returns null when base path does not exist', function (): void {
-        $basePath = storage_path('app/non-existent-base');
-        $itemPath = $basePath.'/some-item';
+    it( 'returns null when base path does not exist', function (): void {
+        $basePath = storage_path( 'app/non-existent-base');
+        $itemPath = $basePath . '/some-item';
 
-        $result = $this->parser->resolveSecurePath($itemPath, $basePath);
+        $result = $this->parser->resolveSecurePath( $itemPath, $basePath);
 
-        expect($result)->toBeNull();
+        expect( $result)->toBeNull();
     });
 });

--- a/tests/Unit/Core/HasManifestParsingTest.php
+++ b/tests/Unit/Core/HasManifestParsingTest.php
@@ -159,11 +159,11 @@ describe( 'resolveSecurePath', function (): void {
     } );
 
     it( 'returns null when base path does not exist', function (): void {
-        $basePath = storage_path( 'app/non-existent-base');
+        $basePath = storage_path( 'app/non-existent-base' );
         $itemPath = $basePath . '/some-item';
 
-        $result = $this->parser->resolveSecurePath( $itemPath, $basePath);
+        $result = $this->parser->resolveSecurePath( $itemPath, $basePath );
 
-        expect( $result)->toBeNull();
-    });
-});
+        expect( $result )->toBeNull();
+    } );
+} );

--- a/tests/Unit/Core/HasManifestParsingTest.php
+++ b/tests/Unit/Core/HasManifestParsingTest.php
@@ -1,0 +1,169 @@
+<?php
+
+declare(strict_types=1);
+
+use ArtisanPackUI\CMSFramework\Modules\Core\Managers\Concerns\HasManifestParsing;
+use Illuminate\Support\Facades\File;
+
+/**
+ * Anonymous class that uses the trait so we can test the trait methods directly.
+ */
+beforeEach(function (): void {
+    $this->parser = new class {
+        use HasManifestParsing {
+            parseManifest as public;
+            validateSlug as public;
+            resolveSecurePath as public;
+        }
+    };
+});
+
+describe('parseManifest', function (): void {
+    it('parses valid JSON manifest', function (): void {
+        $tempFile = storage_path('app/test-manifest.json');
+        File::put($tempFile, json_encode([
+            'slug'    => 'test-package',
+            'name'    => 'Test Package',
+            'version' => '1.0.0',
+        ]));
+
+        $manifest = $this->parser->parseManifest($tempFile);
+
+        expect($manifest)->toBeArray()
+            ->and($manifest['slug'])->toBe('test-package')
+            ->and($manifest['name'])->toBe('Test Package')
+            ->and($manifest['version'])->toBe('1.0.0');
+
+        File::delete($tempFile);
+    });
+
+    it('returns null for non-existent manifest', function (): void {
+        $manifest = $this->parser->parseManifest('/non/existent/path/manifest.json');
+
+        expect($manifest)->toBeNull();
+    });
+
+    it('returns null for invalid JSON', function (): void {
+        $tempFile = storage_path('app/invalid-manifest.json');
+        File::put($tempFile, '{invalid json content}');
+
+        $manifest = $this->parser->parseManifest($tempFile);
+
+        expect($manifest)->toBeNull();
+
+        File::delete($tempFile);
+    });
+
+    it('returns null for empty file', function (): void {
+        $tempFile = storage_path('app/empty-manifest.json');
+        File::put($tempFile, '');
+
+        $manifest = $this->parser->parseManifest($tempFile);
+
+        expect($manifest)->toBeNull();
+
+        File::delete($tempFile);
+    });
+
+    it('handles nested JSON structures', function (): void {
+        $tempFile = storage_path('app/nested-manifest.json');
+        File::put($tempFile, json_encode([
+            'slug'     => 'nested-package',
+            'name'     => 'Nested Package',
+            'version'  => '2.0.0',
+            'autoload' => [
+                'psr-4' => [
+                    'NestedPackage\\' => 'src/',
+                ],
+            ],
+        ]));
+
+        $manifest = $this->parser->parseManifest($tempFile);
+
+        expect($manifest)->toBeArray()
+            ->and($manifest['autoload']['psr-4'])->toBeArray()
+            ->and($manifest['autoload']['psr-4']['NestedPackage\\'])->toBe('src/');
+
+        File::delete($tempFile);
+    });
+});
+
+describe('validateSlug', function (): void {
+    it('accepts valid slugs', function (string $slug): void {
+        expect($this->parser->validateSlug($slug))->toBeTrue();
+    })->with([
+        'lowercase'          => 'my-plugin',
+        'uppercase'          => 'MyPlugin',
+        'mixed case'         => 'My-Plugin',
+        'underscores'        => 'my_plugin',
+        'hyphens'            => 'my-plugin',
+        'numbers'            => 'plugin123',
+        'mixed'              => 'my-Plugin_123',
+        'single character'   => 'a',
+        'all numbers'        => '123',
+    ]);
+
+    it('rejects invalid slugs', function (string $slug): void {
+        expect($this->parser->validateSlug($slug))->toBeFalse();
+    })->with([
+        'path traversal'     => '../../../etc/passwd',
+        'slashes'            => 'plugin/with/slashes',
+        'spaces'             => 'plugin with spaces',
+        'special characters' => 'plugin@special',
+        'dots'               => 'plugin.name',
+        'dot dot'            => '../../vendor',
+        'empty string'       => '',
+        'backslash'          => 'plugin\\name',
+        'semicolon'          => 'plugin;name',
+        'pipe'               => 'plugin|name',
+    ]);
+});
+
+describe('resolveSecurePath', function (): void {
+    it('resolves a valid path within base directory', function (): void {
+        $basePath = storage_path('app');
+        $itemPath = $basePath.'/test-item';
+
+        // Create the directory so realpath works
+        File::ensureDirectoryExists($itemPath);
+
+        $result = $this->parser->resolveSecurePath($itemPath, $basePath);
+
+        expect($result)->not->toBeNull()
+            ->and($result)->toContain('test-item');
+
+        File::deleteDirectory($itemPath);
+    });
+
+    it('returns null for non-existent path', function (): void {
+        $basePath = storage_path('app');
+        $itemPath = $basePath.'/non-existent-directory';
+
+        $result = $this->parser->resolveSecurePath($itemPath, $basePath);
+
+        expect($result)->toBeNull();
+    });
+
+    it('returns null for path traversal attempt', function (): void {
+        $basePath = storage_path('app/plugins');
+        File::ensureDirectoryExists($basePath);
+
+        // Try to escape the base directory
+        $itemPath = $basePath.'/../../';
+
+        $result = $this->parser->resolveSecurePath($itemPath, $basePath);
+
+        expect($result)->toBeNull();
+
+        File::deleteDirectory($basePath);
+    });
+
+    it('returns null when base path does not exist', function (): void {
+        $basePath = storage_path('app/non-existent-base');
+        $itemPath = $basePath.'/some-item';
+
+        $result = $this->parser->resolveSecurePath($itemPath, $basePath);
+
+        expect($result)->toBeNull();
+    });
+});

--- a/tests/Unit/ExampleTest.php
+++ b/tests/Unit/ExampleTest.php
@@ -21,5 +21,5 @@ test( 'array operations', function (): void {
 
     expect( $array )->toHaveCount( 5 );
     expect( $array )->toContain( 3 );
-    expect( $array)->not()->toContain( 6);
-});
+    expect( $array )->not()->toContain( 6 );
+} );

--- a/tests/Unit/HasIncludableRelationshipsTest.php
+++ b/tests/Unit/HasIncludableRelationshipsTest.php
@@ -97,8 +97,8 @@ test( 'returns empty arrays when properties are not defined', function (): void 
     };
 
     $includable = invokeMethod( $controller, 'getIncludableRelationships', [] );
-    $defaults   = invokeMethod( $controller, 'getDefaultIncludes', []);
+    $defaults   = invokeMethod( $controller, 'getDefaultIncludes', [] );
 
-    expect( $includable)->toBe( []);
-    expect( $defaults)->toBe( []);
-});
+    expect( $includable )->toBe( [] );
+    expect( $defaults )->toBe( [] );
+} );

--- a/tests/Unit/HasIncludableRelationshipsTest.php
+++ b/tests/Unit/HasIncludableRelationshipsTest.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+use ArtisanPackUI\CMSFramework\Http\Controllers\Concerns\HasIncludableRelationships;
+use Illuminate\Http\Request;
+
+beforeEach(function (): void {
+    $this->controller = new class {
+        use HasIncludableRelationships;
+
+        protected array $includableRelationships = ['author', 'categories', 'tags'];
+
+        protected array $defaultIncludes = ['author', 'categories'];
+    };
+});
+
+test('returns default includes when no include parameter is present', function (): void {
+    $request = Request::create('/test', 'GET');
+
+    $result = invokeMethod($this->controller, 'getRequestedIncludes', [$request]);
+
+    expect($result)->toBe(['author', 'categories']);
+});
+
+test('returns requested valid includes when include parameter is present', function (): void {
+    $request = Request::create('/test', 'GET', ['include' => 'author,tags']);
+
+    $result = invokeMethod($this->controller, 'getRequestedIncludes', [$request]);
+
+    expect($result)->toBe(['author', 'tags']);
+});
+
+test('filters out invalid includes', function (): void {
+    $request = Request::create('/test', 'GET', ['include' => 'author,nonexistent,tags']);
+
+    $result = invokeMethod($this->controller, 'getRequestedIncludes', [$request]);
+
+    expect($result)->toBe(['author', 'tags']);
+});
+
+test('returns empty array when include parameter is empty string', function (): void {
+    $request = Request::create('/test', 'GET', ['include' => '']);
+
+    $result = invokeMethod($this->controller, 'getRequestedIncludes', [$request]);
+
+    expect($result)->toBe([]);
+});
+
+test('returns empty array when all includes are invalid', function (): void {
+    $request = Request::create('/test', 'GET', ['include' => 'foo,bar,baz']);
+
+    $result = invokeMethod($this->controller, 'getRequestedIncludes', [$request]);
+
+    expect($result)->toBe([]);
+});
+
+test('trims whitespace from include values', function (): void {
+    $request = Request::create('/test', 'GET', ['include' => ' author , tags ']);
+
+    $result = invokeMethod($this->controller, 'getRequestedIncludes', [$request]);
+
+    expect($result)->toBe(['author', 'tags']);
+});
+
+test('returns single valid include', function (): void {
+    $request = Request::create('/test', 'GET', ['include' => 'categories']);
+
+    $result = invokeMethod($this->controller, 'getRequestedIncludes', [$request]);
+
+    expect($result)->toBe(['categories']);
+});
+
+test('returns all allowed includes when all requested', function (): void {
+    $request = Request::create('/test', 'GET', ['include' => 'author,categories,tags']);
+
+    $result = invokeMethod($this->controller, 'getRequestedIncludes', [$request]);
+
+    expect($result)->toBe(['author', 'categories', 'tags']);
+});
+
+test('getIncludableRelationships returns the property value', function (): void {
+    $result = invokeMethod($this->controller, 'getIncludableRelationships', []);
+
+    expect($result)->toBe(['author', 'categories', 'tags']);
+});
+
+test('getDefaultIncludes returns the property value', function (): void {
+    $result = invokeMethod($this->controller, 'getDefaultIncludes', []);
+
+    expect($result)->toBe(['author', 'categories']);
+});
+
+test('returns empty arrays when properties are not defined', function (): void {
+    $controller = new class {
+        use HasIncludableRelationships;
+    };
+
+    $includable = invokeMethod($controller, 'getIncludableRelationships', []);
+    $defaults   = invokeMethod($controller, 'getDefaultIncludes', []);
+
+    expect($includable)->toBe([]);
+    expect($defaults)->toBe([]);
+});

--- a/tests/Unit/HasIncludableRelationshipsTest.php
+++ b/tests/Unit/HasIncludableRelationshipsTest.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare( strict_types=1 );
 
 use ArtisanPackUI\CMSFramework\Http\Controllers\Concerns\HasIncludableRelationships;
 use Illuminate\Http\Request;
 
-beforeEach(function (): void {
+beforeEach( function (): void {
     $this->controller = new class {
         use HasIncludableRelationships;
 
@@ -13,92 +13,92 @@ beforeEach(function (): void {
 
         protected array $defaultIncludes = ['author', 'categories'];
     };
-});
+} );
 
-test('returns default includes when no include parameter is present', function (): void {
-    $request = Request::create('/test', 'GET');
+test( 'returns default includes when no include parameter is present', function (): void {
+    $request = Request::create( '/test', 'GET' );
 
-    $result = invokeMethod($this->controller, 'getRequestedIncludes', [$request]);
+    $result = invokeMethod( $this->controller, 'getRequestedIncludes', [$request] );
 
-    expect($result)->toBe(['author', 'categories']);
-});
+    expect( $result )->toBe( ['author', 'categories'] );
+} );
 
-test('returns requested valid includes when include parameter is present', function (): void {
-    $request = Request::create('/test', 'GET', ['include' => 'author,tags']);
+test( 'returns requested valid includes when include parameter is present', function (): void {
+    $request = Request::create( '/test', 'GET', ['include' => 'author,tags'] );
 
-    $result = invokeMethod($this->controller, 'getRequestedIncludes', [$request]);
+    $result = invokeMethod( $this->controller, 'getRequestedIncludes', [$request] );
 
-    expect($result)->toBe(['author', 'tags']);
-});
+    expect( $result )->toBe( ['author', 'tags'] );
+} );
 
-test('filters out invalid includes', function (): void {
-    $request = Request::create('/test', 'GET', ['include' => 'author,nonexistent,tags']);
+test( 'filters out invalid includes', function (): void {
+    $request = Request::create( '/test', 'GET', ['include' => 'author,nonexistent,tags'] );
 
-    $result = invokeMethod($this->controller, 'getRequestedIncludes', [$request]);
+    $result = invokeMethod( $this->controller, 'getRequestedIncludes', [$request] );
 
-    expect($result)->toBe(['author', 'tags']);
-});
+    expect( $result )->toBe( ['author', 'tags'] );
+} );
 
-test('returns empty array when include parameter is empty string', function (): void {
-    $request = Request::create('/test', 'GET', ['include' => '']);
+test( 'returns empty array when include parameter is empty string', function (): void {
+    $request = Request::create( '/test', 'GET', ['include' => ''] );
 
-    $result = invokeMethod($this->controller, 'getRequestedIncludes', [$request]);
+    $result = invokeMethod( $this->controller, 'getRequestedIncludes', [$request] );
 
-    expect($result)->toBe([]);
-});
+    expect( $result )->toBe( [] );
+} );
 
-test('returns empty array when all includes are invalid', function (): void {
-    $request = Request::create('/test', 'GET', ['include' => 'foo,bar,baz']);
+test( 'returns empty array when all includes are invalid', function (): void {
+    $request = Request::create( '/test', 'GET', ['include' => 'foo,bar,baz'] );
 
-    $result = invokeMethod($this->controller, 'getRequestedIncludes', [$request]);
+    $result = invokeMethod( $this->controller, 'getRequestedIncludes', [$request] );
 
-    expect($result)->toBe([]);
-});
+    expect( $result )->toBe( [] );
+} );
 
-test('trims whitespace from include values', function (): void {
-    $request = Request::create('/test', 'GET', ['include' => ' author , tags ']);
+test( 'trims whitespace from include values', function (): void {
+    $request = Request::create( '/test', 'GET', ['include' => ' author , tags '] );
 
-    $result = invokeMethod($this->controller, 'getRequestedIncludes', [$request]);
+    $result = invokeMethod( $this->controller, 'getRequestedIncludes', [$request] );
 
-    expect($result)->toBe(['author', 'tags']);
-});
+    expect( $result )->toBe( ['author', 'tags'] );
+} );
 
-test('returns single valid include', function (): void {
-    $request = Request::create('/test', 'GET', ['include' => 'categories']);
+test( 'returns single valid include', function (): void {
+    $request = Request::create( '/test', 'GET', ['include' => 'categories'] );
 
-    $result = invokeMethod($this->controller, 'getRequestedIncludes', [$request]);
+    $result = invokeMethod( $this->controller, 'getRequestedIncludes', [$request] );
 
-    expect($result)->toBe(['categories']);
-});
+    expect( $result )->toBe( ['categories'] );
+} );
 
-test('returns all allowed includes when all requested', function (): void {
-    $request = Request::create('/test', 'GET', ['include' => 'author,categories,tags']);
+test( 'returns all allowed includes when all requested', function (): void {
+    $request = Request::create( '/test', 'GET', ['include' => 'author,categories,tags'] );
 
-    $result = invokeMethod($this->controller, 'getRequestedIncludes', [$request]);
+    $result = invokeMethod( $this->controller, 'getRequestedIncludes', [$request] );
 
-    expect($result)->toBe(['author', 'categories', 'tags']);
-});
+    expect( $result )->toBe( ['author', 'categories', 'tags'] );
+} );
 
-test('getIncludableRelationships returns the property value', function (): void {
-    $result = invokeMethod($this->controller, 'getIncludableRelationships', []);
+test( 'getIncludableRelationships returns the property value', function (): void {
+    $result = invokeMethod( $this->controller, 'getIncludableRelationships', [] );
 
-    expect($result)->toBe(['author', 'categories', 'tags']);
-});
+    expect( $result )->toBe( ['author', 'categories', 'tags'] );
+} );
 
-test('getDefaultIncludes returns the property value', function (): void {
-    $result = invokeMethod($this->controller, 'getDefaultIncludes', []);
+test( 'getDefaultIncludes returns the property value', function (): void {
+    $result = invokeMethod( $this->controller, 'getDefaultIncludes', [] );
 
-    expect($result)->toBe(['author', 'categories']);
-});
+    expect( $result )->toBe( ['author', 'categories'] );
+} );
 
-test('returns empty arrays when properties are not defined', function (): void {
+test( 'returns empty arrays when properties are not defined', function (): void {
     $controller = new class {
         use HasIncludableRelationships;
     };
 
-    $includable = invokeMethod($controller, 'getIncludableRelationships', []);
-    $defaults   = invokeMethod($controller, 'getDefaultIncludes', []);
+    $includable = invokeMethod( $controller, 'getIncludableRelationships', [] );
+    $defaults   = invokeMethod( $controller, 'getDefaultIncludes', []);
 
-    expect($includable)->toBe([]);
-    expect($defaults)->toBe([]);
+    expect( $includable)->toBe( []);
+    expect( $defaults)->toBe( []);
 });

--- a/tests/Unit/HasRolesAndPermissionsTest.php
+++ b/tests/Unit/HasRolesAndPermissionsTest.php
@@ -168,4 +168,4 @@ test( 'hasPermissionTo works with role that has multiple permissions', function 
     expect( $user->hasPermissionTo( 'edit-posts' ) )->toBeTrue();
     expect( $user->hasPermissionTo( 'delete-posts' ) )->toBeTrue();
     expect( $user->hasPermissionTo( 'non-existent-permission' ) )->toBeFalse();
-});
+} );

--- a/tests/Unit/HasRolesAndPermissionsTest.php
+++ b/tests/Unit/HasRolesAndPermissionsTest.php
@@ -164,8 +164,8 @@ test( 'hasPermissionTo works with role that has multiple permissions', function 
     $adminRole->permissions()->attach( $permissions );
     $user->roles()->attach( $adminRole );
 
-    expect( $user->hasPermissionTo( 'create-posts'))->toBeTrue();
-    expect( $user->hasPermissionTo( 'edit-posts'))->toBeTrue();
-    expect( $user->hasPermissionTo( 'delete-posts'))->toBeTrue();
-    expect( $user->hasPermissionTo( 'non-existent-permission'))->toBeFalse();
+    expect( $user->hasPermissionTo( 'create-posts' ) )->toBeTrue();
+    expect( $user->hasPermissionTo( 'edit-posts' ) )->toBeTrue();
+    expect( $user->hasPermissionTo( 'delete-posts' ) )->toBeTrue();
+    expect( $user->hasPermissionTo( 'non-existent-permission' ) )->toBeFalse();
 });

--- a/tests/Unit/HelpersTest.php
+++ b/tests/Unit/HelpersTest.php
@@ -141,5 +141,5 @@ test( 'helper functions use app container correctly', function (): void {
 
     $role = ap_register_role( 'test-role', 'Test Role' );
     expect( $role )->toBeInstanceOf( Role::class );
-    expect( $role->slug )->toBe( 'test-role');
+    expect( $role->slug )->toBe( 'test-role' );
 });

--- a/tests/Unit/HelpersTest.php
+++ b/tests/Unit/HelpersTest.php
@@ -142,4 +142,4 @@ test( 'helper functions use app container correctly', function (): void {
     $role = ap_register_role( 'test-role', 'Test Role' );
     expect( $role )->toBeInstanceOf( Role::class );
     expect( $role->slug )->toBe( 'test-role' );
-});
+} );

--- a/tests/Unit/Notifications/NotificationModelTest.php
+++ b/tests/Unit/Notifications/NotificationModelTest.php
@@ -184,11 +184,11 @@ test( 'factory info state creates info notification', function (): void {
 test( 'factory withEmail state enables email sending', function (): void {
     $notification = Notification::factory()->withEmail()->create();
 
-    expect( $notification->send_email)->toBeTrue();
-});
+    expect( $notification->send_email )->toBeTrue();
+} );
 
 test( 'factory withoutEmail state disables email sending', function (): void {
     $notification = Notification::factory()->withoutEmail()->create();
 
-    expect( $notification->send_email)->toBeFalse();
+    expect( $notification->send_email )->toBeFalse();
 });

--- a/tests/Unit/Notifications/NotificationModelTest.php
+++ b/tests/Unit/Notifications/NotificationModelTest.php
@@ -191,4 +191,4 @@ test( 'factory withoutEmail state disables email sending', function (): void {
     $notification = Notification::factory()->withoutEmail()->create();
 
     expect( $notification->send_email )->toBeFalse();
-});
+} );

--- a/tests/Unit/Notifications/NotificationPolicyTest.php
+++ b/tests/Unit/Notifications/NotificationPolicyTest.php
@@ -58,5 +58,5 @@ test( 'update policy denies user from updating others notification', function ()
     $policy = new NotificationPolicy;
     $result = $policy->update( $user, $notification );
 
-    expect( $result)->toBeFalse();
-});
+    expect( $result )->toBeFalse();
+} );

--- a/tests/Unit/Notifications/NotificationPreferenceModelTest.php
+++ b/tests/Unit/Notifications/NotificationPreferenceModelTest.php
@@ -116,5 +116,5 @@ test( 'factory emailEnabled state enables email notifications', function (): voi
 test( 'factory emailDisabled state disables email notifications', function (): void {
     $preference = NotificationPreference::factory()->emailDisabled()->create();
 
-    expect( $preference->email_enabled)->toBeFalse();
-});
+    expect( $preference->email_enabled )->toBeFalse();
+} );

--- a/tests/Unit/OpenApi/OpenApiServiceProviderTest.php
+++ b/tests/Unit/OpenApi/OpenApiServiceProviderTest.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare( strict_types=1 );
 
 /**
  * Unit Tests for the OpenAPI Service Provider.
@@ -13,40 +13,40 @@ declare(strict_types=1);
 
 use ArtisanPackUI\CMSFramework\Modules\OpenApi\Providers\OpenApiServiceProvider;
 
-test('service provider is registered', function (): void {
-    $providers = array_keys(app()->getLoadedProviders());
+test( 'service provider is registered', function (): void {
+    $providers = array_keys( app()->getLoadedProviders() );
 
-    expect($providers)->toContain(OpenApiServiceProvider::class);
-});
+    expect( $providers )->toContain( OpenApiServiceProvider::class );
+} );
 
-test('export command is registered', function (): void {
-    $this->artisan('cms:openapi:export', ['--help' => true])
+test( 'export command is registered', function (): void {
+    $this->artisan( 'cms:openapi:export', ['--help' => true] )
         ->assertSuccessful();
-});
+} );
 
-test('openapi config has default values', function (): void {
-    $config = config('artisanpack.cms-framework.openapi');
+test( 'openapi config has default values', function (): void {
+    $config = config( 'artisanpack.cms-framework.openapi' );
 
-    expect($config)
+    expect( $config )
         ->toBeArray()
-        ->toHaveKey('enabled')
-        ->toHaveKey('info')
-        ->toHaveKey('ui_path')
-        ->toHaveKey('document_path');
+        ->toHaveKey( 'enabled' )
+        ->toHaveKey( 'info' )
+        ->toHaveKey( 'ui_path' )
+        ->toHaveKey( 'document_path' );
 
-    expect($config['enabled'])->toBeTrue();
-    expect($config['info']['title'])->toBe('ArtisanPack CMS Framework API');
-    expect($config['info']['version'])->toBe('1.1.0');
-    expect($config['ui_path'])->toBe('/docs/api/cms');
-    expect($config['document_path'])->toBe('/docs/api/cms.json');
-});
+    expect( $config['enabled'] )->toBeTrue();
+    expect( $config['info']['title'] )->toBe( 'ArtisanPack CMS Framework API' );
+    expect( $config['info']['version'] )->toBe( '1.1.0' );
+    expect( $config['ui_path'] )->toBe( '/docs/api/cms' );
+    expect( $config['document_path'] )->toBe( '/docs/api/cms.json' );
+} );
 
-test('openapi config values can be overridden', function (): void {
-    config([
+test( 'openapi config values can be overridden', function (): void {
+    config( [
         'artisanpack.cms-framework.openapi.info.title'   => 'Custom API Title',
         'artisanpack.cms-framework.openapi.info.version' => '2.0.0',
-    ]);
+    ] );
 
-    expect(config('artisanpack.cms-framework.openapi.info.title'))->toBe('Custom API Title');
-    expect(config('artisanpack.cms-framework.openapi.info.version'))->toBe('2.0.0');
+    expect( config( 'artisanpack.cms-framework.openapi.info.title' ) )->toBe( 'Custom API Title');
+    expect( config( 'artisanpack.cms-framework.openapi.info.version'))->toBe( '2.0.0');
 });

--- a/tests/Unit/OpenApi/OpenApiServiceProviderTest.php
+++ b/tests/Unit/OpenApi/OpenApiServiceProviderTest.php
@@ -47,6 +47,6 @@ test( 'openapi config values can be overridden', function (): void {
         'artisanpack.cms-framework.openapi.info.version' => '2.0.0',
     ] );
 
-    expect( config( 'artisanpack.cms-framework.openapi.info.title' ) )->toBe( 'Custom API Title');
-    expect( config( 'artisanpack.cms-framework.openapi.info.version'))->toBe( '2.0.0');
-});
+    expect( config( 'artisanpack.cms-framework.openapi.info.title' ) )->toBe( 'Custom API Title' );
+    expect( config( 'artisanpack.cms-framework.openapi.info.version' ) )->toBe( '2.0.0' );
+} );

--- a/tests/Unit/OpenApi/OpenApiServiceProviderTest.php
+++ b/tests/Unit/OpenApi/OpenApiServiceProviderTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Unit Tests for the OpenAPI Service Provider.
+ *
+ * Verifies that the OpenAPI documentation is properly registered
+ * and configured through the service provider.
+ *
+ * @since 1.1.0
+ */
+
+use ArtisanPackUI\CMSFramework\Modules\OpenApi\Providers\OpenApiServiceProvider;
+
+test('service provider is registered', function (): void {
+    $providers = array_keys(app()->getLoadedProviders());
+
+    expect($providers)->toContain(OpenApiServiceProvider::class);
+});
+
+test('export command is registered', function (): void {
+    $this->artisan('cms:openapi:export', ['--help' => true])
+        ->assertSuccessful();
+});
+
+test('openapi config has default values', function (): void {
+    $config = config('artisanpack.cms-framework.openapi');
+
+    expect($config)
+        ->toBeArray()
+        ->toHaveKey('enabled')
+        ->toHaveKey('info')
+        ->toHaveKey('ui_path')
+        ->toHaveKey('document_path');
+
+    expect($config['enabled'])->toBeTrue();
+    expect($config['info']['title'])->toBe('ArtisanPack CMS Framework API');
+    expect($config['info']['version'])->toBe('1.1.0');
+    expect($config['ui_path'])->toBe('/docs/api/cms');
+    expect($config['document_path'])->toBe('/docs/api/cms.json');
+});
+
+test('openapi config values can be overridden', function (): void {
+    config([
+        'artisanpack.cms-framework.openapi.info.title'   => 'Custom API Title',
+        'artisanpack.cms-framework.openapi.info.version' => '2.0.0',
+    ]);
+
+    expect(config('artisanpack.cms-framework.openapi.info.title'))->toBe('Custom API Title');
+    expect(config('artisanpack.cms-framework.openapi.info.version'))->toBe('2.0.0');
+});

--- a/tests/Unit/Pages/PageModelTest.php
+++ b/tests/Unit/Pages/PageModelTest.php
@@ -567,14 +567,14 @@ test( 'page has tags relationship', function (): void {
 
     expect( $page->tags )->toHaveCount( 1 );
     expect( $page->tags->first()->name )->toBe( 'Important' );
-});
+} );
 
 test( 'page uses soft deletes', function (): void {
     $user = TestUser::create( [
         'name'     => 'Test Author',
         'email'    => 'author@example.com',
         'password' => 'password',
-    ]);
+    ] );
 
     $page = Page::create( [
         'title'     => 'Test Page',
@@ -582,12 +582,12 @@ test( 'page uses soft deletes', function (): void {
         'author_id' => $user->id,
         'status'    => 'published',
         'order'     => 1,
-    ]);
+    ] );
 
     $pageId = $page->id;
 
     $page->delete();
 
-    expect( Page::find( $pageId))->toBeNull();
-    expect( Page::withTrashed()->find( $pageId))->not->toBeNull();
+    expect( Page::find( $pageId ) )->toBeNull();
+    expect( Page::withTrashed()->find( $pageId ) )->not->toBeNull();
 });

--- a/tests/Unit/Pages/PageModelTest.php
+++ b/tests/Unit/Pages/PageModelTest.php
@@ -590,4 +590,4 @@ test( 'page uses soft deletes', function (): void {
 
     expect( Page::find( $pageId ) )->toBeNull();
     expect( Page::withTrashed()->find( $pageId ) )->not->toBeNull();
-});
+} );

--- a/tests/Unit/PermissionManagerTest.php
+++ b/tests/Unit/PermissionManagerTest.php
@@ -115,4 +115,4 @@ test( 'permission manager registers permissions with long names', function (): v
     expect( $permission )->toBeInstanceOf( Permission::class );
     expect( $permission->slug )->toBe( 'long-permission' );
     expect( $permission->name )->toBe( $longName );
-});
+} );

--- a/tests/Unit/PermissionManagerTest.php
+++ b/tests/Unit/PermissionManagerTest.php
@@ -110,9 +110,9 @@ test( 'permission manager registers permissions with long names', function (): v
 
     $longName = 'This is a very long permission name that contains multiple words and describes a complex permission that might be used in a real application with detailed requirements and specifications';
 
-    $permission = $permissionManager->register( 'long-permission', $longName);
+    $permission = $permissionManager->register( 'long-permission', $longName );
 
-    expect( $permission)->toBeInstanceOf( Permission::class);
-    expect( $permission->slug)->toBe( 'long-permission');
-    expect( $permission->name)->toBe( $longName);
+    expect( $permission )->toBeInstanceOf( Permission::class );
+    expect( $permission->slug )->toBe( 'long-permission' );
+    expect( $permission->name )->toBe( $longName );
 });

--- a/tests/Unit/PermissionTest.php
+++ b/tests/Unit/PermissionTest.php
@@ -96,6 +96,6 @@ test( 'permission relationship works both ways', function (): void {
     $permission->roles()->attach( $role );
 
     // Check both sides of the relationship
-    expect( $permission->roles->first()->slug)->toBe( 'publisher');
-    expect( $role->fresh()->permissions->first()->slug)->toBe( 'publish-content');
+    expect( $permission->roles->first()->slug )->toBe( 'publisher' );
+    expect( $role->fresh()->permissions->first()->slug )->toBe( 'publish-content' );
 });

--- a/tests/Unit/PermissionTest.php
+++ b/tests/Unit/PermissionTest.php
@@ -98,4 +98,4 @@ test( 'permission relationship works both ways', function (): void {
     // Check both sides of the relationship
     expect( $permission->roles->first()->slug )->toBe( 'publisher' );
     expect( $role->fresh()->permissions->first()->slug )->toBe( 'publish-content' );
-});
+} );

--- a/tests/Unit/Plugins/PluginManagerTest.php
+++ b/tests/Unit/Plugins/PluginManagerTest.php
@@ -201,5 +201,5 @@ describe( 'Manifest Parsing', function (): void {
         expect( $manifest )->toBeNull();
 
         File::delete( $tempFile );
-    });
-});
+    } );
+} );

--- a/tests/Unit/Plugins/PluginModelTest.php
+++ b/tests/Unit/Plugins/PluginModelTest.php
@@ -130,4 +130,4 @@ it( 'checks if has service provider', function (): void {
 
     expect( $pluginWithSP->hasServiceProvider() )->toBeTrue()
         ->and( $pluginWithoutSP->hasServiceProvider() )->toBeFalse();
-});
+} );

--- a/tests/Unit/Plugins/UpdateManagerTest.php
+++ b/tests/Unit/Plugins/UpdateManagerTest.php
@@ -269,4 +269,4 @@ describe( 'Version Comparison', function (): void {
 
         expect( $method->invoke( $updateManager, '1.0.0', '1.0.0' ) )->toBeFalse();
     } );
-});
+} );

--- a/tests/Unit/RoleManagerTest.php
+++ b/tests/Unit/RoleManagerTest.php
@@ -120,10 +120,10 @@ test( 'role manager addPermissionToRole method works with app container', functi
     $roleManager = app( RoleManager::class );
 
     $role       = Role::create( ['slug' => 'author', 'name' => 'Author'] );
-    $permission = Permission::create( ['slug' => 'publish-posts', 'name' => 'Publish Posts']);
+    $permission = Permission::create( ['slug' => 'publish-posts', 'name' => 'Publish Posts'] );
 
-    $roleManager->addPermissionToRole( 'author', 'publish-posts');
+    $roleManager->addPermissionToRole( 'author', 'publish-posts' );
 
     $role->refresh();
-    expect( $role->permissions->first()->slug)->toBe( 'publish-posts');
+    expect( $role->permissions->first()->slug )->toBe( 'publish-posts' );
 });

--- a/tests/Unit/RoleManagerTest.php
+++ b/tests/Unit/RoleManagerTest.php
@@ -126,4 +126,4 @@ test( 'role manager addPermissionToRole method works with app container', functi
 
     $role->refresh();
     expect( $role->permissions->first()->slug )->toBe( 'publish-posts' );
-});
+} );

--- a/tests/Unit/RoleTest.php
+++ b/tests/Unit/RoleTest.php
@@ -99,4 +99,4 @@ test( 'role can have multiple permissions', function (): void {
     expect( $role->permissions->pluck( 'slug' )->toArray() )->toContain( 'create-posts' );
     expect( $role->permissions->pluck( 'slug' )->toArray() )->toContain( 'edit-posts' );
     expect( $role->permissions->pluck( 'slug' )->toArray() )->toContain( 'delete-posts' );
-});
+} );

--- a/tests/Unit/RoleTest.php
+++ b/tests/Unit/RoleTest.php
@@ -97,6 +97,6 @@ test( 'role can have multiple permissions', function (): void {
 
     expect( $role->permissions )->toHaveCount( 3 );
     expect( $role->permissions->pluck( 'slug' )->toArray() )->toContain( 'create-posts' );
-    expect( $role->permissions->pluck( 'slug')->toArray())->toContain( 'edit-posts');
-    expect( $role->permissions->pluck( 'slug')->toArray())->toContain( 'delete-posts');
+    expect( $role->permissions->pluck( 'slug' )->toArray() )->toContain( 'edit-posts' );
+    expect( $role->permissions->pluck( 'slug' )->toArray() )->toContain( 'delete-posts' );
 });

--- a/tests/Unit/Settings/SettingModelTest.php
+++ b/tests/Unit/Settings/SettingModelTest.php
@@ -131,4 +131,4 @@ test( 'it handles null value', function (): void {
 
     expect( $setting->type )->toBe( 'integer' );
     expect( $setting->value )->toBeNull(); // Getter returns null for null non-string type
-});
+} );

--- a/tests/Unit/Settings/SettingModelTest.php
+++ b/tests/Unit/Settings/SettingModelTest.php
@@ -126,9 +126,9 @@ test( 'it handles null value', function (): void {
 
     // Test case 3: Simulating a raw null value from DB for a non-string type
     $setting = Setting::create( ['key' => 'test-raw-null-int', 'value' => 123, 'type' => 'integer'] );                        // Create with initial value
-    Illuminate\Support\Facades\DB::table( 'settings' )->where( 'key', 'test-raw-null-int' )->update( ['value' => null]);    // Force DB null
+    Illuminate\Support\Facades\DB::table( 'settings' )->where( 'key', 'test-raw-null-int' )->update( ['value' => null] );    // Force DB null
     $setting->refresh();                                                                                                        // Reload
 
-    expect( $setting->type)->toBe( 'integer');
-    expect( $setting->value)->toBeNull(); // Getter returns null for null non-string type
+    expect( $setting->type )->toBe( 'integer' );
+    expect( $setting->value )->toBeNull(); // Getter returns null for null non-string type
 });

--- a/tests/Unit/Settings/SettingTypeEnumTest.php
+++ b/tests/Unit/Settings/SettingTypeEnumTest.php
@@ -93,6 +93,10 @@ test('cast throws JsonException for malformed json', function (): void {
 
 test('serialize throws JsonException for unencodable value', function (): void {
     $resource = fopen('php://memory', 'r');
-    SettingType::Json->serialize($resource);
-    fclose($resource);
+
+    try {
+        SettingType::Json->serialize($resource);
+    } finally {
+        fclose($resource);
+    }
 })->throws(JsonException::class);

--- a/tests/Unit/Settings/SettingTypeEnumTest.php
+++ b/tests/Unit/Settings/SettingTypeEnumTest.php
@@ -84,19 +84,19 @@ test( 'serialize handles null values', function (): void {
     expect( SettingType::Boolean->serialize( null ) )->toBe( '0' );
     expect( SettingType::Integer->serialize( null ) )->toBe( '' );
     expect( SettingType::Float->serialize( null ) )->toBe( '' );
-    expect( SettingType::Json->serialize( null))->toBe( 'null');
-});
+    expect( SettingType::Json->serialize( null ) )->toBe( 'null' );
+} );
 
 test( 'cast throws JsonException for malformed json', function (): void {
-    SettingType::Json->cast( '{invalid json}');
-})->throws( JsonException::class);
+    SettingType::Json->cast( '{invalid json}' );
+} )->throws( JsonException::class );
 
 test( 'serialize throws JsonException for unencodable value', function (): void {
-    $resource = fopen( 'php://memory', 'r');
+    $resource = fopen( 'php://memory', 'r' );
 
     try {
-        SettingType::Json->serialize( $resource);
+        SettingType::Json->serialize( $resource );
     } finally {
-        fclose( $resource);
+        fclose( $resource );
     }
-})->throws( JsonException::class);
+} )->throws( JsonException::class );

--- a/tests/Unit/Settings/SettingTypeEnumTest.php
+++ b/tests/Unit/Settings/SettingTypeEnumTest.php
@@ -79,6 +79,20 @@ test('serialize converts values to storage strings', function (): void {
     expect(SettingType::Json->serialize(['a' => 1]))->toBe('{"a":1}');
 });
 
-test('serialize handles null for string type', function (): void {
+test('serialize handles null values', function (): void {
     expect(SettingType::String->serialize(null))->toBe('');
+    expect(SettingType::Boolean->serialize(null))->toBe('0');
+    expect(SettingType::Integer->serialize(null))->toBe('');
+    expect(SettingType::Float->serialize(null))->toBe('');
+    expect(SettingType::Json->serialize(null))->toBe('null');
 });
+
+test('cast throws JsonException for malformed json', function (): void {
+    SettingType::Json->cast('{invalid json}');
+})->throws(JsonException::class);
+
+test('serialize throws JsonException for unencodable value', function (): void {
+    $resource = fopen('php://memory', 'r');
+    SettingType::Json->serialize($resource);
+    fclose($resource);
+})->throws(JsonException::class);

--- a/tests/Unit/Settings/SettingTypeEnumTest.php
+++ b/tests/Unit/Settings/SettingTypeEnumTest.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+use ArtisanPackUI\CMSFramework\Modules\Settings\Enums\SettingType;
+
+test('setting type enum has expected cases', function (): void {
+    $cases = SettingType::cases();
+
+    expect($cases)->toHaveCount(5);
+    expect(SettingType::String->value)->toBe('string');
+    expect(SettingType::Integer->value)->toBe('integer');
+    expect(SettingType::Boolean->value)->toBe('boolean');
+    expect(SettingType::Float->value)->toBe('float');
+    expect(SettingType::Json->value)->toBe('json');
+});
+
+test('setting type enum can be created from string values', function (): void {
+    expect(SettingType::from('string'))->toBe(SettingType::String);
+    expect(SettingType::from('integer'))->toBe(SettingType::Integer);
+    expect(SettingType::from('boolean'))->toBe(SettingType::Boolean);
+    expect(SettingType::from('float'))->toBe(SettingType::Float);
+    expect(SettingType::from('json'))->toBe(SettingType::Json);
+});
+
+test('setting type enum tryFrom returns null for invalid value', function (): void {
+    expect(SettingType::tryFrom('invalid'))->toBeNull();
+});
+
+test('fromValue detects boolean type', function (): void {
+    expect(SettingType::fromValue(true))->toBe(SettingType::Boolean);
+    expect(SettingType::fromValue(false))->toBe(SettingType::Boolean);
+});
+
+test('fromValue detects integer type', function (): void {
+    expect(SettingType::fromValue(42))->toBe(SettingType::Integer);
+    expect(SettingType::fromValue(0))->toBe(SettingType::Integer);
+});
+
+test('fromValue detects float type', function (): void {
+    expect(SettingType::fromValue(3.14))->toBe(SettingType::Float);
+    expect(SettingType::fromValue(0.0))->toBe(SettingType::Float);
+});
+
+test('fromValue detects json type for arrays and objects', function (): void {
+    expect(SettingType::fromValue(['a' => 1]))->toBe(SettingType::Json);
+    expect(SettingType::fromValue((object) ['a' => 1]))->toBe(SettingType::Json);
+});
+
+test('fromValue detects string type for strings and null', function (): void {
+    expect(SettingType::fromValue('hello'))->toBe(SettingType::String);
+    expect(SettingType::fromValue(''))->toBe(SettingType::String);
+    expect(SettingType::fromValue(null))->toBe(SettingType::String);
+});
+
+test('cast returns correct types', function (): void {
+    expect(SettingType::String->cast('hello'))->toBe('hello');
+    expect(SettingType::Integer->cast('42'))->toBe(42);
+    expect(SettingType::Float->cast('3.14'))->toBe(3.14);
+    expect(SettingType::Boolean->cast('1'))->toBeTrue();
+    expect(SettingType::Boolean->cast('0'))->toBeFalse();
+    expect(SettingType::Json->cast('{"a":1}'))->toBe(['a' => 1]);
+});
+
+test('cast handles null values', function (): void {
+    expect(SettingType::String->cast(null))->toBe('');
+    expect(SettingType::Integer->cast(null))->toBeNull();
+    expect(SettingType::Float->cast(null))->toBeNull();
+    expect(SettingType::Boolean->cast(null))->toBeNull();
+    expect(SettingType::Json->cast(null))->toBeNull();
+});
+
+test('serialize converts values to storage strings', function (): void {
+    expect(SettingType::String->serialize('hello'))->toBe('hello');
+    expect(SettingType::Integer->serialize(42))->toBe('42');
+    expect(SettingType::Float->serialize(3.14))->toBe('3.14');
+    expect(SettingType::Boolean->serialize(true))->toBe('1');
+    expect(SettingType::Boolean->serialize(false))->toBe('0');
+    expect(SettingType::Json->serialize(['a' => 1]))->toBe('{"a":1}');
+});
+
+test('serialize handles null for string type', function (): void {
+    expect(SettingType::String->serialize(null))->toBe('');
+});

--- a/tests/Unit/Settings/SettingTypeEnumTest.php
+++ b/tests/Unit/Settings/SettingTypeEnumTest.php
@@ -1,102 +1,102 @@
 <?php
 
-declare(strict_types=1);
+declare( strict_types=1 );
 
 use ArtisanPackUI\CMSFramework\Modules\Settings\Enums\SettingType;
 
-test('setting type enum has expected cases', function (): void {
+test( 'setting type enum has expected cases', function (): void {
     $cases = SettingType::cases();
 
-    expect($cases)->toHaveCount(5);
-    expect(SettingType::String->value)->toBe('string');
-    expect(SettingType::Integer->value)->toBe('integer');
-    expect(SettingType::Boolean->value)->toBe('boolean');
-    expect(SettingType::Float->value)->toBe('float');
-    expect(SettingType::Json->value)->toBe('json');
+    expect( $cases )->toHaveCount( 5 );
+    expect( SettingType::String->value )->toBe( 'string' );
+    expect( SettingType::Integer->value )->toBe( 'integer' );
+    expect( SettingType::Boolean->value )->toBe( 'boolean' );
+    expect( SettingType::Float->value )->toBe( 'float' );
+    expect( SettingType::Json->value )->toBe( 'json' );
+} );
+
+test( 'setting type enum can be created from string values', function (): void {
+    expect( SettingType::from( 'string' ) )->toBe( SettingType::String );
+    expect( SettingType::from( 'integer' ) )->toBe( SettingType::Integer );
+    expect( SettingType::from( 'boolean' ) )->toBe( SettingType::Boolean );
+    expect( SettingType::from( 'float' ) )->toBe( SettingType::Float );
+    expect( SettingType::from( 'json' ) )->toBe( SettingType::Json );
+} );
+
+test( 'setting type enum tryFrom returns null for invalid value', function (): void {
+    expect( SettingType::tryFrom( 'invalid' ) )->toBeNull();
+} );
+
+test( 'fromValue detects boolean type', function (): void {
+    expect( SettingType::fromValue( true ) )->toBe( SettingType::Boolean );
+    expect( SettingType::fromValue( false ) )->toBe( SettingType::Boolean );
+} );
+
+test( 'fromValue detects integer type', function (): void {
+    expect( SettingType::fromValue( 42 ) )->toBe( SettingType::Integer );
+    expect( SettingType::fromValue( 0 ) )->toBe( SettingType::Integer );
+} );
+
+test( 'fromValue detects float type', function (): void {
+    expect( SettingType::fromValue( 3.14 ) )->toBe( SettingType::Float );
+    expect( SettingType::fromValue( 0.0 ) )->toBe( SettingType::Float );
+} );
+
+test( 'fromValue detects json type for arrays and objects', function (): void {
+    expect( SettingType::fromValue( ['a' => 1] ) )->toBe( SettingType::Json );
+    expect( SettingType::fromValue( (object) ['a' => 1] ) )->toBe( SettingType::Json );
+} );
+
+test( 'fromValue detects string type for strings and null', function (): void {
+    expect( SettingType::fromValue( 'hello' ) )->toBe( SettingType::String );
+    expect( SettingType::fromValue( '' ) )->toBe( SettingType::String );
+    expect( SettingType::fromValue( null ) )->toBe( SettingType::String );
+} );
+
+test( 'cast returns correct types', function (): void {
+    expect( SettingType::String->cast( 'hello' ) )->toBe( 'hello' );
+    expect( SettingType::Integer->cast( '42' ) )->toBe( 42 );
+    expect( SettingType::Float->cast( '3.14' ) )->toBe( 3.14 );
+    expect( SettingType::Boolean->cast( '1' ) )->toBeTrue();
+    expect( SettingType::Boolean->cast( '0' ) )->toBeFalse();
+    expect( SettingType::Json->cast( '{"a":1}' ) )->toBe( ['a' => 1] );
+} );
+
+test( 'cast handles null values', function (): void {
+    expect( SettingType::String->cast( null ) )->toBe( '' );
+    expect( SettingType::Integer->cast( null ) )->toBeNull();
+    expect( SettingType::Float->cast( null ) )->toBeNull();
+    expect( SettingType::Boolean->cast( null ) )->toBeNull();
+    expect( SettingType::Json->cast( null ) )->toBeNull();
+} );
+
+test( 'serialize converts values to storage strings', function (): void {
+    expect( SettingType::String->serialize( 'hello' ) )->toBe( 'hello' );
+    expect( SettingType::Integer->serialize( 42 ) )->toBe( '42' );
+    expect( SettingType::Float->serialize( 3.14 ) )->toBe( '3.14' );
+    expect( SettingType::Boolean->serialize( true ) )->toBe( '1' );
+    expect( SettingType::Boolean->serialize( false ) )->toBe( '0' );
+    expect( SettingType::Json->serialize( ['a' => 1] ) )->toBe( '{"a":1}' );
+} );
+
+test( 'serialize handles null values', function (): void {
+    expect( SettingType::String->serialize( null ) )->toBe( '' );
+    expect( SettingType::Boolean->serialize( null ) )->toBe( '0' );
+    expect( SettingType::Integer->serialize( null ) )->toBe( '' );
+    expect( SettingType::Float->serialize( null ) )->toBe( '' );
+    expect( SettingType::Json->serialize( null))->toBe( 'null');
 });
 
-test('setting type enum can be created from string values', function (): void {
-    expect(SettingType::from('string'))->toBe(SettingType::String);
-    expect(SettingType::from('integer'))->toBe(SettingType::Integer);
-    expect(SettingType::from('boolean'))->toBe(SettingType::Boolean);
-    expect(SettingType::from('float'))->toBe(SettingType::Float);
-    expect(SettingType::from('json'))->toBe(SettingType::Json);
-});
+test( 'cast throws JsonException for malformed json', function (): void {
+    SettingType::Json->cast( '{invalid json}');
+})->throws( JsonException::class);
 
-test('setting type enum tryFrom returns null for invalid value', function (): void {
-    expect(SettingType::tryFrom('invalid'))->toBeNull();
-});
-
-test('fromValue detects boolean type', function (): void {
-    expect(SettingType::fromValue(true))->toBe(SettingType::Boolean);
-    expect(SettingType::fromValue(false))->toBe(SettingType::Boolean);
-});
-
-test('fromValue detects integer type', function (): void {
-    expect(SettingType::fromValue(42))->toBe(SettingType::Integer);
-    expect(SettingType::fromValue(0))->toBe(SettingType::Integer);
-});
-
-test('fromValue detects float type', function (): void {
-    expect(SettingType::fromValue(3.14))->toBe(SettingType::Float);
-    expect(SettingType::fromValue(0.0))->toBe(SettingType::Float);
-});
-
-test('fromValue detects json type for arrays and objects', function (): void {
-    expect(SettingType::fromValue(['a' => 1]))->toBe(SettingType::Json);
-    expect(SettingType::fromValue((object) ['a' => 1]))->toBe(SettingType::Json);
-});
-
-test('fromValue detects string type for strings and null', function (): void {
-    expect(SettingType::fromValue('hello'))->toBe(SettingType::String);
-    expect(SettingType::fromValue(''))->toBe(SettingType::String);
-    expect(SettingType::fromValue(null))->toBe(SettingType::String);
-});
-
-test('cast returns correct types', function (): void {
-    expect(SettingType::String->cast('hello'))->toBe('hello');
-    expect(SettingType::Integer->cast('42'))->toBe(42);
-    expect(SettingType::Float->cast('3.14'))->toBe(3.14);
-    expect(SettingType::Boolean->cast('1'))->toBeTrue();
-    expect(SettingType::Boolean->cast('0'))->toBeFalse();
-    expect(SettingType::Json->cast('{"a":1}'))->toBe(['a' => 1]);
-});
-
-test('cast handles null values', function (): void {
-    expect(SettingType::String->cast(null))->toBe('');
-    expect(SettingType::Integer->cast(null))->toBeNull();
-    expect(SettingType::Float->cast(null))->toBeNull();
-    expect(SettingType::Boolean->cast(null))->toBeNull();
-    expect(SettingType::Json->cast(null))->toBeNull();
-});
-
-test('serialize converts values to storage strings', function (): void {
-    expect(SettingType::String->serialize('hello'))->toBe('hello');
-    expect(SettingType::Integer->serialize(42))->toBe('42');
-    expect(SettingType::Float->serialize(3.14))->toBe('3.14');
-    expect(SettingType::Boolean->serialize(true))->toBe('1');
-    expect(SettingType::Boolean->serialize(false))->toBe('0');
-    expect(SettingType::Json->serialize(['a' => 1]))->toBe('{"a":1}');
-});
-
-test('serialize handles null values', function (): void {
-    expect(SettingType::String->serialize(null))->toBe('');
-    expect(SettingType::Boolean->serialize(null))->toBe('0');
-    expect(SettingType::Integer->serialize(null))->toBe('');
-    expect(SettingType::Float->serialize(null))->toBe('');
-    expect(SettingType::Json->serialize(null))->toBe('null');
-});
-
-test('cast throws JsonException for malformed json', function (): void {
-    SettingType::Json->cast('{invalid json}');
-})->throws(JsonException::class);
-
-test('serialize throws JsonException for unencodable value', function (): void {
-    $resource = fopen('php://memory', 'r');
+test( 'serialize throws JsonException for unencodable value', function (): void {
+    $resource = fopen( 'php://memory', 'r');
 
     try {
-        SettingType::Json->serialize($resource);
+        SettingType::Json->serialize( $resource);
     } finally {
-        fclose($resource);
+        fclose( $resource);
     }
-})->throws(JsonException::class);
+})->throws( JsonException::class);

--- a/tests/Unit/Settings/SettingsHelpersTest.php
+++ b/tests/Unit/Settings/SettingsHelpersTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Unit Tests for the Settings Helper Functions.
  *
@@ -8,55 +10,56 @@
  * @since      2.0.0
  */
 
+use ArtisanPackUI\CMSFramework\Modules\Settings\Enums\SettingType;
 use ArtisanPackUI\CMSFramework\Modules\Settings\Managers\SettingsManager;
 
-beforeEach( function (): void {
+beforeEach(function (): void {
     // Mock the manager and bind it to the service container
-    $this->artisan( 'migrate', ['--database' => 'testing'] );
-    $this->managerMock = Mockery::mock( SettingsManager::class );
-    $this->app->instance( SettingsManager::class, $this->managerMock );
-} );
+    $this->artisan('migrate', ['--database' => 'testing']);
+    $this->managerMock = Mockery::mock(SettingsManager::class);
+    $this->app->instance(SettingsManager::class, $this->managerMock);
+});
 
-afterEach( function (): void {
+afterEach(function (): void {
     Mockery::close();
-} );
+});
 
-test( 'apGetSetting helper', function (): void {
+test('apGetSetting helper', function (): void {
     $this->managerMock
-        ->shouldReceive( 'getSetting' )
-        ->with( 'test-key', 'default' )
+        ->shouldReceive('getSetting')
+        ->with('test-key', 'default')
         ->once()
-        ->andReturn( 'expected-value' );
+        ->andReturn('expected-value');
 
-    $value = apGetSetting( 'test-key', 'default' );
+    $value = apGetSetting('test-key', 'default');
 
-    expect( $value )->toBe( 'expected-value' );
-} );
+    expect($value)->toBe('expected-value');
+});
 
-test( 'apRegisterSetting helper', function (): void {
+test('apRegisterSetting helper', function (): void {
     $callback = fn () => 'test';
 
     $this->managerMock
-        ->shouldReceive( 'registerSetting' )
+        ->shouldReceive('registerSetting')
         // --- FIX: Correct argument order ---
-        ->with( 'test-key', 'default', $callback, 'string' )
+        ->with('test-key', 'default', $callback, SettingType::String)
         ->once();
 
     // The actual call matches the helper and manager signature
-    apRegisterSetting( 'test-key', 'default', $callback, 'string' );
+    apRegisterSetting('test-key', 'default', $callback, SettingType::String);
 
     // Mockery assertions are checked automatically in afterEach.
-    expect( true )->toBeTrue();
-} );
+    expect(true)->toBeTrue();
+});
 
-test( 'apUpdateSetting helper', function (): void {
+test('apUpdateSetting helper', function (): void {
     $this->managerMock
-        ->shouldReceive( 'updateSetting' )
-        ->with( 'test-key', 'new-value' )
+        ->shouldReceive('updateSetting')
+        ->with('test-key', 'new-value')
         ->once();
 
-    apUpdateSetting( 'test-key', 'new-value' );
+    apUpdateSetting('test-key', 'new-value');
 
     // Mockery assertions are checked automatically in afterEach.
-    expect( true)->toBeTrue();
+    expect(true)->toBeTrue();
 });

--- a/tests/Unit/Settings/SettingsHelpersTest.php
+++ b/tests/Unit/Settings/SettingsHelpersTest.php
@@ -58,8 +58,8 @@ test( 'apUpdateSetting helper', function (): void {
         ->with( 'test-key', 'new-value' )
         ->once();
 
-    apUpdateSetting( 'test-key', 'new-value');
+    apUpdateSetting( 'test-key', 'new-value' );
 
     // Mockery assertions are checked automatically in afterEach.
-    expect( true)->toBeTrue();
-});
+    expect( true )->toBeTrue();
+} );

--- a/tests/Unit/Settings/SettingsHelpersTest.php
+++ b/tests/Unit/Settings/SettingsHelpersTest.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare( strict_types=1 );
 
 /**
  * Unit Tests for the Settings Helper Functions.
@@ -13,53 +13,53 @@ declare(strict_types=1);
 use ArtisanPackUI\CMSFramework\Modules\Settings\Enums\SettingType;
 use ArtisanPackUI\CMSFramework\Modules\Settings\Managers\SettingsManager;
 
-beforeEach(function (): void {
+beforeEach( function (): void {
     // Mock the manager and bind it to the service container
-    $this->artisan('migrate', ['--database' => 'testing']);
-    $this->managerMock = Mockery::mock(SettingsManager::class);
-    $this->app->instance(SettingsManager::class, $this->managerMock);
-});
+    $this->artisan( 'migrate', ['--database' => 'testing'] );
+    $this->managerMock = Mockery::mock( SettingsManager::class );
+    $this->app->instance( SettingsManager::class, $this->managerMock );
+} );
 
-afterEach(function (): void {
+afterEach( function (): void {
     Mockery::close();
-});
+} );
 
-test('apGetSetting helper', function (): void {
+test( 'apGetSetting helper', function (): void {
     $this->managerMock
-        ->shouldReceive('getSetting')
-        ->with('test-key', 'default')
+        ->shouldReceive( 'getSetting' )
+        ->with( 'test-key', 'default' )
         ->once()
-        ->andReturn('expected-value');
+        ->andReturn( 'expected-value' );
 
-    $value = apGetSetting('test-key', 'default');
+    $value = apGetSetting( 'test-key', 'default' );
 
-    expect($value)->toBe('expected-value');
-});
+    expect( $value )->toBe( 'expected-value' );
+} );
 
-test('apRegisterSetting helper', function (): void {
+test( 'apRegisterSetting helper', function (): void {
     $callback = fn () => 'test';
 
     $this->managerMock
-        ->shouldReceive('registerSetting')
+        ->shouldReceive( 'registerSetting' )
         // --- FIX: Correct argument order ---
-        ->with('test-key', 'default', $callback, SettingType::String)
+        ->with( 'test-key', 'default', $callback, SettingType::String )
         ->once();
 
     // The actual call matches the helper and manager signature
-    apRegisterSetting('test-key', 'default', $callback, SettingType::String);
+    apRegisterSetting( 'test-key', 'default', $callback, SettingType::String );
 
     // Mockery assertions are checked automatically in afterEach.
-    expect(true)->toBeTrue();
-});
+    expect( true )->toBeTrue();
+} );
 
-test('apUpdateSetting helper', function (): void {
+test( 'apUpdateSetting helper', function (): void {
     $this->managerMock
-        ->shouldReceive('updateSetting')
-        ->with('test-key', 'new-value')
+        ->shouldReceive( 'updateSetting' )
+        ->with( 'test-key', 'new-value' )
         ->once();
 
-    apUpdateSetting('test-key', 'new-value');
+    apUpdateSetting( 'test-key', 'new-value');
 
     // Mockery assertions are checked automatically in afterEach.
-    expect(true)->toBeTrue();
+    expect( true)->toBeTrue();
 });

--- a/tests/Unit/Settings/SettingsManagerTest.php
+++ b/tests/Unit/Settings/SettingsManagerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Unit Tests for the SettingsManager.
  *
@@ -8,92 +10,93 @@
  * @since      2.0.0
  */
 
+use ArtisanPackUI\CMSFramework\Modules\Settings\Enums\SettingType;
 use ArtisanPackUI\CMSFramework\Modules\Settings\Managers\SettingsManager;
 use ArtisanPackUI\CMSFramework\Modules\Settings\Models\Setting;
 
 // Define properties using Pest's dataset feature or beforeEach
-beforeEach( function (): void {
-    $this->artisan( 'migrate', ['--database' => 'testing'] );
+beforeEach(function (): void {
+    $this->artisan('migrate', ['--database' => 'testing']);
 
-    $this->manager   = app( SettingsManager::class );
+    $this->manager   = app(SettingsManager::class);
     $this->filterTag = 'ap.settings.registeredSettings';
-} );
+});
 
-test( 'it registers setting via filter', function (): void {
+test('it registers setting via filter', function (): void {
     $this->manager->registerSetting(
         'test-key',
         'default-value',
-        fn ( $value ) => trim( $value ), // Using a placeholder string for the callable
-        'string',
+        fn ($value) => trim($value), // Using a placeholder string for the callable
+        SettingType::String,
     );
 
-    $settings = applyFilters( $this->filterTag, [] );
+    $settings = applyFilters($this->filterTag, []);
 
-    expect( $settings )->toHaveKey( 'test-key' );
-    expect( $settings['test-key']['default'] )->toBe( 'default-value' );
-    expect( $settings['test-key']['type'] )->toBe( 'string' );
-} );
+    expect($settings)->toHaveKey('test-key');
+    expect($settings['test-key']['default'])->toBe('default-value');
+    expect($settings['test-key']['type'])->toBe(SettingType::String);
+});
 
-test( 'it gets setting from database', function (): void {
-    Setting::create( ['key' => 'db-key', 'value' => 'db-value'] );
+test('it gets setting from database', function (): void {
+    Setting::create(['key' => 'db-key', 'value' => 'db-value']);
 
-    $value = $this->manager->getSetting( 'db-key', 'default' );
+    $value = $this->manager->getSetting('db-key', 'default');
 
-    expect( $value )->toBe( 'db-value' );
-} );
+    expect($value)->toBe('db-value');
+});
 
-test( 'it gets registered default setting', function (): void {
-    $this->manager->registerSetting( 'reg-key', 'reg-default', 'trim', 'string' );
+test('it gets registered default setting', function (): void {
+    $this->manager->registerSetting('reg-key', 'reg-default', 'trim', SettingType::String);
 
-    $value = $this->manager->getSetting( 'reg-key' );
+    $value = $this->manager->getSetting('reg-key');
 
-    expect( $value )->toBe( 'reg-default' );
-} );
+    expect($value)->toBe('reg-default');
+});
 
-test( 'it gets user provided default setting', function (): void {
-    $this->manager->registerSetting( 'reg-key', 'reg-default', 'trim', 'string' );
+test('it gets user provided default setting', function (): void {
+    $this->manager->registerSetting('reg-key', 'reg-default', 'trim', SettingType::String);
 
     // The user-provided default takes precedence (based on current logic).
-    $value = $this->manager->getSetting( 'reg-key', 'user-default' );
+    $value = $this->manager->getSetting('reg-key', 'user-default');
 
-    expect( $value )->toBe( 'user-default' );
-} );
+    expect($value)->toBe('user-default');
+});
 
-test( 'it returns null for non existent setting', function (): void {
-    $value = $this->manager->getSetting( 'non-existent-key' );
-    expect( $value )->toBeNull();
-} );
+test('it returns null for non existent setting', function (): void {
+    $value = $this->manager->getSetting('non-existent-key');
+    expect($value)->toBeNull();
+});
 
-test( 'it updates setting and creates new', function (): void {
+test('it updates setting and creates new', function (): void {
     $this->manager->registerSetting(
         'new-key',
         '',
-        fn ( $value ) => trim( $value ), // Use a real callable
-        'string',
+        fn ($value) => trim($value), // Use a real callable
+        SettingType::String,
     );
 
-    $this->manager->updateSetting( 'new-key', '  new-value  ' );
+    $this->manager->updateSetting('new-key', '  new-value  ');
 
-    $this->assertDatabaseHas( 'settings', [
+    $this->assertDatabaseHas('settings', [
         'key'   => 'new-key',
         'value' => 'new-value', // Value should be trimmed
         'type'  => 'string',
-    ] );
-} );
+    ]);
+});
 
-test( 'it updates setting and updates existing', function (): void {
-    Setting::create( ['key' => 'existing-key', 'value' => 'old-value', 'type' => 'string'] );
+test('it updates setting and updates existing', function (): void {
+    Setting::create(['key' => 'existing-key', 'value' => 'old-value', 'type' => 'string']);
 
     $this->manager->registerSetting(
         'existing-key',
         '',
-        fn ( $value ) => (string) ( (int) $value * 2 ), // Dummy sanitization
-        'string',
+        fn ($value) => (string) ((int) $value * 2), // Dummy sanitization
+        SettingType::String,
     );
 
-    $this->manager->updateSetting( 'existing-key', '100');
+    $this->manager->updateSetting('existing-key', '100');
 
-    $this->assertDatabaseHas( 'settings', [
+    $this->assertDatabaseHas('settings', [
         'key'   => 'existing-key',
         'value' => '200', // Value should be "sanitized"
     ]);

--- a/tests/Unit/Settings/SettingsManagerTest.php
+++ b/tests/Unit/Settings/SettingsManagerTest.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare( strict_types=1 );
 
 /**
  * Unit Tests for the SettingsManager.
@@ -15,88 +15,88 @@ use ArtisanPackUI\CMSFramework\Modules\Settings\Managers\SettingsManager;
 use ArtisanPackUI\CMSFramework\Modules\Settings\Models\Setting;
 
 // Define properties using Pest's dataset feature or beforeEach
-beforeEach(function (): void {
-    $this->artisan('migrate', ['--database' => 'testing']);
+beforeEach( function (): void {
+    $this->artisan( 'migrate', ['--database' => 'testing'] );
 
-    $this->manager   = app(SettingsManager::class);
+    $this->manager   = app( SettingsManager::class );
     $this->filterTag = 'ap.settings.registeredSettings';
-});
+} );
 
-test('it registers setting via filter', function (): void {
+test( 'it registers setting via filter', function (): void {
     $this->manager->registerSetting(
         'test-key',
         'default-value',
-        fn ($value) => trim($value), // Using a placeholder string for the callable
+        fn ( $value ) => trim( $value ), // Using a placeholder string for the callable
         SettingType::String,
     );
 
-    $settings = applyFilters($this->filterTag, []);
+    $settings = applyFilters( $this->filterTag, [] );
 
-    expect($settings)->toHaveKey('test-key');
-    expect($settings['test-key']['default'])->toBe('default-value');
-    expect($settings['test-key']['type'])->toBe(SettingType::String);
-});
+    expect( $settings )->toHaveKey( 'test-key' );
+    expect( $settings['test-key']['default'] )->toBe( 'default-value' );
+    expect( $settings['test-key']['type'] )->toBe( SettingType::String );
+} );
 
-test('it gets setting from database', function (): void {
-    Setting::create(['key' => 'db-key', 'value' => 'db-value']);
+test( 'it gets setting from database', function (): void {
+    Setting::create( ['key' => 'db-key', 'value' => 'db-value'] );
 
-    $value = $this->manager->getSetting('db-key', 'default');
+    $value = $this->manager->getSetting( 'db-key', 'default' );
 
-    expect($value)->toBe('db-value');
-});
+    expect( $value )->toBe( 'db-value' );
+} );
 
-test('it gets registered default setting', function (): void {
-    $this->manager->registerSetting('reg-key', 'reg-default', 'trim', SettingType::String);
+test( 'it gets registered default setting', function (): void {
+    $this->manager->registerSetting( 'reg-key', 'reg-default', 'trim', SettingType::String );
 
-    $value = $this->manager->getSetting('reg-key');
+    $value = $this->manager->getSetting( 'reg-key' );
 
-    expect($value)->toBe('reg-default');
-});
+    expect( $value )->toBe( 'reg-default' );
+} );
 
-test('it gets user provided default setting', function (): void {
-    $this->manager->registerSetting('reg-key', 'reg-default', 'trim', SettingType::String);
+test( 'it gets user provided default setting', function (): void {
+    $this->manager->registerSetting( 'reg-key', 'reg-default', 'trim', SettingType::String );
 
     // The user-provided default takes precedence (based on current logic).
-    $value = $this->manager->getSetting('reg-key', 'user-default');
+    $value = $this->manager->getSetting( 'reg-key', 'user-default' );
 
-    expect($value)->toBe('user-default');
-});
+    expect( $value )->toBe( 'user-default' );
+} );
 
-test('it returns null for non existent setting', function (): void {
-    $value = $this->manager->getSetting('non-existent-key');
-    expect($value)->toBeNull();
-});
+test( 'it returns null for non existent setting', function (): void {
+    $value = $this->manager->getSetting( 'non-existent-key' );
+    expect( $value )->toBeNull();
+} );
 
-test('it updates setting and creates new', function (): void {
+test( 'it updates setting and creates new', function (): void {
     $this->manager->registerSetting(
         'new-key',
         '',
-        fn ($value) => trim($value), // Use a real callable
+        fn ( $value ) => trim( $value ), // Use a real callable
         SettingType::String,
     );
 
-    $this->manager->updateSetting('new-key', '  new-value  ');
+    $this->manager->updateSetting( 'new-key', '  new-value  ' );
 
-    $this->assertDatabaseHas('settings', [
+    $this->assertDatabaseHas( 'settings', [
         'key'   => 'new-key',
         'value' => 'new-value', // Value should be trimmed
         'type'  => 'string',
-    ]);
-});
+    ] );
+} );
 
-test('it updates setting and updates existing', function (): void {
-    Setting::create(['key' => 'existing-key', 'value' => 'old-value', 'type' => 'string']);
+test( 'it updates setting and updates existing', function (): void {
+    Setting::create( ['key' => 'existing-key', 'value' => 'old-value', 'type' => 'string'] );
 
     $this->manager->registerSetting(
         'existing-key',
         '',
-        fn ($value) => (string) ((int) $value * 2), // Dummy sanitization
+        fn ( $value ) => (string) ( (int) $value * 2 ), // Dummy sanitization
         SettingType::String,
     );
 
-    $this->manager->updateSetting('existing-key', '100');
+    $this->manager->updateSetting( 'existing-key', '100');
 
-    $this->assertDatabaseHas('settings', [
+    $this->assertDatabaseHas( 'settings', [
         'key'   => 'existing-key',
         'value' => '200', // Value should be "sanitized"
     ]);

--- a/tests/Unit/Settings/SettingsManagerTest.php
+++ b/tests/Unit/Settings/SettingsManagerTest.php
@@ -94,10 +94,10 @@ test( 'it updates setting and updates existing', function (): void {
         SettingType::String,
     );
 
-    $this->manager->updateSetting( 'existing-key', '100');
+    $this->manager->updateSetting( 'existing-key', '100' );
 
     $this->assertDatabaseHas( 'settings', [
         'key'   => 'existing-key',
         'value' => '200', // Value should be "sanitized"
-    ]);
+    ] );
 });

--- a/tests/Unit/Updates/ApplicationUpdateManagerTest.php
+++ b/tests/Unit/Updates/ApplicationUpdateManagerTest.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare( strict_types=1 );
 
 namespace ArtisanPackUI\CMSFramework\Tests\Unit\Updates;
 
@@ -33,16 +33,16 @@ class ApplicationUpdateManagerTest extends TestCase
             downloadUrl: 'https://example.com/update.zip',
         );
 
-        $checker = $this->createMock(UpdateChecker::class);
-        $checker->method('checkForUpdate')->willReturn($updateInfo);
+        $checker = $this->createMock( UpdateChecker::class );
+        $checker->method( 'checkForUpdate' )->willReturn( $updateInfo );
 
-        $manager->setUpdateChecker($checker);
+        $manager->setUpdateChecker( $checker );
 
         $result = $manager->checkForUpdate();
 
-        $this->assertInstanceOf(UpdateInfo::class, $result);
-        $this->assertTrue($result->hasUpdate());
-        $this->assertEquals('2.0.0', $result->latestVersion);
+        $this->assertInstanceOf( UpdateInfo::class, $result );
+        $this->assertTrue( $result->hasUpdate() );
+        $this->assertEquals( '2.0.0', $result->latestVersion );
     }
 
     /**
@@ -52,12 +52,12 @@ class ApplicationUpdateManagerTest extends TestCase
      */
     public function test_throws_exception_when_no_update_url(): void
     {
-        config(['cms.updates.update_source_url' => null]);
+        config( ['cms.updates.update_source_url' => null] );
 
         $manager = new ApplicationUpdateManager;
 
-        $this->expectException(UpdateException::class);
-        $this->expectExceptionMessage('Update URL not configured');
+        $this->expectException( UpdateException::class );
+        $this->expectExceptionMessage( 'Update URL not configured' );
 
         $manager->checkForUpdate();
     }
@@ -77,13 +77,13 @@ class ApplicationUpdateManagerTest extends TestCase
             downloadUrl: 'https://example.com/update.zip',
         );
 
-        $checker = $this->createMock(UpdateChecker::class);
-        $checker->method('checkForUpdate')->willReturn($updateInfo);
+        $checker = $this->createMock( UpdateChecker::class );
+        $checker->method( 'checkForUpdate' )->willReturn( $updateInfo );
 
-        $manager->setUpdateChecker($checker);
+        $manager->setUpdateChecker( $checker );
 
-        $this->expectException(UpdateException::class);
-        $this->expectExceptionMessage('No update available');
+        $this->expectException( UpdateException::class );
+        $this->expectExceptionMessage( 'No update available' );
 
         $manager->performUpdate();
     }
@@ -97,13 +97,13 @@ class ApplicationUpdateManagerTest extends TestCase
     {
         $manager = new ApplicationUpdateManager;
 
-        $checker = $this->createMock(UpdateChecker::class);
-        $checker->expects($this->once())->method('clearCache');
+        $checker = $this->createMock( UpdateChecker::class );
+        $checker->expects( $this->once() )->method( 'clearCache' );
 
-        $manager->setUpdateChecker($checker);
+        $manager->setUpdateChecker( $checker );
         $manager->clearCache();
 
-        $this->assertTrue(true); // If we get here, the test passed
+        $this->assertTrue( true ); // If we get here, the test passed
     }
 
     /**
@@ -115,21 +115,21 @@ class ApplicationUpdateManagerTest extends TestCase
     {
         $manager = new ApplicationUpdateManager;
 
-        $reflection = new ReflectionClass($manager);
-        $method     = $reflection->getMethod('isPathExcluded');
-        $method->setAccessible(true);
+        $reflection = new ReflectionClass( $manager );
+        $method     = $reflection->getMethod( 'isPathExcluded' );
+        $method->setAccessible( true );
 
         // Test exact match
-        $this->assertTrue($method->invoke($manager, 'storage/logs/test.log', ['storage']));
+        $this->assertTrue( $method->invoke( $manager, 'storage/logs/test.log', ['storage'] ) );
 
         // Test non-match
-        $this->assertFalse($method->invoke($manager, 'app/Models/User.php', ['storage']));
+        $this->assertFalse( $method->invoke( $manager, 'app/Models/User.php', ['storage'] ) );
 
         // Test wildcard match
-        $this->assertTrue($method->invoke($manager, 'bootstrap/cache/config.php', ['bootstrap/cache/*.php']));
+        $this->assertTrue( $method->invoke( $manager, 'bootstrap/cache/config.php', ['bootstrap/cache/*.php'] ) );
 
         // Test no match with wildcard
-        $this->assertFalse($method->invoke($manager, 'bootstrap/app.php', ['bootstrap/cache/*.php']));
+        $this->assertFalse( $method->invoke( $manager, 'bootstrap/app.php', ['bootstrap/cache/*.php'] ) );
     }
 
     /**
@@ -141,10 +141,10 @@ class ApplicationUpdateManagerTest extends TestCase
     {
         $manager = new ApplicationUpdateManager;
 
-        $this->expectException(UpdateException::class);
-        $this->expectExceptionMessage('Backup not found');
+        $this->expectException( UpdateException::class );
+        $this->expectExceptionMessage( 'Backup not found' );
 
-        $manager->rollback('/nonexistent/backup.zip');
+        $manager->rollback( '/nonexistent/backup.zip' );
     }
 
     /**
@@ -162,14 +162,14 @@ class ApplicationUpdateManagerTest extends TestCase
             downloadUrl: 'https://example.com/update.zip',
         );
 
-        $checker = $this->createMock(UpdateChecker::class);
-        $checker->method('checkForUpdate')->willReturn($updateInfo);
+        $checker = $this->createMock( UpdateChecker::class );
+        $checker->method( 'checkForUpdate' )->willReturn( $updateInfo );
 
-        $manager->setUpdateChecker($checker);
+        $manager->setUpdateChecker( $checker );
 
         $result = $manager->checkForUpdate();
 
-        $this->assertEquals('2.0.0', $result->latestVersion);
+        $this->assertEquals( '2.0.0', $result->latestVersion );
     }
 
     /**
@@ -179,15 +179,15 @@ class ApplicationUpdateManagerTest extends TestCase
      *
      * @param  \Illuminate\Foundation\Application  $app
      */
-    protected function defineEnvironment($app): void
+    protected function defineEnvironment( $app ): void
     {
-        $app['config']->set('cms.updates.update_source_url', 'https://github.com/test/repo');
-        $app['config']->set('cms.updates.backup_enabled', true);
-        $app['config']->set('cms.updates.backup_path', 'backups/application');
-        $app['config']->set('cms.updates.backup_retention_days', 30);
-        $app['config']->set('cms.updates.verify_checksum', false); // Disable for tests
-        $app['config']->set('cms.updates.composer_install_command', 'composer install --no-dev');
-        $app['config']->set('cms.updates.composer_timeout', 600);
-        $app['config']->set('cms.updates.exclude_from_update', ['.env', 'storage', 'vendor']);
+        $app['config']->set( 'cms.updates.update_source_url', 'https://github.com/test/repo' );
+        $app['config']->set( 'cms.updates.backup_enabled', true );
+        $app['config']->set( 'cms.updates.backup_path', 'backups/application' );
+        $app['config']->set( 'cms.updates.backup_retention_days', 30 );
+        $app['config']->set( 'cms.updates.verify_checksum', false ); // Disable for tests
+        $app['config']->set( 'cms.updates.composer_install_command', 'composer install --no-dev');
+        $app['config']->set( 'cms.updates.composer_timeout', 600);
+        $app['config']->set( 'cms.updates.exclude_from_update', ['.env', 'storage', 'vendor']);
     }
 }

--- a/tests/Unit/Updates/ApplicationUpdateManagerTest.php
+++ b/tests/Unit/Updates/ApplicationUpdateManagerTest.php
@@ -1,6 +1,6 @@
 <?php
 
-declare( strict_types = 1 );
+declare(strict_types=1);
 
 namespace ArtisanPackUI\CMSFramework\Tests\Unit\Updates;
 
@@ -30,20 +30,19 @@ class ApplicationUpdateManagerTest extends TestCase
         $updateInfo = new UpdateInfo(
             currentVersion: '1.0.0',
             latestVersion: '2.0.0',
-            hasUpdate: true,
             downloadUrl: 'https://example.com/update.zip',
         );
 
-        $checker = $this->createMock( UpdateChecker::class );
-        $checker->method( 'checkForUpdate' )->willReturn( $updateInfo );
+        $checker = $this->createMock(UpdateChecker::class);
+        $checker->method('checkForUpdate')->willReturn($updateInfo);
 
-        $manager->setUpdateChecker( $checker );
+        $manager->setUpdateChecker($checker);
 
         $result = $manager->checkForUpdate();
 
-        $this->assertInstanceOf( UpdateInfo::class, $result );
-        $this->assertTrue( $result->hasUpdate );
-        $this->assertEquals( '2.0.0', $result->latestVersion );
+        $this->assertInstanceOf(UpdateInfo::class, $result);
+        $this->assertTrue($result->hasUpdate());
+        $this->assertEquals('2.0.0', $result->latestVersion);
     }
 
     /**
@@ -53,12 +52,12 @@ class ApplicationUpdateManagerTest extends TestCase
      */
     public function test_throws_exception_when_no_update_url(): void
     {
-        config( ['cms.updates.update_source_url' => null] );
+        config(['cms.updates.update_source_url' => null]);
 
         $manager = new ApplicationUpdateManager;
 
-        $this->expectException( UpdateException::class );
-        $this->expectExceptionMessage( 'Update URL not configured' );
+        $this->expectException(UpdateException::class);
+        $this->expectExceptionMessage('Update URL not configured');
 
         $manager->checkForUpdate();
     }
@@ -75,17 +74,16 @@ class ApplicationUpdateManagerTest extends TestCase
         $updateInfo = new UpdateInfo(
             currentVersion: '1.0.0',
             latestVersion: '1.0.0',
-            hasUpdate: false,
             downloadUrl: 'https://example.com/update.zip',
         );
 
-        $checker = $this->createMock( UpdateChecker::class );
-        $checker->method( 'checkForUpdate' )->willReturn( $updateInfo );
+        $checker = $this->createMock(UpdateChecker::class);
+        $checker->method('checkForUpdate')->willReturn($updateInfo);
 
-        $manager->setUpdateChecker( $checker );
+        $manager->setUpdateChecker($checker);
 
-        $this->expectException( UpdateException::class );
-        $this->expectExceptionMessage( 'No update available' );
+        $this->expectException(UpdateException::class);
+        $this->expectExceptionMessage('No update available');
 
         $manager->performUpdate();
     }
@@ -99,13 +97,13 @@ class ApplicationUpdateManagerTest extends TestCase
     {
         $manager = new ApplicationUpdateManager;
 
-        $checker = $this->createMock( UpdateChecker::class );
-        $checker->expects( $this->once() )->method( 'clearCache' );
+        $checker = $this->createMock(UpdateChecker::class);
+        $checker->expects($this->once())->method('clearCache');
 
-        $manager->setUpdateChecker( $checker );
+        $manager->setUpdateChecker($checker);
         $manager->clearCache();
 
-        $this->assertTrue( true ); // If we get here, the test passed
+        $this->assertTrue(true); // If we get here, the test passed
     }
 
     /**
@@ -117,21 +115,21 @@ class ApplicationUpdateManagerTest extends TestCase
     {
         $manager = new ApplicationUpdateManager;
 
-        $reflection = new ReflectionClass( $manager );
-        $method     = $reflection->getMethod( 'isPathExcluded' );
-        $method->setAccessible( true );
+        $reflection = new ReflectionClass($manager);
+        $method     = $reflection->getMethod('isPathExcluded');
+        $method->setAccessible(true);
 
         // Test exact match
-        $this->assertTrue( $method->invoke( $manager, 'storage/logs/test.log', ['storage'] ) );
+        $this->assertTrue($method->invoke($manager, 'storage/logs/test.log', ['storage']));
 
         // Test non-match
-        $this->assertFalse( $method->invoke( $manager, 'app/Models/User.php', ['storage'] ) );
+        $this->assertFalse($method->invoke($manager, 'app/Models/User.php', ['storage']));
 
         // Test wildcard match
-        $this->assertTrue( $method->invoke( $manager, 'bootstrap/cache/config.php', ['bootstrap/cache/*.php'] ) );
+        $this->assertTrue($method->invoke($manager, 'bootstrap/cache/config.php', ['bootstrap/cache/*.php']));
 
         // Test no match with wildcard
-        $this->assertFalse( $method->invoke( $manager, 'bootstrap/app.php', ['bootstrap/cache/*.php'] ) );
+        $this->assertFalse($method->invoke($manager, 'bootstrap/app.php', ['bootstrap/cache/*.php']));
     }
 
     /**
@@ -143,10 +141,10 @@ class ApplicationUpdateManagerTest extends TestCase
     {
         $manager = new ApplicationUpdateManager;
 
-        $this->expectException( UpdateException::class );
-        $this->expectExceptionMessage( 'Backup not found' );
+        $this->expectException(UpdateException::class);
+        $this->expectExceptionMessage('Backup not found');
 
-        $manager->rollback( '/nonexistent/backup.zip' );
+        $manager->rollback('/nonexistent/backup.zip');
     }
 
     /**
@@ -161,18 +159,17 @@ class ApplicationUpdateManagerTest extends TestCase
         $updateInfo = new UpdateInfo(
             currentVersion: '1.0.0',
             latestVersion: '2.0.0',
-            hasUpdate: true,
             downloadUrl: 'https://example.com/update.zip',
         );
 
-        $checker = $this->createMock( UpdateChecker::class );
-        $checker->method( 'checkForUpdate' )->willReturn( $updateInfo );
+        $checker = $this->createMock(UpdateChecker::class);
+        $checker->method('checkForUpdate')->willReturn($updateInfo);
 
-        $manager->setUpdateChecker( $checker );
+        $manager->setUpdateChecker($checker);
 
         $result = $manager->checkForUpdate();
 
-        $this->assertEquals( '2.0.0', $result->latestVersion );
+        $this->assertEquals('2.0.0', $result->latestVersion);
     }
 
     /**
@@ -182,15 +179,15 @@ class ApplicationUpdateManagerTest extends TestCase
      *
      * @param  \Illuminate\Foundation\Application  $app
      */
-    protected function defineEnvironment( $app ): void
+    protected function defineEnvironment($app): void
     {
-        $app['config']->set( 'cms.updates.update_source_url', 'https://github.com/test/repo' );
-        $app['config']->set( 'cms.updates.backup_enabled', true );
-        $app['config']->set( 'cms.updates.backup_path', 'backups/application' );
-        $app['config']->set( 'cms.updates.backup_retention_days', 30 );
-        $app['config']->set( 'cms.updates.verify_checksum', false ); // Disable for tests
-        $app['config']->set( 'cms.updates.composer_install_command', 'composer install --no-dev' );
-        $app['config']->set( 'cms.updates.composer_timeout', 600 );
-        $app['config']->set( 'cms.updates.exclude_from_update', ['.env', 'storage', 'vendor'] );
+        $app['config']->set('cms.updates.update_source_url', 'https://github.com/test/repo');
+        $app['config']->set('cms.updates.backup_enabled', true);
+        $app['config']->set('cms.updates.backup_path', 'backups/application');
+        $app['config']->set('cms.updates.backup_retention_days', 30);
+        $app['config']->set('cms.updates.verify_checksum', false); // Disable for tests
+        $app['config']->set('cms.updates.composer_install_command', 'composer install --no-dev');
+        $app['config']->set('cms.updates.composer_timeout', 600);
+        $app['config']->set('cms.updates.exclude_from_update', ['.env', 'storage', 'vendor']);
     }
 }

--- a/tests/Unit/Updates/ApplicationUpdateManagerTest.php
+++ b/tests/Unit/Updates/ApplicationUpdateManagerTest.php
@@ -186,8 +186,8 @@ class ApplicationUpdateManagerTest extends TestCase
         $app['config']->set( 'cms.updates.backup_path', 'backups/application' );
         $app['config']->set( 'cms.updates.backup_retention_days', 30 );
         $app['config']->set( 'cms.updates.verify_checksum', false ); // Disable for tests
-        $app['config']->set( 'cms.updates.composer_install_command', 'composer install --no-dev');
-        $app['config']->set( 'cms.updates.composer_timeout', 600);
-        $app['config']->set( 'cms.updates.exclude_from_update', ['.env', 'storage', 'vendor']);
+        $app['config']->set( 'cms.updates.composer_install_command', 'composer install --no-dev' );
+        $app['config']->set( 'cms.updates.composer_timeout', 600 );
+        $app['config']->set( 'cms.updates.exclude_from_update', ['.env', 'storage', 'vendor'] );
     }
 }

--- a/tests/Unit/Updates/ApplicationUpdateManagerTest.php
+++ b/tests/Unit/Updates/ApplicationUpdateManagerTest.php
@@ -14,14 +14,14 @@ use ReflectionClass;
 /**
  * Application Update Manager Tests
  *
- * @since 2.0.0
+ * @since 1.0.0
  */
 class ApplicationUpdateManagerTest extends TestCase
 {
     /**
      * Test manager can check for updates.
      *
-     * @since 2.0.0
+     * @since 1.0.0
      */
     public function test_can_check_for_update(): void
     {
@@ -48,7 +48,7 @@ class ApplicationUpdateManagerTest extends TestCase
     /**
      * Test manager throws exception when no update URL configured.
      *
-     * @since 2.0.0
+     * @since 1.0.0
      */
     public function test_throws_exception_when_no_update_url(): void
     {
@@ -65,7 +65,7 @@ class ApplicationUpdateManagerTest extends TestCase
     /**
      * Test manager throws exception when no update available.
      *
-     * @since 2.0.0
+     * @since 1.0.0
      */
     public function test_throws_exception_when_no_update_available(): void
     {
@@ -91,7 +91,7 @@ class ApplicationUpdateManagerTest extends TestCase
     /**
      * Test manager can clear cache.
      *
-     * @since 2.0.0
+     * @since 1.0.0
      */
     public function test_can_clear_cache(): void
     {
@@ -109,7 +109,7 @@ class ApplicationUpdateManagerTest extends TestCase
     /**
      * Test path exclusion logic.
      *
-     * @since 2.0.0
+     * @since 1.0.0
      */
     public function test_path_exclusion_logic(): void
     {
@@ -135,7 +135,7 @@ class ApplicationUpdateManagerTest extends TestCase
     /**
      * Test rollback throws exception when backup not found.
      *
-     * @since 2.0.0
+     * @since 1.0.0
      */
     public function test_rollback_throws_exception_when_backup_not_found(): void
     {
@@ -150,7 +150,7 @@ class ApplicationUpdateManagerTest extends TestCase
     /**
      * Test manager sets custom update checker.
      *
-     * @since 2.0.0
+     * @since 1.0.0
      */
     public function test_can_set_custom_update_checker(): void
     {
@@ -175,7 +175,7 @@ class ApplicationUpdateManagerTest extends TestCase
     /**
      * Define environment setup.
      *
-     * @since 2.0.0
+     * @since 1.0.0
      *
      * @param  \Illuminate\Foundation\Application  $app
      */

--- a/tests/Unit/Updates/CustomJsonUpdateSourceTest.php
+++ b/tests/Unit/Updates/CustomJsonUpdateSourceTest.php
@@ -1,6 +1,6 @@
 <?php
 
-declare( strict_types = 1 );
+declare(strict_types=1);
 
 namespace ArtisanPackUI\CMSFramework\Tests\Unit\Updates;
 
@@ -24,12 +24,12 @@ class CustomJsonUpdateSourceTest extends TestCase
      */
     public function test_supports_all_urls(): void
     {
-        $source = new CustomJsonUpdateSource( 'https://example.com/updates.json', '1.0.0' );
+        $source = new CustomJsonUpdateSource('https://example.com/updates.json', '1.0.0');
 
-        $this->assertTrue( $source->supports( 'https://example.com/updates.json' ) );
-        $this->assertTrue( $source->supports( 'https://github.com/user/repo' ) );
-        $this->assertTrue( $source->supports( 'https://gitlab.com/user/repo' ) );
-        $this->assertTrue( $source->supports( 'https://anything.com/anything' ) );
+        $this->assertTrue($source->supports('https://example.com/updates.json'));
+        $this->assertTrue($source->supports('https://github.com/user/repo'));
+        $this->assertTrue($source->supports('https://gitlab.com/user/repo'));
+        $this->assertTrue($source->supports('https://anything.com/anything'));
     }
 
     /**
@@ -39,9 +39,9 @@ class CustomJsonUpdateSourceTest extends TestCase
      */
     public function test_returns_correct_name(): void
     {
-        $source = new CustomJsonUpdateSource( 'https://example.com/updates.json', '1.0.0' );
+        $source = new CustomJsonUpdateSource('https://example.com/updates.json', '1.0.0');
 
-        $this->assertEquals( 'Custom JSON', $source->getName() );
+        $this->assertEquals('Custom JSON', $source->getName());
     }
 
     /**
@@ -51,24 +51,24 @@ class CustomJsonUpdateSourceTest extends TestCase
      */
     public function test_can_check_for_updates(): void
     {
-        Http::fake( [
-            'example.com/updates.json' => Http::response( [
+        Http::fake([
+            'example.com/updates.json' => Http::response([
                 'version'      => '2.0.0',
                 'download_url' => 'https://example.com/releases/cms-2.0.0.zip',
                 'changelog'    => 'New features',
                 'release_date' => '2024-12-15T10:00:00Z',
-            ], 200 ),
-        ] );
+            ], 200),
+        ]);
 
-        $source     = new CustomJsonUpdateSource( 'https://example.com/updates.json', '1.0.0' );
+        $source     = new CustomJsonUpdateSource('https://example.com/updates.json', '1.0.0');
         $updateInfo = $source->checkForUpdate();
 
-        $this->assertInstanceOf( UpdateInfo::class, $updateInfo );
-        $this->assertEquals( '1.0.0', $updateInfo->currentVersion );
-        $this->assertEquals( '2.0.0', $updateInfo->latestVersion );
-        $this->assertTrue( $updateInfo->hasUpdate );
-        $this->assertEquals( 'https://example.com/releases/cms-2.0.0.zip', $updateInfo->downloadUrl );
-        $this->assertEquals( 'New features', $updateInfo->changelog );
+        $this->assertInstanceOf(UpdateInfo::class, $updateInfo);
+        $this->assertEquals('1.0.0', $updateInfo->currentVersion);
+        $this->assertEquals('2.0.0', $updateInfo->latestVersion);
+        $this->assertTrue($updateInfo->hasUpdate());
+        $this->assertEquals('https://example.com/releases/cms-2.0.0.zip', $updateInfo->downloadUrl);
+        $this->assertEquals('New features', $updateInfo->changelog);
     }
 
     /**
@@ -78,16 +78,16 @@ class CustomJsonUpdateSourceTest extends TestCase
      */
     public function test_throws_exception_when_version_missing(): void
     {
-        Http::fake( [
-            'example.com/updates.json' => Http::response( [
+        Http::fake([
+            'example.com/updates.json' => Http::response([
                 'download_url' => 'https://example.com/releases/cms-2.0.0.zip',
-            ], 200 ),
-        ] );
+            ], 200),
+        ]);
 
-        $source = new CustomJsonUpdateSource( 'https://example.com/updates.json', '1.0.0' );
+        $source = new CustomJsonUpdateSource('https://example.com/updates.json', '1.0.0');
 
-        $this->expectException( UpdateException::class );
-        $this->expectExceptionMessage( 'missing required field: version' );
+        $this->expectException(UpdateException::class);
+        $this->expectExceptionMessage('missing required field: version');
 
         $source->checkForUpdate();
     }
@@ -99,16 +99,16 @@ class CustomJsonUpdateSourceTest extends TestCase
      */
     public function test_throws_exception_when_download_url_missing(): void
     {
-        Http::fake( [
-            'example.com/updates.json' => Http::response( [
+        Http::fake([
+            'example.com/updates.json' => Http::response([
                 'version' => '2.0.0',
-            ], 200 ),
-        ] );
+            ], 200),
+        ]);
 
-        $source = new CustomJsonUpdateSource( 'https://example.com/updates.json', '1.0.0' );
+        $source = new CustomJsonUpdateSource('https://example.com/updates.json', '1.0.0');
 
-        $this->expectException( UpdateException::class );
-        $this->expectExceptionMessage( 'missing required field: download_url' );
+        $this->expectException(UpdateException::class);
+        $this->expectExceptionMessage('missing required field: download_url');
 
         $source->checkForUpdate();
     }
@@ -120,14 +120,14 @@ class CustomJsonUpdateSourceTest extends TestCase
      */
     public function test_handles_api_errors(): void
     {
-        Http::fake( [
-            'example.com/updates.json' => Http::response( [], 500 ),
-        ] );
+        Http::fake([
+            'example.com/updates.json' => Http::response([], 500),
+        ]);
 
-        $source = new CustomJsonUpdateSource( 'https://example.com/updates.json', '1.0.0' );
+        $source = new CustomJsonUpdateSource('https://example.com/updates.json', '1.0.0');
 
-        $this->expectException( UpdateException::class );
-        $this->expectExceptionMessage( 'Failed to check for updates' );
+        $this->expectException(UpdateException::class);
+        $this->expectExceptionMessage('Failed to check for updates');
 
         $source->checkForUpdate();
     }
@@ -139,14 +139,14 @@ class CustomJsonUpdateSourceTest extends TestCase
      */
     public function test_handles_invalid_json(): void
     {
-        Http::fake( [
-            'example.com/updates.json' => Http::response( 'not json', 200 ),
-        ] );
+        Http::fake([
+            'example.com/updates.json' => Http::response('not json', 200),
+        ]);
 
-        $source = new CustomJsonUpdateSource( 'https://example.com/updates.json', '1.0.0' );
+        $source = new CustomJsonUpdateSource('https://example.com/updates.json', '1.0.0');
 
-        $this->expectException( UpdateException::class );
-        $this->expectExceptionMessage( 'Invalid JSON response' );
+        $this->expectException(UpdateException::class);
+        $this->expectExceptionMessage('Invalid JSON response');
 
         $source->checkForUpdate();
     }
@@ -158,19 +158,19 @@ class CustomJsonUpdateSourceTest extends TestCase
      */
     public function test_can_set_authentication_with_string(): void
     {
-        Http::fake( [
-            'example.com/updates.json?token=secret123' => Http::response( [
+        Http::fake([
+            'example.com/updates.json?token=secret123' => Http::response([
                 'version'      => '2.0.0',
                 'download_url' => 'https://example.com/releases/cms-2.0.0.zip',
-            ], 200 ),
-        ] );
+            ], 200),
+        ]);
 
-        $source = new CustomJsonUpdateSource( 'https://example.com/updates.json', '1.0.0' );
-        $source->setAuthentication( 'secret123' );
+        $source = new CustomJsonUpdateSource('https://example.com/updates.json', '1.0.0');
+        $source->setAuthentication('secret123');
 
         $updateInfo = $source->checkForUpdate();
 
-        $this->assertInstanceOf( UpdateInfo::class, $updateInfo );
+        $this->assertInstanceOf(UpdateInfo::class, $updateInfo);
     }
 
     /**
@@ -180,22 +180,22 @@ class CustomJsonUpdateSourceTest extends TestCase
      */
     public function test_can_set_authentication_with_array(): void
     {
-        Http::fake( [
-            'example.com/updates.json?api_key=key123&license=lic456' => Http::response( [
+        Http::fake([
+            'example.com/updates.json?api_key=key123&license=lic456' => Http::response([
                 'version'      => '2.0.0',
                 'download_url' => 'https://example.com/releases/cms-2.0.0.zip',
-            ], 200 ),
-        ] );
+            ], 200),
+        ]);
 
-        $source = new CustomJsonUpdateSource( 'https://example.com/updates.json', '1.0.0' );
-        $source->setAuthentication( [
+        $source = new CustomJsonUpdateSource('https://example.com/updates.json', '1.0.0');
+        $source->setAuthentication([
             'api_key' => 'key123',
             'license' => 'lic456',
-        ] );
+        ]);
 
         $updateInfo = $source->checkForUpdate();
 
-        $this->assertInstanceOf( UpdateInfo::class, $updateInfo );
+        $this->assertInstanceOf(UpdateInfo::class, $updateInfo);
     }
 
     /**
@@ -205,19 +205,19 @@ class CustomJsonUpdateSourceTest extends TestCase
      */
     public function test_handles_urls_with_existing_query_params(): void
     {
-        Http::fake( [
-            'example.com/updates.json?existing=param&token=secret123' => Http::response( [
+        Http::fake([
+            'example.com/updates.json?existing=param&token=secret123' => Http::response([
                 'version'      => '2.0.0',
                 'download_url' => 'https://example.com/releases/cms-2.0.0.zip',
-            ], 200 ),
-        ] );
+            ], 200),
+        ]);
 
-        $source = new CustomJsonUpdateSource( 'https://example.com/updates.json?existing=param', '1.0.0' );
-        $source->setAuthentication( 'secret123' );
+        $source = new CustomJsonUpdateSource('https://example.com/updates.json?existing=param', '1.0.0');
+        $source->setAuthentication('secret123');
 
         $updateInfo = $source->checkForUpdate();
 
-        $this->assertInstanceOf( UpdateInfo::class, $updateInfo );
+        $this->assertInstanceOf(UpdateInfo::class, $updateInfo);
     }
 
     /**
@@ -227,8 +227,8 @@ class CustomJsonUpdateSourceTest extends TestCase
      */
     public function test_parses_all_optional_fields(): void
     {
-        Http::fake( [
-            'example.com/updates.json' => Http::response( [
+        Http::fake([
+            'example.com/updates.json' => Http::response([
                 'version'               => '2.0.0',
                 'download_url'          => 'https://example.com/releases/cms-2.0.0.zip',
                 'changelog'             => 'Release notes',
@@ -238,19 +238,19 @@ class CustomJsonUpdateSourceTest extends TestCase
                 'sha256'                => 'abc123',
                 'file_size'             => 1024000,
                 'metadata'              => ['custom' => 'data'],
-            ], 200 ),
-        ] );
+            ], 200),
+        ]);
 
-        $source     = new CustomJsonUpdateSource( 'https://example.com/updates.json', '1.0.0' );
+        $source     = new CustomJsonUpdateSource('https://example.com/updates.json', '1.0.0');
         $updateInfo = $source->checkForUpdate();
 
-        $this->assertEquals( 'Release notes', $updateInfo->changelog );
-        $this->assertEquals( '2024-12-15T10:00:00Z', $updateInfo->releaseDate );
-        $this->assertEquals( '8.2', $updateInfo->minPhpVersion );
-        $this->assertEquals( '2.0.0', $updateInfo->minFrameworkVersion );
-        $this->assertEquals( 'abc123', $updateInfo->sha256 );
-        $this->assertEquals( 1024000, $updateInfo->fileSize );
-        $this->assertEquals( ['custom' => 'data'], $updateInfo->metadata );
+        $this->assertEquals('Release notes', $updateInfo->changelog);
+        $this->assertEquals('2024-12-15T10:00:00Z', $updateInfo->releaseDate);
+        $this->assertEquals('8.2', $updateInfo->minPhpVersion);
+        $this->assertEquals('2.0.0', $updateInfo->minFrameworkVersion);
+        $this->assertEquals('abc123', $updateInfo->sha256);
+        $this->assertEquals(1024000, $updateInfo->fileSize);
+        $this->assertEquals(['custom' => 'data'], $updateInfo->metadata);
     }
 
     /**
@@ -260,17 +260,17 @@ class CustomJsonUpdateSourceTest extends TestCase
      */
     public function test_detects_no_update_when_versions_match(): void
     {
-        Http::fake( [
-            'example.com/updates.json' => Http::response( [
+        Http::fake([
+            'example.com/updates.json' => Http::response([
                 'version'      => '1.0.0',
                 'download_url' => 'https://example.com/releases/cms-1.0.0.zip',
-            ], 200 ),
-        ] );
+            ], 200),
+        ]);
 
-        $source     = new CustomJsonUpdateSource( 'https://example.com/updates.json', '1.0.0' );
+        $source     = new CustomJsonUpdateSource('https://example.com/updates.json', '1.0.0');
         $updateInfo = $source->checkForUpdate();
 
-        $this->assertFalse( $updateInfo->hasUpdate );
+        $this->assertFalse($updateInfo->hasUpdate());
     }
 
     /**
@@ -280,10 +280,10 @@ class CustomJsonUpdateSourceTest extends TestCase
      *
      * @param  \Illuminate\Foundation\Application  $app
      */
-    protected function defineEnvironment( $app ): void
+    protected function defineEnvironment($app): void
     {
-        $app['config']->set( 'cms.updates.http_timeout', 15 );
-        $app['config']->set( 'cms.updates.http_retries', 3 );
-        $app['config']->set( 'cms.updates.download_timeout', 300 );
+        $app['config']->set('cms.updates.http_timeout', 15);
+        $app['config']->set('cms.updates.http_retries', 3);
+        $app['config']->set('cms.updates.download_timeout', 300);
     }
 }

--- a/tests/Unit/Updates/CustomJsonUpdateSourceTest.php
+++ b/tests/Unit/Updates/CustomJsonUpdateSourceTest.php
@@ -13,14 +13,14 @@ use Orchestra\Testbench\TestCase;
 /**
  * Custom JSON Update Source Tests
  *
- * @since 2.0.0
+ * @since 1.0.0
  */
 class CustomJsonUpdateSourceTest extends TestCase
 {
     /**
      * Test custom JSON source supports all URLs (fallback source).
      *
-     * @since 2.0.0
+     * @since 1.0.0
      */
     public function test_supports_all_urls(): void
     {
@@ -35,7 +35,7 @@ class CustomJsonUpdateSourceTest extends TestCase
     /**
      * Test custom JSON source returns correct name.
      *
-     * @since 2.0.0
+     * @since 1.0.0
      */
     public function test_returns_correct_name(): void
     {
@@ -47,7 +47,7 @@ class CustomJsonUpdateSourceTest extends TestCase
     /**
      * Test custom JSON source can check for updates.
      *
-     * @since 2.0.0
+     * @since 1.0.0
      */
     public function test_can_check_for_updates(): void
     {
@@ -74,7 +74,7 @@ class CustomJsonUpdateSourceTest extends TestCase
     /**
      * Test custom JSON source throws exception when version is missing.
      *
-     * @since 2.0.0
+     * @since 1.0.0
      */
     public function test_throws_exception_when_version_missing(): void
     {
@@ -95,7 +95,7 @@ class CustomJsonUpdateSourceTest extends TestCase
     /**
      * Test custom JSON source throws exception when download_url is missing.
      *
-     * @since 2.0.0
+     * @since 1.0.0
      */
     public function test_throws_exception_when_download_url_missing(): void
     {
@@ -116,7 +116,7 @@ class CustomJsonUpdateSourceTest extends TestCase
     /**
      * Test custom JSON source handles API errors.
      *
-     * @since 2.0.0
+     * @since 1.0.0
      */
     public function test_handles_api_errors(): void
     {
@@ -135,7 +135,7 @@ class CustomJsonUpdateSourceTest extends TestCase
     /**
      * Test custom JSON source handles invalid JSON.
      *
-     * @since 2.0.0
+     * @since 1.0.0
      */
     public function test_handles_invalid_json(): void
     {
@@ -154,7 +154,7 @@ class CustomJsonUpdateSourceTest extends TestCase
     /**
      * Test custom JSON source can set authentication with string token.
      *
-     * @since 2.0.0
+     * @since 1.0.0
      */
     public function test_can_set_authentication_with_string(): void
     {
@@ -176,7 +176,7 @@ class CustomJsonUpdateSourceTest extends TestCase
     /**
      * Test custom JSON source can set authentication with array.
      *
-     * @since 2.0.0
+     * @since 1.0.0
      */
     public function test_can_set_authentication_with_array(): void
     {
@@ -201,7 +201,7 @@ class CustomJsonUpdateSourceTest extends TestCase
     /**
      * Test custom JSON source handles URLs with existing query params.
      *
-     * @since 2.0.0
+     * @since 1.0.0
      */
     public function test_handles_urls_with_existing_query_params(): void
     {
@@ -223,7 +223,7 @@ class CustomJsonUpdateSourceTest extends TestCase
     /**
      * Test custom JSON source parses all optional fields.
      *
-     * @since 2.0.0
+     * @since 1.0.0
      */
     public function test_parses_all_optional_fields(): void
     {
@@ -256,7 +256,7 @@ class CustomJsonUpdateSourceTest extends TestCase
     /**
      * Test custom JSON source detects no update when versions match.
      *
-     * @since 2.0.0
+     * @since 1.0.0
      */
     public function test_detects_no_update_when_versions_match(): void
     {
@@ -276,7 +276,7 @@ class CustomJsonUpdateSourceTest extends TestCase
     /**
      * Define environment setup.
      *
-     * @since 2.0.0
+     * @since 1.0.0
      *
      * @param  \Illuminate\Foundation\Application  $app
      */

--- a/tests/Unit/Updates/CustomJsonUpdateSourceTest.php
+++ b/tests/Unit/Updates/CustomJsonUpdateSourceTest.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare( strict_types=1 );
 
 namespace ArtisanPackUI\CMSFramework\Tests\Unit\Updates;
 
@@ -24,12 +24,12 @@ class CustomJsonUpdateSourceTest extends TestCase
      */
     public function test_supports_all_urls(): void
     {
-        $source = new CustomJsonUpdateSource('https://example.com/updates.json', '1.0.0');
+        $source = new CustomJsonUpdateSource( 'https://example.com/updates.json', '1.0.0' );
 
-        $this->assertTrue($source->supports('https://example.com/updates.json'));
-        $this->assertTrue($source->supports('https://github.com/user/repo'));
-        $this->assertTrue($source->supports('https://gitlab.com/user/repo'));
-        $this->assertTrue($source->supports('https://anything.com/anything'));
+        $this->assertTrue( $source->supports( 'https://example.com/updates.json' ) );
+        $this->assertTrue( $source->supports( 'https://github.com/user/repo' ) );
+        $this->assertTrue( $source->supports( 'https://gitlab.com/user/repo' ) );
+        $this->assertTrue( $source->supports( 'https://anything.com/anything' ) );
     }
 
     /**
@@ -39,9 +39,9 @@ class CustomJsonUpdateSourceTest extends TestCase
      */
     public function test_returns_correct_name(): void
     {
-        $source = new CustomJsonUpdateSource('https://example.com/updates.json', '1.0.0');
+        $source = new CustomJsonUpdateSource( 'https://example.com/updates.json', '1.0.0' );
 
-        $this->assertEquals('Custom JSON', $source->getName());
+        $this->assertEquals( 'Custom JSON', $source->getName() );
     }
 
     /**
@@ -51,24 +51,24 @@ class CustomJsonUpdateSourceTest extends TestCase
      */
     public function test_can_check_for_updates(): void
     {
-        Http::fake([
-            'example.com/updates.json' => Http::response([
+        Http::fake( [
+            'example.com/updates.json' => Http::response( [
                 'version'      => '2.0.0',
                 'download_url' => 'https://example.com/releases/cms-2.0.0.zip',
                 'changelog'    => 'New features',
                 'release_date' => '2024-12-15T10:00:00Z',
-            ], 200),
-        ]);
+            ], 200 ),
+        ] );
 
-        $source     = new CustomJsonUpdateSource('https://example.com/updates.json', '1.0.0');
+        $source     = new CustomJsonUpdateSource( 'https://example.com/updates.json', '1.0.0' );
         $updateInfo = $source->checkForUpdate();
 
-        $this->assertInstanceOf(UpdateInfo::class, $updateInfo);
-        $this->assertEquals('1.0.0', $updateInfo->currentVersion);
-        $this->assertEquals('2.0.0', $updateInfo->latestVersion);
-        $this->assertTrue($updateInfo->hasUpdate());
-        $this->assertEquals('https://example.com/releases/cms-2.0.0.zip', $updateInfo->downloadUrl);
-        $this->assertEquals('New features', $updateInfo->changelog);
+        $this->assertInstanceOf( UpdateInfo::class, $updateInfo );
+        $this->assertEquals( '1.0.0', $updateInfo->currentVersion );
+        $this->assertEquals( '2.0.0', $updateInfo->latestVersion );
+        $this->assertTrue( $updateInfo->hasUpdate() );
+        $this->assertEquals( 'https://example.com/releases/cms-2.0.0.zip', $updateInfo->downloadUrl );
+        $this->assertEquals( 'New features', $updateInfo->changelog );
     }
 
     /**
@@ -78,16 +78,16 @@ class CustomJsonUpdateSourceTest extends TestCase
      */
     public function test_throws_exception_when_version_missing(): void
     {
-        Http::fake([
-            'example.com/updates.json' => Http::response([
+        Http::fake( [
+            'example.com/updates.json' => Http::response( [
                 'download_url' => 'https://example.com/releases/cms-2.0.0.zip',
-            ], 200),
-        ]);
+            ], 200 ),
+        ] );
 
-        $source = new CustomJsonUpdateSource('https://example.com/updates.json', '1.0.0');
+        $source = new CustomJsonUpdateSource( 'https://example.com/updates.json', '1.0.0' );
 
-        $this->expectException(UpdateException::class);
-        $this->expectExceptionMessage('missing required field: version');
+        $this->expectException( UpdateException::class );
+        $this->expectExceptionMessage( 'missing required field: version' );
 
         $source->checkForUpdate();
     }
@@ -99,16 +99,16 @@ class CustomJsonUpdateSourceTest extends TestCase
      */
     public function test_throws_exception_when_download_url_missing(): void
     {
-        Http::fake([
-            'example.com/updates.json' => Http::response([
+        Http::fake( [
+            'example.com/updates.json' => Http::response( [
                 'version' => '2.0.0',
-            ], 200),
-        ]);
+            ], 200 ),
+        ] );
 
-        $source = new CustomJsonUpdateSource('https://example.com/updates.json', '1.0.0');
+        $source = new CustomJsonUpdateSource( 'https://example.com/updates.json', '1.0.0' );
 
-        $this->expectException(UpdateException::class);
-        $this->expectExceptionMessage('missing required field: download_url');
+        $this->expectException( UpdateException::class );
+        $this->expectExceptionMessage( 'missing required field: download_url' );
 
         $source->checkForUpdate();
     }
@@ -120,14 +120,14 @@ class CustomJsonUpdateSourceTest extends TestCase
      */
     public function test_handles_api_errors(): void
     {
-        Http::fake([
-            'example.com/updates.json' => Http::response([], 500),
-        ]);
+        Http::fake( [
+            'example.com/updates.json' => Http::response( [], 500 ),
+        ] );
 
-        $source = new CustomJsonUpdateSource('https://example.com/updates.json', '1.0.0');
+        $source = new CustomJsonUpdateSource( 'https://example.com/updates.json', '1.0.0' );
 
-        $this->expectException(UpdateException::class);
-        $this->expectExceptionMessage('Failed to check for updates');
+        $this->expectException( UpdateException::class );
+        $this->expectExceptionMessage( 'Failed to check for updates' );
 
         $source->checkForUpdate();
     }
@@ -139,14 +139,14 @@ class CustomJsonUpdateSourceTest extends TestCase
      */
     public function test_handles_invalid_json(): void
     {
-        Http::fake([
-            'example.com/updates.json' => Http::response('not json', 200),
-        ]);
+        Http::fake( [
+            'example.com/updates.json' => Http::response( 'not json', 200 ),
+        ] );
 
-        $source = new CustomJsonUpdateSource('https://example.com/updates.json', '1.0.0');
+        $source = new CustomJsonUpdateSource( 'https://example.com/updates.json', '1.0.0' );
 
-        $this->expectException(UpdateException::class);
-        $this->expectExceptionMessage('Invalid JSON response');
+        $this->expectException( UpdateException::class );
+        $this->expectExceptionMessage( 'Invalid JSON response' );
 
         $source->checkForUpdate();
     }
@@ -158,19 +158,19 @@ class CustomJsonUpdateSourceTest extends TestCase
      */
     public function test_can_set_authentication_with_string(): void
     {
-        Http::fake([
-            'example.com/updates.json?token=secret123' => Http::response([
+        Http::fake( [
+            'example.com/updates.json?token=secret123' => Http::response( [
                 'version'      => '2.0.0',
                 'download_url' => 'https://example.com/releases/cms-2.0.0.zip',
-            ], 200),
-        ]);
+            ], 200 ),
+        ] );
 
-        $source = new CustomJsonUpdateSource('https://example.com/updates.json', '1.0.0');
-        $source->setAuthentication('secret123');
+        $source = new CustomJsonUpdateSource( 'https://example.com/updates.json', '1.0.0' );
+        $source->setAuthentication( 'secret123' );
 
         $updateInfo = $source->checkForUpdate();
 
-        $this->assertInstanceOf(UpdateInfo::class, $updateInfo);
+        $this->assertInstanceOf( UpdateInfo::class, $updateInfo );
     }
 
     /**
@@ -180,22 +180,22 @@ class CustomJsonUpdateSourceTest extends TestCase
      */
     public function test_can_set_authentication_with_array(): void
     {
-        Http::fake([
-            'example.com/updates.json?api_key=key123&license=lic456' => Http::response([
+        Http::fake( [
+            'example.com/updates.json?api_key=key123&license=lic456' => Http::response( [
                 'version'      => '2.0.0',
                 'download_url' => 'https://example.com/releases/cms-2.0.0.zip',
-            ], 200),
-        ]);
+            ], 200 ),
+        ] );
 
-        $source = new CustomJsonUpdateSource('https://example.com/updates.json', '1.0.0');
-        $source->setAuthentication([
+        $source = new CustomJsonUpdateSource( 'https://example.com/updates.json', '1.0.0' );
+        $source->setAuthentication( [
             'api_key' => 'key123',
             'license' => 'lic456',
-        ]);
+        ] );
 
         $updateInfo = $source->checkForUpdate();
 
-        $this->assertInstanceOf(UpdateInfo::class, $updateInfo);
+        $this->assertInstanceOf( UpdateInfo::class, $updateInfo );
     }
 
     /**
@@ -205,19 +205,19 @@ class CustomJsonUpdateSourceTest extends TestCase
      */
     public function test_handles_urls_with_existing_query_params(): void
     {
-        Http::fake([
-            'example.com/updates.json?existing=param&token=secret123' => Http::response([
+        Http::fake( [
+            'example.com/updates.json?existing=param&token=secret123' => Http::response( [
                 'version'      => '2.0.0',
                 'download_url' => 'https://example.com/releases/cms-2.0.0.zip',
-            ], 200),
-        ]);
+            ], 200 ),
+        ] );
 
-        $source = new CustomJsonUpdateSource('https://example.com/updates.json?existing=param', '1.0.0');
-        $source->setAuthentication('secret123');
+        $source = new CustomJsonUpdateSource( 'https://example.com/updates.json?existing=param', '1.0.0' );
+        $source->setAuthentication( 'secret123' );
 
         $updateInfo = $source->checkForUpdate();
 
-        $this->assertInstanceOf(UpdateInfo::class, $updateInfo);
+        $this->assertInstanceOf( UpdateInfo::class, $updateInfo );
     }
 
     /**
@@ -227,8 +227,8 @@ class CustomJsonUpdateSourceTest extends TestCase
      */
     public function test_parses_all_optional_fields(): void
     {
-        Http::fake([
-            'example.com/updates.json' => Http::response([
+        Http::fake( [
+            'example.com/updates.json' => Http::response( [
                 'version'               => '2.0.0',
                 'download_url'          => 'https://example.com/releases/cms-2.0.0.zip',
                 'changelog'             => 'Release notes',
@@ -238,19 +238,19 @@ class CustomJsonUpdateSourceTest extends TestCase
                 'sha256'                => 'abc123',
                 'file_size'             => 1024000,
                 'metadata'              => ['custom' => 'data'],
-            ], 200),
-        ]);
+            ], 200 ),
+        ] );
 
-        $source     = new CustomJsonUpdateSource('https://example.com/updates.json', '1.0.0');
+        $source     = new CustomJsonUpdateSource( 'https://example.com/updates.json', '1.0.0' );
         $updateInfo = $source->checkForUpdate();
 
-        $this->assertEquals('Release notes', $updateInfo->changelog);
-        $this->assertEquals('2024-12-15T10:00:00Z', $updateInfo->releaseDate);
-        $this->assertEquals('8.2', $updateInfo->minPhpVersion);
-        $this->assertEquals('2.0.0', $updateInfo->minFrameworkVersion);
-        $this->assertEquals('abc123', $updateInfo->sha256);
-        $this->assertEquals(1024000, $updateInfo->fileSize);
-        $this->assertEquals(['custom' => 'data'], $updateInfo->metadata);
+        $this->assertEquals( 'Release notes', $updateInfo->changelog );
+        $this->assertEquals( '2024-12-15T10:00:00Z', $updateInfo->releaseDate );
+        $this->assertEquals( '8.2', $updateInfo->minPhpVersion );
+        $this->assertEquals( '2.0.0', $updateInfo->minFrameworkVersion );
+        $this->assertEquals( 'abc123', $updateInfo->sha256 );
+        $this->assertEquals( 1024000, $updateInfo->fileSize );
+        $this->assertEquals( ['custom' => 'data'], $updateInfo->metadata );
     }
 
     /**
@@ -260,17 +260,17 @@ class CustomJsonUpdateSourceTest extends TestCase
      */
     public function test_detects_no_update_when_versions_match(): void
     {
-        Http::fake([
-            'example.com/updates.json' => Http::response([
+        Http::fake( [
+            'example.com/updates.json' => Http::response( [
                 'version'      => '1.0.0',
                 'download_url' => 'https://example.com/releases/cms-1.0.0.zip',
-            ], 200),
-        ]);
+            ], 200 ),
+        ] );
 
-        $source     = new CustomJsonUpdateSource('https://example.com/updates.json', '1.0.0');
+        $source     = new CustomJsonUpdateSource( 'https://example.com/updates.json', '1.0.0' );
         $updateInfo = $source->checkForUpdate();
 
-        $this->assertFalse($updateInfo->hasUpdate());
+        $this->assertFalse( $updateInfo->hasUpdate() );
     }
 
     /**
@@ -280,10 +280,10 @@ class CustomJsonUpdateSourceTest extends TestCase
      *
      * @param  \Illuminate\Foundation\Application  $app
      */
-    protected function defineEnvironment($app): void
+    protected function defineEnvironment( $app): void
     {
-        $app['config']->set('cms.updates.http_timeout', 15);
-        $app['config']->set('cms.updates.http_retries', 3);
-        $app['config']->set('cms.updates.download_timeout', 300);
+        $app['config']->set( 'cms.updates.http_timeout', 15);
+        $app['config']->set( 'cms.updates.http_retries', 3);
+        $app['config']->set( 'cms.updates.download_timeout', 300);
     }
 }

--- a/tests/Unit/Updates/CustomJsonUpdateSourceTest.php
+++ b/tests/Unit/Updates/CustomJsonUpdateSourceTest.php
@@ -280,10 +280,10 @@ class CustomJsonUpdateSourceTest extends TestCase
      *
      * @param  \Illuminate\Foundation\Application  $app
      */
-    protected function defineEnvironment( $app): void
+    protected function defineEnvironment( $app ): void
     {
-        $app['config']->set( 'cms.updates.http_timeout', 15);
-        $app['config']->set( 'cms.updates.http_retries', 3);
-        $app['config']->set( 'cms.updates.download_timeout', 300);
+        $app['config']->set( 'cms.updates.http_timeout', 15 );
+        $app['config']->set( 'cms.updates.http_retries', 3 );
+        $app['config']->set( 'cms.updates.download_timeout', 300 );
     }
 }

--- a/tests/Unit/Updates/GitHubUpdateSourceTest.php
+++ b/tests/Unit/Updates/GitHubUpdateSourceTest.php
@@ -31,6 +31,7 @@ class GitHubUpdateSourceTest extends TestCase
         $this->assertTrue($source->supports('https://github.com/another-user/another-repo'));
         $this->assertFalse($source->supports('https://gitlab.com/user/repo'));
         $this->assertFalse($source->supports('https://example.com/updates.json'));
+        $this->assertFalse($source->supports('https://example.com/github.com/user/repo'));
     }
 
     /**

--- a/tests/Unit/Updates/GitHubUpdateSourceTest.php
+++ b/tests/Unit/Updates/GitHubUpdateSourceTest.php
@@ -14,14 +14,14 @@ use Orchestra\Testbench\TestCase;
 /**
  * GitHub Update Source Tests
  *
- * @since 2.0.0
+ * @since 1.0.0
  */
 class GitHubUpdateSourceTest extends TestCase
 {
     /**
      * Test GitHub source supports GitHub URLs.
      *
-     * @since 2.0.0
+     * @since 1.0.0
      */
     public function test_supports_github_urls(): void
     {
@@ -37,7 +37,7 @@ class GitHubUpdateSourceTest extends TestCase
     /**
      * Test GitHub source returns correct name.
      *
-     * @since 2.0.0
+     * @since 1.0.0
      */
     public function test_returns_correct_name(): void
     {
@@ -49,7 +49,7 @@ class GitHubUpdateSourceTest extends TestCase
     /**
      * Test GitHub source can check for updates.
      *
-     * @since 2.0.0
+     * @since 1.0.0
      */
     public function test_can_check_for_updates(): void
     {
@@ -87,7 +87,7 @@ class GitHubUpdateSourceTest extends TestCase
     /**
      * Test GitHub source handles no releases.
      *
-     * @since 2.0.0
+     * @since 1.0.0
      */
     public function test_throws_exception_when_no_releases(): void
     {
@@ -106,7 +106,7 @@ class GitHubUpdateSourceTest extends TestCase
     /**
      * Test GitHub source skips prerelease versions.
      *
-     * @since 2.0.0
+     * @since 1.0.0
      */
     public function test_skips_prerelease_versions(): void
     {
@@ -144,7 +144,7 @@ class GitHubUpdateSourceTest extends TestCase
     /**
      * Test GitHub source falls back to zipball_url when no assets.
      *
-     * @since 2.0.0
+     * @since 1.0.0
      */
     public function test_falls_back_to_zipball_when_no_assets(): void
     {
@@ -172,7 +172,7 @@ class GitHubUpdateSourceTest extends TestCase
     /**
      * Test GitHub source handles API errors.
      *
-     * @since 2.0.0
+     * @since 1.0.0
      */
     public function test_handles_api_errors(): void
     {
@@ -191,7 +191,7 @@ class GitHubUpdateSourceTest extends TestCase
     /**
      * Test GitHub source can set authentication.
      *
-     * @since 2.0.0
+     * @since 1.0.0
      */
     public function test_can_set_authentication(): void
     {
@@ -223,7 +223,7 @@ class GitHubUpdateSourceTest extends TestCase
     /**
      * Test GitHub source parses repository owner and name correctly.
      *
-     * @since 2.0.0
+     * @since 1.0.0
      */
     public function test_parses_repository_url_correctly(): void
     {
@@ -251,7 +251,7 @@ class GitHubUpdateSourceTest extends TestCase
     /**
      * Test GitHub source throws exception for invalid URLs.
      *
-     * @since 2.0.0
+     * @since 1.0.0
      */
     public function test_throws_exception_for_invalid_urls(): void
     {
@@ -264,7 +264,7 @@ class GitHubUpdateSourceTest extends TestCase
     /**
      * Test GitHub source strips 'v' prefix from version tags.
      *
-     * @since 2.0.0
+     * @since 1.0.0
      */
     public function test_strips_v_prefix_from_version_tags(): void
     {
@@ -291,7 +291,7 @@ class GitHubUpdateSourceTest extends TestCase
     /**
      * Define environment setup.
      *
-     * @since 2.0.0
+     * @since 1.0.0
      *
      * @param  \Illuminate\Foundation\Application  $app
      */

--- a/tests/Unit/Updates/GitHubUpdateSourceTest.php
+++ b/tests/Unit/Updates/GitHubUpdateSourceTest.php
@@ -1,6 +1,6 @@
 <?php
 
-declare( strict_types = 1 );
+declare(strict_types=1);
 
 namespace ArtisanPackUI\CMSFramework\Tests\Unit\Updates;
 
@@ -25,12 +25,12 @@ class GitHubUpdateSourceTest extends TestCase
      */
     public function test_supports_github_urls(): void
     {
-        $source = new GitHubUpdateSource( 'https://github.com/user/repo', '1.0.0' );
+        $source = new GitHubUpdateSource('https://github.com/user/repo', '1.0.0');
 
-        $this->assertTrue( $source->supports( 'https://github.com/user/repo' ) );
-        $this->assertTrue( $source->supports( 'https://github.com/another-user/another-repo' ) );
-        $this->assertFalse( $source->supports( 'https://gitlab.com/user/repo' ) );
-        $this->assertFalse( $source->supports( 'https://example.com/updates.json' ) );
+        $this->assertTrue($source->supports('https://github.com/user/repo'));
+        $this->assertTrue($source->supports('https://github.com/another-user/another-repo'));
+        $this->assertFalse($source->supports('https://gitlab.com/user/repo'));
+        $this->assertFalse($source->supports('https://example.com/updates.json'));
     }
 
     /**
@@ -40,9 +40,9 @@ class GitHubUpdateSourceTest extends TestCase
      */
     public function test_returns_correct_name(): void
     {
-        $source = new GitHubUpdateSource( 'https://github.com/user/repo', '1.0.0' );
+        $source = new GitHubUpdateSource('https://github.com/user/repo', '1.0.0');
 
-        $this->assertEquals( 'GitHub', $source->getName() );
+        $this->assertEquals('GitHub', $source->getName());
     }
 
     /**
@@ -52,8 +52,8 @@ class GitHubUpdateSourceTest extends TestCase
      */
     public function test_can_check_for_updates(): void
     {
-        Http::fake( [
-            'api.github.com/repos/user/repo/releases' => Http::response( [
+        Http::fake([
+            'api.github.com/repos/user/repo/releases' => Http::response([
                 [
                     'tag_name'     => 'v2.0.0',
                     'prerelease'   => false,
@@ -69,18 +69,18 @@ class GitHubUpdateSourceTest extends TestCase
                     ],
                     'zipball_url' => 'https://api.github.com/repos/user/repo/zipball/v2.0.0',
                 ],
-            ], 200 ),
-        ] );
+            ], 200),
+        ]);
 
-        $source     = new GitHubUpdateSource( 'https://github.com/user/repo', '1.0.0' );
+        $source     = new GitHubUpdateSource('https://github.com/user/repo', '1.0.0');
         $updateInfo = $source->checkForUpdate();
 
-        $this->assertInstanceOf( UpdateInfo::class, $updateInfo );
-        $this->assertEquals( '1.0.0', $updateInfo->currentVersion );
-        $this->assertEquals( '2.0.0', $updateInfo->latestVersion );
-        $this->assertTrue( $updateInfo->hasUpdate );
-        $this->assertStringContainsString( 'github.com', $updateInfo->downloadUrl );
-        $this->assertEquals( 'Release notes here', $updateInfo->changelog );
+        $this->assertInstanceOf(UpdateInfo::class, $updateInfo);
+        $this->assertEquals('1.0.0', $updateInfo->currentVersion);
+        $this->assertEquals('2.0.0', $updateInfo->latestVersion);
+        $this->assertTrue($updateInfo->hasUpdate());
+        $this->assertStringContainsString('github.com', $updateInfo->downloadUrl);
+        $this->assertEquals('Release notes here', $updateInfo->changelog);
     }
 
     /**
@@ -90,14 +90,14 @@ class GitHubUpdateSourceTest extends TestCase
      */
     public function test_throws_exception_when_no_releases(): void
     {
-        Http::fake( [
-            'api.github.com/repos/user/repo/releases' => Http::response( [], 200 ),
-        ] );
+        Http::fake([
+            'api.github.com/repos/user/repo/releases' => Http::response([], 200),
+        ]);
 
-        $source = new GitHubUpdateSource( 'https://github.com/user/repo', '1.0.0' );
+        $source = new GitHubUpdateSource('https://github.com/user/repo', '1.0.0');
 
-        $this->expectException( UpdateException::class );
-        $this->expectExceptionMessage( 'No releases found' );
+        $this->expectException(UpdateException::class);
+        $this->expectExceptionMessage('No releases found');
 
         $source->checkForUpdate();
     }
@@ -109,8 +109,8 @@ class GitHubUpdateSourceTest extends TestCase
      */
     public function test_skips_prerelease_versions(): void
     {
-        Http::fake( [
-            'api.github.com/repos/user/repo/releases' => Http::response( [
+        Http::fake([
+            'api.github.com/repos/user/repo/releases' => Http::response([
                 [
                     'tag_name'     => 'v3.0.0-beta',
                     'prerelease'   => true,
@@ -131,13 +131,13 @@ class GitHubUpdateSourceTest extends TestCase
                     'assets'       => [],
                     'zipball_url'  => 'https://api.github.com/repos/user/repo/zipball/v2.0.0',
                 ],
-            ], 200 ),
-        ] );
+            ], 200),
+        ]);
 
-        $source     = new GitHubUpdateSource( 'https://github.com/user/repo', '1.0.0' );
+        $source     = new GitHubUpdateSource('https://github.com/user/repo', '1.0.0');
         $updateInfo = $source->checkForUpdate();
 
-        $this->assertEquals( '2.0.0', $updateInfo->latestVersion );
+        $this->assertEquals('2.0.0', $updateInfo->latestVersion);
     }
 
     /**
@@ -147,8 +147,8 @@ class GitHubUpdateSourceTest extends TestCase
      */
     public function test_falls_back_to_zipball_when_no_assets(): void
     {
-        Http::fake( [
-            'api.github.com/repos/user/repo/releases' => Http::response( [
+        Http::fake([
+            'api.github.com/repos/user/repo/releases' => Http::response([
                 [
                     'tag_name'     => 'v2.0.0',
                     'prerelease'   => false,
@@ -159,13 +159,13 @@ class GitHubUpdateSourceTest extends TestCase
                     'assets'       => [],
                     'zipball_url'  => 'https://api.github.com/repos/user/repo/zipball/v2.0.0',
                 ],
-            ], 200 ),
-        ] );
+            ], 200),
+        ]);
 
-        $source     = new GitHubUpdateSource( 'https://github.com/user/repo', '1.0.0' );
+        $source     = new GitHubUpdateSource('https://github.com/user/repo', '1.0.0');
         $updateInfo = $source->checkForUpdate();
 
-        $this->assertStringContainsString( 'zipball', $updateInfo->downloadUrl );
+        $this->assertStringContainsString('zipball', $updateInfo->downloadUrl);
     }
 
     /**
@@ -175,14 +175,14 @@ class GitHubUpdateSourceTest extends TestCase
      */
     public function test_handles_api_errors(): void
     {
-        Http::fake( [
-            'api.github.com/repos/user/repo/releases' => Http::response( [], 500 ),
-        ] );
+        Http::fake([
+            'api.github.com/repos/user/repo/releases' => Http::response([], 500),
+        ]);
 
-        $source = new GitHubUpdateSource( 'https://github.com/user/repo', '1.0.0' );
+        $source = new GitHubUpdateSource('https://github.com/user/repo', '1.0.0');
 
-        $this->expectException( UpdateException::class );
-        $this->expectExceptionMessage( 'GitHub API error' );
+        $this->expectException(UpdateException::class);
+        $this->expectExceptionMessage('GitHub API error');
 
         $source->checkForUpdate();
     }
@@ -194,11 +194,11 @@ class GitHubUpdateSourceTest extends TestCase
      */
     public function test_can_set_authentication(): void
     {
-        $source = new GitHubUpdateSource( 'https://github.com/user/repo', '1.0.0' );
-        $source->setAuthentication( 'ghp_test_token' );
+        $source = new GitHubUpdateSource('https://github.com/user/repo', '1.0.0');
+        $source->setAuthentication('ghp_test_token');
 
         // We can't directly test the token is used, but we can verify the method doesn't throw
-        $this->assertTrue( true );
+        $this->assertTrue(true);
     }
 
     /**
@@ -208,8 +208,8 @@ class GitHubUpdateSourceTest extends TestCase
      */
     public function test_parses_repository_url_correctly(): void
     {
-        Http::fake( [
-            'api.github.com/repos/test-owner/test-repo/releases' => Http::response( [
+        Http::fake([
+            'api.github.com/repos/test-owner/test-repo/releases' => Http::response([
                 [
                     'tag_name'     => 'v1.0.0',
                     'prerelease'   => false,
@@ -219,14 +219,14 @@ class GitHubUpdateSourceTest extends TestCase
                     'assets'       => [],
                     'zipball_url'  => 'https://api.github.com/repos/test-owner/test-repo/zipball/v1.0.0',
                 ],
-            ], 200 ),
-        ] );
+            ], 200),
+        ]);
 
-        $source     = new GitHubUpdateSource( 'https://github.com/test-owner/test-repo', '0.9.0' );
+        $source     = new GitHubUpdateSource('https://github.com/test-owner/test-repo', '0.9.0');
         $updateInfo = $source->checkForUpdate();
 
         // If we get here without exception, the URL was parsed correctly
-        $this->assertInstanceOf( UpdateInfo::class, $updateInfo );
+        $this->assertInstanceOf(UpdateInfo::class, $updateInfo);
     }
 
     /**
@@ -236,10 +236,10 @@ class GitHubUpdateSourceTest extends TestCase
      */
     public function test_throws_exception_for_invalid_urls(): void
     {
-        $this->expectException( InvalidArgumentException::class );
-        $this->expectExceptionMessage( 'Invalid GitHub URL' );
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid GitHub URL');
 
-        new GitHubUpdateSource( 'https://invalid-url.com', '1.0.0' );
+        new GitHubUpdateSource('https://invalid-url.com', '1.0.0');
     }
 
     /**
@@ -249,8 +249,8 @@ class GitHubUpdateSourceTest extends TestCase
      */
     public function test_strips_v_prefix_from_version_tags(): void
     {
-        Http::fake( [
-            'api.github.com/repos/user/repo/releases' => Http::response( [
+        Http::fake([
+            'api.github.com/repos/user/repo/releases' => Http::response([
                 [
                     'tag_name'     => 'v2.5.1',
                     'prerelease'   => false,
@@ -260,13 +260,13 @@ class GitHubUpdateSourceTest extends TestCase
                     'assets'       => [],
                     'zipball_url'  => 'https://api.github.com/repos/user/repo/zipball/v2.5.1',
                 ],
-            ], 200 ),
-        ] );
+            ], 200),
+        ]);
 
-        $source     = new GitHubUpdateSource( 'https://github.com/user/repo', '1.0.0' );
+        $source     = new GitHubUpdateSource('https://github.com/user/repo', '1.0.0');
         $updateInfo = $source->checkForUpdate();
 
-        $this->assertEquals( '2.5.1', $updateInfo->latestVersion );
+        $this->assertEquals('2.5.1', $updateInfo->latestVersion);
     }
 
     /**
@@ -276,9 +276,9 @@ class GitHubUpdateSourceTest extends TestCase
      *
      * @param  \Illuminate\Foundation\Application  $app
      */
-    protected function defineEnvironment( $app ): void
+    protected function defineEnvironment($app): void
     {
-        $app['config']->set( 'cms.updates.http_timeout', 15 );
-        $app['config']->set( 'cms.updates.download_timeout', 300 );
+        $app['config']->set('cms.updates.http_timeout', 15);
+        $app['config']->set('cms.updates.download_timeout', 300);
     }
 }

--- a/tests/Unit/Updates/GitHubUpdateSourceTest.php
+++ b/tests/Unit/Updates/GitHubUpdateSourceTest.php
@@ -285,7 +285,7 @@ class GitHubUpdateSourceTest extends TestCase
         $source     = new GitHubUpdateSource( 'https://github.com/user/repo', '1.0.0' );
         $updateInfo = $source->checkForUpdate();
 
-        $this->assertEquals( '2.5.1', $updateInfo->latestVersion);
+        $this->assertEquals( '2.5.1', $updateInfo->latestVersion );
     }
 
     /**
@@ -295,9 +295,9 @@ class GitHubUpdateSourceTest extends TestCase
      *
      * @param  \Illuminate\Foundation\Application  $app
      */
-    protected function defineEnvironment( $app): void
+    protected function defineEnvironment( $app ): void
     {
-        $app['config']->set( 'cms.updates.http_timeout', 15);
-        $app['config']->set( 'cms.updates.download_timeout', 300);
+        $app['config']->set( 'cms.updates.http_timeout', 15 );
+        $app['config']->set( 'cms.updates.download_timeout', 300 );
     }
 }

--- a/tests/Unit/Updates/GitHubUpdateSourceTest.php
+++ b/tests/Unit/Updates/GitHubUpdateSourceTest.php
@@ -195,11 +195,29 @@ class GitHubUpdateSourceTest extends TestCase
      */
     public function test_can_set_authentication(): void
     {
+        Http::fake([
+            'api.github.com/repos/user/repo/releases' => Http::response([
+                [
+                    'tag_name'     => 'v2.0.0',
+                    'prerelease'   => false,
+                    'body'         => 'Release',
+                    'published_at' => '2024-12-15T10:00:00Z',
+                    'html_url'     => 'https://github.com/user/repo/releases/tag/v2.0.0',
+                    'id'           => 123,
+                    'assets'       => [],
+                    'zipball_url'  => 'https://api.github.com/repos/user/repo/zipball/v2.0.0',
+                ],
+            ], 200),
+        ]);
+
         $source = new GitHubUpdateSource('https://github.com/user/repo', '1.0.0');
         $source->setAuthentication('ghp_test_token');
 
-        // We can't directly test the token is used, but we can verify the method doesn't throw
-        $this->assertTrue(true);
+        $source->checkForUpdate();
+
+        Http::assertSent(function ($request) {
+            return $request->hasHeader('Authorization', 'token ghp_test_token');
+        });
     }
 
     /**

--- a/tests/Unit/Updates/GitHubUpdateSourceTest.php
+++ b/tests/Unit/Updates/GitHubUpdateSourceTest.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare( strict_types=1 );
 
 namespace ArtisanPackUI\CMSFramework\Tests\Unit\Updates;
 
@@ -25,13 +25,13 @@ class GitHubUpdateSourceTest extends TestCase
      */
     public function test_supports_github_urls(): void
     {
-        $source = new GitHubUpdateSource('https://github.com/user/repo', '1.0.0');
+        $source = new GitHubUpdateSource( 'https://github.com/user/repo', '1.0.0' );
 
-        $this->assertTrue($source->supports('https://github.com/user/repo'));
-        $this->assertTrue($source->supports('https://github.com/another-user/another-repo'));
-        $this->assertFalse($source->supports('https://gitlab.com/user/repo'));
-        $this->assertFalse($source->supports('https://example.com/updates.json'));
-        $this->assertFalse($source->supports('https://example.com/github.com/user/repo'));
+        $this->assertTrue( $source->supports( 'https://github.com/user/repo' ) );
+        $this->assertTrue( $source->supports( 'https://github.com/another-user/another-repo' ) );
+        $this->assertFalse( $source->supports( 'https://gitlab.com/user/repo' ) );
+        $this->assertFalse( $source->supports( 'https://example.com/updates.json' ) );
+        $this->assertFalse( $source->supports( 'https://example.com/github.com/user/repo' ) );
     }
 
     /**
@@ -41,9 +41,9 @@ class GitHubUpdateSourceTest extends TestCase
      */
     public function test_returns_correct_name(): void
     {
-        $source = new GitHubUpdateSource('https://github.com/user/repo', '1.0.0');
+        $source = new GitHubUpdateSource( 'https://github.com/user/repo', '1.0.0' );
 
-        $this->assertEquals('GitHub', $source->getName());
+        $this->assertEquals( 'GitHub', $source->getName() );
     }
 
     /**
@@ -53,8 +53,8 @@ class GitHubUpdateSourceTest extends TestCase
      */
     public function test_can_check_for_updates(): void
     {
-        Http::fake([
-            'api.github.com/repos/user/repo/releases' => Http::response([
+        Http::fake( [
+            'api.github.com/repos/user/repo/releases' => Http::response( [
                 [
                     'tag_name'     => 'v2.0.0',
                     'prerelease'   => false,
@@ -70,18 +70,18 @@ class GitHubUpdateSourceTest extends TestCase
                     ],
                     'zipball_url' => 'https://api.github.com/repos/user/repo/zipball/v2.0.0',
                 ],
-            ], 200),
-        ]);
+            ], 200 ),
+        ] );
 
-        $source     = new GitHubUpdateSource('https://github.com/user/repo', '1.0.0');
+        $source     = new GitHubUpdateSource( 'https://github.com/user/repo', '1.0.0' );
         $updateInfo = $source->checkForUpdate();
 
-        $this->assertInstanceOf(UpdateInfo::class, $updateInfo);
-        $this->assertEquals('1.0.0', $updateInfo->currentVersion);
-        $this->assertEquals('2.0.0', $updateInfo->latestVersion);
-        $this->assertTrue($updateInfo->hasUpdate());
-        $this->assertStringContainsString('github.com', $updateInfo->downloadUrl);
-        $this->assertEquals('Release notes here', $updateInfo->changelog);
+        $this->assertInstanceOf( UpdateInfo::class, $updateInfo );
+        $this->assertEquals( '1.0.0', $updateInfo->currentVersion );
+        $this->assertEquals( '2.0.0', $updateInfo->latestVersion );
+        $this->assertTrue( $updateInfo->hasUpdate() );
+        $this->assertStringContainsString( 'github.com', $updateInfo->downloadUrl );
+        $this->assertEquals( 'Release notes here', $updateInfo->changelog );
     }
 
     /**
@@ -91,14 +91,14 @@ class GitHubUpdateSourceTest extends TestCase
      */
     public function test_throws_exception_when_no_releases(): void
     {
-        Http::fake([
-            'api.github.com/repos/user/repo/releases' => Http::response([], 200),
-        ]);
+        Http::fake( [
+            'api.github.com/repos/user/repo/releases' => Http::response( [], 200 ),
+        ] );
 
-        $source = new GitHubUpdateSource('https://github.com/user/repo', '1.0.0');
+        $source = new GitHubUpdateSource( 'https://github.com/user/repo', '1.0.0' );
 
-        $this->expectException(UpdateException::class);
-        $this->expectExceptionMessage('No releases found');
+        $this->expectException( UpdateException::class );
+        $this->expectExceptionMessage( 'No releases found' );
 
         $source->checkForUpdate();
     }
@@ -110,8 +110,8 @@ class GitHubUpdateSourceTest extends TestCase
      */
     public function test_skips_prerelease_versions(): void
     {
-        Http::fake([
-            'api.github.com/repos/user/repo/releases' => Http::response([
+        Http::fake( [
+            'api.github.com/repos/user/repo/releases' => Http::response( [
                 [
                     'tag_name'     => 'v3.0.0-beta',
                     'prerelease'   => true,
@@ -132,13 +132,13 @@ class GitHubUpdateSourceTest extends TestCase
                     'assets'       => [],
                     'zipball_url'  => 'https://api.github.com/repos/user/repo/zipball/v2.0.0',
                 ],
-            ], 200),
-        ]);
+            ], 200 ),
+        ] );
 
-        $source     = new GitHubUpdateSource('https://github.com/user/repo', '1.0.0');
+        $source     = new GitHubUpdateSource( 'https://github.com/user/repo', '1.0.0' );
         $updateInfo = $source->checkForUpdate();
 
-        $this->assertEquals('2.0.0', $updateInfo->latestVersion);
+        $this->assertEquals( '2.0.0', $updateInfo->latestVersion );
     }
 
     /**
@@ -148,8 +148,8 @@ class GitHubUpdateSourceTest extends TestCase
      */
     public function test_falls_back_to_zipball_when_no_assets(): void
     {
-        Http::fake([
-            'api.github.com/repos/user/repo/releases' => Http::response([
+        Http::fake( [
+            'api.github.com/repos/user/repo/releases' => Http::response( [
                 [
                     'tag_name'     => 'v2.0.0',
                     'prerelease'   => false,
@@ -160,13 +160,13 @@ class GitHubUpdateSourceTest extends TestCase
                     'assets'       => [],
                     'zipball_url'  => 'https://api.github.com/repos/user/repo/zipball/v2.0.0',
                 ],
-            ], 200),
-        ]);
+            ], 200 ),
+        ] );
 
-        $source     = new GitHubUpdateSource('https://github.com/user/repo', '1.0.0');
+        $source     = new GitHubUpdateSource( 'https://github.com/user/repo', '1.0.0' );
         $updateInfo = $source->checkForUpdate();
 
-        $this->assertStringContainsString('zipball', $updateInfo->downloadUrl);
+        $this->assertStringContainsString( 'zipball', $updateInfo->downloadUrl );
     }
 
     /**
@@ -176,14 +176,14 @@ class GitHubUpdateSourceTest extends TestCase
      */
     public function test_handles_api_errors(): void
     {
-        Http::fake([
-            'api.github.com/repos/user/repo/releases' => Http::response([], 500),
-        ]);
+        Http::fake( [
+            'api.github.com/repos/user/repo/releases' => Http::response( [], 500 ),
+        ] );
 
-        $source = new GitHubUpdateSource('https://github.com/user/repo', '1.0.0');
+        $source = new GitHubUpdateSource( 'https://github.com/user/repo', '1.0.0' );
 
-        $this->expectException(UpdateException::class);
-        $this->expectExceptionMessage('GitHub API error');
+        $this->expectException( UpdateException::class );
+        $this->expectExceptionMessage( 'GitHub API error' );
 
         $source->checkForUpdate();
     }
@@ -195,8 +195,8 @@ class GitHubUpdateSourceTest extends TestCase
      */
     public function test_can_set_authentication(): void
     {
-        Http::fake([
-            'api.github.com/repos/user/repo/releases' => Http::response([
+        Http::fake( [
+            'api.github.com/repos/user/repo/releases' => Http::response( [
                 [
                     'tag_name'     => 'v2.0.0',
                     'prerelease'   => false,
@@ -207,17 +207,17 @@ class GitHubUpdateSourceTest extends TestCase
                     'assets'       => [],
                     'zipball_url'  => 'https://api.github.com/repos/user/repo/zipball/v2.0.0',
                 ],
-            ], 200),
-        ]);
+            ], 200 ),
+        ] );
 
-        $source = new GitHubUpdateSource('https://github.com/user/repo', '1.0.0');
-        $source->setAuthentication('ghp_test_token');
+        $source = new GitHubUpdateSource( 'https://github.com/user/repo', '1.0.0' );
+        $source->setAuthentication( 'ghp_test_token' );
 
         $source->checkForUpdate();
 
-        Http::assertSent(function ($request) {
-            return $request->hasHeader('Authorization', 'token ghp_test_token');
-        });
+        Http::assertSent( function ( $request ) {
+            return $request->hasHeader( 'Authorization', 'token ghp_test_token' );
+        } );
     }
 
     /**
@@ -227,8 +227,8 @@ class GitHubUpdateSourceTest extends TestCase
      */
     public function test_parses_repository_url_correctly(): void
     {
-        Http::fake([
-            'api.github.com/repos/test-owner/test-repo/releases' => Http::response([
+        Http::fake( [
+            'api.github.com/repos/test-owner/test-repo/releases' => Http::response( [
                 [
                     'tag_name'     => 'v1.0.0',
                     'prerelease'   => false,
@@ -238,14 +238,14 @@ class GitHubUpdateSourceTest extends TestCase
                     'assets'       => [],
                     'zipball_url'  => 'https://api.github.com/repos/test-owner/test-repo/zipball/v1.0.0',
                 ],
-            ], 200),
-        ]);
+            ], 200 ),
+        ] );
 
-        $source     = new GitHubUpdateSource('https://github.com/test-owner/test-repo', '0.9.0');
+        $source     = new GitHubUpdateSource( 'https://github.com/test-owner/test-repo', '0.9.0' );
         $updateInfo = $source->checkForUpdate();
 
         // If we get here without exception, the URL was parsed correctly
-        $this->assertInstanceOf(UpdateInfo::class, $updateInfo);
+        $this->assertInstanceOf( UpdateInfo::class, $updateInfo );
     }
 
     /**
@@ -255,10 +255,10 @@ class GitHubUpdateSourceTest extends TestCase
      */
     public function test_throws_exception_for_invalid_urls(): void
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Invalid GitHub URL');
+        $this->expectException( InvalidArgumentException::class );
+        $this->expectExceptionMessage( 'Invalid GitHub URL' );
 
-        new GitHubUpdateSource('https://invalid-url.com', '1.0.0');
+        new GitHubUpdateSource( 'https://invalid-url.com', '1.0.0' );
     }
 
     /**
@@ -268,8 +268,8 @@ class GitHubUpdateSourceTest extends TestCase
      */
     public function test_strips_v_prefix_from_version_tags(): void
     {
-        Http::fake([
-            'api.github.com/repos/user/repo/releases' => Http::response([
+        Http::fake( [
+            'api.github.com/repos/user/repo/releases' => Http::response( [
                 [
                     'tag_name'     => 'v2.5.1',
                     'prerelease'   => false,
@@ -279,13 +279,13 @@ class GitHubUpdateSourceTest extends TestCase
                     'assets'       => [],
                     'zipball_url'  => 'https://api.github.com/repos/user/repo/zipball/v2.5.1',
                 ],
-            ], 200),
-        ]);
+            ], 200 ),
+        ] );
 
-        $source     = new GitHubUpdateSource('https://github.com/user/repo', '1.0.0');
+        $source     = new GitHubUpdateSource( 'https://github.com/user/repo', '1.0.0' );
         $updateInfo = $source->checkForUpdate();
 
-        $this->assertEquals('2.5.1', $updateInfo->latestVersion);
+        $this->assertEquals( '2.5.1', $updateInfo->latestVersion);
     }
 
     /**
@@ -295,9 +295,9 @@ class GitHubUpdateSourceTest extends TestCase
      *
      * @param  \Illuminate\Foundation\Application  $app
      */
-    protected function defineEnvironment($app): void
+    protected function defineEnvironment( $app): void
     {
-        $app['config']->set('cms.updates.http_timeout', 15);
-        $app['config']->set('cms.updates.download_timeout', 300);
+        $app['config']->set( 'cms.updates.http_timeout', 15);
+        $app['config']->set( 'cms.updates.download_timeout', 300);
     }
 }

--- a/tests/Unit/Updates/GitLabUpdateSourceTest.php
+++ b/tests/Unit/Updates/GitLabUpdateSourceTest.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare( strict_types=1 );
 
 namespace ArtisanPackUI\CMSFramework\Tests\Unit\Updates;
 
@@ -25,13 +25,13 @@ class GitLabUpdateSourceTest extends TestCase
      */
     public function test_supports_gitlab_urls(): void
     {
-        $source = new GitLabUpdateSource('https://gitlab.com/user/repo', '1.0.0');
+        $source = new GitLabUpdateSource( 'https://gitlab.com/user/repo', '1.0.0' );
 
-        $this->assertTrue($source->supports('https://gitlab.com/user/repo'));
-        $this->assertTrue($source->supports('https://gitlab.com/another-user/another-repo'));
-        $this->assertFalse($source->supports('https://github.com/user/repo'));
-        $this->assertFalse($source->supports('https://example.com/updates.json'));
-        $this->assertFalse($source->supports('https://example.com/gitlab.com/user/repo'));
+        $this->assertTrue( $source->supports( 'https://gitlab.com/user/repo' ) );
+        $this->assertTrue( $source->supports( 'https://gitlab.com/another-user/another-repo' ) );
+        $this->assertFalse( $source->supports( 'https://github.com/user/repo' ) );
+        $this->assertFalse( $source->supports( 'https://example.com/updates.json' ) );
+        $this->assertFalse( $source->supports( 'https://example.com/gitlab.com/user/repo' ) );
     }
 
     /**
@@ -41,21 +41,21 @@ class GitLabUpdateSourceTest extends TestCase
      */
     public function test_excludes_query_strings_from_project_id(): void
     {
-        Http::fake([
-            'gitlab.com/api/v4/projects/user%2Frepo/releases' => Http::response([
+        Http::fake( [
+            'gitlab.com/api/v4/projects/user%2Frepo/releases' => Http::response( [
                 [
                     'tag_name'    => 'v2.0.0',
                     'description' => 'Release',
                     'created_at'  => '2024-12-15T10:00:00.000Z',
                 ],
-            ], 200),
-        ]);
+            ], 200 ),
+        ] );
 
-        $source     = new GitLabUpdateSource('https://gitlab.com/user/repo?ref=main', '1.0.0');
+        $source     = new GitLabUpdateSource( 'https://gitlab.com/user/repo?ref=main', '1.0.0' );
         $updateInfo = $source->checkForUpdate();
 
-        $this->assertInstanceOf(UpdateInfo::class, $updateInfo);
-        $this->assertEquals('2.0.0', $updateInfo->latestVersion);
+        $this->assertInstanceOf( UpdateInfo::class, $updateInfo );
+        $this->assertEquals( '2.0.0', $updateInfo->latestVersion );
     }
 
     /**
@@ -65,9 +65,9 @@ class GitLabUpdateSourceTest extends TestCase
      */
     public function test_returns_correct_name(): void
     {
-        $source = new GitLabUpdateSource('https://gitlab.com/user/repo', '1.0.0');
+        $source = new GitLabUpdateSource( 'https://gitlab.com/user/repo', '1.0.0' );
 
-        $this->assertEquals('GitLab', $source->getName());
+        $this->assertEquals( 'GitLab', $source->getName() );
     }
 
     /**
@@ -77,25 +77,25 @@ class GitLabUpdateSourceTest extends TestCase
      */
     public function test_can_check_for_updates(): void
     {
-        Http::fake([
-            'gitlab.com/api/v4/projects/user%2Frepo/releases' => Http::response([
+        Http::fake( [
+            'gitlab.com/api/v4/projects/user%2Frepo/releases' => Http::response( [
                 [
                     'tag_name'    => 'v2.0.0',
                     'description' => 'Release notes here',
                     'created_at'  => '2024-12-15T10:00:00.000Z',
                 ],
-            ], 200),
-        ]);
+            ], 200 ),
+        ] );
 
-        $source     = new GitLabUpdateSource('https://gitlab.com/user/repo', '1.0.0');
+        $source     = new GitLabUpdateSource( 'https://gitlab.com/user/repo', '1.0.0' );
         $updateInfo = $source->checkForUpdate();
 
-        $this->assertInstanceOf(UpdateInfo::class, $updateInfo);
-        $this->assertEquals('1.0.0', $updateInfo->currentVersion);
-        $this->assertEquals('2.0.0', $updateInfo->latestVersion);
-        $this->assertTrue($updateInfo->hasUpdate());
-        $this->assertStringContainsString('gitlab.com', $updateInfo->downloadUrl);
-        $this->assertEquals('Release notes here', $updateInfo->changelog);
+        $this->assertInstanceOf( UpdateInfo::class, $updateInfo );
+        $this->assertEquals( '1.0.0', $updateInfo->currentVersion );
+        $this->assertEquals( '2.0.0', $updateInfo->latestVersion );
+        $this->assertTrue( $updateInfo->hasUpdate() );
+        $this->assertStringContainsString( 'gitlab.com', $updateInfo->downloadUrl );
+        $this->assertEquals( 'Release notes here', $updateInfo->changelog );
     }
 
     /**
@@ -105,14 +105,14 @@ class GitLabUpdateSourceTest extends TestCase
      */
     public function test_throws_exception_when_no_releases(): void
     {
-        Http::fake([
-            'gitlab.com/api/v4/projects/user%2Frepo/releases' => Http::response([], 200),
-        ]);
+        Http::fake( [
+            'gitlab.com/api/v4/projects/user%2Frepo/releases' => Http::response( [], 200 ),
+        ] );
 
-        $source = new GitLabUpdateSource('https://gitlab.com/user/repo', '1.0.0');
+        $source = new GitLabUpdateSource( 'https://gitlab.com/user/repo', '1.0.0' );
 
-        $this->expectException(UpdateException::class);
-        $this->expectExceptionMessage('No releases found');
+        $this->expectException( UpdateException::class );
+        $this->expectExceptionMessage( 'No releases found' );
 
         $source->checkForUpdate();
     }
@@ -124,14 +124,14 @@ class GitLabUpdateSourceTest extends TestCase
      */
     public function test_handles_api_errors(): void
     {
-        Http::fake([
-            'gitlab.com/api/v4/projects/user%2Frepo/releases' => Http::response([], 500),
-        ]);
+        Http::fake( [
+            'gitlab.com/api/v4/projects/user%2Frepo/releases' => Http::response( [], 500 ),
+        ] );
 
-        $source = new GitLabUpdateSource('https://gitlab.com/user/repo', '1.0.0');
+        $source = new GitLabUpdateSource( 'https://gitlab.com/user/repo', '1.0.0' );
 
-        $this->expectException(UpdateException::class);
-        $this->expectExceptionMessage('GitLab API error');
+        $this->expectException( UpdateException::class );
+        $this->expectExceptionMessage( 'GitLab API error' );
 
         $source->checkForUpdate();
     }
@@ -143,24 +143,24 @@ class GitLabUpdateSourceTest extends TestCase
      */
     public function test_can_set_authentication(): void
     {
-        Http::fake([
-            'gitlab.com/api/v4/projects/user%2Frepo/releases' => Http::response([
+        Http::fake( [
+            'gitlab.com/api/v4/projects/user%2Frepo/releases' => Http::response( [
                 [
                     'tag_name'    => 'v2.0.0',
                     'description' => 'Release',
                     'created_at'  => '2024-12-15T10:00:00.000Z',
                 ],
-            ], 200),
-        ]);
+            ], 200 ),
+        ] );
 
-        $source = new GitLabUpdateSource('https://gitlab.com/user/repo', '1.0.0');
-        $source->setAuthentication('glpat-test_token');
+        $source = new GitLabUpdateSource( 'https://gitlab.com/user/repo', '1.0.0' );
+        $source->setAuthentication( 'glpat-test_token' );
 
         $source->checkForUpdate();
 
-        Http::assertSent(function ($request) {
-            return $request->hasHeader('PRIVATE-TOKEN', 'glpat-test_token');
-        });
+        Http::assertSent( function ( $request ) {
+            return $request->hasHeader( 'PRIVATE-TOKEN', 'glpat-test_token' );
+        } );
     }
 
     /**
@@ -170,21 +170,21 @@ class GitLabUpdateSourceTest extends TestCase
      */
     public function test_parses_repository_url_correctly(): void
     {
-        Http::fake([
-            'gitlab.com/api/v4/projects/test-group%2Ftest-repo/releases' => Http::response([
+        Http::fake( [
+            'gitlab.com/api/v4/projects/test-group%2Ftest-repo/releases' => Http::response( [
                 [
                     'tag_name'    => 'v1.0.0',
                     'description' => 'First release',
                     'created_at'  => '2024-12-15T10:00:00.000Z',
                 ],
-            ], 200),
-        ]);
+            ], 200 ),
+        ] );
 
-        $source     = new GitLabUpdateSource('https://gitlab.com/test-group/test-repo', '0.9.0');
+        $source     = new GitLabUpdateSource( 'https://gitlab.com/test-group/test-repo', '0.9.0' );
         $updateInfo = $source->checkForUpdate();
 
         // If we get here without exception, the URL was parsed correctly
-        $this->assertInstanceOf(UpdateInfo::class, $updateInfo);
+        $this->assertInstanceOf( UpdateInfo::class, $updateInfo );
     }
 
     /**
@@ -194,20 +194,20 @@ class GitLabUpdateSourceTest extends TestCase
      */
     public function test_handles_nested_group_paths(): void
     {
-        Http::fake([
-            'gitlab.com/api/v4/projects/group%2Fsubgroup%2Fproject/releases' => Http::response([
+        Http::fake( [
+            'gitlab.com/api/v4/projects/group%2Fsubgroup%2Fproject/releases' => Http::response( [
                 [
                     'tag_name'    => 'v1.0.0',
                     'description' => 'Release',
                     'created_at'  => '2024-12-15T10:00:00.000Z',
                 ],
-            ], 200),
-        ]);
+            ], 200 ),
+        ] );
 
-        $source     = new GitLabUpdateSource('https://gitlab.com/group/subgroup/project', '0.9.0');
+        $source     = new GitLabUpdateSource( 'https://gitlab.com/group/subgroup/project', '0.9.0' );
         $updateInfo = $source->checkForUpdate();
 
-        $this->assertInstanceOf(UpdateInfo::class, $updateInfo);
+        $this->assertInstanceOf( UpdateInfo::class, $updateInfo );
     }
 
     /**
@@ -217,10 +217,10 @@ class GitLabUpdateSourceTest extends TestCase
      */
     public function test_throws_exception_for_invalid_urls(): void
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Invalid GitLab URL');
+        $this->expectException( InvalidArgumentException::class );
+        $this->expectExceptionMessage( 'Invalid GitLab URL' );
 
-        new GitLabUpdateSource('https://invalid-url.com', '1.0.0');
+        new GitLabUpdateSource( 'https://invalid-url.com', '1.0.0' );
     }
 
     /**
@@ -230,20 +230,20 @@ class GitLabUpdateSourceTest extends TestCase
      */
     public function test_strips_v_prefix_from_version_tags(): void
     {
-        Http::fake([
-            'gitlab.com/api/v4/projects/user%2Frepo/releases' => Http::response([
+        Http::fake( [
+            'gitlab.com/api/v4/projects/user%2Frepo/releases' => Http::response( [
                 [
                     'tag_name'    => 'v2.5.1',
                     'description' => 'Release',
                     'created_at'  => '2024-12-15T10:00:00.000Z',
                 ],
-            ], 200),
-        ]);
+            ], 200 ),
+        ] );
 
-        $source     = new GitLabUpdateSource('https://gitlab.com/user/repo', '1.0.0');
+        $source     = new GitLabUpdateSource( 'https://gitlab.com/user/repo', '1.0.0' );
         $updateInfo = $source->checkForUpdate();
 
-        $this->assertEquals('2.5.1', $updateInfo->latestVersion);
+        $this->assertEquals( '2.5.1', $updateInfo->latestVersion );
     }
 
     /**
@@ -253,21 +253,21 @@ class GitLabUpdateSourceTest extends TestCase
      */
     public function test_generates_correct_download_url(): void
     {
-        Http::fake([
-            'gitlab.com/api/v4/projects/user%2Frepo/releases' => Http::response([
+        Http::fake( [
+            'gitlab.com/api/v4/projects/user%2Frepo/releases' => Http::response( [
                 [
                     'tag_name'    => 'v2.0.0',
                     'description' => 'Release',
                     'created_at'  => '2024-12-15T10:00:00.000Z',
                 ],
-            ], 200),
-        ]);
+            ], 200 ),
+        ] );
 
-        $source     = new GitLabUpdateSource('https://gitlab.com/user/repo', '1.0.0');
+        $source     = new GitLabUpdateSource( 'https://gitlab.com/user/repo', '1.0.0' );
         $updateInfo = $source->checkForUpdate();
 
-        $this->assertStringContainsString('gitlab.com/api/v4/projects/user%2Frepo/repository/archive.zip', $updateInfo->downloadUrl);
-        $this->assertStringContainsString('sha=v2.0.0', $updateInfo->downloadUrl);
+        $this->assertStringContainsString( 'gitlab.com/api/v4/projects/user%2Frepo/repository/archive.zip', $updateInfo->downloadUrl );
+        $this->assertStringContainsString( 'sha=v2.0.0', $updateInfo->downloadUrl );
     }
 
     /**
@@ -277,21 +277,21 @@ class GitLabUpdateSourceTest extends TestCase
      */
     public function test_includes_metadata(): void
     {
-        Http::fake([
-            'gitlab.com/api/v4/projects/user%2Frepo/releases' => Http::response([
+        Http::fake( [
+            'gitlab.com/api/v4/projects/user%2Frepo/releases' => Http::response( [
                 [
                     'tag_name'    => 'v2.0.0',
                     'description' => 'Release',
                     'created_at'  => '2024-12-15T10:00:00.000Z',
                 ],
-            ], 200),
-        ]);
+            ], 200 ),
+        ] );
 
-        $source     = new GitLabUpdateSource('https://gitlab.com/user/repo', '1.0.0');
+        $source     = new GitLabUpdateSource( 'https://gitlab.com/user/repo', '1.0.0' );
         $updateInfo = $source->checkForUpdate();
 
-        $this->assertEquals('gitlab', $updateInfo->metadata['source']);
-        $this->assertArrayHasKey('release_url', $updateInfo->metadata);
+        $this->assertEquals( 'gitlab', $updateInfo->metadata['source'] );
+        $this->assertArrayHasKey( 'release_url', $updateInfo->metadata);
     }
 
     /**
@@ -301,9 +301,9 @@ class GitLabUpdateSourceTest extends TestCase
      *
      * @param  \Illuminate\Foundation\Application  $app
      */
-    protected function defineEnvironment($app): void
+    protected function defineEnvironment( $app): void
     {
-        $app['config']->set('cms.updates.http_timeout', 15);
-        $app['config']->set('cms.updates.download_timeout', 300);
+        $app['config']->set( 'cms.updates.http_timeout', 15);
+        $app['config']->set( 'cms.updates.download_timeout', 300);
     }
 }

--- a/tests/Unit/Updates/GitLabUpdateSourceTest.php
+++ b/tests/Unit/Updates/GitLabUpdateSourceTest.php
@@ -143,11 +143,24 @@ class GitLabUpdateSourceTest extends TestCase
      */
     public function test_can_set_authentication(): void
     {
+        Http::fake([
+            'gitlab.com/api/v4/projects/user%2Frepo/releases' => Http::response([
+                [
+                    'tag_name'    => 'v2.0.0',
+                    'description' => 'Release',
+                    'created_at'  => '2024-12-15T10:00:00.000Z',
+                ],
+            ], 200),
+        ]);
+
         $source = new GitLabUpdateSource('https://gitlab.com/user/repo', '1.0.0');
         $source->setAuthentication('glpat-test_token');
 
-        // We can't directly test the token is used, but we can verify the method doesn't throw
-        $this->assertTrue(true);
+        $source->checkForUpdate();
+
+        Http::assertSent(function ($request) {
+            return $request->hasHeader('PRIVATE-TOKEN', 'glpat-test_token');
+        });
     }
 
     /**

--- a/tests/Unit/Updates/GitLabUpdateSourceTest.php
+++ b/tests/Unit/Updates/GitLabUpdateSourceTest.php
@@ -1,6 +1,6 @@
 <?php
 
-declare( strict_types = 1 );
+declare(strict_types=1);
 
 namespace ArtisanPackUI\CMSFramework\Tests\Unit\Updates;
 
@@ -25,12 +25,12 @@ class GitLabUpdateSourceTest extends TestCase
      */
     public function test_supports_gitlab_urls(): void
     {
-        $source = new GitLabUpdateSource( 'https://gitlab.com/user/repo', '1.0.0' );
+        $source = new GitLabUpdateSource('https://gitlab.com/user/repo', '1.0.0');
 
-        $this->assertTrue( $source->supports( 'https://gitlab.com/user/repo' ) );
-        $this->assertTrue( $source->supports( 'https://gitlab.com/another-user/another-repo' ) );
-        $this->assertFalse( $source->supports( 'https://github.com/user/repo' ) );
-        $this->assertFalse( $source->supports( 'https://example.com/updates.json' ) );
+        $this->assertTrue($source->supports('https://gitlab.com/user/repo'));
+        $this->assertTrue($source->supports('https://gitlab.com/another-user/another-repo'));
+        $this->assertFalse($source->supports('https://github.com/user/repo'));
+        $this->assertFalse($source->supports('https://example.com/updates.json'));
     }
 
     /**
@@ -40,9 +40,9 @@ class GitLabUpdateSourceTest extends TestCase
      */
     public function test_returns_correct_name(): void
     {
-        $source = new GitLabUpdateSource( 'https://gitlab.com/user/repo', '1.0.0' );
+        $source = new GitLabUpdateSource('https://gitlab.com/user/repo', '1.0.0');
 
-        $this->assertEquals( 'GitLab', $source->getName() );
+        $this->assertEquals('GitLab', $source->getName());
     }
 
     /**
@@ -52,25 +52,25 @@ class GitLabUpdateSourceTest extends TestCase
      */
     public function test_can_check_for_updates(): void
     {
-        Http::fake( [
-            'gitlab.com/api/v4/projects/user%2Frepo/releases' => Http::response( [
+        Http::fake([
+            'gitlab.com/api/v4/projects/user%2Frepo/releases' => Http::response([
                 [
                     'tag_name'    => 'v2.0.0',
                     'description' => 'Release notes here',
                     'created_at'  => '2024-12-15T10:00:00.000Z',
                 ],
-            ], 200 ),
-        ] );
+            ], 200),
+        ]);
 
-        $source     = new GitLabUpdateSource( 'https://gitlab.com/user/repo', '1.0.0' );
+        $source     = new GitLabUpdateSource('https://gitlab.com/user/repo', '1.0.0');
         $updateInfo = $source->checkForUpdate();
 
-        $this->assertInstanceOf( UpdateInfo::class, $updateInfo );
-        $this->assertEquals( '1.0.0', $updateInfo->currentVersion );
-        $this->assertEquals( '2.0.0', $updateInfo->latestVersion );
-        $this->assertTrue( $updateInfo->hasUpdate );
-        $this->assertStringContainsString( 'gitlab.com', $updateInfo->downloadUrl );
-        $this->assertEquals( 'Release notes here', $updateInfo->changelog );
+        $this->assertInstanceOf(UpdateInfo::class, $updateInfo);
+        $this->assertEquals('1.0.0', $updateInfo->currentVersion);
+        $this->assertEquals('2.0.0', $updateInfo->latestVersion);
+        $this->assertTrue($updateInfo->hasUpdate());
+        $this->assertStringContainsString('gitlab.com', $updateInfo->downloadUrl);
+        $this->assertEquals('Release notes here', $updateInfo->changelog);
     }
 
     /**
@@ -80,14 +80,14 @@ class GitLabUpdateSourceTest extends TestCase
      */
     public function test_throws_exception_when_no_releases(): void
     {
-        Http::fake( [
-            'gitlab.com/api/v4/projects/user%2Frepo/releases' => Http::response( [], 200 ),
-        ] );
+        Http::fake([
+            'gitlab.com/api/v4/projects/user%2Frepo/releases' => Http::response([], 200),
+        ]);
 
-        $source = new GitLabUpdateSource( 'https://gitlab.com/user/repo', '1.0.0' );
+        $source = new GitLabUpdateSource('https://gitlab.com/user/repo', '1.0.0');
 
-        $this->expectException( UpdateException::class );
-        $this->expectExceptionMessage( 'No releases found' );
+        $this->expectException(UpdateException::class);
+        $this->expectExceptionMessage('No releases found');
 
         $source->checkForUpdate();
     }
@@ -99,14 +99,14 @@ class GitLabUpdateSourceTest extends TestCase
      */
     public function test_handles_api_errors(): void
     {
-        Http::fake( [
-            'gitlab.com/api/v4/projects/user%2Frepo/releases' => Http::response( [], 500 ),
-        ] );
+        Http::fake([
+            'gitlab.com/api/v4/projects/user%2Frepo/releases' => Http::response([], 500),
+        ]);
 
-        $source = new GitLabUpdateSource( 'https://gitlab.com/user/repo', '1.0.0' );
+        $source = new GitLabUpdateSource('https://gitlab.com/user/repo', '1.0.0');
 
-        $this->expectException( UpdateException::class );
-        $this->expectExceptionMessage( 'GitLab API error' );
+        $this->expectException(UpdateException::class);
+        $this->expectExceptionMessage('GitLab API error');
 
         $source->checkForUpdate();
     }
@@ -118,11 +118,11 @@ class GitLabUpdateSourceTest extends TestCase
      */
     public function test_can_set_authentication(): void
     {
-        $source = new GitLabUpdateSource( 'https://gitlab.com/user/repo', '1.0.0' );
-        $source->setAuthentication( 'glpat-test_token' );
+        $source = new GitLabUpdateSource('https://gitlab.com/user/repo', '1.0.0');
+        $source->setAuthentication('glpat-test_token');
 
         // We can't directly test the token is used, but we can verify the method doesn't throw
-        $this->assertTrue( true );
+        $this->assertTrue(true);
     }
 
     /**
@@ -132,21 +132,21 @@ class GitLabUpdateSourceTest extends TestCase
      */
     public function test_parses_repository_url_correctly(): void
     {
-        Http::fake( [
-            'gitlab.com/api/v4/projects/test-group%2Ftest-repo/releases' => Http::response( [
+        Http::fake([
+            'gitlab.com/api/v4/projects/test-group%2Ftest-repo/releases' => Http::response([
                 [
                     'tag_name'    => 'v1.0.0',
                     'description' => 'First release',
                     'created_at'  => '2024-12-15T10:00:00.000Z',
                 ],
-            ], 200 ),
-        ] );
+            ], 200),
+        ]);
 
-        $source     = new GitLabUpdateSource( 'https://gitlab.com/test-group/test-repo', '0.9.0' );
+        $source     = new GitLabUpdateSource('https://gitlab.com/test-group/test-repo', '0.9.0');
         $updateInfo = $source->checkForUpdate();
 
         // If we get here without exception, the URL was parsed correctly
-        $this->assertInstanceOf( UpdateInfo::class, $updateInfo );
+        $this->assertInstanceOf(UpdateInfo::class, $updateInfo);
     }
 
     /**
@@ -156,20 +156,20 @@ class GitLabUpdateSourceTest extends TestCase
      */
     public function test_handles_nested_group_paths(): void
     {
-        Http::fake( [
-            'gitlab.com/api/v4/projects/group%2Fsubgroup%2Fproject/releases' => Http::response( [
+        Http::fake([
+            'gitlab.com/api/v4/projects/group%2Fsubgroup%2Fproject/releases' => Http::response([
                 [
                     'tag_name'    => 'v1.0.0',
                     'description' => 'Release',
                     'created_at'  => '2024-12-15T10:00:00.000Z',
                 ],
-            ], 200 ),
-        ] );
+            ], 200),
+        ]);
 
-        $source     = new GitLabUpdateSource( 'https://gitlab.com/group/subgroup/project', '0.9.0' );
+        $source     = new GitLabUpdateSource('https://gitlab.com/group/subgroup/project', '0.9.0');
         $updateInfo = $source->checkForUpdate();
 
-        $this->assertInstanceOf( UpdateInfo::class, $updateInfo );
+        $this->assertInstanceOf(UpdateInfo::class, $updateInfo);
     }
 
     /**
@@ -179,10 +179,10 @@ class GitLabUpdateSourceTest extends TestCase
      */
     public function test_throws_exception_for_invalid_urls(): void
     {
-        $this->expectException( InvalidArgumentException::class );
-        $this->expectExceptionMessage( 'Invalid GitLab URL' );
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid GitLab URL');
 
-        new GitLabUpdateSource( 'https://invalid-url.com', '1.0.0' );
+        new GitLabUpdateSource('https://invalid-url.com', '1.0.0');
     }
 
     /**
@@ -192,20 +192,20 @@ class GitLabUpdateSourceTest extends TestCase
      */
     public function test_strips_v_prefix_from_version_tags(): void
     {
-        Http::fake( [
-            'gitlab.com/api/v4/projects/user%2Frepo/releases' => Http::response( [
+        Http::fake([
+            'gitlab.com/api/v4/projects/user%2Frepo/releases' => Http::response([
                 [
                     'tag_name'    => 'v2.5.1',
                     'description' => 'Release',
                     'created_at'  => '2024-12-15T10:00:00.000Z',
                 ],
-            ], 200 ),
-        ] );
+            ], 200),
+        ]);
 
-        $source     = new GitLabUpdateSource( 'https://gitlab.com/user/repo', '1.0.0' );
+        $source     = new GitLabUpdateSource('https://gitlab.com/user/repo', '1.0.0');
         $updateInfo = $source->checkForUpdate();
 
-        $this->assertEquals( '2.5.1', $updateInfo->latestVersion );
+        $this->assertEquals('2.5.1', $updateInfo->latestVersion);
     }
 
     /**
@@ -215,21 +215,21 @@ class GitLabUpdateSourceTest extends TestCase
      */
     public function test_generates_correct_download_url(): void
     {
-        Http::fake( [
-            'gitlab.com/api/v4/projects/user%2Frepo/releases' => Http::response( [
+        Http::fake([
+            'gitlab.com/api/v4/projects/user%2Frepo/releases' => Http::response([
                 [
                     'tag_name'    => 'v2.0.0',
                     'description' => 'Release',
                     'created_at'  => '2024-12-15T10:00:00.000Z',
                 ],
-            ], 200 ),
-        ] );
+            ], 200),
+        ]);
 
-        $source     = new GitLabUpdateSource( 'https://gitlab.com/user/repo', '1.0.0' );
+        $source     = new GitLabUpdateSource('https://gitlab.com/user/repo', '1.0.0');
         $updateInfo = $source->checkForUpdate();
 
-        $this->assertStringContainsString( 'gitlab.com/api/v4/projects/user%2Frepo/repository/archive.zip', $updateInfo->downloadUrl );
-        $this->assertStringContainsString( 'sha=v2.0.0', $updateInfo->downloadUrl );
+        $this->assertStringContainsString('gitlab.com/api/v4/projects/user%2Frepo/repository/archive.zip', $updateInfo->downloadUrl);
+        $this->assertStringContainsString('sha=v2.0.0', $updateInfo->downloadUrl);
     }
 
     /**
@@ -239,21 +239,21 @@ class GitLabUpdateSourceTest extends TestCase
      */
     public function test_includes_metadata(): void
     {
-        Http::fake( [
-            'gitlab.com/api/v4/projects/user%2Frepo/releases' => Http::response( [
+        Http::fake([
+            'gitlab.com/api/v4/projects/user%2Frepo/releases' => Http::response([
                 [
                     'tag_name'    => 'v2.0.0',
                     'description' => 'Release',
                     'created_at'  => '2024-12-15T10:00:00.000Z',
                 ],
-            ], 200 ),
-        ] );
+            ], 200),
+        ]);
 
-        $source     = new GitLabUpdateSource( 'https://gitlab.com/user/repo', '1.0.0' );
+        $source     = new GitLabUpdateSource('https://gitlab.com/user/repo', '1.0.0');
         $updateInfo = $source->checkForUpdate();
 
-        $this->assertEquals( 'gitlab', $updateInfo->metadata['source'] );
-        $this->assertArrayHasKey( 'release_url', $updateInfo->metadata );
+        $this->assertEquals('gitlab', $updateInfo->metadata['source']);
+        $this->assertArrayHasKey('release_url', $updateInfo->metadata);
     }
 
     /**
@@ -263,9 +263,9 @@ class GitLabUpdateSourceTest extends TestCase
      *
      * @param  \Illuminate\Foundation\Application  $app
      */
-    protected function defineEnvironment( $app ): void
+    protected function defineEnvironment($app): void
     {
-        $app['config']->set( 'cms.updates.http_timeout', 15 );
-        $app['config']->set( 'cms.updates.download_timeout', 300 );
+        $app['config']->set('cms.updates.http_timeout', 15);
+        $app['config']->set('cms.updates.download_timeout', 300);
     }
 }

--- a/tests/Unit/Updates/GitLabUpdateSourceTest.php
+++ b/tests/Unit/Updates/GitLabUpdateSourceTest.php
@@ -291,7 +291,7 @@ class GitLabUpdateSourceTest extends TestCase
         $updateInfo = $source->checkForUpdate();
 
         $this->assertEquals( 'gitlab', $updateInfo->metadata['source'] );
-        $this->assertArrayHasKey( 'release_url', $updateInfo->metadata);
+        $this->assertArrayHasKey( 'release_url', $updateInfo->metadata );
     }
 
     /**
@@ -301,9 +301,9 @@ class GitLabUpdateSourceTest extends TestCase
      *
      * @param  \Illuminate\Foundation\Application  $app
      */
-    protected function defineEnvironment( $app): void
+    protected function defineEnvironment( $app ): void
     {
-        $app['config']->set( 'cms.updates.http_timeout', 15);
-        $app['config']->set( 'cms.updates.download_timeout', 300);
+        $app['config']->set( 'cms.updates.http_timeout', 15 );
+        $app['config']->set( 'cms.updates.download_timeout', 300 );
     }
 }

--- a/tests/Unit/Updates/GitLabUpdateSourceTest.php
+++ b/tests/Unit/Updates/GitLabUpdateSourceTest.php
@@ -14,14 +14,14 @@ use Orchestra\Testbench\TestCase;
 /**
  * GitLab Update Source Tests
  *
- * @since 2.0.0
+ * @since 1.0.0
  */
 class GitLabUpdateSourceTest extends TestCase
 {
     /**
      * Test GitLab source supports GitLab URLs.
      *
-     * @since 2.0.0
+     * @since 1.0.0
      */
     public function test_supports_gitlab_urls(): void
     {
@@ -61,7 +61,7 @@ class GitLabUpdateSourceTest extends TestCase
     /**
      * Test GitLab source returns correct name.
      *
-     * @since 2.0.0
+     * @since 1.0.0
      */
     public function test_returns_correct_name(): void
     {
@@ -73,7 +73,7 @@ class GitLabUpdateSourceTest extends TestCase
     /**
      * Test GitLab source can check for updates.
      *
-     * @since 2.0.0
+     * @since 1.0.0
      */
     public function test_can_check_for_updates(): void
     {
@@ -101,7 +101,7 @@ class GitLabUpdateSourceTest extends TestCase
     /**
      * Test GitLab source handles no releases.
      *
-     * @since 2.0.0
+     * @since 1.0.0
      */
     public function test_throws_exception_when_no_releases(): void
     {
@@ -120,7 +120,7 @@ class GitLabUpdateSourceTest extends TestCase
     /**
      * Test GitLab source handles API errors.
      *
-     * @since 2.0.0
+     * @since 1.0.0
      */
     public function test_handles_api_errors(): void
     {
@@ -139,7 +139,7 @@ class GitLabUpdateSourceTest extends TestCase
     /**
      * Test GitLab source can set authentication.
      *
-     * @since 2.0.0
+     * @since 1.0.0
      */
     public function test_can_set_authentication(): void
     {
@@ -166,7 +166,7 @@ class GitLabUpdateSourceTest extends TestCase
     /**
      * Test GitLab source parses repository URL correctly.
      *
-     * @since 2.0.0
+     * @since 1.0.0
      */
     public function test_parses_repository_url_correctly(): void
     {
@@ -190,7 +190,7 @@ class GitLabUpdateSourceTest extends TestCase
     /**
      * Test GitLab source handles nested group paths.
      *
-     * @since 2.0.0
+     * @since 1.0.0
      */
     public function test_handles_nested_group_paths(): void
     {
@@ -213,7 +213,7 @@ class GitLabUpdateSourceTest extends TestCase
     /**
      * Test GitLab source throws exception for invalid URLs.
      *
-     * @since 2.0.0
+     * @since 1.0.0
      */
     public function test_throws_exception_for_invalid_urls(): void
     {
@@ -226,7 +226,7 @@ class GitLabUpdateSourceTest extends TestCase
     /**
      * Test GitLab source strips 'v' prefix from version tags.
      *
-     * @since 2.0.0
+     * @since 1.0.0
      */
     public function test_strips_v_prefix_from_version_tags(): void
     {
@@ -249,7 +249,7 @@ class GitLabUpdateSourceTest extends TestCase
     /**
      * Test GitLab source generates correct download URL.
      *
-     * @since 2.0.0
+     * @since 1.0.0
      */
     public function test_generates_correct_download_url(): void
     {
@@ -273,7 +273,7 @@ class GitLabUpdateSourceTest extends TestCase
     /**
      * Test GitLab source includes metadata.
      *
-     * @since 2.0.0
+     * @since 1.0.0
      */
     public function test_includes_metadata(): void
     {
@@ -297,7 +297,7 @@ class GitLabUpdateSourceTest extends TestCase
     /**
      * Define environment setup.
      *
-     * @since 2.0.0
+     * @since 1.0.0
      *
      * @param  \Illuminate\Foundation\Application  $app
      */

--- a/tests/Unit/Updates/GitLabUpdateSourceTest.php
+++ b/tests/Unit/Updates/GitLabUpdateSourceTest.php
@@ -31,6 +31,31 @@ class GitLabUpdateSourceTest extends TestCase
         $this->assertTrue($source->supports('https://gitlab.com/another-user/another-repo'));
         $this->assertFalse($source->supports('https://github.com/user/repo'));
         $this->assertFalse($source->supports('https://example.com/updates.json'));
+        $this->assertFalse($source->supports('https://example.com/gitlab.com/user/repo'));
+    }
+
+    /**
+     * Test GitLab source excludes query strings from project ID.
+     *
+     * @since 1.1.0
+     */
+    public function test_excludes_query_strings_from_project_id(): void
+    {
+        Http::fake([
+            'gitlab.com/api/v4/projects/user%2Frepo/releases' => Http::response([
+                [
+                    'tag_name'    => 'v2.0.0',
+                    'description' => 'Release',
+                    'created_at'  => '2024-12-15T10:00:00.000Z',
+                ],
+            ], 200),
+        ]);
+
+        $source     = new GitLabUpdateSource('https://gitlab.com/user/repo?ref=main', '1.0.0');
+        $updateInfo = $source->checkForUpdate();
+
+        $this->assertInstanceOf(UpdateInfo::class, $updateInfo);
+        $this->assertEquals('2.0.0', $updateInfo->latestVersion);
     }
 
     /**

--- a/tests/Unit/Updates/UpdateCheckerFactoryTest.php
+++ b/tests/Unit/Updates/UpdateCheckerFactoryTest.php
@@ -1,9 +1,10 @@
 <?php
 
-declare( strict_types = 1 );
+declare(strict_types=1);
 
 namespace ArtisanPackUI\CMSFramework\Tests\Unit\Updates;
 
+use ArtisanPackUI\CMSFramework\Modules\Core\Updates\Enums\UpdateType;
 use ArtisanPackUI\CMSFramework\Modules\Core\Updates\UpdateChecker;
 use ArtisanPackUI\CMSFramework\Modules\Core\Updates\UpdateCheckerFactory;
 use Orchestra\Testbench\TestCase;
@@ -24,13 +25,13 @@ class UpdateCheckerFactoryTest extends TestCase
     {
         $checker = UpdateCheckerFactory::buildUpdateChecker(
             'https://github.com/username/repo',
-            'application',
+            UpdateType::Application,
             'test-app',
             '1.0.0',
         );
 
-        $this->assertInstanceOf( UpdateChecker::class, $checker );
-        $this->assertEquals( 'GitHub', $checker->getSourceName() );
+        $this->assertInstanceOf(UpdateChecker::class, $checker);
+        $this->assertEquals('GitHub', $checker->getSourceName());
     }
 
     /**
@@ -42,13 +43,13 @@ class UpdateCheckerFactoryTest extends TestCase
     {
         $checker = UpdateCheckerFactory::buildUpdateChecker(
             'https://gitlab.com/username/repo',
-            'application',
+            UpdateType::Application,
             'test-app',
             '1.0.0',
         );
 
-        $this->assertInstanceOf( UpdateChecker::class, $checker );
-        $this->assertEquals( 'GitLab', $checker->getSourceName() );
+        $this->assertInstanceOf(UpdateChecker::class, $checker);
+        $this->assertEquals('GitLab', $checker->getSourceName());
     }
 
     /**
@@ -60,13 +61,13 @@ class UpdateCheckerFactoryTest extends TestCase
     {
         $checker = UpdateCheckerFactory::buildUpdateChecker(
             'https://example.com/updates.json',
-            'application',
+            UpdateType::Application,
             'test-app',
             '1.0.0',
         );
 
-        $this->assertInstanceOf( UpdateChecker::class, $checker );
-        $this->assertEquals( 'Custom JSON', $checker->getSourceName() );
+        $this->assertInstanceOf(UpdateChecker::class, $checker);
+        $this->assertEquals('Custom JSON', $checker->getSourceName());
     }
 
     /**
@@ -78,11 +79,11 @@ class UpdateCheckerFactoryTest extends TestCase
     {
         $checker = UpdateCheckerFactory::buildUpdateChecker(
             'https://github.com/username/repo',
-            'application',
+            UpdateType::Application,
             'test-app',
         );
 
-        $this->assertInstanceOf( UpdateChecker::class, $checker );
+        $this->assertInstanceOf(UpdateChecker::class, $checker);
     }
 
     /**
@@ -94,13 +95,13 @@ class UpdateCheckerFactoryTest extends TestCase
     {
         $checker = UpdateCheckerFactory::buildUpdateChecker(
             'https://github.com/username/repo',
-            'plugin',
+            UpdateType::Plugin,
             'test-plugin',
             '1.0.0',
         );
 
-        $this->assertEquals( 'plugin', $checker->getType() );
-        $this->assertEquals( 'test-plugin', $checker->getSlug() );
+        $this->assertSame(UpdateType::Plugin, $checker->getType());
+        $this->assertEquals('test-plugin', $checker->getSlug());
     }
 
     /**
@@ -110,9 +111,9 @@ class UpdateCheckerFactoryTest extends TestCase
      *
      * @param  \Illuminate\Foundation\Application  $app
      */
-    protected function defineEnvironment( $app ): void
+    protected function defineEnvironment($app): void
     {
         // Set app version for testing
-        $app['config']->set( 'app.version', '1.0.0' );
+        $app['config']->set('app.version', '1.0.0');
     }
 }

--- a/tests/Unit/Updates/UpdateCheckerFactoryTest.php
+++ b/tests/Unit/Updates/UpdateCheckerFactoryTest.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare( strict_types=1 );
 
 namespace ArtisanPackUI\CMSFramework\Tests\Unit\Updates;
 
@@ -30,8 +30,8 @@ class UpdateCheckerFactoryTest extends TestCase
             '1.0.0',
         );
 
-        $this->assertInstanceOf(UpdateChecker::class, $checker);
-        $this->assertEquals('GitHub', $checker->getSourceName());
+        $this->assertInstanceOf( UpdateChecker::class, $checker );
+        $this->assertEquals( 'GitHub', $checker->getSourceName() );
     }
 
     /**
@@ -48,8 +48,8 @@ class UpdateCheckerFactoryTest extends TestCase
             '1.0.0',
         );
 
-        $this->assertInstanceOf(UpdateChecker::class, $checker);
-        $this->assertEquals('GitLab', $checker->getSourceName());
+        $this->assertInstanceOf( UpdateChecker::class, $checker );
+        $this->assertEquals( 'GitLab', $checker->getSourceName() );
     }
 
     /**
@@ -66,8 +66,8 @@ class UpdateCheckerFactoryTest extends TestCase
             '1.0.0',
         );
 
-        $this->assertInstanceOf(UpdateChecker::class, $checker);
-        $this->assertEquals('Custom JSON', $checker->getSourceName());
+        $this->assertInstanceOf( UpdateChecker::class, $checker );
+        $this->assertEquals( 'Custom JSON', $checker->getSourceName() );
     }
 
     /**
@@ -83,7 +83,7 @@ class UpdateCheckerFactoryTest extends TestCase
             'test-app',
         );
 
-        $this->assertInstanceOf(UpdateChecker::class, $checker);
+        $this->assertInstanceOf( UpdateChecker::class, $checker );
     }
 
     /**
@@ -100,8 +100,8 @@ class UpdateCheckerFactoryTest extends TestCase
             '1.0.0',
         );
 
-        $this->assertSame(UpdateType::Plugin, $checker->getType());
-        $this->assertEquals('test-plugin', $checker->getSlug());
+        $this->assertSame( UpdateType::Plugin, $checker->getType() );
+        $this->assertEquals( 'test-plugin', $checker->getSlug() );
     }
 
     /**
@@ -111,9 +111,9 @@ class UpdateCheckerFactoryTest extends TestCase
      *
      * @param  \Illuminate\Foundation\Application  $app
      */
-    protected function defineEnvironment($app): void
+    protected function defineEnvironment( $app ): void
     {
         // Set app version for testing
-        $app['config']->set('app.version', '1.0.0');
+        $app['config']->set( 'app.version', '1.0.0');
     }
 }

--- a/tests/Unit/Updates/UpdateCheckerFactoryTest.php
+++ b/tests/Unit/Updates/UpdateCheckerFactoryTest.php
@@ -114,6 +114,6 @@ class UpdateCheckerFactoryTest extends TestCase
     protected function defineEnvironment( $app ): void
     {
         // Set app version for testing
-        $app['config']->set( 'app.version', '1.0.0');
+        $app['config']->set( 'app.version', '1.0.0' );
     }
 }

--- a/tests/Unit/Updates/UpdateCheckerFactoryTest.php
+++ b/tests/Unit/Updates/UpdateCheckerFactoryTest.php
@@ -12,14 +12,14 @@ use Orchestra\Testbench\TestCase;
 /**
  * Update Checker Factory Tests
  *
- * @since 2.0.0
+ * @since 1.0.0
  */
 class UpdateCheckerFactoryTest extends TestCase
 {
     /**
      * Test factory detects GitHub source.
      *
-     * @since 2.0.0
+     * @since 1.0.0
      */
     public function test_detects_github_source(): void
     {
@@ -37,7 +37,7 @@ class UpdateCheckerFactoryTest extends TestCase
     /**
      * Test factory detects GitLab source.
      *
-     * @since 2.0.0
+     * @since 1.0.0
      */
     public function test_detects_gitlab_source(): void
     {
@@ -55,7 +55,7 @@ class UpdateCheckerFactoryTest extends TestCase
     /**
      * Test factory falls back to custom JSON source.
      *
-     * @since 2.0.0
+     * @since 1.0.0
      */
     public function test_falls_back_to_custom_json_source(): void
     {
@@ -73,7 +73,7 @@ class UpdateCheckerFactoryTest extends TestCase
     /**
      * Test factory auto-detects application version.
      *
-     * @since 2.0.0
+     * @since 1.0.0
      */
     public function test_auto_detects_application_version(): void
     {
@@ -89,7 +89,7 @@ class UpdateCheckerFactoryTest extends TestCase
     /**
      * Test factory returns correct update type.
      *
-     * @since 2.0.0
+     * @since 1.0.0
      */
     public function test_returns_correct_update_type(): void
     {
@@ -107,7 +107,7 @@ class UpdateCheckerFactoryTest extends TestCase
     /**
      * Define environment setup.
      *
-     * @since 2.0.0
+     * @since 1.0.0
      *
      * @param  \Illuminate\Foundation\Application  $app
      */

--- a/tests/Unit/Updates/UpdateInfoTest.php
+++ b/tests/Unit/Updates/UpdateInfoTest.php
@@ -116,7 +116,7 @@ class UpdateInfoTest extends TestCase
         $this->assertEquals( '1.0.0', $array['current'] );
         $this->assertEquals( '2.0.0', $array['latest'] );
         $this->assertTrue( $array['hasUpdate'] );
-        $this->assertEquals( 'https://example.com/update.zip', $array['download_url']);
-        $this->assertEquals( 'New features', $array['changelog']);
+        $this->assertEquals( 'https://example.com/update.zip', $array['download_url'] );
+        $this->assertEquals( 'New features', $array['changelog'] );
     }
 }

--- a/tests/Unit/Updates/UpdateInfoTest.php
+++ b/tests/Unit/Updates/UpdateInfoTest.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare( strict_types=1 );
 
 namespace ArtisanPackUI\CMSFramework\Tests\Unit\Updates;
 
@@ -27,10 +27,10 @@ class UpdateInfoTest extends TestCase
             downloadUrl: 'https://example.com/update.zip',
         );
 
-        $this->assertEquals('1.0.0', $info->currentVersion);
-        $this->assertEquals('2.0.0', $info->latestVersion);
-        $this->assertTrue($info->hasUpdate());
-        $this->assertEquals('https://example.com/update.zip', $info->downloadUrl);
+        $this->assertEquals( '1.0.0', $info->currentVersion );
+        $this->assertEquals( '2.0.0', $info->latestVersion );
+        $this->assertTrue( $info->hasUpdate() );
+        $this->assertEquals( 'https://example.com/update.zip', $info->downloadUrl );
     }
 
     /**
@@ -47,14 +47,14 @@ class UpdateInfoTest extends TestCase
             'sha256'       => 'abc123',
         ];
 
-        $info = UpdateInfo::fromArray($data, '1.0.0');
+        $info = UpdateInfo::fromArray( $data, '1.0.0' );
 
-        $this->assertEquals('1.0.0', $info->currentVersion);
-        $this->assertEquals('2.0.0', $info->latestVersion);
-        $this->assertTrue($info->hasUpdate());
-        $this->assertEquals('https://example.com/update.zip', $info->downloadUrl);
-        $this->assertEquals('New features', $info->changelog);
-        $this->assertEquals('abc123', $info->sha256);
+        $this->assertEquals( '1.0.0', $info->currentVersion );
+        $this->assertEquals( '2.0.0', $info->latestVersion );
+        $this->assertTrue( $info->hasUpdate() );
+        $this->assertEquals( 'https://example.com/update.zip', $info->downloadUrl );
+        $this->assertEquals( 'New features', $info->changelog );
+        $this->assertEquals( 'abc123', $info->sha256 );
     }
 
     /**
@@ -69,9 +69,9 @@ class UpdateInfoTest extends TestCase
             'download_url' => 'https://example.com/update.zip',
         ];
 
-        $info = UpdateInfo::fromArray($data, '1.0.0');
+        $info = UpdateInfo::fromArray( $data, '1.0.0' );
 
-        $this->assertFalse($info->hasUpdate());
+        $this->assertFalse( $info->hasUpdate() );
     }
 
     /**
@@ -86,9 +86,9 @@ class UpdateInfoTest extends TestCase
             'download_url' => 'https://example.com/update.zip',
         ];
 
-        $info = UpdateInfo::fromArray($data, '2.0.0');
+        $info = UpdateInfo::fromArray( $data, '2.0.0' );
 
-        $this->assertFalse($info->hasUpdate());
+        $this->assertFalse( $info->hasUpdate() );
     }
 
     /**
@@ -107,16 +107,16 @@ class UpdateInfoTest extends TestCase
 
         $array = $info->toArray();
 
-        $this->assertArrayHasKey('current', $array);
-        $this->assertArrayHasKey('latest', $array);
-        $this->assertArrayHasKey('hasUpdate', $array);
-        $this->assertArrayHasKey('download_url', $array);
-        $this->assertArrayHasKey('changelog', $array);
+        $this->assertArrayHasKey( 'current', $array );
+        $this->assertArrayHasKey( 'latest', $array );
+        $this->assertArrayHasKey( 'hasUpdate', $array );
+        $this->assertArrayHasKey( 'download_url', $array );
+        $this->assertArrayHasKey( 'changelog', $array );
 
-        $this->assertEquals('1.0.0', $array['current']);
-        $this->assertEquals('2.0.0', $array['latest']);
-        $this->assertTrue($array['hasUpdate']);
-        $this->assertEquals('https://example.com/update.zip', $array['download_url']);
-        $this->assertEquals('New features', $array['changelog']);
+        $this->assertEquals( '1.0.0', $array['current'] );
+        $this->assertEquals( '2.0.0', $array['latest'] );
+        $this->assertTrue( $array['hasUpdate'] );
+        $this->assertEquals( 'https://example.com/update.zip', $array['download_url']);
+        $this->assertEquals( 'New features', $array['changelog']);
     }
 }

--- a/tests/Unit/Updates/UpdateInfoTest.php
+++ b/tests/Unit/Updates/UpdateInfoTest.php
@@ -10,14 +10,14 @@ use PHPUnit\Framework\TestCase;
 /**
  * Update Info Tests
  *
- * @since 2.0.0
+ * @since 1.0.0
  */
 class UpdateInfoTest extends TestCase
 {
     /**
      * Test UpdateInfo can be instantiated.
      *
-     * @since 2.0.0
+     * @since 1.0.0
      */
     public function test_can_create_update_info(): void
     {
@@ -36,7 +36,7 @@ class UpdateInfoTest extends TestCase
     /**
      * Test UpdateInfo can be created from array.
      *
-     * @since 2.0.0
+     * @since 1.0.0
      */
     public function test_can_create_from_array(): void
     {
@@ -60,7 +60,7 @@ class UpdateInfoTest extends TestCase
     /**
      * Test UpdateInfo detects no update when versions match.
      *
-     * @since 2.0.0
+     * @since 1.0.0
      */
     public function test_detects_no_update_when_versions_match(): void
     {
@@ -77,7 +77,7 @@ class UpdateInfoTest extends TestCase
     /**
      * Test UpdateInfo detects no update when current is newer.
      *
-     * @since 2.0.0
+     * @since 1.0.0
      */
     public function test_detects_no_update_when_current_is_newer(): void
     {
@@ -94,7 +94,7 @@ class UpdateInfoTest extends TestCase
     /**
      * Test UpdateInfo can be converted to array.
      *
-     * @since 2.0.0
+     * @since 1.0.0
      */
     public function test_can_convert_to_array(): void
     {

--- a/tests/Unit/Updates/UpdateInfoTest.php
+++ b/tests/Unit/Updates/UpdateInfoTest.php
@@ -1,6 +1,6 @@
 <?php
 
-declare( strict_types = 1 );
+declare(strict_types=1);
 
 namespace ArtisanPackUI\CMSFramework\Tests\Unit\Updates;
 
@@ -24,14 +24,13 @@ class UpdateInfoTest extends TestCase
         $info = new UpdateInfo(
             currentVersion: '1.0.0',
             latestVersion: '2.0.0',
-            hasUpdate: true,
             downloadUrl: 'https://example.com/update.zip',
         );
 
-        $this->assertEquals( '1.0.0', $info->currentVersion );
-        $this->assertEquals( '2.0.0', $info->latestVersion );
-        $this->assertTrue( $info->hasUpdate );
-        $this->assertEquals( 'https://example.com/update.zip', $info->downloadUrl );
+        $this->assertEquals('1.0.0', $info->currentVersion);
+        $this->assertEquals('2.0.0', $info->latestVersion);
+        $this->assertTrue($info->hasUpdate());
+        $this->assertEquals('https://example.com/update.zip', $info->downloadUrl);
     }
 
     /**
@@ -48,14 +47,14 @@ class UpdateInfoTest extends TestCase
             'sha256'       => 'abc123',
         ];
 
-        $info = UpdateInfo::fromArray( $data, '1.0.0' );
+        $info = UpdateInfo::fromArray($data, '1.0.0');
 
-        $this->assertEquals( '1.0.0', $info->currentVersion );
-        $this->assertEquals( '2.0.0', $info->latestVersion );
-        $this->assertTrue( $info->hasUpdate );
-        $this->assertEquals( 'https://example.com/update.zip', $info->downloadUrl );
-        $this->assertEquals( 'New features', $info->changelog );
-        $this->assertEquals( 'abc123', $info->sha256 );
+        $this->assertEquals('1.0.0', $info->currentVersion);
+        $this->assertEquals('2.0.0', $info->latestVersion);
+        $this->assertTrue($info->hasUpdate());
+        $this->assertEquals('https://example.com/update.zip', $info->downloadUrl);
+        $this->assertEquals('New features', $info->changelog);
+        $this->assertEquals('abc123', $info->sha256);
     }
 
     /**
@@ -70,9 +69,9 @@ class UpdateInfoTest extends TestCase
             'download_url' => 'https://example.com/update.zip',
         ];
 
-        $info = UpdateInfo::fromArray( $data, '1.0.0' );
+        $info = UpdateInfo::fromArray($data, '1.0.0');
 
-        $this->assertFalse( $info->hasUpdate );
+        $this->assertFalse($info->hasUpdate());
     }
 
     /**
@@ -87,9 +86,9 @@ class UpdateInfoTest extends TestCase
             'download_url' => 'https://example.com/update.zip',
         ];
 
-        $info = UpdateInfo::fromArray( $data, '2.0.0' );
+        $info = UpdateInfo::fromArray($data, '2.0.0');
 
-        $this->assertFalse( $info->hasUpdate );
+        $this->assertFalse($info->hasUpdate());
     }
 
     /**
@@ -102,23 +101,22 @@ class UpdateInfoTest extends TestCase
         $info = new UpdateInfo(
             currentVersion: '1.0.0',
             latestVersion: '2.0.0',
-            hasUpdate: true,
             downloadUrl: 'https://example.com/update.zip',
             changelog: 'New features',
         );
 
         $array = $info->toArray();
 
-        $this->assertArrayHasKey( 'current', $array );
-        $this->assertArrayHasKey( 'latest', $array );
-        $this->assertArrayHasKey( 'hasUpdate', $array );
-        $this->assertArrayHasKey( 'download_url', $array );
-        $this->assertArrayHasKey( 'changelog', $array );
+        $this->assertArrayHasKey('current', $array);
+        $this->assertArrayHasKey('latest', $array);
+        $this->assertArrayHasKey('hasUpdate', $array);
+        $this->assertArrayHasKey('download_url', $array);
+        $this->assertArrayHasKey('changelog', $array);
 
-        $this->assertEquals( '1.0.0', $array['current'] );
-        $this->assertEquals( '2.0.0', $array['latest'] );
-        $this->assertTrue( $array['hasUpdate'] );
-        $this->assertEquals( 'https://example.com/update.zip', $array['download_url'] );
-        $this->assertEquals( 'New features', $array['changelog'] );
+        $this->assertEquals('1.0.0', $array['current']);
+        $this->assertEquals('2.0.0', $array['latest']);
+        $this->assertTrue($array['hasUpdate']);
+        $this->assertEquals('https://example.com/update.zip', $array['download_url']);
+        $this->assertEquals('New features', $array['changelog']);
     }
 }

--- a/tests/Unit/Updates/UpdateTypeTest.php
+++ b/tests/Unit/Updates/UpdateTypeTest.php
@@ -73,6 +73,6 @@ class UpdateTypeTest extends TestCase
      */
     public function test_try_from_returns_null_for_invalid_string(): void
     {
-        $this->assertNull( UpdateType::tryFrom( 'invalid'));
+        $this->assertNull( UpdateType::tryFrom( 'invalid' ) );
     }
 }

--- a/tests/Unit/Updates/UpdateTypeTest.php
+++ b/tests/Unit/Updates/UpdateTypeTest.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ArtisanPackUI\CMSFramework\Tests\Unit\Updates;
+
+use ArtisanPackUI\CMSFramework\Modules\Core\Updates\Enums\UpdateType;
+use Orchestra\Testbench\TestCase;
+use ValueError;
+
+/**
+ * Update Type Enum Tests
+ *
+ * @since 1.1.0
+ */
+class UpdateTypeTest extends TestCase
+{
+    /**
+     * Test enum has the correct cases.
+     *
+     * @since 1.1.0
+     */
+    public function test_has_correct_cases(): void
+    {
+        $cases = UpdateType::cases();
+
+        $this->assertCount(3, $cases);
+        $this->assertContains(UpdateType::Application, $cases);
+        $this->assertContains(UpdateType::Plugin, $cases);
+        $this->assertContains(UpdateType::Theme, $cases);
+    }
+
+    /**
+     * Test enum has correct string values.
+     *
+     * @since 1.1.0
+     */
+    public function test_has_correct_string_values(): void
+    {
+        $this->assertEquals('application', UpdateType::Application->value);
+        $this->assertEquals('plugin', UpdateType::Plugin->value);
+        $this->assertEquals('theme', UpdateType::Theme->value);
+    }
+
+    /**
+     * Test enum can be created from valid string values.
+     *
+     * @since 1.1.0
+     */
+    public function test_can_be_created_from_valid_string(): void
+    {
+        $this->assertSame(UpdateType::Application, UpdateType::from('application'));
+        $this->assertSame(UpdateType::Plugin, UpdateType::from('plugin'));
+        $this->assertSame(UpdateType::Theme, UpdateType::from('theme'));
+    }
+
+    /**
+     * Test enum throws exception for invalid string value.
+     *
+     * @since 1.1.0
+     */
+    public function test_throws_exception_for_invalid_string(): void
+    {
+        $this->expectException(ValueError::class);
+
+        UpdateType::from('invalid');
+    }
+
+    /**
+     * Test tryFrom returns null for invalid string value.
+     *
+     * @since 1.1.0
+     */
+    public function test_try_from_returns_null_for_invalid_string(): void
+    {
+        $this->assertNull(UpdateType::tryFrom('invalid'));
+    }
+}

--- a/tests/Unit/Updates/UpdateTypeTest.php
+++ b/tests/Unit/Updates/UpdateTypeTest.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare( strict_types=1 );
 
 namespace ArtisanPackUI\CMSFramework\Tests\Unit\Updates;
 
@@ -24,10 +24,10 @@ class UpdateTypeTest extends TestCase
     {
         $cases = UpdateType::cases();
 
-        $this->assertCount(3, $cases);
-        $this->assertContains(UpdateType::Application, $cases);
-        $this->assertContains(UpdateType::Plugin, $cases);
-        $this->assertContains(UpdateType::Theme, $cases);
+        $this->assertCount( 3, $cases );
+        $this->assertContains( UpdateType::Application, $cases );
+        $this->assertContains( UpdateType::Plugin, $cases );
+        $this->assertContains( UpdateType::Theme, $cases );
     }
 
     /**
@@ -37,9 +37,9 @@ class UpdateTypeTest extends TestCase
      */
     public function test_has_correct_string_values(): void
     {
-        $this->assertEquals('application', UpdateType::Application->value);
-        $this->assertEquals('plugin', UpdateType::Plugin->value);
-        $this->assertEquals('theme', UpdateType::Theme->value);
+        $this->assertEquals( 'application', UpdateType::Application->value );
+        $this->assertEquals( 'plugin', UpdateType::Plugin->value );
+        $this->assertEquals( 'theme', UpdateType::Theme->value );
     }
 
     /**
@@ -49,9 +49,9 @@ class UpdateTypeTest extends TestCase
      */
     public function test_can_be_created_from_valid_string(): void
     {
-        $this->assertSame(UpdateType::Application, UpdateType::from('application'));
-        $this->assertSame(UpdateType::Plugin, UpdateType::from('plugin'));
-        $this->assertSame(UpdateType::Theme, UpdateType::from('theme'));
+        $this->assertSame( UpdateType::Application, UpdateType::from( 'application' ) );
+        $this->assertSame( UpdateType::Plugin, UpdateType::from( 'plugin' ) );
+        $this->assertSame( UpdateType::Theme, UpdateType::from( 'theme' ) );
     }
 
     /**
@@ -61,9 +61,9 @@ class UpdateTypeTest extends TestCase
      */
     public function test_throws_exception_for_invalid_string(): void
     {
-        $this->expectException(ValueError::class);
+        $this->expectException( ValueError::class );
 
-        UpdateType::from('invalid');
+        UpdateType::from( 'invalid' );
     }
 
     /**
@@ -73,6 +73,6 @@ class UpdateTypeTest extends TestCase
      */
     public function test_try_from_returns_null_for_invalid_string(): void
     {
-        $this->assertNull(UpdateType::tryFrom('invalid'));
+        $this->assertNull( UpdateType::tryFrom( 'invalid'));
     }
 }


### PR DESCRIPTION

## Release Information

- **Release Version:** v1.1.0
- **Release Date:** 2026-04-06
- **Release Type:** Minor
- **Release Branch:** `release/1.1`
- **Target Branch:** `main`

## Release Summary

Minor release adding bulk action API endpoints, OpenAPI specification generation, TypeScript type definitions, on-demand relationship loading, standardized error responses, and multiple refactors replacing magic strings with enums and extracting shared logic into traits. Also adds CI/CD improvements including a lint job, PHP matrix testing, and a dedicated release workflow with Packagist integration.

## Changelog

### Added
- Bulk action API endpoints for posts, pages, and users (publish, unpublish, trash, restore, delete)
- OpenAPI specification generation for all API endpoints via Scramble
- `include` query parameter for on-demand relationship loading across API endpoints
- TypeScript type definitions for all API responses and models
- GitHub Actions CI workflow with lint and test jobs
- GitHub Actions release workflow with changelog-based release notes and Packagist integration
- Claude Code and Claude Code Review GitHub Actions workflows
- Auto-assign milestone workflow for new issues
- GitHub issue and pull request templates

### Changed
- Standardized JSON error response format across all API endpoints
- Extracted shared manifest parsing and discovery logic into `HasManifestParsing` trait
- Extracted shared content query and filter logic into reusable traits
- Converted `UpdateInfo::hasUpdate` from stored state to a computed method
- Replaced magic strings with enums: `ContentStatus`, `SettingType`, `FieldType`, `ColumnType`, `UpdateType`
- Hoisted policy and permission resolution before loops in bulk actions
- Added php-cs-fixer and ran code style formatting across the package
- Updated PHP version requirement to 8.4 for CI
- Migrated repository from GitLab to GitHub

### Deprecated
- N/A

### Removed
- N/A

### Fixed
- Sanitized error responses and normalized `published_at` in bulk actions
- Corrected LIKE wildcard escaping order and added ESCAPE clause
- Hardened URL parsing and cache serialization in update sources
- Fixed incorrect `@since 2.0.0` tags to `@since 1.0.0` in update test files

### Security
- N/A

## Issues and Pull Requests

**Related PRs:**
- #81 — Add ContentStatus enum
- #82 — Extract shared content query/filter logic
- #83 — Add SettingType enum
- #84 — Add FieldType and ColumnType enums
- #85 — Add UpdateType enum
- #86 — Convert UpdateInfo::hasUpdate to derived property
- #87 — Extract shared manifest parsing/discovery
- #88 — Publish TypeScript type definitions
- #89 — Standardize JSON error response format
- #90 — Add include parameter for on-demand relationship loading
- #91 — Generate OpenAPI specification
- #92 — Add bulk action API endpoints

## Breaking Changes

- [x] No breaking changes

## Testing Checklist

- [x] All automated tests passing (596 passed, 4 skipped)
- [ ] Manual testing completed
- [ ] Accessibility tests passing
- [ ] Performance tests passing (if applicable)
- [ ] Security scan completed
- [ ] Tested in staging environment
- [ ] Database migrations tested (if applicable)

**Testing notes:**
All 596 tests pass with 1535 assertions. 4 tests skipped (pre-existing).

## Documentation Checklist

- [x] CHANGELOG updated
- [ ] README updated (if needed)
- [ ] API documentation updated (if needed)
- [ ] Migration guide written (if breaking changes)
- [x] Release notes written
- [ ] Wiki updated (if applicable)

## Pre-Release Checklist

- [x] Version number updated in all necessary files
- [ ] Git tag prepared: `v1.1.0`
- [x] Release branch created/updated: `release/1.1`
- [x] Dependencies updated and tested
- [ ] Build artifacts generated
- [ ] Deployment plan reviewed
- [ ] Rollback plan prepared
- [ ] Stakeholders notified

## Deployment

**Deployment steps:**
1. Merge this PR to main
2. Tag `v1.1.0` on main: `git tag v1.1.0 && git push origin v1.1.0`
3. Release workflow auto-creates GitHub release and notifies Packagist

**Rollback plan:**
1. Delete the tag: `git push --delete origin v1.1.0 && git tag -d v1.1.0`
2. Revert the merge commit on main

## Post-Release Tasks

- [ ] Tag created: `v1.1.0`
- [ ] Release notes published
- [ ] Documentation deployed
- [ ] Announcement sent
- [ ] Monitoring verified
- [ ] Previous version support documented

## Notes

- PHPCS step in CI is set to `continue-on-error: true` due to pre-existing issues with the ArtisanPackUIStandard ruleset (e.g., false positive on magic method casing). A follow-up issue should be created to resolve these.
- Packagist integration requires `PACKAGIST_USERNAME` and `PACKAGIST_API_TOKEN` organization secrets to be configured in GitHub.

---

**Release Manager:** @JMWebDevelopment