### PR TITLE
Adopt HasBlockContent on Post and Page (#94)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `block_content` JSON column on the `posts` and `pages` tables for visual editor block trees, alongside the existing `content` longText column
+- `Post` and `Page` models adopt `ArtisanPackUI\VisualEditor\Concerns\HasBlockContent` with a polyfill stub so visual-editor remains an optional integration rather than a hard composer dependency
+
 ### Changed
 
 ### Deprecated

--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,7 @@
       "ArtisanPackUI\\Database\\": "database/"
     },
     "files": [
+      "src/Compatibility/visual-editor.php",
       "src/Modules/Users/helpers.php",
       "src/Modules/Admin/helpers.php",
       "src/Modules/Core/helpers.php",

--- a/src/Compatibility/visual-editor.php
+++ b/src/Compatibility/visual-editor.php
@@ -1,0 +1,92 @@
+<?php
+
+/**
+ * Polyfill stub for ArtisanPackUI\VisualEditor\Concerns\HasBlockContent.
+ *
+ * Loaded via composer's autoload.files. When artisanpack-ui/visual-editor is
+ * installed, the real trait is autoloaded via PSR-4 and this stub is skipped.
+ * When visual-editor is not installed, the stub registers a minimal trait so
+ * Post and Page (which `use HasBlockContent`) still load and their
+ * `block_content` column casts to array.
+ *
+ * Keeps cms-framework's adoption of the trait soft so visual-editor remains
+ * an optional integration rather than a hard composer dependency.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage CMSFramework
+ *
+ * @since      1.2.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditor\Concerns {
+	if ( ! trait_exists( __NAMESPACE__ . '\\HasBlockContent', true ) ) {
+		/**
+		 * Minimal stub of HasBlockContent.
+		 *
+		 * Only implements cast registration and column resolution — enough for
+		 * models to round-trip the `block_content` JSON column. Apps that
+		 * actually need the editor surface install artisanpack-ui/visual-editor,
+		 * which ships the full trait (search extractor, query scope, etc.).
+		 *
+		 * @mixin \Illuminate\Database\Eloquent\Model
+		 */
+		trait HasBlockContent
+		{
+			/**
+			 * Registers an `array` cast for the configured block content column.
+			 *
+			 * @since 1.2.0
+			 */
+			public function initializeHasBlockContent(): void
+			{
+				$column = $this->getBlockContentColumn();
+
+				if ( ! array_key_exists( $column, $this->getCasts() ) ) {
+					$this->mergeCasts( [ $column => 'array' ] );
+				}
+			}
+
+			/**
+			 * Returns the column that stores the block tree JSON.
+			 *
+			 * Override by setting `protected $blockContentColumn = 'body';` on the model.
+			 *
+			 * @since 1.2.0
+			 */
+			public function getBlockContentColumn(): string
+			{
+				return isset( $this->blockContentColumn ) && is_string( $this->blockContentColumn )
+					? $this->blockContentColumn
+					: 'content';
+			}
+
+			/**
+			 * Returns the current block tree for the model.
+			 *
+			 * @since 1.2.0
+			 *
+			 * @return array<int, array<string, mixed>>
+			 */
+			public function getBlockContent(): array
+			{
+				$value = $this->getAttribute( $this->getBlockContentColumn() );
+
+				return is_array( $value ) ? $value : [];
+			}
+
+			/**
+			 * Persists a new block tree for the model.
+			 *
+			 * @since 1.2.0
+			 *
+			 * @param  array<int, array<string, mixed>>  $blocks  The block tree to store.
+			 */
+			public function setBlockContent( array $blocks ): void
+			{
+				$this->setAttribute( $this->getBlockContentColumn(), $blocks );
+			}
+		}
+	}
+}

--- a/src/Modules/Blog/Models/Post.php
+++ b/src/Modules/Blog/Models/Post.php
@@ -17,6 +17,7 @@ use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Models\Concerns\HasContentSt
 use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Models\Concerns\HasCustomFields;
 use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Models\Concerns\HasFeaturedImage;
 use ArtisanPackUI\MediaLibrary\Models\Media;
+use ArtisanPackUI\VisualEditor\Concerns\HasBlockContent;
 use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
@@ -32,6 +33,7 @@ use Illuminate\Database\Eloquent\SoftDeletes;
  * @property string $title
  * @property string $slug
  * @property string|null $content
+ * @property array<int, array<string, mixed>>|null $block_content
  * @property string|null $excerpt
  * @property int $author_id
  * @property ContentStatus $status
@@ -45,11 +47,21 @@ use Illuminate\Database\Eloquent\SoftDeletes;
  */
 class Post extends Model
 {
+    use HasBlockContent;
     use HasContentStatus;
     use HasCustomFields;
     use HasFactory;
     use HasFeaturedImage;
     use SoftDeletes;
+
+    /**
+     * The column that stores the visual editor block tree JSON.
+     *
+     * @since 1.2.0
+     *
+     * @var string
+     */
+    protected string $blockContentColumn = 'block_content';
 
     /**
      * The attributes that are mass assignable.
@@ -62,6 +74,7 @@ class Post extends Model
         'title',
         'slug',
         'content',
+        'block_content',
         'excerpt',
         'featured_image_id',
         'author_id',

--- a/src/Modules/Blog/Models/Post.php
+++ b/src/Modules/Blog/Models/Post.php
@@ -74,7 +74,6 @@ class Post extends Model
         'title',
         'slug',
         'content',
-        'block_content',
         'excerpt',
         'featured_image_id',
         'author_id',

--- a/src/Modules/Blog/database/migrations/2026_04_28_000001_add_block_content_to_posts_table.php
+++ b/src/Modules/Blog/database/migrations/2026_04_28_000001_add_block_content_to_posts_table.php
@@ -1,0 +1,29 @@
+<?php
+
+declare( strict_types=1 );
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table( 'posts', function ( Blueprint $table ): void {
+            $table->json( 'block_content' )->nullable()->after( 'content' );
+        } );
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table( 'posts', function ( Blueprint $table ): void {
+            $table->dropColumn( 'block_content' );
+        } );
+    }
+};

--- a/src/Modules/Pages/Models/Page.php
+++ b/src/Modules/Pages/Models/Page.php
@@ -79,7 +79,6 @@ class Page extends Model
         'title',
         'slug',
         'content',
-        'block_content',
         'excerpt',
         'featured_image_id',
         'author_id',

--- a/src/Modules/Pages/Models/Page.php
+++ b/src/Modules/Pages/Models/Page.php
@@ -17,6 +17,7 @@ use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Models\Concerns\HasContentSt
 use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Models\Concerns\HasCustomFields;
 use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Models\Concerns\HasFeaturedImage;
 use ArtisanPackUI\MediaLibrary\Models\Media;
+use ArtisanPackUI\VisualEditor\Concerns\HasBlockContent;
 use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
@@ -34,6 +35,7 @@ use Illuminate\Support\Collection;
  * @property string $title
  * @property string $slug
  * @property string|null $content
+ * @property array<int, array<string, mixed>>|null $block_content
  * @property string|null $excerpt
  * @property int $author_id
  * @property int|null $parent_id
@@ -50,11 +52,21 @@ use Illuminate\Support\Collection;
  */
 class Page extends Model
 {
+    use HasBlockContent;
     use HasContentStatus;
     use HasCustomFields;
     use HasFactory;
     use HasFeaturedImage;
     use SoftDeletes;
+
+    /**
+     * The column that stores the visual editor block tree JSON.
+     *
+     * @since 1.2.0
+     *
+     * @var string
+     */
+    protected string $blockContentColumn = 'block_content';
 
     /**
      * The attributes that are mass assignable.
@@ -67,6 +79,7 @@ class Page extends Model
         'title',
         'slug',
         'content',
+        'block_content',
         'excerpt',
         'featured_image_id',
         'author_id',

--- a/src/Modules/Pages/database/migrations/2026_04_28_000001_add_block_content_to_pages_table.php
+++ b/src/Modules/Pages/database/migrations/2026_04_28_000001_add_block_content_to_pages_table.php
@@ -1,0 +1,29 @@
+<?php
+
+declare( strict_types=1 );
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table( 'pages', function ( Blueprint $table ): void {
+            $table->json( 'block_content' )->nullable()->after( 'content' );
+        } );
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table( 'pages', function ( Blueprint $table ): void {
+            $table->dropColumn( 'block_content' );
+        } );
+    }
+};

--- a/tests/Unit/Blog/PostBlockContentTest.php
+++ b/tests/Unit/Blog/PostBlockContentTest.php
@@ -30,16 +30,39 @@ test( 'post block_content round-trips an array through the cast', function (): v
     ];
 
     $post = Post::create( [
-        'title'         => 'Block Post',
-        'slug'          => 'block-post',
-        'block_content' => $blocks,
-        'author_id'     => $user->id,
-        'status'        => 'draft',
+        'title'     => 'Block Post',
+        'slug'      => 'block-post',
+        'author_id' => $user->id,
+        'status'    => 'draft',
     ] );
+
+    $post->setBlockContent( $blocks );
+    $post->save();
 
     $fresh = Post::find( $post->id );
 
     expect( $fresh->block_content )->toBe( $blocks );
+} );
+
+test( 'post block_content is excluded from mass assignment', function (): void {
+    $user = TestUser::create( [
+        'name'     => 'Author',
+        'email'    => 'author@example.com',
+        'password' => 'password',
+    ] );
+
+    $post = Post::create( [
+        'title'         => 'Mass Assign',
+        'slug'          => 'mass-assign',
+        'author_id'     => $user->id,
+        'status'        => 'draft',
+        'block_content' => [
+            [ 'blockName' => 'core/paragraph', 'attrs' => [], 'innerHTML' => '<p>nope</p>' ],
+        ],
+    ] );
+
+    expect( $post->block_content )->toBeNull();
+    expect( $post->fresh()->block_content )->toBeNull();
 } );
 
 test( 'post exposes block_content via HasBlockContent helpers', function (): void {

--- a/tests/Unit/Blog/PostBlockContentTest.php
+++ b/tests/Unit/Blog/PostBlockContentTest.php
@@ -1,0 +1,89 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\CMSFramework\Modules\Blog\Models\Post;
+use ArtisanPackUI\CMSFramework\Tests\Support\TestUser;
+
+beforeEach( function (): void {
+    $this->artisan( 'migrate', ['--database' => 'testing'] );
+} );
+
+test( 'post block_content round-trips an array through the cast', function (): void {
+    $user = TestUser::create( [
+        'name'     => 'Author',
+        'email'    => 'author@example.com',
+        'password' => 'password',
+    ] );
+
+    $blocks = [
+        [
+            'blockName' => 'core/heading',
+            'attrs'     => [ 'level' => 2 ],
+            'innerHTML' => '<h2>Hello</h2>',
+        ],
+        [
+            'blockName' => 'core/paragraph',
+            'attrs'     => [],
+            'innerHTML' => '<p>World</p>',
+        ],
+    ];
+
+    $post = Post::create( [
+        'title'         => 'Block Post',
+        'slug'          => 'block-post',
+        'block_content' => $blocks,
+        'author_id'     => $user->id,
+        'status'        => 'draft',
+    ] );
+
+    $fresh = Post::find( $post->id );
+
+    expect( $fresh->block_content )->toBe( $blocks );
+} );
+
+test( 'post exposes block_content via HasBlockContent helpers', function (): void {
+    $user = TestUser::create( [
+        'name'     => 'Author',
+        'email'    => 'author@example.com',
+        'password' => 'password',
+    ] );
+
+    $post = Post::create( [
+        'title'     => 'Helpers Post',
+        'slug'      => 'helpers-post',
+        'author_id' => $user->id,
+        'status'    => 'draft',
+    ] );
+
+    expect( $post->getBlockContent() )->toBe( [] );
+    expect( $post->getBlockContentColumn() )->toBe( 'block_content' );
+
+    $blocks = [
+        [ 'blockName' => 'core/paragraph', 'attrs' => [], 'innerHTML' => '<p>Hi</p>' ],
+    ];
+
+    $post->setBlockContent( $blocks );
+    $post->save();
+
+    $fresh = Post::find( $post->id );
+
+    expect( $fresh->getBlockContent() )->toBe( $blocks );
+} );
+
+test( 'post block_content is nullable and defaults to null', function (): void {
+    $user = TestUser::create( [
+        'name'     => 'Author',
+        'email'    => 'author@example.com',
+        'password' => 'password',
+    ] );
+
+    $post = Post::create( [
+        'title'     => 'No Blocks',
+        'slug'      => 'no-blocks',
+        'author_id' => $user->id,
+        'status'    => 'draft',
+    ] );
+
+    expect( $post->block_content )->toBeNull();
+} );

--- a/tests/Unit/Pages/PageBlockContentTest.php
+++ b/tests/Unit/Pages/PageBlockContentTest.php
@@ -30,17 +30,41 @@ test( 'page block_content round-trips an array through the cast', function (): v
     ];
 
     $page = Page::create( [
-        'title'         => 'Block Page',
-        'slug'          => 'block-page',
-        'block_content' => $blocks,
-        'author_id'     => $user->id,
-        'status'        => 'draft',
-        'order'         => 0,
+        'title'     => 'Block Page',
+        'slug'      => 'block-page',
+        'author_id' => $user->id,
+        'status'    => 'draft',
+        'order'     => 0,
     ] );
+
+    $page->setBlockContent( $blocks );
+    $page->save();
 
     $fresh = Page::find( $page->id );
 
     expect( $fresh->block_content )->toBe( $blocks );
+} );
+
+test( 'page block_content is excluded from mass assignment', function (): void {
+    $user = TestUser::create( [
+        'name'     => 'Author',
+        'email'    => 'author@example.com',
+        'password' => 'password',
+    ] );
+
+    $page = Page::create( [
+        'title'         => 'Mass Assign Page',
+        'slug'          => 'mass-assign-page',
+        'author_id'     => $user->id,
+        'status'        => 'draft',
+        'order'         => 0,
+        'block_content' => [
+            [ 'blockName' => 'core/paragraph', 'attrs' => [], 'innerHTML' => '<p>nope</p>' ],
+        ],
+    ] );
+
+    expect( $page->block_content )->toBeNull();
+    expect( $page->fresh()->block_content )->toBeNull();
 } );
 
 test( 'page exposes block_content via HasBlockContent helpers', function (): void {

--- a/tests/Unit/Pages/PageBlockContentTest.php
+++ b/tests/Unit/Pages/PageBlockContentTest.php
@@ -1,0 +1,92 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\CMSFramework\Modules\Pages\Models\Page;
+use ArtisanPackUI\CMSFramework\Tests\Support\TestUser;
+
+beforeEach( function (): void {
+    $this->artisan( 'migrate', ['--database' => 'testing'] );
+} );
+
+test( 'page block_content round-trips an array through the cast', function (): void {
+    $user = TestUser::create( [
+        'name'     => 'Author',
+        'email'    => 'author@example.com',
+        'password' => 'password',
+    ] );
+
+    $blocks = [
+        [
+            'blockName' => 'core/heading',
+            'attrs'     => [ 'level' => 1 ],
+            'innerHTML' => '<h1>Hello</h1>',
+        ],
+        [
+            'blockName' => 'core/paragraph',
+            'attrs'     => [],
+            'innerHTML' => '<p>World</p>',
+        ],
+    ];
+
+    $page = Page::create( [
+        'title'         => 'Block Page',
+        'slug'          => 'block-page',
+        'block_content' => $blocks,
+        'author_id'     => $user->id,
+        'status'        => 'draft',
+        'order'         => 0,
+    ] );
+
+    $fresh = Page::find( $page->id );
+
+    expect( $fresh->block_content )->toBe( $blocks );
+} );
+
+test( 'page exposes block_content via HasBlockContent helpers', function (): void {
+    $user = TestUser::create( [
+        'name'     => 'Author',
+        'email'    => 'author@example.com',
+        'password' => 'password',
+    ] );
+
+    $page = Page::create( [
+        'title'     => 'Helpers Page',
+        'slug'      => 'helpers-page',
+        'author_id' => $user->id,
+        'status'    => 'draft',
+        'order'     => 0,
+    ] );
+
+    expect( $page->getBlockContent() )->toBe( [] );
+    expect( $page->getBlockContentColumn() )->toBe( 'block_content' );
+
+    $blocks = [
+        [ 'blockName' => 'core/paragraph', 'attrs' => [], 'innerHTML' => '<p>Hi</p>' ],
+    ];
+
+    $page->setBlockContent( $blocks );
+    $page->save();
+
+    $fresh = Page::find( $page->id );
+
+    expect( $fresh->getBlockContent() )->toBe( $blocks );
+} );
+
+test( 'page block_content is nullable and defaults to null', function (): void {
+    $user = TestUser::create( [
+        'name'     => 'Author',
+        'email'    => 'author@example.com',
+        'password' => 'password',
+    ] );
+
+    $page = Page::create( [
+        'title'     => 'No Blocks Page',
+        'slug'      => 'no-blocks-page',
+        'author_id' => $user->id,
+        'status'    => 'draft',
+        'order'     => 0,
+    ] );
+
+    expect( $page->block_content )->toBeNull();
+} );


### PR DESCRIPTION
## Description

Adds the `block_content` JSON column to the `posts` and `pages` tables and adopts `ArtisanPackUI\VisualEditor\Concerns\HasBlockContent` on the `Post` and `Page` models so the visual editor can edit their content as a block tree. The legacy `content` longText column is preserved untouched.

This is **Wave 1, G1a** of the visual-editor V1 issue roadmap (`docs/plans/15-issue-roadmap.md` in the visual-editor repo). It unblocks G1b (`#99` — register Post/Page into the resource filter) and the rest of Phase G.

**Closes:** #94

## Type of Change

- [x] New feature (adds new functionality)

## Related Issue

**Issue:** #94

## Motivation and Context

Phase G of the visual-editor V1 plan needs cms-framework's `Post` and `Page` to expose a block tree the editor can read/write through the WP-shape REST entity adapter (visual-editor `#399`). G1a is the database + model adoption step — separate from filter registration (G1b/#99) so apps that don't install visual-editor still get the column without picking up unused integration code.

The `HasBlockContent` trait is provided by visual-editor and **must not** become a hard composer dependency on cms-framework. A polyfill stub at `src/Compatibility/visual-editor.php` (registered via `composer.json` `autoload.files`) defines a minimal stand-in only when visual-editor is not installed. PSR-4 autoloading finds the real trait first when it is, so the polyfill is skipped.

## Changes Made

- New migration `2026_04_28_000001_add_block_content_to_posts_table.php` — adds `block_content json nullable` after `content` on `posts`. Reverse drops the column.
- New migration `2026_04_28_000001_add_block_content_to_pages_table.php` — same shape on `pages`.
- `Post` and `Page` models adopt `use HasBlockContent;` with `protected string \$blockContentColumn = 'block_content';` and add `block_content` to `\$fillable`. `HasBlockContent::initializeHasBlockContent()` registers the array cast automatically — no entry in `casts()` required.
- `src/Compatibility/visual-editor.php` — polyfill stub trait (cast registration + `getBlockContent`/`setBlockContent` + column resolution). Loaded via `composer.json` `autoload.files`, gated by `trait_exists()` so the real trait wins when visual-editor is installed.
- New tests `tests/Unit/Blog/PostBlockContentTest.php` and `tests/Unit/Pages/PageBlockContentTest.php` — round-trip the array through the cast, verify trait helpers work, and verify the column defaults to null.
- `CHANGELOG.md` — Unreleased entry.

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS
- PHP Version: 8.4.3
- Project Version: \`release/1.2\` HEAD

**Tests Performed:**
1. \`./vendor/bin/pest tests/Unit/Blog/PostBlockContentTest.php tests/Unit/Pages/PageBlockContentTest.php --compact\` — 6 new tests pass (10 assertions).
2. \`./vendor/bin/pest --compact\` — full suite: 4 skipped, 602 passed (1545 assertions). No regressions.
3. \`./vendor/bin/php-cs-fixer fix --dry-run --diff\` — clean (no fixes required).
4. Manual tinker round-trip in the dev app: \`Page::create([..., 'block_content' => [...]])\` followed by \`->fresh()->block_content\` returns the expected array.

## Accessibility Tests Run

- [x] N/A — backend-only change (database column + model trait). No UI affected.

## Tests Added

- [x] Unit tests added
- [x] All tests passing

**Test details:** 3 tests per model (round-trip cast, trait helpers, null default) — 6 tests, 10 assertions total.

## Documentation

- [x] Inline code documentation added (PHPDoc on polyfill, migration, and model changes)
- [x] CHANGELOG updated

**Documentation details:** Polyfill file documents the autoload-files contract and the trait_exists guard. Model PHPDoc adds `block_content` `@property` annotation.

## Pre-Submission Checklist

- [x] Code passes all tests
- [x] Code has been linted (php-cs-fixer)
- [x] Code follows project style guide
- [x] Self-review completed
- [x] No new warnings generated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Posts and Pages now support visual block content for richer editing and structured storage.

* **Chores**
  * Added optional visual-editor integration while keeping it non-mandatory and backward-compatible.
  * Database schema updated to store block content alongside existing content with reversible migrations.

* **Tests**
  * New unit tests cover block content persistence, defaults, and mass-assignment behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->