### PR TITLE
feat: H0 — extend theme.json with WP schema (#100)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,8 @@
     "artisanpack-ui/security": "^1.0.3",
     "artisanpack-ui/core": "^1.0",
     "artisanpack-ui/hooks": "^1.1",
-    "dedoc/scramble": "^0.12 || ^0.13"
+    "dedoc/scramble": "^0.12 || ^0.13",
+    "justinrainbow/json-schema": "^6.0"
   },
   "require-dev": {
     "pestphp/pest": "^3.8",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "93b3dbd8864ebe1fd031830abf454eb4",
+    "content-hash": "72c516e40ec3e129b18b47fa14f1e49a",
     "packages": [
         {
             "name": "artisanpack-ui/accessibility",
@@ -1400,6 +1400,81 @@
             "time": "2025-08-22T14:27:06+00:00"
         },
         {
+            "name": "justinrainbow/json-schema",
+            "version": "6.8.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/jsonrainbow/json-schema.git",
+                "reference": "89ac92bcfe5d0a8a4433c7b89d394553ae7250cc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/jsonrainbow/json-schema/zipball/89ac92bcfe5d0a8a4433c7b89d394553ae7250cc",
+                "reference": "89ac92bcfe5d0a8a4433c7b89d394553ae7250cc",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "marc-mabe/php-enum": "^4.4",
+                "php": "^7.2 || ^8.0"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "3.3.0",
+                "json-schema/json-schema-test-suite": "^23.2",
+                "marc-mabe/php-enum-phpstan": "^2.0",
+                "phpspec/prophecy": "^1.19",
+                "phpstan/phpstan": "^1.12",
+                "phpunit/phpunit": "^8.5"
+            },
+            "bin": [
+                "bin/validate-json"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "6.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "JsonSchema\\": "src/JsonSchema/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Bruno Prieto Reis",
+                    "email": "bruno.p.reis@gmail.com"
+                },
+                {
+                    "name": "Justin Rainbow",
+                    "email": "justin.rainbow@gmail.com"
+                },
+                {
+                    "name": "Igor Wiedler",
+                    "email": "igor@wiedler.ch"
+                },
+                {
+                    "name": "Robert Schönthal",
+                    "email": "seroscho@googlemail.com"
+                }
+            ],
+            "description": "A library to validate a json schema.",
+            "homepage": "https://github.com/jsonrainbow/json-schema",
+            "keywords": [
+                "json",
+                "schema"
+            ],
+            "support": {
+                "issues": "https://github.com/jsonrainbow/json-schema/issues",
+                "source": "https://github.com/jsonrainbow/json-schema/tree/6.8.0"
+            },
+            "time": "2026-04-02T12:43:11+00:00"
+        },
+        {
             "name": "laminas/laminas-escaper",
             "version": "2.18.0",
             "source": {
@@ -2426,6 +2501,79 @@
                 }
             ],
             "time": "2025-12-07T16:03:21+00:00"
+        },
+        {
+            "name": "marc-mabe/php-enum",
+            "version": "v4.7.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/marc-mabe/php-enum.git",
+                "reference": "bb426fcdd65c60fb3638ef741e8782508fda7eef"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/marc-mabe/php-enum/zipball/bb426fcdd65c60fb3638ef741e8782508fda7eef",
+                "reference": "bb426fcdd65c60fb3638ef741e8782508fda7eef",
+                "shasum": ""
+            },
+            "require": {
+                "ext-reflection": "*",
+                "php": "^7.1 | ^8.0"
+            },
+            "require-dev": {
+                "phpbench/phpbench": "^0.16.10 || ^1.0.4",
+                "phpstan/phpstan": "^1.3.1",
+                "phpunit/phpunit": "^7.5.20 | ^8.5.22 | ^9.5.11",
+                "vimeo/psalm": "^4.17.0 | ^5.26.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-3.x": "3.2-dev",
+                    "dev-master": "4.7-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "MabeEnum\\": "src/"
+                },
+                "classmap": [
+                    "stubs/Stringable.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Marc Bennewitz",
+                    "email": "dev@mabe.berlin",
+                    "homepage": "https://mabe.berlin/",
+                    "role": "Lead"
+                }
+            ],
+            "description": "Simple and fast implementation of enumerations with native PHP",
+            "homepage": "https://github.com/marc-mabe/php-enum",
+            "keywords": [
+                "enum",
+                "enum-map",
+                "enum-set",
+                "enumeration",
+                "enumerator",
+                "enummap",
+                "enumset",
+                "map",
+                "set",
+                "type",
+                "type-hint",
+                "typehint"
+            ],
+            "support": {
+                "issues": "https://github.com/marc-mabe/php-enum/issues",
+                "source": "https://github.com/marc-mabe/php-enum/tree/v4.7.2"
+            },
+            "time": "2025-09-14T11:18:39+00:00"
         },
         {
             "name": "monolog/monolog",

--- a/docs/themes.md
+++ b/docs/themes.md
@@ -73,9 +73,98 @@ return [
         'cacheEnabled' => env('THEMES_CACHE_ENABLED', true),
         'cacheKey' => 'cms.themes.discovered',
         'cacheTtl' => 3600, // 1 hour
+
+        // WordPress theme.json schema version used to validate the WP-shape
+        // subset of theme.json. Pinned to match the @wordpress/* package
+        // versions in artisanpack-ui/visual-editor.
+        'wpThemeJsonSchemaVersion' => '3',
     ],
 ];
 ```
+
+## Theme Manifest
+
+`theme.json` carries cms-framework metadata plus an optional WordPress-shape subset for site-editor integration.
+
+### cms-framework manifest fields
+
+```json
+{
+    "name": "Digital Shopfront",
+    "slug": "digital-shopfront",
+    "version": "1.0.0",
+    "description": "A reference theme.",
+    "author": "Jacob Martella",
+    "screenshot": "screenshot.png"
+}
+```
+
+These fields are unchanged from earlier versions and are required for theme discovery.
+
+### WordPress theme.json subset
+
+Themes can additionally carry the WordPress `theme.json` top-level keys to drive global styles, custom templates, template parts, and patterns:
+
+```json
+{
+    "name": "Digital Shopfront",
+    "slug": "digital-shopfront",
+    "version": "1.0.0",
+    "$schema": "https://schemas.wp.org/wp/6.8/theme.json",
+
+    "settings": {
+        "color": {
+            "palette": [
+                { "slug": "primary", "name": "Primary", "color": "#3b82f6" }
+            ]
+        },
+        "typography": {
+            "fontSizes": [
+                { "slug": "small", "name": "Small", "size": "0.875rem" }
+            ]
+        }
+    },
+    "styles": {
+        "color": { "background": "#ffffff", "text": "#111827" }
+    },
+    "customTemplates": [
+        { "name": "page-with-sidebar", "title": "Page with sidebar" }
+    ],
+    "templateParts": [
+        { "name": "header", "title": "Header", "area": "header" }
+    ],
+    "patterns": [ "my-namespace/cta" ]
+}
+```
+
+The WP-shape subset is validated against the WordPress `theme.json` schema version pinned in `cms.themes.wpThemeJsonSchemaVersion` (default `'3'`, matching WordPress 6.8). Bumping the pinned version requires also updating the bundled schema file at `src/Modules/Themes/Validation/schemas/wp-theme-json-v{N}.json`.
+
+### `menus.locations` extension
+
+cms-framework adds a `menus.locations` extension that overrides the default menu locations configured in `config('cms.menus.locations')`. Theme entries replace app-defined locations by key:
+
+```json
+{
+    "menus": {
+        "locations": {
+            "primary": "Primary Menu",
+            "footer":  "Footer Menu"
+        }
+    }
+}
+```
+
+`menus.locations` must be an object mapping location keys (strings) to display labels (strings). Lists or non-string values are rejected.
+
+### Validation behavior
+
+When `ThemeManager::discoverThemes()` runs, each theme is validated in three stages:
+
+1. The theme directory exists.
+2. All `cms.themes.requiredFiles` entries are present.
+3. The `theme.json` manifest passes the pinned WP schema (for any WP-shape keys it carries) and the `menus.locations` extension shape.
+
+Themes that fail any stage are skipped from discovery. Schema failures log a warning naming the offending key (e.g. `settings.color.palette`) so theme authors can correct their manifest.
 
 ## Template Hierarchy
 

--- a/src/Modules/Themes/Managers/ThemeManager.php
+++ b/src/Modules/Themes/Managers/ThemeManager.php
@@ -16,9 +16,11 @@ use Artisan;
 use ArtisanPackUI\CMSFramework\Modules\Core\Managers\Concerns\HasManifestParsing;
 use ArtisanPackUI\CMSFramework\Modules\Settings\Managers\SettingsManager;
 use ArtisanPackUI\CMSFramework\Modules\Themes\Exceptions\ThemeNotFoundException;
+use ArtisanPackUI\CMSFramework\Modules\Themes\Validation\WpThemeJsonValidator;
 use Exception;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\View;
 
 /**
@@ -43,9 +45,11 @@ class ThemeManager
      * @since 1.0.0
      *
      * @param  SettingsManager  $settingsManager  Settings manager instance.
+     * @param  WpThemeJsonValidator  $wpThemeJsonValidator  Validator for the WP-shape subset of theme.json.
      */
     public function __construct(
         private SettingsManager $settingsManager,
+        private WpThemeJsonValidator $wpThemeJsonValidator,
     ) {
     }
 
@@ -317,8 +321,15 @@ class ThemeManager
     /**
      * Validates a theme's structure and manifest.
      *
-     * Checks that the theme directory exists and contains all required files
-     * as specified in the cms.themes.requiredFiles configuration.
+     * Performs three checks:
+     * 1. The theme directory exists.
+     * 2. All `cms.themes.requiredFiles` entries are present.
+     * 3. The `theme.json` manifest passes the pinned WP theme.json schema
+     *    (for any WP-shape keys it carries) and the cms-framework
+     *    `menus.locations` extension shape.
+     *
+     * Manifests that fail schema validation are skipped from discovery and
+     * a warning is logged naming the offending key.
      *
      * @since 1.0.0
      *
@@ -338,6 +349,28 @@ class ThemeManager
             if ( ! File::exists( $themePath . '/' . $file ) ) {
                 return false;
             }
+        }
+
+        $manifest = $this->parseManifest( $themePath . '/theme.json' );
+
+        if ( null === $manifest ) {
+            Log::warning( 'Theme has invalid theme.json (parse failed).', [
+                'path' => $themePath,
+            ] );
+
+            return false;
+        }
+
+        $result = $this->wpThemeJsonValidator->validate( $manifest );
+
+        if ( ! $result->valid ) {
+            Log::warning( 'Theme rejected: theme.json failed schema validation.', [
+                'path'         => $themePath,
+                'offendingKey' => $result->offendingKey,
+                'message'      => $result->message,
+            ] );
+
+            return false;
         }
 
         return true;

--- a/src/Modules/Themes/Providers/ThemesServiceProvider.php
+++ b/src/Modules/Themes/Providers/ThemesServiceProvider.php
@@ -15,6 +15,7 @@ namespace ArtisanPackUI\CMSFramework\Modules\Themes\Providers;
 use ArtisanPackUI\CMSFramework\Modules\Settings\Enums\SettingType;
 use ArtisanPackUI\CMSFramework\Modules\Settings\Managers\SettingsManager;
 use ArtisanPackUI\CMSFramework\Modules\Themes\Managers\ThemeManager;
+use ArtisanPackUI\CMSFramework\Modules\Themes\Validation\WpThemeJsonValidator;
 use Illuminate\Support\ServiceProvider;
 
 /**
@@ -41,10 +42,14 @@ class ThemesServiceProvider extends ServiceProvider
      */
     public function register(): void
     {
+        // Register WP theme.json validator as singleton
+        $this->app->singleton( WpThemeJsonValidator::class );
+
         // Register ThemeManager as singleton
         $this->app->singleton( ThemeManager::class, function ( $app ) {
             return new ThemeManager(
                 $app->make( SettingsManager::class ),
+                $app->make( WpThemeJsonValidator::class ),
             );
         } );
 

--- a/src/Modules/Themes/Validation/WpThemeJsonValidationResult.php
+++ b/src/Modules/Themes/Validation/WpThemeJsonValidationResult.php
@@ -1,0 +1,59 @@
+<?php
+
+/**
+ * WP theme.json Validation Result
+ *
+ * @since      1.2.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Modules\Themes\Validation;
+
+/**
+ * Outcome of a {@see WpThemeJsonValidator::validate()} call.
+ *
+ * Carries enough detail for the caller to log a warning naming the offending
+ * key when validation fails.
+ *
+ * @since 1.2.0
+ */
+final class WpThemeJsonValidationResult
+{
+    /**
+     * @since 1.2.0
+     *
+     * @param  bool  $valid  True when the manifest passes WP-schema + extension shape checks.
+     * @param  string|null  $offendingKey  Dotted path of the first failing property, or null on success.
+     * @param  string|null  $message  Human-readable error message, or null on success.
+     */
+    public function __construct(
+        public readonly bool $valid,
+        public readonly ?string $offendingKey,
+        public readonly ?string $message,
+    ) {
+    }
+
+    /**
+     * Build a passing result.
+     *
+     * @since 1.2.0
+     */
+    public static function success(): self
+    {
+        return new self( true, null, null );
+    }
+
+    /**
+     * Build a failing result.
+     *
+     * @since 1.2.0
+     *
+     * @param  string  $offendingKey  Dotted path of the failing property (e.g. `settings.color`).
+     * @param  string  $message  Description of why the property failed.
+     */
+    public static function failure( string $offendingKey, string $message ): self
+    {
+        return new self( false, $offendingKey, $message );
+    }
+}

--- a/src/Modules/Themes/Validation/WpThemeJsonValidator.php
+++ b/src/Modules/Themes/Validation/WpThemeJsonValidator.php
@@ -1,0 +1,196 @@
+<?php
+
+/**
+ * WordPress theme.json Validator
+ *
+ * Validates the WP-shape subset of a cms-framework theme manifest against
+ * a pinned WordPress theme.json schema, plus the cms-framework `menus.locations`
+ * extension.
+ *
+ * @since      1.2.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Modules\Themes\Validation;
+
+use JsonSchema\Constraints\Constraint;
+use JsonSchema\Validator;
+use RuntimeException;
+
+/**
+ * Validates the WP-shape subset of a theme manifest against the pinned
+ * WordPress theme.json schema, plus the cms-framework `menus.locations`
+ * extension.
+ *
+ * cms-framework's manifest fields (`name`, `version`, `description`, `author`,
+ * `screenshot`, `slug`) are intentionally not run through the WP schema:
+ * the WP schema declares `additionalProperties: false` at the top level and
+ * types `version` as the integer schema-version (`const: 3`), which conflicts
+ * with cms-framework's semver-string `version`. Instead, this validator
+ * extracts only the WP-shape keys and validates them as a synthetic minimal
+ * object.
+ *
+ * @since 1.2.0
+ */
+class WpThemeJsonValidator
+{
+    /**
+     * Top-level keys defined by the WordPress theme.json schema.
+     *
+     * @since 1.2.0
+     */
+    private const WP_SHAPE_KEYS = [
+        'settings',
+        'styles',
+        'customTemplates',
+        'templateParts',
+        'patterns',
+    ];
+
+    /**
+     * Validate a parsed theme manifest.
+     *
+     * Themes carrying none of the WP-shape keys and no `menus` extension
+     * pass through unchecked (backwards-compatible with pre-Phase-H themes).
+     *
+     * @since 1.2.0
+     *
+     * @param  array  $manifest  Decoded theme.json contents.
+     */
+    public function validate( array $manifest ): WpThemeJsonValidationResult
+    {
+        $present = array_intersect_key( $manifest, array_flip( self::WP_SHAPE_KEYS ) );
+
+        if ( [] === $present && ! array_key_exists( 'menus', $manifest ) ) {
+            return WpThemeJsonValidationResult::success();
+        }
+
+        if ( [] !== $present ) {
+            $wpResult = $this->validateAgainstWpSchema( $present );
+
+            if ( ! $wpResult->valid ) {
+                return $wpResult;
+            }
+        }
+
+        if ( array_key_exists( 'menus', $manifest ) ) {
+            $menusResult = $this->validateMenusExtension( $manifest['menus'] );
+
+            if ( ! $menusResult->valid ) {
+                return $menusResult;
+            }
+        }
+
+        return WpThemeJsonValidationResult::success();
+    }
+
+    /**
+     * Run the WP-shape subset through the pinned WP theme.json schema.
+     *
+     * @since 1.2.0
+     *
+     * @param  array  $wpShapeSubset  Manifest keys that overlap with the WP schema.
+     */
+    protected function validateAgainstWpSchema( array $wpShapeSubset ): WpThemeJsonValidationResult
+    {
+        $version = (string) config( 'cms.themes.wpThemeJsonSchemaVersion', '3' );
+        $schema  = $this->loadSchema( $version );
+
+        $subject = json_decode( json_encode( [ 'version' => (int) $version ] + $wpShapeSubset ) );
+
+        $validator = new Validator();
+        $validator->validate( $subject, $schema, Constraint::CHECK_MODE_TYPE_CAST );
+
+        if ( $validator->isValid() ) {
+            return WpThemeJsonValidationResult::success();
+        }
+
+        $errors = $validator->getErrors();
+        $first  = $errors[0] ?? [
+            'property' => '',
+            'message'  => 'Unknown schema validation error',
+        ];
+        $key = '' !== $first['property'] ? $first['property'] : '(root)';
+
+        return WpThemeJsonValidationResult::failure( $key, $first['message'] );
+    }
+
+    /**
+     * Validate the cms-framework `menus.locations` extension shape.
+     *
+     * `menus.locations` must be an object mapping string location keys to
+     * string display labels. Any other shape under `menus` is rejected.
+     *
+     * @since 1.2.0
+     *
+     * @param  mixed  $menus  Value of the manifest's `menus` key.
+     */
+    protected function validateMenusExtension( mixed $menus ): WpThemeJsonValidationResult
+    {
+        if ( ! is_array( $menus ) ) {
+            return WpThemeJsonValidationResult::failure( 'menus', 'menus must be an object.' );
+        }
+
+        if ( ! array_key_exists( 'locations', $menus ) ) {
+            return WpThemeJsonValidationResult::success();
+        }
+
+        $locations = $menus['locations'];
+
+        if ( ! is_array( $locations ) || array_is_list( $locations ) ) {
+            return WpThemeJsonValidationResult::failure(
+                'menus.locations',
+                'menus.locations must be an object mapping location keys to display labels.',
+            );
+        }
+
+        foreach ( $locations as $key => $label ) {
+            if ( ! is_string( $key ) || '' === $key ) {
+                return WpThemeJsonValidationResult::failure(
+                    'menus.locations',
+                    'menus.locations keys must be non-empty strings.',
+                );
+            }
+
+            if ( ! is_string( $label ) ) {
+                return WpThemeJsonValidationResult::failure(
+                    "menus.locations.{$key}",
+                    "menus.locations.{$key} must be a string label.",
+                );
+            }
+        }
+
+        return WpThemeJsonValidationResult::success();
+    }
+
+    /**
+     * Load the bundled WP theme.json schema for the given version.
+     *
+     * @since 1.2.0
+     *
+     * @param  string  $version  Schema version (e.g. `'3'`).
+     *
+     * @throws RuntimeException If the bundled schema file is missing or malformed.
+     */
+    protected function loadSchema( string $version ): object
+    {
+        $path = __DIR__ . "/schemas/wp-theme-json-v{$version}.json";
+
+        if ( ! is_file( $path ) ) {
+            throw new RuntimeException(
+                "Bundled WP theme.json schema for version {$version} not found at {$path}.",
+            );
+        }
+
+        $schema = json_decode( file_get_contents( $path ) );
+
+        if ( ! is_object( $schema ) ) {
+            throw new RuntimeException(
+                "Bundled WP theme.json schema for version {$version} is not valid JSON.",
+            );
+        }
+
+        return $schema;
+    }
+}

--- a/src/Modules/Themes/Validation/WpThemeJsonValidator.php
+++ b/src/Modules/Themes/Validation/WpThemeJsonValidator.php
@@ -119,8 +119,9 @@ class WpThemeJsonValidator
     /**
      * Validate the cms-framework `menus.locations` extension shape.
      *
-     * `menus.locations` must be an object mapping string location keys to
-     * string display labels. Any other shape under `menus` is rejected.
+     * `menus` must be an object containing only `locations` (no other sibling
+     * keys are recognised). `menus.locations` must be an object mapping
+     * string location keys to string display labels.
      *
      * @since 1.2.0
      *
@@ -128,8 +129,17 @@ class WpThemeJsonValidator
      */
     protected function validateMenusExtension( mixed $menus ): WpThemeJsonValidationResult
     {
-        if ( ! is_array( $menus ) ) {
+        if ( ! is_array( $menus ) || ( [] !== $menus && array_is_list( $menus ) ) ) {
             return WpThemeJsonValidationResult::failure( 'menus', 'menus must be an object.' );
+        }
+
+        $unknownKeys = array_diff( array_keys( $menus ), [ 'locations' ] );
+
+        if ( [] !== $unknownKeys ) {
+            return WpThemeJsonValidationResult::failure(
+                'menus',
+                'menus may only contain the "locations" key; unknown keys: ' . implode( ', ', $unknownKeys ) . '.',
+            );
         }
 
         if ( ! array_key_exists( 'locations', $menus ) ) {

--- a/src/Modules/Themes/Validation/schemas/wp-theme-json-v3.json
+++ b/src/Modules/Themes/Validation/schemas/wp-theme-json-v3.json
@@ -1,0 +1,2733 @@
+{
+	"title": "JSON schema for WordPress block theme global settings and styles",
+	"$schema": "http://json-schema.org/draft-07/schema#",
+	"definitions": {
+		"//": {
+			"explainer": "https://developer.wordpress.org/themes/advanced-topics/theme-json/",
+			"createTheme": "https://developer.wordpress.org/themes/",
+			"reference": "https://developer.wordpress.org/block-editor/how-to-guides/themes/theme-json/"
+		},
+		"refComplete": {
+			"type": "object",
+			"properties": {
+				"ref": {
+					"description": "A reference to another property value. e.g. `styles.color.text`",
+					"type": "string"
+				}
+			},
+			"additionalProperties": false
+		},
+		"settingsAppearanceToolsProperties": {
+			"type": "object",
+			"properties": {
+				"appearanceTools": {
+					"description": "Setting that enables the following UI tools:\n\n- background: backgroundImage, backgroundSize\n- border: color, radius, style, width\n- color: link, heading, button, caption\n- dimensions: aspectRatio, minHeight\n- position: sticky\n- spacing: blockGap, margin, padding\n- typography: lineHeight",
+					"type": "boolean",
+					"default": false
+				}
+			}
+		},
+		"settingsBackgroundProperties": {
+			"type": "object",
+			"properties": {
+				"background": {
+					"description": "Settings related to background.",
+					"type": "object",
+					"properties": {
+						"backgroundImage": {
+							"description": "Allow users to set a background image.",
+							"type": "boolean",
+							"default": false
+						},
+						"backgroundSize": {
+							"description": "Allow users to set values related to the size of a background image, including size, position, and repeat controls.",
+							"type": "boolean",
+							"default": false
+						}
+					},
+					"additionalProperties": false
+				}
+			}
+		},
+		"settingsBorderProperties": {
+			"type": "object",
+			"properties": {
+				"border": {
+					"description": "Settings related to borders.",
+					"type": "object",
+					"properties": {
+						"color": {
+							"description": "Allow users to set custom border colors.",
+							"type": "boolean",
+							"default": false
+						},
+						"radius": {
+							"description": "Allow users to set custom border radius.",
+							"type": "boolean",
+							"default": false
+						},
+						"style": {
+							"description": "Allow users to set custom border styles.",
+							"type": "boolean",
+							"default": false
+						},
+						"width": {
+							"description": "Allow users to set custom border widths.",
+							"type": "boolean",
+							"default": false
+						}
+					},
+					"additionalProperties": false
+				}
+			}
+		},
+		"settingsColorProperties": {
+			"type": "object",
+			"properties": {
+				"color": {
+					"description": "Settings related to colors.",
+					"type": "object",
+					"properties": {
+						"background": {
+							"description": "Allow users to set background colors.",
+							"type": "boolean",
+							"default": true
+						},
+						"custom": {
+							"description": "Allow users to select custom colors.",
+							"type": "boolean",
+							"default": true
+						},
+						"customDuotone": {
+							"description": "Allow users to create custom duotone filters.",
+							"type": "boolean",
+							"default": true
+						},
+						"customGradient": {
+							"description": "Allow users to create custom gradients.",
+							"type": "boolean",
+							"default": true
+						},
+						"defaultDuotone": {
+							"description": "Allow users to choose filters from the default duotone filter presets.",
+							"type": "boolean",
+							"default": true
+						},
+						"defaultGradients": {
+							"description": "Allow users to choose colors from the default gradients.",
+							"type": "boolean",
+							"default": true
+						},
+						"defaultPalette": {
+							"description": "Allow users to choose colors from the default palette.",
+							"type": "boolean",
+							"default": true
+						},
+						"duotone": {
+							"description": "Duotone presets for the duotone picker.\nDoesn't generate classes or properties.",
+							"type": "array",
+							"items": {
+								"type": "object",
+								"properties": {
+									"name": {
+										"description": "Name of the duotone preset, translatable.",
+										"type": "string"
+									},
+									"slug": {
+										"description": "Kebab-case unique identifier for the duotone preset.",
+										"type": "string"
+									},
+									"colors": {
+										"description": "List of colors from dark to light.",
+										"type": "array",
+										"items": {
+											"description": "CSS hex or rgb string.",
+											"type": "string"
+										}
+									}
+								},
+								"required": [ "name", "slug", "colors" ],
+								"additionalProperties": false
+							}
+						},
+						"gradients": {
+							"description": "Gradient presets for the gradient picker.\nGenerates a single class (`.has-{slug}-background`) and custom property (`--wp--preset--gradient--{slug}`) per preset value.",
+							"type": "array",
+							"items": {
+								"type": "object",
+								"properties": {
+									"name": {
+										"description": "Name of the gradient preset, translatable.",
+										"type": "string"
+									},
+									"slug": {
+										"description": "Kebab-case unique identifier for the gradient preset.",
+										"type": "string"
+									},
+									"gradient": {
+										"description": "CSS gradient string.",
+										"type": "string"
+									}
+								},
+								"required": [ "name", "slug", "gradient" ],
+								"additionalProperties": false
+							}
+						},
+						"link": {
+							"description": "Allow users to set link colors in a block.",
+							"type": "boolean",
+							"default": false
+						},
+						"palette": {
+							"description": "Color palette presets for the color picker.\nGenerates three classes (`.has-{slug}-color`, `.has-{slug}-background-color`, and `.has-{slug}-border-color`) and a single custom property (`--wp--preset--color--{slug}`) per preset value.",
+							"type": "array",
+							"items": {
+								"type": "object",
+								"properties": {
+									"name": {
+										"description": "Name of the color preset, translatable.",
+										"type": "string"
+									},
+									"slug": {
+										"description": "Kebab-case unique identifier for the color preset.",
+										"type": "string"
+									},
+									"color": {
+										"description": "CSS hex or rgb(a) string.",
+										"type": "string"
+									}
+								},
+								"required": [ "name", "slug", "color" ],
+								"additionalProperties": false
+							}
+						},
+						"text": {
+							"description": "Allow users to set text colors in a block.",
+							"type": "boolean",
+							"default": true
+						},
+						"heading": {
+							"description": "Allow users to set heading colors in a block.",
+							"type": "boolean",
+							"default": true
+						},
+						"button": {
+							"description": "Allow users to set button colors in a block.",
+							"type": "boolean",
+							"default": true
+						},
+						"caption": {
+							"description": "Allow users to set caption colors in a block.",
+							"type": "boolean",
+							"default": true
+						}
+					},
+					"additionalProperties": false
+				}
+			}
+		},
+		"settingsDimensionsProperties": {
+			"type": "object",
+			"properties": {
+				"dimensions": {
+					"description": "Settings related to dimensions.",
+					"type": "object",
+					"properties": {
+						"aspectRatio": {
+							"description": "Allow users to set an aspect ratio.",
+							"type": "boolean",
+							"default": false
+						},
+						"defaultAspectRatios": {
+							"description": "Allow users to choose aspect ratios from the default set of aspect ratios.",
+							"type": "boolean",
+							"default": true
+						},
+						"aspectRatios": {
+							"description": "Allow users to define aspect ratios for some blocks.",
+							"type": "array",
+							"items": {
+								"type": "object",
+								"properties": {
+									"name": {
+										"description": "Name of the aspect ratio preset.",
+										"type": "string"
+									},
+									"slug": {
+										"description": "Kebab-case unique identifier for the aspect ratio preset.",
+										"type": "string"
+									},
+									"ratio": {
+										"description": "Aspect ratio expressed as a division or decimal.",
+										"type": "string"
+									}
+								}
+							}
+						},
+						"minHeight": {
+							"description": "Allow users to set custom minimum height.",
+							"type": "boolean",
+							"default": false
+						}
+					},
+					"additionalProperties": false
+				}
+			}
+		},
+		"settingsLayoutProperties": {
+			"type": "object",
+			"properties": {
+				"layout": {
+					"description": "Settings related to layout.",
+					"type": "object",
+					"properties": {
+						"contentSize": {
+							"description": "Sets the max-width of the content.",
+							"type": "string"
+						},
+						"wideSize": {
+							"description": "Sets the max-width of wide (`.alignwide`) content. Also used as the maximum viewport when calculating fluid font sizes",
+							"type": "string"
+						},
+						"allowEditing": {
+							"description": "Disable the layout UI controls.",
+							"type": "boolean",
+							"default": true
+						},
+						"allowCustomContentAndWideSize": {
+							"description": "Enable or disable the custom content and wide size controls.",
+							"type": "boolean",
+							"default": true
+						}
+					},
+					"additionalProperties": false
+				}
+			}
+		},
+		"settingsLightboxProperties": {
+			"type": "object",
+			"properties": {
+				"lightbox": {
+					"description": "Settings related to the lightbox.",
+					"type": "object",
+					"properties": {
+						"enabled": {
+							"description": "Defines whether the lightbox is enabled or not.",
+							"type": "boolean"
+						},
+						"allowEditing": {
+							"description": "Defines whether to show the Lightbox UI in the block editor. If set to `false`, the user won't be able to change the lightbox settings in the block editor.",
+							"type": "boolean"
+						}
+					},
+					"additionalProperties": false
+				}
+			}
+		},
+		"settingsPositionProperties": {
+			"type": "object",
+			"properties": {
+				"position": {
+					"description": "Settings related to position.",
+					"type": "object",
+					"properties": {
+						"sticky": {
+							"description": "Allow users to set sticky position.",
+							"type": "boolean",
+							"default": false
+						}
+					},
+					"additionalProperties": false
+				}
+			}
+		},
+		"settingsShadowProperties": {
+			"type": "object",
+			"properties": {
+				"shadow": {
+					"description": "Settings related to shadows.",
+					"type": "object",
+					"properties": {
+						"defaultPresets": {
+							"description": "Allow users to choose shadows from the default shadow presets.",
+							"type": "boolean",
+							"default": true
+						},
+						"presets": {
+							"description": "Shadow presets for the shadow picker.\nGenerates a single custom property (`--wp--preset--shadow--{slug}`) per preset value.",
+							"type": "array",
+							"items": {
+								"type": "object",
+								"properties": {
+									"name": {
+										"description": "Name of the shadow preset, translatable.",
+										"type": "string"
+									},
+									"slug": {
+										"description": "Kebab-case unique identifier for the shadow preset.",
+										"type": "string"
+									},
+									"shadow": {
+										"description": "CSS box-shadow value",
+										"type": "string"
+									}
+								},
+								"required": [ "name", "slug", "shadow" ],
+								"additionalProperties": false
+							}
+						}
+					},
+					"additionalProperties": false
+				}
+			}
+		},
+		"settingsSpacingProperties": {
+			"type": "object",
+			"properties": {
+				"spacing": {
+					"description": "Settings related to spacing.",
+					"type": "object",
+					"properties": {
+						"blockGap": {
+							"description": "Enables `--wp--style--block-gap` to be generated from styles.spacing.blockGap.\nA value of `null` instead of `false` further disables layout styles from being generated.",
+							"oneOf": [
+								{ "type": "boolean" },
+								{ "type": "null" }
+							],
+							"default": null
+						},
+						"margin": {
+							"description": "Allow users to set a custom margin.",
+							"type": "boolean",
+							"default": false
+						},
+						"padding": {
+							"description": "Allow users to set a custom padding.",
+							"type": "boolean",
+							"default": false
+						},
+						"units": {
+							"description": "List of units the user can use for spacing values.",
+							"type": "array",
+							"items": {
+								"type": "string"
+							},
+							"minItems": 1,
+							"default": [ "px", "em", "rem", "vh", "vw", "%" ]
+						},
+						"customSpacingSize": {
+							"description": "Allow users to set custom space sizes.",
+							"type": "boolean",
+							"default": true
+						},
+						"defaultSpacingSizes": {
+							"description": "Allow users to choose space sizes from the default space size presets.",
+							"type": "boolean",
+							"default": true
+						},
+						"spacingSizes": {
+							"description": "Space size presets for the space size selector.\nGenerates a custom property (`--wp--preset--spacing--{slug}`) per preset value.",
+							"type": "array",
+							"items": {
+								"type": "object",
+								"properties": {
+									"name": {
+										"description": "Name of the space size preset, translatable.",
+										"type": "string"
+									},
+									"slug": {
+										"description": "Unique identifier for the space size preset. For best cross theme compatibility these should be in the form '10','20','30','40','50','60', etc. with '50' representing the 'Medium' size step. If all slugs begin with a number they will be merged with default and user slugs and sorted numerically.",
+										"type": "string"
+									},
+									"size": {
+										"description": "CSS space-size value, including units.",
+										"type": "string"
+									}
+								},
+								"additionalProperties": false
+							}
+						},
+						"spacingScale": {
+							"description": "Settings to auto-generate space size presets for the space size selector.\nGenerates a custom property (--wp--preset--spacing--{slug}`) per preset value.",
+							"type": "object",
+							"properties": {
+								"operator": {
+									"description": "With + or * depending on whether scale is generated by increment or multiplier.",
+									"type": "string",
+									"enum": [ "+", "*" ],
+									"default": "*"
+								},
+								"increment": {
+									"description": "The amount to increment each step by.",
+									"type": "number",
+									"exclusiveMinimum": 0,
+									"default": 1.5
+								},
+								"steps": {
+									"description": "Number of steps to generate in scale.",
+									"type": "integer",
+									"minimum": 1,
+									"maximum": 10,
+									"default": 7
+								},
+								"mediumStep": {
+									"description": "The value to medium setting in the scale.",
+									"type": "number",
+									"exclusiveMinimum": 0,
+									"default": 1.5
+								},
+								"unit": {
+									"description": "Unit that the scale uses, eg. rem, em, px.",
+									"type": "string",
+									"enum": [
+										"px",
+										"em",
+										"rem",
+										"%",
+										"vw",
+										"svw",
+										"lvw",
+										"dvw",
+										"vh",
+										"svh",
+										"lvh",
+										"dvh",
+										"vi",
+										"svi",
+										"lvi",
+										"dvi",
+										"vb",
+										"svb",
+										"lvb",
+										"dvb",
+										"vmin",
+										"svmin",
+										"lvmin",
+										"dvmin",
+										"vmax",
+										"svmax",
+										"lvmax",
+										"dvmax"
+									],
+									"default": "rem"
+								}
+							},
+							"additionalProperties": false
+						}
+					},
+					"additionalProperties": false
+				}
+			}
+		},
+		"settingsTypographyProperties": {
+			"type": "object",
+			"properties": {
+				"typography": {
+					"description": "Settings related to typography.",
+					"type": "object",
+					"properties": {
+						"defaultFontSizes": {
+							"description": "Allow users to choose font sizes from the default font size presets.",
+							"type": "boolean",
+							"default": true
+						},
+						"customFontSize": {
+							"description": "Allow users to set custom font sizes.",
+							"type": "boolean",
+							"default": true
+						},
+						"fontStyle": {
+							"description": "Allow users to set custom font styles.",
+							"type": "boolean",
+							"default": true
+						},
+						"fontWeight": {
+							"description": "Allow users to set custom font weights.",
+							"type": "boolean",
+							"default": true
+						},
+						"fluid": {
+							"description": "Enables fluid typography and allows users to set global fluid typography parameters.",
+							"oneOf": [
+								{
+									"type": "object",
+									"properties": {
+										"minFontSize": {
+											"description": "Allow users to set a global minimum font size boundary in px, rem or em. Custom font sizes below this value will not be clamped, and all calculated minimum font sizes will be, at a minimum, this value.",
+											"type": "string"
+										},
+										"maxViewportWidth": {
+											"description": "Allow users to set custom a max viewport width in px, rem or em, used to set the maximum size boundary of a fluid font size.",
+											"type": "string"
+										},
+										"minViewportWidth": {
+											"description": "Allow users to set a custom min viewport width in px, rem or em, used to set the minimum size boundary of a fluid font size.",
+											"type": "string"
+										}
+									},
+									"additionalProperties": false
+								},
+								{
+									"type": "boolean"
+								}
+							],
+							"default": false
+						},
+						"letterSpacing": {
+							"description": "Allow users to set custom letter spacing.",
+							"type": "boolean",
+							"default": true
+						},
+						"lineHeight": {
+							"description": "Allow users to set custom line height.",
+							"type": "boolean",
+							"default": false
+						},
+						"textAlign": {
+							"description": "Allow users to set the text align.",
+							"type": "boolean",
+							"default": true
+						},
+						"textColumns": {
+							"description": "Allow users to set the number of text columns.",
+							"type": "boolean",
+							"default": false
+						},
+						"textDecoration": {
+							"description": "Allow users to set custom text decorations.",
+							"type": "boolean",
+							"default": true
+						},
+						"writingMode": {
+							"description": "Allow users to set the writing mode.",
+							"type": "boolean",
+							"default": false
+						},
+						"textTransform": {
+							"description": "Allow users to set custom text transforms.",
+							"type": "boolean",
+							"default": true
+						},
+						"dropCap": {
+							"description": "Enable drop cap.",
+							"type": "boolean",
+							"default": true
+						},
+						"fontSizes": {
+							"description": "Font size presets for the font size selector.\nGenerates a single class (`.has-{slug}-color`) and custom property (`--wp--preset--font-size--{slug}`) per preset value.",
+							"type": "array",
+							"items": {
+								"type": "object",
+								"properties": {
+									"name": {
+										"description": "Name of the font size preset, translatable.",
+										"type": "string"
+									},
+									"slug": {
+										"description": "Kebab-case unique identifier for the font size preset.",
+										"type": "string"
+									},
+									"size": {
+										"description": "CSS font-size value, including units.",
+										"type": "string"
+									},
+									"fluid": {
+										"description": "Specifies the minimum and maximum font size value of a fluid font size. Set to `false` to bypass fluid calculations and use the static `size` value.",
+										"oneOf": [
+											{
+												"type": "object",
+												"properties": {
+													"min": {
+														"description": "A min font size for fluid font size calculations in px, rem or em.",
+														"type": "string"
+													},
+													"max": {
+														"description": "A max font size for fluid font size calculations in px, rem or em.",
+														"type": "string"
+													}
+												},
+												"additionalProperties": false
+											},
+											{
+												"type": "boolean"
+											}
+										]
+									}
+								},
+								"additionalProperties": false
+							}
+						},
+						"fontFamilies": {
+							"description": "Font family presets for the font family selector.\nGenerates a single custom property (`--wp--preset--font-family--{slug}`) per preset value.",
+							"type": "array",
+							"items": {
+								"description": "Font family preset",
+								"type": "object",
+								"properties": {
+									"name": {
+										"description": "Name of the font family preset, translatable.",
+										"type": "string"
+									},
+									"slug": {
+										"description": "Kebab-case unique identifier for the font family preset.",
+										"type": "string"
+									},
+									"fontFamily": {
+										"description": "CSS font-family value.",
+										"type": "string"
+									},
+									"fontFace": {
+										"description": "Array of font-face declarations.",
+										"type": "array",
+										"items": {
+											"type": "object",
+											"properties": {
+												"fontFamily": {
+													"description": "CSS font-family value.",
+													"type": "string",
+													"default": ""
+												},
+												"fontStyle": {
+													"description": "CSS font-style value.",
+													"type": "string",
+													"default": "normal"
+												},
+												"fontWeight": {
+													"description": "List of available font weights, separated by a space.",
+													"oneOf": [
+														{
+															"type": "string"
+														},
+														{
+															"type": "integer"
+														}
+													],
+													"default": "400"
+												},
+												"fontDisplay": {
+													"description": "CSS font-display value.",
+													"type": "string",
+													"enum": [
+														"auto",
+														"block",
+														"fallback",
+														"swap",
+														"optional"
+													],
+													"default": "fallback"
+												},
+												"src": {
+													"description": "Paths or URLs to the font files.",
+													"oneOf": [
+														{
+															"type": "string"
+														},
+														{
+															"type": "array",
+															"items": {
+																"type": "string"
+															}
+														}
+													],
+													"default": []
+												},
+												"fontStretch": {
+													"description": "CSS font-stretch value.",
+													"type": "string"
+												},
+												"ascentOverride": {
+													"description": "CSS ascent-override value.",
+													"type": "string"
+												},
+												"descentOverride": {
+													"description": "CSS descent-override value.",
+													"type": "string"
+												},
+												"fontVariant": {
+													"description": "CSS font-variant value.",
+													"type": "string"
+												},
+												"fontFeatureSettings": {
+													"description": "CSS font-feature-settings value.",
+													"type": "string"
+												},
+												"fontVariationSettings": {
+													"description": "CSS font-variation-settings value.",
+													"type": "string"
+												},
+												"lineGapOverride": {
+													"description": "CSS line-gap-override value.",
+													"type": "string"
+												},
+												"sizeAdjust": {
+													"description": "CSS size-adjust value.",
+													"type": "string"
+												},
+												"unicodeRange": {
+													"description": "CSS unicode-range value.",
+													"type": "string"
+												}
+											},
+											"required": [ "fontFamily", "src" ],
+											"additionalProperties": false
+										}
+									}
+								},
+								"additionalProperties": false
+							}
+						}
+					},
+					"additionalProperties": false
+				}
+			}
+		},
+		"settingsCustomProperties": {
+			"type": "object",
+			"properties": {
+				"custom": {
+					"$ref": "#/definitions/settingsCustomAdditionalProperties"
+				}
+			}
+		},
+		"settingsProperties": {
+			"allOf": [
+				{ "$ref": "#/definitions/settingsAppearanceToolsProperties" },
+				{ "$ref": "#/definitions/settingsBackgroundProperties" },
+				{ "$ref": "#/definitions/settingsBorderProperties" },
+				{ "$ref": "#/definitions/settingsColorProperties" },
+				{ "$ref": "#/definitions/settingsDimensionsProperties" },
+				{ "$ref": "#/definitions/settingsLayoutProperties" },
+				{ "$ref": "#/definitions/settingsLightboxProperties" },
+				{ "$ref": "#/definitions/settingsPositionProperties" },
+				{ "$ref": "#/definitions/settingsShadowProperties" },
+				{ "$ref": "#/definitions/settingsSpacingProperties" },
+				{ "$ref": "#/definitions/settingsTypographyProperties" },
+				{ "$ref": "#/definitions/settingsCustomProperties" }
+			]
+		},
+		"settingsPropertyNames": {
+			"enum": [
+				"appearanceTools",
+				"background",
+				"border",
+				"color",
+				"dimensions",
+				"layout",
+				"lightbox",
+				"position",
+				"shadow",
+				"spacing",
+				"typography",
+				"custom"
+			]
+		},
+		"settingsPropertiesComplete": {
+			"allOf": [
+				{
+					"$ref": "#/definitions/settingsProperties"
+				},
+				{
+					"type": "object",
+					"propertyNames": {
+						"$ref": "#/definitions/settingsPropertyNames"
+					}
+				}
+			]
+		},
+		"settingsBlocksPropertiesComplete": {
+			"description": "Settings defined on a per-block basis.",
+			"type": "object",
+			"properties": {
+				"core/archives": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/audio": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/avatar": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/block": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/button": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/buttons": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/calendar": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/categories": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/code": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/column": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/columns": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/comment-author-avatar": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/comment-author-name": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/comment-content": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/comment-date": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/comment-edit-link": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/comment-reply-link": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/comments": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/comments-pagination": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/comments-pagination-next": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/comments-pagination-numbers": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/comments-pagination-previous": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/comments-title": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/comment-template": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/cover": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/details": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/embed": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/file": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/footnotes": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/freeform": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/gallery": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/group": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/heading": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/home-link": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/html": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/image": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/latest-comments": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/latest-posts": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/list": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/list-item": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/loginout": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/media-text": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/missing": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/more": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/navigation": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/navigation-link": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/navigation-submenu": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/nextpage": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/page-list": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/page-list-item": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/paragraph": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/post-author": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/post-author-biography": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/post-author-name": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/post-comment": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/post-comments-count": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/post-comments-form": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/post-comments-link": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/post-content": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/post-date": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/post-excerpt": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/post-featured-image": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/post-navigation-link": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/post-template": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/post-terms": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/post-title": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/preformatted": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/pullquote": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/query": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/query-no-results": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/query-pagination": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/query-pagination-next": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/query-pagination-numbers": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/query-pagination-previous": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/query-title": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/query-total": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/quote": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/read-more": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/rss": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/search": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/separator": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/shortcode": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/site-logo": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/site-tagline": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/site-title": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/social-link": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/social-links": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/spacer": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/table": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/tag-cloud": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/template-part": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/term-description": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/text-columns": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/verse": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/video": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/widget-area": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/legacy-widget": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/widget-group": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				}
+			},
+			"patternProperties": {
+				"^[a-z][a-z0-9-]*/[a-z][a-z0-9-]*$": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				}
+			},
+			"additionalProperties": false
+		},
+		"settingsCustomAdditionalProperties": {
+			"description": "Generate custom CSS custom properties of the form `--wp--custom--{key}--{nested-key}: {value};`. `camelCased` keys are transformed to `kebab-case` as to follow the CSS property naming schema. Keys at different depth levels are separated by `--`, so keys should not include `--` in the name.",
+			"type": "object",
+			"additionalProperties": {
+				"oneOf": [
+					{
+						"type": "string"
+					},
+					{
+						"type": "number"
+					},
+					{
+						"$ref": "#/definitions/settingsCustomAdditionalProperties"
+					}
+				]
+			}
+		},
+		"stylesProperties": {
+			"type": "object",
+			"properties": {
+				"background": {
+					"description": "Background styles.",
+					"type": "object",
+					"properties": {
+						"backgroundImage": {
+							"description": "Sets the `background-image` CSS property.",
+							"oneOf": [
+								{ "type": "string" },
+								{ "$ref": "#/definitions/refComplete" },
+								{
+									"type": "object",
+									"properties": {
+										"url": {
+											"description": "A URL to an image file, or a path to a file relative to the theme root directory, and prefixed with `file:`, e.g., 'file:./path/to/file.png'.",
+											"type": "string"
+										}
+									},
+									"additionalProperties": false
+								}
+							]
+						},
+						"backgroundPosition": {
+							"description": "Sets the `background-position` CSS property.",
+							"oneOf": [
+								{ "type": "string" },
+								{ "$ref": "#/definitions/refComplete" }
+							]
+						},
+						"backgroundRepeat": {
+							"description": "Sets the `background-repeat` CSS property.",
+							"oneOf": [
+								{ "type": "string" },
+								{ "$ref": "#/definitions/refComplete" }
+							]
+						},
+						"backgroundSize": {
+							"description": "Sets the `background-size` CSS property.",
+							"oneOf": [
+								{ "type": "string" },
+								{ "$ref": "#/definitions/refComplete" }
+							]
+						},
+						"backgroundAttachment": {
+							"description": "Sets the `background-attachment` CSS property.",
+							"oneOf": [
+								{ "type": "string" },
+								{ "$ref": "#/definitions/refComplete" }
+							]
+						}
+					},
+					"additionalProperties": false
+				},
+				"border": {
+					"description": "Border styles.",
+					"type": "object",
+					"properties": {
+						"color": {
+							"description": "Sets the `border-color` CSS property.",
+							"oneOf": [
+								{ "type": "string" },
+								{ "$ref": "#/definitions/refComplete" }
+							]
+						},
+						"radius": {
+							"description": "Sets the `border-radius` CSS property.",
+							"anyOf": [
+								{ "type": "string" },
+								{ "$ref": "#/definitions/refComplete" },
+								{
+									"type": "object",
+									"properties": {
+										"topLeft": {
+											"description": "Sets the `border-top-left-radius` CSS property.",
+											"oneOf": [
+												{ "type": "string" },
+												{
+													"$ref": "#/definitions/refComplete"
+												}
+											]
+										},
+										"topRight": {
+											"description": "Sets the `border-top-right-radius` CSS property.",
+											"oneOf": [
+												{ "type": "string" },
+												{
+													"$ref": "#/definitions/refComplete"
+												}
+											]
+										},
+										"bottomLeft": {
+											"description": "Sets the `border-bottom-left-radius` CSS property.",
+											"oneOf": [
+												{ "type": "string" },
+												{
+													"$ref": "#/definitions/refComplete"
+												}
+											]
+										},
+										"bottomRight": {
+											"description": "Sets the `border-bottom-right-radius` CSS property.",
+											"oneOf": [
+												{ "type": "string" },
+												{
+													"$ref": "#/definitions/refComplete"
+												}
+											]
+										}
+									}
+								}
+							]
+						},
+						"style": {
+							"description": "Sets the `border-style` CSS property.",
+							"oneOf": [
+								{ "type": "string" },
+								{ "$ref": "#/definitions/refComplete" }
+							]
+						},
+						"width": {
+							"description": "Sets the `border-width` CSS property.",
+							"oneOf": [
+								{ "type": "string" },
+								{ "$ref": "#/definitions/refComplete" }
+							]
+						},
+						"top": {
+							"type": "object",
+							"properties": {
+								"color": {
+									"description": "Sets the `border-top-color` CSS property.",
+									"oneOf": [
+										{ "type": "string" },
+										{ "$ref": "#/definitions/refComplete" }
+									]
+								},
+								"style": {
+									"description": "Sets the `border-top-style` CSS property.",
+									"oneOf": [
+										{ "type": "string" },
+										{ "$ref": "#/definitions/refComplete" }
+									]
+								},
+								"width": {
+									"description": "Sets the `border-top-width` CSS property.",
+									"oneOf": [
+										{ "type": "string" },
+										{ "$ref": "#/definitions/refComplete" }
+									]
+								}
+							},
+							"additionalProperties": false
+						},
+						"right": {
+							"type": "object",
+							"properties": {
+								"color": {
+									"description": "Sets the `border-right-color` CSS property.",
+									"oneOf": [
+										{ "type": "string" },
+										{ "$ref": "#/definitions/refComplete" }
+									]
+								},
+								"style": {
+									"description": "Sets the `border-right-style` CSS property.",
+									"oneOf": [
+										{ "type": "string" },
+										{ "$ref": "#/definitions/refComplete" }
+									]
+								},
+								"width": {
+									"description": "Sets the `border-right-width` CSS property.",
+									"oneOf": [
+										{ "type": "string" },
+										{ "$ref": "#/definitions/refComplete" }
+									]
+								}
+							},
+							"additionalProperties": false
+						},
+						"bottom": {
+							"type": "object",
+							"properties": {
+								"color": {
+									"description": "Sets the `border-bottom-color` CSS property.",
+									"oneOf": [
+										{ "type": "string" },
+										{ "$ref": "#/definitions/refComplete" }
+									]
+								},
+								"style": {
+									"description": "Sets the `border-bottom-style` CSS property.",
+									"oneOf": [
+										{ "type": "string" },
+										{ "$ref": "#/definitions/refComplete" }
+									]
+								},
+								"width": {
+									"description": "Sets the `border-bottom-width` CSS property.",
+									"oneOf": [
+										{ "type": "string" },
+										{ "$ref": "#/definitions/refComplete" }
+									]
+								}
+							},
+							"additionalProperties": false
+						},
+						"left": {
+							"type": "object",
+							"properties": {
+								"color": {
+									"description": "Sets the `border-left-color` CSS property.",
+									"oneOf": [
+										{ "type": "string" },
+										{ "$ref": "#/definitions/refComplete" }
+									]
+								},
+								"style": {
+									"description": "Sets the `border-left-style` CSS property.",
+									"oneOf": [
+										{ "type": "string" },
+										{ "$ref": "#/definitions/refComplete" }
+									]
+								},
+								"width": {
+									"description": "Sets the `border-left-width` CSS property.",
+									"oneOf": [
+										{ "type": "string" },
+										{ "$ref": "#/definitions/refComplete" }
+									]
+								}
+							},
+							"additionalProperties": false
+						}
+					},
+					"additionalProperties": false
+				},
+				"color": {
+					"description": "Color styles.",
+					"type": "object",
+					"properties": {
+						"background": {
+							"description": "Sets the `background-color` CSS property.",
+							"oneOf": [
+								{ "type": "string" },
+								{ "$ref": "#/definitions/refComplete" }
+							]
+						},
+						"gradient": {
+							"description": "Sets the `background` CSS property.",
+							"oneOf": [
+								{ "type": "string" },
+								{ "$ref": "#/definitions/refComplete" }
+							]
+						},
+						"text": {
+							"description": "Sets the `color` CSS property.",
+							"oneOf": [
+								{ "type": "string" },
+								{ "$ref": "#/definitions/refComplete" }
+							]
+						}
+					},
+					"additionalProperties": false
+				},
+				"css": {
+					"description": "Sets custom CSS to apply styling not covered by other theme.json properties.",
+					"type": "string"
+				},
+				"dimensions": {
+					"description": "Dimensions styles.",
+					"type": "object",
+					"properties": {
+						"aspectRatio": {
+							"description": "Sets the `aspect-ratio` CSS property.",
+							"oneOf": [
+								{ "type": "string" },
+								{ "$ref": "#/definitions/refComplete" }
+							]
+						},
+						"minHeight": {
+							"description": "Sets the `min-height` CSS property.",
+							"oneOf": [
+								{ "type": "string" },
+								{ "$ref": "#/definitions/refComplete" }
+							]
+						}
+					}
+				},
+				"filter": {
+					"description": "CSS and SVG filter styles.",
+					"type": "object",
+					"properties": {
+						"duotone": {
+							"description": "Sets the duotone filter.",
+							"oneOf": [
+								{ "type": "string" },
+								{ "$ref": "#/definitions/refComplete" }
+							]
+						}
+					},
+					"additionalProperties": false
+				},
+				"outline": {
+					"description": "Outline styles.",
+					"type": "object",
+					"properties": {
+						"color": {
+							"description": "Sets the `outline-color` CSS property.",
+							"oneOf": [
+								{ "type": "string" },
+								{ "$ref": "#/definitions/refComplete" }
+							]
+						},
+						"offset": {
+							"description": "Sets the `outline-offset` CSS property.",
+							"oneOf": [
+								{ "type": "string" },
+								{ "$ref": "#/definitions/refComplete" }
+							]
+						},
+						"style": {
+							"description": "Sets the `outline-style` CSS property.",
+							"oneOf": [
+								{ "type": "string" },
+								{ "$ref": "#/definitions/refComplete" }
+							]
+						},
+						"width": {
+							"description": "Sets the `outline-width` CSS property.",
+							"oneOf": [
+								{ "type": "string" },
+								{ "$ref": "#/definitions/refComplete" }
+							]
+						}
+					},
+					"additionalProperties": false
+				},
+				"shadow": {
+					"description": "Box shadow styles.",
+					"oneOf": [
+						{ "type": "string" },
+						{ "$ref": "#/definitions/refComplete" }
+					]
+				},
+				"spacing": {
+					"description": "Spacing styles.",
+					"type": "object",
+					"properties": {
+						"blockGap": {
+							"description": "Sets the `--wp--style--block-gap` CSS custom property when settings.spacing.blockGap is true.",
+							"oneOf": [
+								{ "type": "string" },
+								{ "$ref": "#/definitions/refComplete" }
+							]
+						},
+						"margin": {
+							"description": "Margin styles.",
+							"type": "object",
+							"properties": {
+								"top": {
+									"description": "Sets the `margin-top` CSS property.",
+									"oneOf": [
+										{ "type": "string" },
+										{ "$ref": "#/definitions/refComplete" }
+									]
+								},
+								"right": {
+									"description": "Sets the `margin-right` CSS property.",
+									"oneOf": [
+										{ "type": "string" },
+										{ "$ref": "#/definitions/refComplete" }
+									]
+								},
+								"bottom": {
+									"description": "Sets the `margin-bottom` CSS property.",
+									"oneOf": [
+										{ "type": "string" },
+										{ "$ref": "#/definitions/refComplete" }
+									]
+								},
+								"left": {
+									"description": "Sets the `margin-left` CSS property.",
+									"oneOf": [
+										{ "type": "string" },
+										{ "$ref": "#/definitions/refComplete" }
+									]
+								}
+							},
+							"additionalProperties": false
+						},
+						"padding": {
+							"description": "Padding styles.",
+							"type": "object",
+							"properties": {
+								"top": {
+									"description": "Sets the `padding-top` CSS property.",
+									"oneOf": [
+										{ "type": "string" },
+										{ "$ref": "#/definitions/refComplete" }
+									]
+								},
+								"right": {
+									"description": "Sets the `padding-right` CSS property.",
+									"oneOf": [
+										{ "type": "string" },
+										{ "$ref": "#/definitions/refComplete" }
+									]
+								},
+								"bottom": {
+									"description": "Sets the `padding-bottom` CSS property.",
+									"oneOf": [
+										{ "type": "string" },
+										{ "$ref": "#/definitions/refComplete" }
+									]
+								},
+								"left": {
+									"description": "Sets the `padding-left` CSS property.",
+									"oneOf": [
+										{ "type": "string" },
+										{ "$ref": "#/definitions/refComplete" }
+									]
+								}
+							},
+							"additionalProperties": false
+						}
+					},
+					"additionalProperties": false
+				},
+				"typography": {
+					"description": "Typography styles.",
+					"type": "object",
+					"properties": {
+						"fontFamily": {
+							"description": "Sets the `font-family` CSS property.",
+							"oneOf": [
+								{ "type": "string" },
+								{ "$ref": "#/definitions/refComplete" }
+							]
+						},
+						"fontSize": {
+							"description": "Sets the `font-size` CSS property.",
+							"oneOf": [
+								{ "type": "string" },
+								{ "$ref": "#/definitions/refComplete" }
+							]
+						},
+						"fontStyle": {
+							"description": "Sets the `font-style` CSS property.",
+							"oneOf": [
+								{ "type": "string" },
+								{ "$ref": "#/definitions/refComplete" }
+							]
+						},
+						"fontWeight": {
+							"description": "Sets the `font-weight` CSS property.",
+							"oneOf": [
+								{ "type": "string" },
+								{ "$ref": "#/definitions/refComplete" }
+							]
+						},
+						"letterSpacing": {
+							"description": "Sets the `letter-spacing` CSS property.",
+							"oneOf": [
+								{ "type": "string" },
+								{ "$ref": "#/definitions/refComplete" }
+							]
+						},
+						"lineHeight": {
+							"description": "Sets the `line-height` CSS property.",
+							"oneOf": [
+								{ "type": "string" },
+								{ "$ref": "#/definitions/refComplete" }
+							]
+						},
+						"textAlign": {
+							"description": "Sets the `text-align` CSS property.",
+							"oneOf": [
+								{ "type": "string" },
+								{ "$ref": "#/definitions/refComplete" }
+							]
+						},
+						"textColumns": {
+							"description": "Sets the `column-count` CSS property.",
+							"oneOf": [
+								{ "type": "string" },
+								{ "$ref": "#/definitions/refComplete" }
+							]
+						},
+						"textDecoration": {
+							"description": "Sets the `text-decoration` CSS property.",
+							"oneOf": [
+								{ "type": "string" },
+								{ "$ref": "#/definitions/refComplete" }
+							]
+						},
+						"writingMode": {
+							"description": "Sets the `writing-mode` CSS property.",
+							"oneOf": [
+								{ "type": "string" },
+								{ "$ref": "#/definitions/refComplete" }
+							]
+						},
+						"textTransform": {
+							"description": "Sets the `text-transform` CSS property.",
+							"oneOf": [
+								{ "type": "string" },
+								{ "$ref": "#/definitions/refComplete" }
+							]
+						}
+					},
+					"additionalProperties": false
+				}
+			}
+		},
+		"stylesPropertyNames": {
+			"enum": [
+				"background",
+				"border",
+				"color",
+				"css",
+				"dimensions",
+				"filter",
+				"outline",
+				"shadow",
+				"spacing",
+				"typography"
+			]
+		},
+		"stylesPropertiesComplete": {
+			"allOf": [
+				{
+					"$ref": "#/definitions/stylesProperties"
+				},
+				{
+					"type": "object",
+					"propertyNames": {
+						"$ref": "#/definitions/stylesPropertyNames"
+					}
+				}
+			]
+		},
+		"stylesElementsPseudoSelectorsProperties": {
+			"type": "object",
+			"properties": {
+				":active": {
+					"$ref": "#/definitions/stylesPropertiesComplete"
+				},
+				":any-link": {
+					"$ref": "#/definitions/stylesPropertiesComplete"
+				},
+				":focus": {
+					"$ref": "#/definitions/stylesPropertiesComplete"
+				},
+				":focus-visible": {
+					"$ref": "#/definitions/stylesPropertiesComplete"
+				},
+				":hover": {
+					"$ref": "#/definitions/stylesPropertiesComplete"
+				},
+				":link": {
+					"$ref": "#/definitions/stylesPropertiesComplete"
+				},
+				":visited": {
+					"$ref": "#/definitions/stylesPropertiesComplete"
+				}
+			}
+		},
+		"stylesElementsPseudoSelectorsPropertyNames": {
+			"enum": [
+				":active",
+				":any-link",
+				":focus",
+				":focus-visible",
+				":hover",
+				":link",
+				":visited"
+			]
+		},
+		"stylesElementsPropertiesComplete": {
+			"description": "Styles defined on a per-element basis using the element's selector.",
+			"type": "object",
+			"properties": {
+				"button": {
+					"allOf": [
+						{
+							"$ref": "#/definitions/stylesProperties"
+						},
+						{
+							"$ref": "#/definitions/stylesElementsPseudoSelectorsProperties"
+						},
+						{
+							"type": "object",
+							"propertyNames": {
+								"anyOf": [
+									{
+										"$ref": "#/definitions/stylesPropertyNames"
+									},
+									{
+										"$ref": "#/definitions/stylesElementsPseudoSelectorsPropertyNames"
+									}
+								]
+							}
+						}
+					]
+				},
+				"link": {
+					"allOf": [
+						{
+							"$ref": "#/definitions/stylesProperties"
+						},
+						{
+							"$ref": "#/definitions/stylesElementsPseudoSelectorsProperties"
+						},
+						{
+							"type": "object",
+							"propertyNames": {
+								"anyOf": [
+									{
+										"$ref": "#/definitions/stylesPropertyNames"
+									},
+									{
+										"$ref": "#/definitions/stylesElementsPseudoSelectorsPropertyNames"
+									}
+								]
+							}
+						}
+					]
+				},
+				"heading": {
+					"$ref": "#/definitions/stylesPropertiesComplete"
+				},
+				"h1": {
+					"$ref": "#/definitions/stylesPropertiesComplete"
+				},
+				"h2": {
+					"$ref": "#/definitions/stylesPropertiesComplete"
+				},
+				"h3": {
+					"$ref": "#/definitions/stylesPropertiesComplete"
+				},
+				"h4": {
+					"$ref": "#/definitions/stylesPropertiesComplete"
+				},
+				"h5": {
+					"$ref": "#/definitions/stylesPropertiesComplete"
+				},
+				"h6": {
+					"$ref": "#/definitions/stylesPropertiesComplete"
+				},
+				"caption": {
+					"$ref": "#/definitions/stylesPropertiesComplete"
+				},
+				"cite": {
+					"$ref": "#/definitions/stylesPropertiesComplete"
+				}
+			},
+			"additionalProperties": false
+		},
+		"stylesBlocksPropertiesComplete": {
+			"description": "Styles defined on a per-block basis using the block's selector.",
+			"type": "object",
+			"properties": {
+				"core/archives": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/audio": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/avatar": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/block": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/button": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/buttons": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/calendar": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/categories": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/code": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/column": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/columns": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/comment-author-avatar": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/comment-author-name": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/comment-content": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/comment-date": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/comment-edit-link": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/comment-reply-link": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/comments": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/comments-pagination": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/comments-pagination-next": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/comments-pagination-numbers": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/comments-pagination-previous": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/comments-title": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/comment-template": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/cover": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/details": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/embed": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/file": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/footnotes": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/freeform": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/gallery": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/group": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/heading": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/home-link": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/html": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/image": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/latest-comments": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/latest-posts": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/list": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/list-item": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/loginout": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/media-text": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/missing": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/more": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/navigation": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/navigation-link": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/navigation-submenu": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/nextpage": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/page-list": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/page-list-item": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/paragraph": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/post-author": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/post-author-biography": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/post-author-name": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/post-comment": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/post-comments-count": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/post-comments-form": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/post-comments-link": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/post-content": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/post-date": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/post-excerpt": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/post-featured-image": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/post-navigation-link": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/post-template": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/post-terms": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/post-title": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/preformatted": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/pullquote": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/query": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/query-no-results": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/query-pagination": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/query-pagination-next": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/query-pagination-numbers": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/query-pagination-previous": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/query-title": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/query-total": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/quote": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/read-more": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/rss": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/search": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/separator": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/shortcode": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/site-logo": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/site-tagline": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/site-title": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/social-link": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/social-links": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/spacer": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/table": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/tag-cloud": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/template-part": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/term-description": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/text-columns": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/verse": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/video": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/widget-area": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/legacy-widget": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/widget-group": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				}
+			},
+			"patternProperties": {
+				"^[a-z][a-z0-9-]*/[a-z][a-z0-9-]*$": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				}
+			},
+			"additionalProperties": false
+		},
+		"stylesPropertiesAndElementsComplete": {
+			"allOf": [
+				{
+					"$ref": "#/definitions/stylesProperties"
+				},
+				{
+					"type": "object",
+					"properties": {
+						"elements": {
+							"$ref": "#/definitions/stylesElementsPropertiesComplete"
+						},
+						"variations": {
+							"$ref": "#/definitions/stylesVariationsPropertiesComplete"
+						}
+					}
+				},
+				{
+					"type": "object",
+					"propertyNames": {
+						"anyOf": [
+							{
+								"$ref": "#/definitions/stylesPropertyNames"
+							},
+							{
+								"enum": [ "elements", "variations" ]
+							}
+						]
+					}
+				}
+			]
+		},
+		"stylesVariationsProperties": {
+			"type": "object",
+			"patternProperties": {
+				"^[a-z][a-z0-9-]*$": {
+					"$ref": "#/definitions/stylesVariationProperties"
+				}
+			}
+		},
+		"stylesVariationProperties": {
+			"allOf": [
+				{
+					"$ref": "#/definitions/stylesProperties"
+				},
+				{
+					"type": "object",
+					"properties": {
+						"elements": {
+							"$ref": "#/definitions/stylesElementsPropertiesComplete"
+						},
+						"blocks": {
+							"$ref": "#/definitions/stylesVariationBlocksPropertiesComplete"
+						}
+					}
+				},
+				{
+					"type": "object",
+					"propertyNames": {
+						"anyOf": [
+							{
+								"$ref": "#/definitions/stylesPropertyNames"
+							},
+							{
+								"enum": [ "elements", "blocks" ]
+							}
+						]
+					}
+				}
+			]
+		},
+		"stylesVariationsPropertiesComplete": {
+			"type": "object",
+			"patternProperties": {
+				"^[a-z][a-z0-9-]*$": {
+					"$ref": "#/definitions/stylesVariationPropertiesComplete"
+				}
+			}
+		},
+		"stylesVariationPropertiesComplete": {
+			"allOf": [
+				{
+					"$ref": "#/definitions/stylesProperties"
+				},
+				{
+					"type": "object",
+					"properties": {
+						"elements": {
+							"$ref": "#/definitions/stylesElementsPropertiesComplete"
+						},
+						"blocks": {
+							"$ref": "#/definitions/stylesVariationBlocksPropertiesComplete"
+						}
+					}
+				},
+				{
+					"type": "object",
+					"propertyNames": {
+						"anyOf": [
+							{
+								"$ref": "#/definitions/stylesPropertyNames"
+							},
+							{
+								"enum": [ "elements", "blocks" ]
+							}
+						]
+					}
+				}
+			]
+		},
+		"stylesVariationBlocksPropertiesComplete": {
+			"type": "object",
+			"properties": {
+				"core/archives": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/audio": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/avatar": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/block": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/button": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/buttons": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/calendar": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/categories": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/code": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/column": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/columns": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/comment-author-avatar": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/comment-author-name": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/comment-content": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/comment-date": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/comment-edit-link": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/comment-reply-link": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/comments": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/comments-pagination": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/comments-pagination-next": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/comments-pagination-numbers": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/comments-pagination-previous": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/comments-title": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/comment-template": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/cover": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/details": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/embed": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/file": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/footnotes": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/freeform": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/gallery": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/group": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/heading": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/home-link": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/html": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/image": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/latest-comments": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/latest-posts": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/list": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/list-item": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/loginout": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/media-text": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/missing": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/more": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/navigation": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/navigation-link": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/navigation-submenu": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/nextpage": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/page-list": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/page-list-item": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/paragraph": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/post-author": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/post-author-biography": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/post-author-name": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/post-comment": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/post-comments-count": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/post-comments-form": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/post-comments-link": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/post-content": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/post-date": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/post-excerpt": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/post-featured-image": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/post-navigation-link": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/post-template": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/post-terms": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/post-title": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/preformatted": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/pullquote": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/query": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/query-no-results": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/query-pagination": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/query-pagination-next": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/query-pagination-numbers": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/query-pagination-previous": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/query-title": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/query-total": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/quote": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/read-more": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/rss": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/search": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/separator": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/shortcode": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/site-logo": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/site-tagline": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/site-title": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/social-link": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/social-links": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/spacer": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/table": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/tag-cloud": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/template-part": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/term-description": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/text-columns": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/verse": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/video": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/widget-area": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/legacy-widget": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/widget-group": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				}
+			},
+			"patternProperties": {
+				"^[a-z][a-z0-9-]*/[a-z][a-z0-9-]*$": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				}
+			},
+			"additionalProperties": false
+		},
+		"stylesVariationBlockPropertiesComplete": {
+			"allOf": [
+				{
+					"$ref": "#/definitions/stylesProperties"
+				},
+				{
+					"type": "object",
+					"properties": {
+						"elements": {
+							"$ref": "#/definitions/stylesElementsPropertiesComplete"
+						}
+					}
+				},
+				{
+					"type": "object",
+					"propertyNames": {
+						"anyOf": [
+							{
+								"$ref": "#/definitions/stylesPropertyNames"
+							},
+							{
+								"enum": [ "elements" ]
+							}
+						]
+					}
+				}
+			]
+		}
+	},
+	"type": "object",
+	"properties": {
+		"$schema": {
+			"description": "JSON schema URI for theme.json.",
+			"type": "string"
+		},
+		"version": {
+			"description": "Version of theme.json to use.",
+			"type": "integer",
+			"const": 3
+		},
+		"title": {
+			"description": "Title of the global styles variation. If not defined, the file name will be used.",
+			"type": "string"
+		},
+		"slug": {
+			"description": "Slug of the global styles variation. If not defined, the kebab-case title will be used.",
+			"type": "string"
+		},
+		"description": {
+			"description": "Description of the global styles variation.",
+			"type": "string"
+		},
+		"blockTypes": {
+			"description": "List of block types that can use the block style variation this theme.json file represents.",
+			"type": "array",
+			"items": {
+				"type": "string"
+			}
+		},
+		"settings": {
+			"description": "Settings for the block editor and individual blocks. These include things like:\n- Which customization options should be available to the user. \n- The default colors, font sizes... available to the user. \n- CSS custom properties and class names used in styles.\n- And the default layout of the editor (widths and available alignments).",
+			"allOf": [
+				{
+					"$ref": "#/definitions/settingsProperties"
+				},
+				{
+					"type": "object",
+					"properties": {
+						"useRootPaddingAwareAlignments": {
+							"description": "Enables root padding (the values from `styles.spacing.padding`) to be applied to the contents of full-width blocks instead of the root block.\n\nPlease note that when using this setting, `styles.spacing.padding` should always be set as an object with `top`, `right`, `bottom`, `left` values declared separately.",
+							"type": "boolean",
+							"default": false
+						},
+						"blocks": {
+							"$ref": "#/definitions/settingsBlocksPropertiesComplete"
+						}
+					}
+				},
+				{
+					"type": "object",
+					"propertyNames": {
+						"anyOf": [
+							{
+								"$ref": "#/definitions/settingsPropertyNames"
+							},
+							{
+								"enum": [
+									"useRootPaddingAwareAlignments",
+									"blocks"
+								]
+							}
+						]
+					}
+				}
+			]
+		},
+		"styles": {
+			"description": "Organized way to set CSS properties. Styles in the top-level will be added in the `body` selector.",
+			"allOf": [
+				{
+					"$ref": "#/definitions/stylesProperties"
+				},
+				{
+					"type": "object",
+					"properties": {
+						"elements": {
+							"$ref": "#/definitions/stylesElementsPropertiesComplete"
+						},
+						"blocks": {
+							"$ref": "#/definitions/stylesBlocksPropertiesComplete"
+						},
+						"variations": {
+							"$ref": "#/definitions/stylesVariationsProperties"
+						}
+					}
+				},
+				{
+					"type": "object",
+					"propertyNames": {
+						"anyOf": [
+							{
+								"$ref": "#/definitions/stylesPropertyNames"
+							},
+							{
+								"enum": [ "elements", "blocks", "variations" ]
+							}
+						]
+					}
+				}
+			]
+		},
+		"customTemplates": {
+			"description": "Additional metadata for custom templates defined in the templates folder.",
+			"type": "array",
+			"items": {
+				"type": "object",
+				"properties": {
+					"name": {
+						"description": "Filename, without extension, of the template in the templates folder.",
+						"type": "string"
+					},
+					"title": {
+						"description": "Title of the template, translatable.",
+						"type": "string"
+					},
+					"postTypes": {
+						"description": "List of post types that can use this custom template.",
+						"type": "array",
+						"items": {
+							"type": "string"
+						},
+						"default": [ "page" ]
+					}
+				},
+				"required": [ "name", "title" ],
+				"additionalProperties": false
+			}
+		},
+		"templateParts": {
+			"description": "Additional metadata for template parts defined in the parts folder.",
+			"type": "array",
+			"items": {
+				"type": "object",
+				"properties": {
+					"name": {
+						"description": "Filename, without extension, of the template in the parts folder.",
+						"type": "string"
+					},
+					"title": {
+						"description": "Title of the template, translatable.",
+						"type": "string"
+					},
+					"area": {
+						"description": "The area the template part is used for. Block variations for `header` and `footer` values exist and will be used when the area is set to one of those.",
+						"type": "string",
+						"default": "uncategorized"
+					}
+				},
+				"required": [ "name" ],
+				"additionalProperties": false
+			}
+		},
+		"patterns": {
+			"description": "An array of pattern slugs to be registered from the Pattern Directory.",
+			"type": "array",
+			"items": {
+				"type": "string"
+			}
+		}
+	},
+	"required": [ "version" ],
+	"additionalProperties": false
+}

--- a/src/Modules/Themes/config/themes.php
+++ b/src/Modules/Themes/config/themes.php
@@ -54,4 +54,20 @@ return [
     'cacheEnabled' => env( 'THEMES_CACHE_ENABLED', true ),
     'cacheKey'     => 'cms.themes.discovered',
     'cacheTtl'     => 3600, // 1 hour
+
+    /*
+    |--------------------------------------------------------------------------
+    | WordPress theme.json Schema Version
+    |--------------------------------------------------------------------------
+    |
+    | The WordPress theme.json schema version against which the WP-shape
+    | subset of theme.json (settings, styles, customTemplates, templateParts,
+    | patterns) is validated. Bumping this requires also updating the bundled
+    | schema file at src/Modules/Themes/Validation/schemas/wp-theme-json-v{N}.json.
+    |
+    | Pinned to match the @wordpress/* package versions in
+    | artisanpack-ui/visual-editor.
+    |
+    */
+    'wpThemeJsonSchemaVersion' => '3',
 ];

--- a/tests/Feature/Themes/ThemeManagerSchemaValidationTest.php
+++ b/tests/Feature/Themes/ThemeManagerSchemaValidationTest.php
@@ -10,6 +10,7 @@ use Illuminate\Support\Facades\Log;
 beforeEach( function (): void {
     $this->manager    = app( ThemeManager::class );
     $this->themesPath = base_path( 'themes' );
+    $this->testSlugs  = [];
 
     File::ensureDirectoryExists( $this->themesPath );
 
@@ -18,17 +19,32 @@ beforeEach( function (): void {
 } );
 
 afterEach( function (): void {
-    foreach ( File::directories( $this->themesPath ) as $directory ) {
-        File::deleteDirectory( $directory );
+    // Only delete subdirectories created by this test, not anything else
+    // that may live under base_path('themes').
+    foreach ( $this->testSlugs as $slug ) {
+        $path = $this->themesPath . '/' . $slug;
+
+        if ( File::exists( $path ) ) {
+            File::deleteDirectory( $path );
+        }
     }
 } );
 
 /**
  * Write a theme.json file into a fresh test theme directory and return its path.
+ *
+ * Tracks the slug into $slugs (passed by reference) so afterEach() can clean up
+ * only the directories this test created.
+ *
+ * @param  string  $themesPath  Themes base path.
+ * @param  string  $slug  Theme slug (also the subdirectory name).
+ * @param  array  $manifest  theme.json contents.
+ * @param  array  $slugs  Reference to a slug-tracking array.
  */
-function writeTheme( string $themesPath, string $slug, array $manifest ): string
+function writeTheme( string $themesPath, string $slug, array $manifest, array &$slugs ): string
 {
-    $path = $themesPath . '/' . $slug;
+    $slugs[] = $slug;
+    $path    = $themesPath . '/' . $slug;
     File::ensureDirectoryExists( $path );
     File::put( $path . '/theme.json', json_encode( $manifest, JSON_PRETTY_PRINT ) );
 
@@ -46,7 +62,7 @@ describe( 'discoverThemes() with extended theme.json validation', function (): v
             'description' => 'Legacy.',
             'author'      => 'Test',
             'screenshot'  => 'screenshot.png',
-        ] );
+        ], $this->testSlugs );
 
         $themes = $this->manager->discoverThemes();
         $slugs  = array_column( $themes, 'slug' );
@@ -77,7 +93,7 @@ describe( 'discoverThemes() with extended theme.json validation', function (): v
                 [ 'name' => 'header', 'title' => 'Header', 'area' => 'header' ],
             ],
             'patterns' => [ 'my-namespace/cta' ],
-        ] );
+        ], $this->testSlugs );
 
         $themes = $this->manager->discoverThemes();
         $slugs  = array_column( $themes, 'slug' );
@@ -96,7 +112,7 @@ describe( 'discoverThemes() with extended theme.json validation', function (): v
                     'footer'  => 'Footer Menu',
                 ],
             ],
-        ] );
+        ], $this->testSlugs );
 
         $themes = $this->manager->discoverThemes();
         $slugs  = array_column( $themes, 'slug' );
@@ -116,7 +132,7 @@ describe( 'discoverThemes() with extended theme.json validation', function (): v
                     'palette' => 'not-an-array',
                 ],
             ],
-        ] );
+        ], $this->testSlugs );
 
         $themes = $this->manager->discoverThemes();
         $slugs  = array_column( $themes, 'slug' );
@@ -135,7 +151,8 @@ describe( 'discoverThemes() with extended theme.json validation', function (): v
     it( 'rejects themes whose theme.json is malformed JSON', function (): void {
         Log::spy();
 
-        $path = $this->themesPath . '/malformed-theme';
+        $this->testSlugs[] = 'malformed-theme';
+        $path              = $this->themesPath . '/malformed-theme';
         File::ensureDirectoryExists( $path );
         File::put( $path . '/theme.json', '{not valid json' );
 

--- a/tests/Feature/Themes/ThemeManagerSchemaValidationTest.php
+++ b/tests/Feature/Themes/ThemeManagerSchemaValidationTest.php
@@ -1,0 +1,153 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\CMSFramework\Modules\Themes\Managers\ThemeManager;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Log;
+
+beforeEach( function (): void {
+    $this->manager    = app( ThemeManager::class );
+    $this->themesPath = base_path( 'themes' );
+
+    File::ensureDirectoryExists( $this->themesPath );
+
+    config()->set( 'cms.themes.cacheEnabled', false );
+    Cache::forget( config( 'cms.themes.cacheKey', 'cms.themes.discovered' ) );
+} );
+
+afterEach( function (): void {
+    foreach ( File::directories( $this->themesPath ) as $directory ) {
+        File::deleteDirectory( $directory );
+    }
+} );
+
+/**
+ * Write a theme.json file into a fresh test theme directory and return its path.
+ */
+function writeTheme( string $themesPath, string $slug, array $manifest ): string
+{
+    $path = $themesPath . '/' . $slug;
+    File::ensureDirectoryExists( $path );
+    File::put( $path . '/theme.json', json_encode( $manifest, JSON_PRETTY_PRINT ) );
+
+    return $path;
+}
+
+describe( 'discoverThemes() with extended theme.json validation', function (): void {
+    it( 'discovers themes with only legacy cms-framework manifest fields without a warning', function (): void {
+        Log::spy();
+
+        writeTheme( $this->themesPath, 'legacy-theme', [
+            'name'        => 'Legacy Theme',
+            'slug'        => 'legacy-theme',
+            'version'     => '1.0.0',
+            'description' => 'Legacy.',
+            'author'      => 'Test',
+            'screenshot'  => 'screenshot.png',
+        ] );
+
+        $themes = $this->manager->discoverThemes();
+        $slugs  = array_column( $themes, 'slug' );
+
+        expect( $slugs )->toContain( 'legacy-theme' );
+        Log::shouldNotHaveReceived( 'warning' );
+    } );
+
+    it( 'discovers themes carrying full WP-shape settings, styles, customTemplates, templateParts, patterns', function (): void {
+        writeTheme( $this->themesPath, 'phase-h-theme', [
+            'name'     => 'Phase H Theme',
+            'slug'     => 'phase-h-theme',
+            'version'  => '1.0.0',
+            'settings' => [
+                'color' => [
+                    'palette' => [
+                        [ 'slug' => 'primary', 'name' => 'Primary', 'color' => '#3b82f6' ],
+                    ],
+                ],
+            ],
+            'styles' => [
+                'color' => [ 'background' => '#ffffff' ],
+            ],
+            'customTemplates' => [
+                [ 'name' => 'page-with-sidebar', 'title' => 'Page with sidebar' ],
+            ],
+            'templateParts' => [
+                [ 'name' => 'header', 'title' => 'Header', 'area' => 'header' ],
+            ],
+            'patterns' => [ 'my-namespace/cta' ],
+        ] );
+
+        $themes = $this->manager->discoverThemes();
+        $slugs  = array_column( $themes, 'slug' );
+
+        expect( $slugs )->toContain( 'phase-h-theme' );
+    } );
+
+    it( 'discovers themes carrying menus.locations as a cms-framework extension', function (): void {
+        writeTheme( $this->themesPath, 'menus-theme', [
+            'name'    => 'Menus Theme',
+            'slug'    => 'menus-theme',
+            'version' => '1.0.0',
+            'menus'   => [
+                'locations' => [
+                    'primary' => 'Primary Menu',
+                    'footer'  => 'Footer Menu',
+                ],
+            ],
+        ] );
+
+        $themes = $this->manager->discoverThemes();
+        $slugs  = array_column( $themes, 'slug' );
+
+        expect( $slugs )->toContain( 'menus-theme' );
+    } );
+
+    it( 'rejects themes with invalid settings shapes and logs a warning naming the offending key', function (): void {
+        Log::spy();
+
+        writeTheme( $this->themesPath, 'broken-theme', [
+            'name'     => 'Broken Theme',
+            'slug'     => 'broken-theme',
+            'version'  => '1.0.0',
+            'settings' => [
+                'color' => [
+                    'palette' => 'not-an-array',
+                ],
+            ],
+        ] );
+
+        $themes = $this->manager->discoverThemes();
+        $slugs  = array_column( $themes, 'slug' );
+
+        expect( $slugs )->not->toContain( 'broken-theme' );
+
+        Log::shouldHaveReceived( 'warning' )
+            ->withArgs( function ( string $message, array $context ): bool {
+                return str_contains( $message, 'schema validation' )
+                    && isset( $context['offendingKey'] )
+                    && str_contains( (string) $context['offendingKey'], 'settings' );
+            } )
+            ->once();
+    } );
+
+    it( 'rejects themes whose theme.json is malformed JSON', function (): void {
+        Log::spy();
+
+        $path = $this->themesPath . '/malformed-theme';
+        File::ensureDirectoryExists( $path );
+        File::put( $path . '/theme.json', '{not valid json' );
+
+        $themes = $this->manager->discoverThemes();
+        $slugs  = array_column( $themes, 'slug' );
+
+        expect( $slugs )->not->toContain( 'malformed-theme' );
+
+        Log::shouldHaveReceived( 'warning' )
+            ->withArgs( function ( string $message ): bool {
+                return str_contains( $message, 'parse failed' );
+            } )
+            ->once();
+    } );
+} );

--- a/tests/Unit/Themes/WpThemeJsonValidatorTest.php
+++ b/tests/Unit/Themes/WpThemeJsonValidatorTest.php
@@ -170,6 +170,49 @@ describe( 'menus.locations cms-framework extension', function (): void {
             ->and( $result->offendingKey )->toBe( 'menus' );
     } );
 
+    it( 'rejects menus when it is a list (numeric keys)', function (): void {
+        $manifest = [
+            'slug'  => 'broken-menus',
+            'menus' => [ 'primary', 'footer' ],
+        ];
+
+        $result = $this->validator->validate( $manifest );
+
+        expect( $result->valid )->toBeFalse()
+            ->and( $result->offendingKey )->toBe( 'menus' );
+    } );
+
+    it( 'rejects unknown sibling keys under menus', function (): void {
+        $manifest = [
+            'slug'  => 'broken-menus',
+            'menus' => [
+                'locations' => [ 'primary' => 'Primary Menu' ],
+                'colors'    => [ 'red', 'blue' ],
+            ],
+        ];
+
+        $result = $this->validator->validate( $manifest );
+
+        expect( $result->valid )->toBeFalse()
+            ->and( $result->offendingKey )->toBe( 'menus' )
+            ->and( $result->message )->toContain( 'colors' );
+    } );
+
+    it( 'rejects menus with only unknown keys (no locations)', function (): void {
+        $manifest = [
+            'slug'  => 'broken-menus',
+            'menus' => [
+                'fonts' => [ 'Inter' ],
+            ],
+        ];
+
+        $result = $this->validator->validate( $manifest );
+
+        expect( $result->valid )->toBeFalse()
+            ->and( $result->offendingKey )->toBe( 'menus' )
+            ->and( $result->message )->toContain( 'fonts' );
+    } );
+
     it( 'rejects menus.locations when it is a list (numeric keys)', function (): void {
         $manifest = [
             'slug'  => 'broken-menus',

--- a/tests/Unit/Themes/WpThemeJsonValidatorTest.php
+++ b/tests/Unit/Themes/WpThemeJsonValidatorTest.php
@@ -1,0 +1,230 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\CMSFramework\Modules\Themes\Validation\WpThemeJsonValidationResult;
+use ArtisanPackUI\CMSFramework\Modules\Themes\Validation\WpThemeJsonValidator;
+
+beforeEach( function (): void {
+    $this->validator = new WpThemeJsonValidator();
+} );
+
+describe( 'pre-Phase-H themes (cms-framework manifest fields only)', function (): void {
+    it( 'passes a manifest carrying only legacy fields', function (): void {
+        $manifest = [
+            'name'        => 'Digital Shopfront',
+            'slug'        => 'digital-shopfront',
+            'version'     => '1.0.0',
+            'description' => 'A reference theme.',
+            'author'      => 'Jacob Martella',
+            'screenshot'  => 'screenshot.png',
+        ];
+
+        $result = $this->validator->validate( $manifest );
+
+        expect( $result )
+            ->toBeInstanceOf( WpThemeJsonValidationResult::class )
+            ->and( $result->valid )->toBeTrue()
+            ->and( $result->offendingKey )->toBeNull();
+    } );
+
+    it( 'passes an empty manifest', function (): void {
+        $result = $this->validator->validate( [] );
+
+        expect( $result->valid )->toBeTrue();
+    } );
+} );
+
+describe( 'WP-shape keys', function (): void {
+    it( 'accepts a manifest with a full WP-shape settings + styles block', function (): void {
+        $manifest = [
+            'name'     => 'Phase H Theme',
+            'slug'     => 'phase-h',
+            'version'  => '1.0.0',
+            'settings' => [
+                'color' => [
+                    'palette' => [
+                        [
+                            'slug'  => 'primary',
+                            'name'  => 'Primary',
+                            'color' => '#3b82f6',
+                        ],
+                    ],
+                ],
+                'typography' => [
+                    'fontSizes' => [
+                        [
+                            'slug' => 'small',
+                            'name' => 'Small',
+                            'size' => '0.875rem',
+                        ],
+                    ],
+                ],
+            ],
+            'styles' => [
+                'color' => [
+                    'background' => '#ffffff',
+                    'text'       => '#111827',
+                ],
+            ],
+        ];
+
+        $result = $this->validator->validate( $manifest );
+
+        expect( $result->valid )->toBeTrue()
+            ->and( $result->offendingKey )->toBeNull();
+    } );
+
+    it( 'accepts customTemplates, templateParts, and patterns arrays', function (): void {
+        $manifest = [
+            'slug'            => 'phase-h',
+            'customTemplates' => [
+                [
+                    'name'  => 'page-with-sidebar',
+                    'title' => 'Page with sidebar',
+                ],
+            ],
+            'templateParts' => [
+                [
+                    'name'  => 'header',
+                    'title' => 'Header',
+                    'area'  => 'header',
+                ],
+            ],
+            'patterns' => [ 'my-namespace/cta' ],
+        ];
+
+        $result = $this->validator->validate( $manifest );
+
+        expect( $result->valid )->toBeTrue();
+    } );
+
+    it( 'rejects an invalid settings.color.palette entry and names the offending key', function (): void {
+        $manifest = [
+            'slug'     => 'broken',
+            'settings' => [
+                'color' => [
+                    // palette must be an array of objects; here we pass a string.
+                    'palette' => 'not-an-array',
+                ],
+            ],
+        ];
+
+        $result = $this->validator->validate( $manifest );
+
+        expect( $result->valid )->toBeFalse()
+            ->and( $result->offendingKey )->toContain( 'settings' )
+            ->and( $result->message )->not->toBeEmpty();
+    } );
+
+    it( 'rejects when styles is the wrong type', function (): void {
+        $manifest = [
+            'slug'   => 'broken-styles',
+            'styles' => 'not-an-object',
+        ];
+
+        $result = $this->validator->validate( $manifest );
+
+        expect( $result->valid )->toBeFalse()
+            ->and( $result->offendingKey )->not->toBeNull();
+    } );
+} );
+
+describe( 'menus.locations cms-framework extension', function (): void {
+    it( 'accepts a flat object of string keys and string labels', function (): void {
+        $manifest = [
+            'slug'  => 'with-menus',
+            'menus' => [
+                'locations' => [
+                    'primary' => 'Primary Menu',
+                    'footer'  => 'Footer Menu',
+                ],
+            ],
+        ];
+
+        $result = $this->validator->validate( $manifest );
+
+        expect( $result->valid )->toBeTrue();
+    } );
+
+    it( 'accepts menus without locations (empty extension)', function (): void {
+        $manifest = [
+            'slug'  => 'with-empty-menus',
+            'menus' => [],
+        ];
+
+        $result = $this->validator->validate( $manifest );
+
+        expect( $result->valid )->toBeTrue();
+    } );
+
+    it( 'rejects menus when not an object', function (): void {
+        $manifest = [
+            'slug'  => 'broken-menus',
+            'menus' => 'not-an-object',
+        ];
+
+        $result = $this->validator->validate( $manifest );
+
+        expect( $result->valid )->toBeFalse()
+            ->and( $result->offendingKey )->toBe( 'menus' );
+    } );
+
+    it( 'rejects menus.locations when it is a list (numeric keys)', function (): void {
+        $manifest = [
+            'slug'  => 'broken-menus',
+            'menus' => [
+                'locations' => [ 'primary', 'footer' ],
+            ],
+        ];
+
+        $result = $this->validator->validate( $manifest );
+
+        expect( $result->valid )->toBeFalse()
+            ->and( $result->offendingKey )->toBe( 'menus.locations' );
+    } );
+
+    it( 'rejects a menus.locations entry whose label is not a string', function (): void {
+        $manifest = [
+            'slug'  => 'broken-menus',
+            'menus' => [
+                'locations' => [
+                    'primary' => [ 'not', 'a', 'string' ],
+                ],
+            ],
+        ];
+
+        $result = $this->validator->validate( $manifest );
+
+        expect( $result->valid )->toBeFalse()
+            ->and( $result->offendingKey )->toBe( 'menus.locations.primary' );
+    } );
+} );
+
+describe( 'configurable schema version', function (): void {
+    it( 'throws when the configured schema version has no bundled file', function (): void {
+        config()->set( 'cms.themes.wpThemeJsonSchemaVersion', '99' );
+
+        $manifest = [
+            'slug'     => 'any',
+            'settings' => [ 'color' => [ 'background' => true ] ],
+        ];
+
+        expect( fn () => $this->validator->validate( $manifest ) )
+            ->toThrow( RuntimeException::class, 'wp-theme-json-v99' );
+    } );
+
+    it( 'reads the configured version when validating WP-shape keys', function (): void {
+        // Default is '3'. Re-asserting it is loadable is sufficient.
+        config()->set( 'cms.themes.wpThemeJsonSchemaVersion', '3' );
+
+        $manifest = [
+            'slug'     => 'configurable',
+            'settings' => [ 'appearanceTools' => true ],
+        ];
+
+        $result = $this->validator->validate( $manifest );
+
+        expect( $result->valid )->toBeTrue();
+    } );
+} );


### PR DESCRIPTION
## Description

Implements **H0** of plan 14 (cms-framework site-editor integration). Extends cms-framework's `theme.json` to incorporate the WordPress `theme.json` schema (settings, styles, customTemplates, templateParts, patterns) plus the cms-framework `menus.locations` extension. Schema validation is wired into `ThemeManager::validateTheme()` via a new `WpThemeJsonValidator` service; invalid manifests are rejected from discovery with a logged warning that names the offending key.

**Closes:** #100

## Type of Change

- [x] New feature (adds new functionality)

## Related Issue

**Issue:** #100

## Motivation and Context

H0 is the foundation for Phase H of V1 — templates, template parts, patterns, global styles, and menu locations being driven by themes. It gates H1–H4 (cms-framework templates, patterns, global styles, menus modules) and indirectly gates H5+ in visual-editor.

The WP-shape subset is validated against a pinned WP `theme.json` schema version so schema upgrades are explicit work, not silent drift (per plan 11 §4.2).

## Changes Made

- New `WpThemeJsonValidator` service at `src/Modules/Themes/Validation/WpThemeJsonValidator.php`. Validates the WP-shape subset against a bundled WP schema using `justinrainbow/json-schema`. The cms-framework `version` field (semver string) is intentionally kept outside WP-schema scope — the validator extracts only the WP-shape keys and validates them as a synthetic minimal object with `version: 3` injected.
- New `WpThemeJsonValidationResult` value object carrying `valid`, `offendingKey`, `message`.
- Bundled WP 6.8 theme.json schema at `src/Modules/Themes/Validation/schemas/wp-theme-json-v3.json` (78 KB, fetched from `schemas.wp.org/wp/6.8/theme.json`). Self-contained — no external `$ref` resolution needed.
- New config key `cms.themes.wpThemeJsonSchemaVersion` defaulting to `'3'`. Pinned to match the `@wordpress/*` packages in visual-editor (WP 6.8). Bumping the pin requires updating the bundled schema file too.
- `ThemeManager::validateTheme()` now calls the validator after the existing required-files check; failures log a warning naming the offending key and skip the theme from discovery. Malformed JSON also logs a warning (previously silent).
- Hand-rolled `menus.locations` shape check (cms-framework extension) — must be an object of `string => string`. Lists or non-string values are rejected.
- Adds `justinrainbow/json-schema:^6.0` as a runtime dep.
- Documentation in `docs/themes.md` covering the extended manifest, both shape sections, the configurable schema version, and the validation behavior.

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS 15.4
- PHP Version: 8.4.3
- Project Version: cms-framework 1.1.0 → 1.2.0 (this PR)

**Tests Performed:**
1. `./vendor/bin/pest tests/Unit/Themes/ tests/Feature/Themes/ --compact` → 18/18 pass.
2. `./vendor/bin/pest --compact` (full suite) → 658 passed, 4 skipped (pre-existing), 0 failures.
3. `./vendor/bin/php-cs-fixer fix` → clean on touched files.
4. `coderabbit review --plain --base origin/release/1.2` → No findings.

## Accessibility Tests Run

- [x] Not applicable — backend/validation work; no UI changes.

**Details:** This PR is purely backend (theme manifest validation). No UI surface affected.

## Tests Added

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] All tests passing

**Test details:**

- `tests/Unit/Themes/WpThemeJsonValidatorTest.php` — 13 tests covering all validator paths: pre-Phase-H themes, full WP-shape settings/styles/customTemplates/templateParts/patterns, invalid `settings.color.palette`, invalid `styles` type, valid `menus.locations`, empty menus, invalid menus shapes (non-object, list-shaped locations, non-string label), missing schema file (raises `RuntimeException`), and configurable schema version.
- `tests/Feature/Themes/ThemeManagerSchemaValidationTest.php` — 5 discovery-flow tests against the live `ThemeManager`: legacy theme discovers without warnings, full WP-shape theme discovers, `menus.locations` theme discovers, broken `settings` theme rejected with `Log::warning` containing offending key, and malformed JSON theme rejected with parse-failed warning.

## Documentation

- [x] Inline code documentation added
- [x] Wiki updated (`docs/themes.md`)

**Documentation details:**

`docs/themes.md` extended with:
- New `wpThemeJsonSchemaVersion` config key.
- "Theme Manifest" section with both the cms-framework manifest fields and the WordPress theme.json subset, with a full WP-shape example and the `$schema` URL pinned to WP 6.8.
- `menus.locations` extension section with shape rules.
- "Validation behavior" section documenting the three validation stages and the warning-on-failure behavior.

## Pre-Submission Checklist

- [x] Followed contributing guidelines
- [x] Checked for other open PRs for same update
- [x] Code passes all tests
- [x] Code has been linted (PHP-CS-Fixer)
- [x] Accessibility tests completed (N/A — backend)
- [x] Code follows project style guide
- [x] Self-review completed
- [x] Comments added for complex code
- [x] No new warnings generated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added WordPress theme.json schema validation during theme discovery; themes failing parse or validation are skipped with logged warnings.
  * Added support for a menus.locations extension for menu configuration.
  * Added a config option to pin the theme.json schema version (defaults to v3).

* **Documentation**
  * Expanded theme manifest docs with schema, discovery/validation behavior, and menus.locations guidance.

* **Chores**
  * Added JSON schema validation runtime dependency.

* **Tests**
  * Added unit and feature tests covering schema parsing, validation, and failure logging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->