### PR TITLE
feat: H1 — Templates + template-parts module (new SiteEditor module) (#108)

### DIFF
--- a/database/migrations/2026_05_01_120000_create_templates_table.php
+++ b/database/migrations/2026_05_01_120000_create_templates_table.php
@@ -1,0 +1,33 @@
+<?php
+
+declare( strict_types=1 );
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create( 'templates', function ( Blueprint $table ): void {
+            $table->id();
+            $table->string( 'theme' );
+            $table->string( 'slug' );
+            $table->string( 'title' );
+            $table->text( 'description' )->nullable();
+            $table->string( 'status' )->default( 'publish' );
+            $table->boolean( 'is_custom' )->default( false );
+            $table->json( 'block_content' )->nullable();
+            $table->foreignId( 'author_id' )->nullable()->constrained( 'users' )->nullOnDelete();
+            $table->timestamps();
+
+            $table->unique( ['theme', 'slug'] );
+            $table->index( 'slug' );
+        } );
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists( 'templates' );
+    }
+};

--- a/database/migrations/2026_05_01_120001_create_template_parts_table.php
+++ b/database/migrations/2026_05_01_120001_create_template_parts_table.php
@@ -1,0 +1,35 @@
+<?php
+
+declare( strict_types=1 );
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create( 'template_parts', function ( Blueprint $table ): void {
+            $table->id();
+            $table->string( 'theme' );
+            $table->string( 'slug' );
+            $table->string( 'title' );
+            $table->text( 'description' )->nullable();
+            $table->string( 'area' )->default( 'general' );
+            $table->string( 'status' )->default( 'publish' );
+            $table->boolean( 'is_custom' )->default( false );
+            $table->json( 'block_content' )->nullable();
+            $table->foreignId( 'author_id' )->nullable()->constrained( 'users' )->nullOnDelete();
+            $table->timestamps();
+
+            $table->unique( ['theme', 'slug'] );
+            $table->index( 'slug' );
+            $table->index( 'area' );
+        } );
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists( 'template_parts' );
+    }
+};

--- a/docs/site-editor.md
+++ b/docs/site-editor.md
@@ -51,6 +51,7 @@ Response shape mirrors WordPress's `/wp/v2/templates`:
     "origin": null,
     "content": {
         "raw": "<!-- wp:paragraph --><p>Hello</p><!-- /wp:paragraph -->",
+        "blocks": [],
         "block_version": 1
     },
     "title": { "raw": "Page", "rendered": "Page" },
@@ -64,7 +65,14 @@ Response shape mirrors WordPress's `/wp/v2/templates`:
 }
 ```
 
-`wp_id` is the DB-row integer ID (0 when only a theme file backs the slug). `id` uses the `theme//slug` form for theme-backed templates and the integer DB ID for purely custom ones.
+`id` is always the `theme//slug` form, matching WP exactly. `wp_id` carries the DB row's integer ID separately (0 when only a theme file backs the slug).
+
+`content.raw` carries the file contents for theme-file-sourced entities and is the empty string `''` for DB-stored entities. `content.blocks` carries the parsed block array for DB-stored entities and is empty `[]` for theme-file-sourced entities. cms-framework's `HasBlockContent` trait stores only the parsed block array — never a raw HTML mirror — so consumers requiring HTML render through the matching renderer package, and consumers needing the parsed tree read from `content.blocks`. This mirrors the visual-editor adapter convention in `Adapters\CmsFramework\WpEntityResource`.
+
+### Conflict and validation behavior
+
+- `POST` returns **409 Conflict** when a `(theme, slug)` row already exists, with `errors.slug` set.
+- `PUT` accepts a body without a slug (route slug is canonical) and returns **422** when a body slug is present but does not match the URL slug.
 
 ## Template parts
 

--- a/docs/site-editor.md
+++ b/docs/site-editor.md
@@ -1,0 +1,121 @@
+---
+title: Site Editor
+---
+
+# Site Editor Module
+
+The Site Editor module hosts the backends behind cms-framework's WordPress-style site-editor surface: templates, template parts, patterns, global styles, and menus. H1 ships templates and template parts; subsequent phases (H2–H4) add patterns, global styles, and menus to the same module.
+
+## Overview
+
+Site-editor entities resolve through a hybrid file + database model: themes ship default content as files (e.g. `themes/{active}/templates/{slug}.html`), and the database stores user overrides. When both exist, the DB row wins. Reverting a DB override deletes the row and returns the entity to its theme-file source.
+
+This mirrors WordPress's site-editor authority chain. Visual-editor (`#407` H5) consumes these endpoints to populate `addEntities()` configuration at editor bootstrap.
+
+## Module placement
+
+`src/Modules/SiteEditor/` is a sibling to `src/Modules/Themes/`. Conceptually it acts as a sub-module of the theme system — site-editor entities are theme-driven with DB overrides — but it earns its own module because:
+
+- It owns its own models, migrations, and REST endpoints.
+- Future phases (patterns, global styles, menus) extend the same module.
+- The Themes module stays focused on theme discovery, activation, view-path registration, and `theme.json` validation.
+
+## Templates
+
+### Storage
+
+- Theme files: `themes/{active}/templates/{slug}.html`
+- DB table: `templates` with columns `id`, `theme`, `slug`, `title`, `description`, `status`, `is_custom`, `block_content` (JSON), `author_id`, timestamps. Unique constraint on `(theme, slug)`.
+
+### REST endpoints
+
+All endpoints live under `/api/v1/` and require authentication.
+
+| Method | Path | Purpose |
+|---|---|---|
+| GET | `/templates` | List resolved templates (file + DB merged; DB wins per slug) |
+| GET | `/templates/{slug}` | Show single resolved template |
+| POST | `/templates` | Create DB-stored template (custom or override) |
+| PUT | `/templates/{slug}` | Upsert DB-stored template |
+| DELETE | `/templates/{slug}` | Revert (deletes DB row; theme file stays authoritative) |
+
+Response shape mirrors WordPress's `/wp/v2/templates`:
+
+```json
+{
+    "id": "{theme}//{slug}",
+    "slug": "page",
+    "theme": "digital-shopfront",
+    "type": "wp_template",
+    "source": "theme",
+    "origin": null,
+    "content": {
+        "raw": "<!-- wp:paragraph --><p>Hello</p><!-- /wp:paragraph -->",
+        "block_version": 1
+    },
+    "title": { "raw": "Page", "rendered": "Page" },
+    "description": "",
+    "status": "publish",
+    "wp_id": 0,
+    "has_theme_file": true,
+    "is_custom": false,
+    "author": 0,
+    "modified": null
+}
+```
+
+`wp_id` is the DB-row integer ID (0 when only a theme file backs the slug). `id` uses the `theme//slug` form for theme-backed templates and the integer DB ID for purely custom ones.
+
+## Template parts
+
+### Storage
+
+- Theme files: `themes/{active}/parts/{slug}.html`
+- DB table: `template_parts` — same shape as `templates` plus a required `area` column.
+
+### Areas
+
+Template parts are constrained to four area values for V1: `header`, `footer`, `sidebar`, `general`. These match WordPress's default areas. Open-ended user-defined areas are deferred to V1.1 per plan 14 §8.
+
+The closed list is enforced at the application layer:
+- Form Request rejects payloads with any other value (HTTP 422).
+- Theme-file parts whose slug starts with a known area prefix (`header-large`, `footer-mini`) are auto-categorized into that area; everything else falls back to `general`.
+
+### REST endpoints
+
+Same shape as templates, but under `/api/v1/template-parts`. The response carries an additional `area` field and `type` is `wp_template_part`.
+
+## Resolver contract
+
+Both entity types implement `ArtisanPackUI\CMSFramework\Modules\SiteEditor\Resolution\EntityResolver`:
+
+```php
+interface EntityResolver
+{
+    public function resolve(string $slug): ?ResolvedEntity;
+    public function all(): array;
+    public function revert(string $slug): bool;
+}
+```
+
+`ResolvedEntity` is a value object carrying the merged source-of-truth: slug, theme, source (`'db'` or `'theme'`), content (block string), title, description, status, `hasThemeFile`, `isCustom`, `area` (parts only), and the backing model (when source is `'db'`).
+
+H2–H4 will add `PatternResolver`, `GlobalStylesResolver`, and `MenuResolver` against the same interface.
+
+## Permissions
+
+The slugs `visual_editor.templates.edit` and `visual_editor.template-parts.edit` are seeded by the parent `CMSFrameworkServiceProvider` via the G5 (#98) bridge. The SiteEditor module does not register additional permissions; routes use the `auth` middleware (V1 baseline of "any authenticated user", per plan 12 §2.6). V1.1 introduces fine-grained policies.
+
+## Service registration
+
+`SiteEditorServiceProvider` is registered from the parent `CMSFrameworkServiceProvider`. It:
+
+- Binds `TemplateResolver` and `TemplatePartResolver` as singletons.
+- Loads `routes/api.php` for the REST endpoints.
+
+Migrations live at the package level (`database/migrations/`) and are loaded by the parent `CMSFrameworkServiceProvider`.
+
+## Coordination with visual-editor
+
+- `#407` (H5 — site-editor resource filters): visual-editor reads the `/templates` and `/template-parts` endpoints to populate `addEntities()` at editor bootstrap.
+- `#399` (G3 — editor entity adapter): visual-editor's WP-shape resource adapter maps the REST responses back into the editor's `useEntityRecord` / `useEntityRecords` selectors.

--- a/src/CMSFrameworkServiceProvider.php
+++ b/src/CMSFrameworkServiceProvider.php
@@ -27,6 +27,7 @@ use ArtisanPackUI\CMSFramework\Modules\Pages\Models\Page;
 use ArtisanPackUI\CMSFramework\Modules\Pages\Providers\PagesServiceProvider;
 use ArtisanPackUI\CMSFramework\Modules\Plugins\Providers\PluginsServiceProvider;
 use ArtisanPackUI\CMSFramework\Modules\Settings\Providers\SettingsServiceProvider;
+use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Providers\SiteEditorServiceProvider;
 use ArtisanPackUI\CMSFramework\Modules\Themes\Providers\ThemesServiceProvider;
 use ArtisanPackUI\CMSFramework\Modules\Users\Managers\PermissionManager;
 use ArtisanPackUI\CMSFramework\Modules\Users\Providers\UserServiceProvider;
@@ -168,6 +169,7 @@ class CMSFrameworkServiceProvider extends ServiceProvider
         $this->app->register( BlogServiceProvider::class );
         $this->app->register( PagesServiceProvider::class );
         $this->app->register( ThemesServiceProvider::class );
+        $this->app->register( SiteEditorServiceProvider::class );
         $this->app->register( PluginsServiceProvider::class );
         $this->app->register( OpenApiServiceProvider::class );
     }

--- a/src/Modules/SiteEditor/Http/Controllers/TemplatePartsController.php
+++ b/src/Modules/SiteEditor/Http/Controllers/TemplatePartsController.php
@@ -117,13 +117,21 @@ class TemplatePartsController extends Controller
             ], 422 );
         }
 
-        $attributes         = $this->normalizeAttributes( $theme, $validated );
-        $attributes['slug'] = $slug;
+        unset( $validated['slug'] );
 
-        $part = TemplatePart::updateOrCreate(
-            [ 'theme' => $theme, 'slug' => $slug ],
-            $attributes,
-        );
+        $existing = TemplatePart::query()
+            ->where( 'theme', $theme )
+            ->where( 'slug', $slug )
+            ->first();
+
+        if ( null !== $existing ) {
+            $existing->update( $validated );
+            $part = $existing->refresh();
+        } else {
+            $attributes         = $this->normalizeAttributes( $theme, $validated );
+            $attributes['slug'] = $slug;
+            $part               = TemplatePart::create( $attributes );
+        }
 
         $entity = $this->resolver->resolve( $part->slug );
 

--- a/src/Modules/SiteEditor/Http/Controllers/TemplatePartsController.php
+++ b/src/Modules/SiteEditor/Http/Controllers/TemplatePartsController.php
@@ -17,6 +17,7 @@ use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Http\Requests\TemplatePartRequ
 use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Http\Resources\TemplateResource;
 use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Models\TemplatePart;
 use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Resolution\TemplatePartResolver;
+use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Support\SlugValidator;
 use ArtisanPackUI\CMSFramework\Modules\Themes\Managers\ThemeManager;
 use Dedoc\Scramble\Attributes\Group;
 use Illuminate\Database\QueryException;
@@ -108,6 +109,16 @@ class TemplatePartsController extends Controller
             return response()->json( [ 'message' => 'No active theme.' ], 409 );
         }
 
+        // The Form Request only validates `slug` when present in the payload.
+        // For PUT, the route slug is canonical and may be the only slug in
+        // play, so guard it directly against the same canonical pattern.
+        if ( ! SlugValidator::isValid( $slug ) ) {
+            return response()->json( [
+                'message' => 'URL slug is not in canonical kebab-case form.',
+                'errors'  => [ 'slug' => [ 'Slug must be lowercase letters, numbers, and hyphens only.' ] ],
+            ], 422 );
+        }
+
         $validated = $request->validated();
 
         if ( array_key_exists( 'slug', $validated ) && $validated['slug'] !== $slug ) {
@@ -119,19 +130,7 @@ class TemplatePartsController extends Controller
 
         unset( $validated['slug'] );
 
-        $existing = TemplatePart::query()
-            ->where( 'theme', $theme )
-            ->where( 'slug', $slug )
-            ->first();
-
-        if ( null !== $existing ) {
-            $existing->update( $validated );
-            $part = $existing->refresh();
-        } else {
-            $attributes         = $this->normalizeAttributes( $theme, $validated );
-            $attributes['slug'] = $slug;
-            $part               = TemplatePart::create( $attributes );
-        }
+        $part = $this->upsertForTheme( $theme, $slug, $validated );
 
         $entity = $this->resolver->resolve( $part->slug );
 
@@ -152,6 +151,51 @@ class TemplatePartsController extends Controller
         }
 
         return response()->json( null, 204 );
+    }
+
+    /**
+     * Race-safe upsert for the active theme + route slug.
+     *
+     * See {@see TemplatesController::upsertForTheme()} for the rationale —
+     * this mirror exists because Templates and TemplateParts each have
+     * their own model class.
+     *
+     * @since 1.2.0
+     *
+     * @param  array<string, mixed>  $validated
+     */
+    protected function upsertForTheme( string $theme, string $slug, array $validated ): TemplatePart
+    {
+        $existing = TemplatePart::query()
+            ->where( 'theme', $theme )
+            ->where( 'slug', $slug )
+            ->first();
+
+        if ( null !== $existing ) {
+            $existing->update( $validated );
+
+            return $existing->refresh();
+        }
+
+        $attributes         = $this->normalizeAttributes( $theme, $validated );
+        $attributes['slug'] = $slug;
+
+        try {
+            return TemplatePart::create( $attributes );
+        } catch ( QueryException $e ) {
+            if ( ! $this->isUniqueViolation( $e ) ) {
+                throw $e;
+            }
+
+            $existing = TemplatePart::query()
+                ->where( 'theme', $theme )
+                ->where( 'slug', $slug )
+                ->firstOrFail();
+
+            $existing->update( $validated );
+
+            return $existing->refresh();
+        }
     }
 
     /**

--- a/src/Modules/SiteEditor/Http/Controllers/TemplatePartsController.php
+++ b/src/Modules/SiteEditor/Http/Controllers/TemplatePartsController.php
@@ -1,0 +1,156 @@
+<?php
+
+/**
+ * Template Parts Controller
+ *
+ * Implements the WordPress `/wp/v2/template-parts` REST shape against
+ * the cms-framework `TemplatePartResolver` + `TemplatePart` model.
+ *
+ * @since      1.2.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Modules\SiteEditor\Http\Controllers;
+
+use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Http\Requests\TemplatePartRequest;
+use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Http\Resources\TemplateResource;
+use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Models\TemplatePart;
+use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Resolution\TemplatePartResolver;
+use ArtisanPackUI\CMSFramework\Modules\Themes\Managers\ThemeManager;
+use Dedoc\Scramble\Attributes\Group;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Routing\Controller;
+
+/**
+ * @since 1.2.0
+ */
+#[Group( 'Site Editor / Template Parts', weight: 31 )]
+class TemplatePartsController extends Controller
+{
+    /**
+     * @since 1.2.0
+     */
+    public function __construct(
+        private TemplatePartResolver $resolver,
+        private ThemeManager $themeManager,
+    ) {
+    }
+
+    /**
+     * GET /api/v1/template-parts — list resolved template parts for the active theme.
+     *
+     * @since 1.2.0
+     */
+    public function index(): JsonResponse
+    {
+        return response()->json( TemplateResource::collection( $this->resolver->all() ) );
+    }
+
+    /**
+     * GET /api/v1/template-parts/{slug} — show a single resolved template part.
+     *
+     * @since 1.2.0
+     */
+    public function show( string $slug ): JsonResponse
+    {
+        $entity = $this->resolver->resolve( $slug );
+
+        if ( null === $entity ) {
+            return response()->json( [ 'message' => 'Template part not found.' ], 404 );
+        }
+
+        return response()->json( TemplateResource::toArray( $entity ) );
+    }
+
+    /**
+     * POST /api/v1/template-parts — create a DB-stored template part.
+     *
+     * @since 1.2.0
+     */
+    public function store( TemplatePartRequest $request ): JsonResponse
+    {
+        $theme = $this->activeThemeSlug();
+
+        if ( null === $theme ) {
+            return response()->json( [ 'message' => 'No active theme.' ], 409 );
+        }
+
+        $part = TemplatePart::create( $this->normalizeAttributes( $theme, $request->validated() ) );
+
+        $entity = $this->resolver->resolve( $part->slug );
+
+        return response()->json( TemplateResource::toArray( $entity ), 201 );
+    }
+
+    /**
+     * PUT /api/v1/template-parts/{slug} — update or upsert a DB-stored template part.
+     *
+     * @since 1.2.0
+     */
+    public function update( TemplatePartRequest $request, string $slug ): JsonResponse
+    {
+        $theme = $this->activeThemeSlug();
+
+        if ( null === $theme ) {
+            return response()->json( [ 'message' => 'No active theme.' ], 409 );
+        }
+
+        $attributes         = $this->normalizeAttributes( $theme, $request->validated() );
+        $attributes['slug'] = $slug;
+
+        $part = TemplatePart::updateOrCreate(
+            [ 'theme' => $theme, 'slug' => $slug ],
+            $attributes,
+        );
+
+        $entity = $this->resolver->resolve( $part->slug );
+
+        return response()->json( TemplateResource::toArray( $entity ) );
+    }
+
+    /**
+     * DELETE /api/v1/template-parts/{slug} — revert to theme file by deleting the DB row.
+     *
+     * @since 1.2.0
+     */
+    public function destroy( string $slug ): JsonResponse
+    {
+        $deleted = $this->resolver->revert( $slug );
+
+        if ( ! $deleted ) {
+            return response()->json( [ 'message' => 'No template part override to revert.' ], 404 );
+        }
+
+        return response()->json( null, 204 );
+    }
+
+    /**
+     * @since 1.2.0
+     */
+    protected function activeThemeSlug(): ?string
+    {
+        $theme = $this->themeManager->getActiveTheme();
+
+        return null !== $theme && ! empty( $theme['slug'] ) ? (string) $theme['slug'] : null;
+    }
+
+    /**
+     * @since 1.2.0
+     *
+     * @param  array<string, mixed>  $validated
+     *
+     * @return array<string, mixed>
+     */
+    protected function normalizeAttributes( string $theme, array $validated ): array
+    {
+        $validated['theme']     = $theme;
+        $validated['author_id'] = $validated['author_id'] ?? auth()->id();
+
+        if ( ! array_key_exists( 'is_custom', $validated ) ) {
+            $validated['is_custom'] = false;
+        }
+
+        return $validated;
+    }
+}

--- a/src/Modules/SiteEditor/Http/Controllers/TemplatePartsController.php
+++ b/src/Modules/SiteEditor/Http/Controllers/TemplatePartsController.php
@@ -19,6 +19,7 @@ use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Models\TemplatePart;
 use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Resolution\TemplatePartResolver;
 use ArtisanPackUI\CMSFramework\Modules\Themes\Managers\ThemeManager;
 use Dedoc\Scramble\Attributes\Group;
+use Illuminate\Database\QueryException;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Routing\Controller;
 
@@ -76,7 +77,18 @@ class TemplatePartsController extends Controller
             return response()->json( [ 'message' => 'No active theme.' ], 409 );
         }
 
-        $part = TemplatePart::create( $this->normalizeAttributes( $theme, $request->validated() ) );
+        try {
+            $part = TemplatePart::create( $this->normalizeAttributes( $theme, $request->validated() ) );
+        } catch ( QueryException $e ) {
+            if ( $this->isUniqueViolation( $e ) ) {
+                return response()->json( [
+                    'message' => 'A template part with this slug already exists for the active theme.',
+                    'errors'  => [ 'slug' => [ 'Slug must be unique within the theme.' ] ],
+                ], 409 );
+            }
+
+            throw $e;
+        }
 
         $entity = $this->resolver->resolve( $part->slug );
 
@@ -96,7 +108,16 @@ class TemplatePartsController extends Controller
             return response()->json( [ 'message' => 'No active theme.' ], 409 );
         }
 
-        $attributes         = $this->normalizeAttributes( $theme, $request->validated() );
+        $validated = $request->validated();
+
+        if ( array_key_exists( 'slug', $validated ) && $validated['slug'] !== $slug ) {
+            return response()->json( [
+                'message' => 'Body slug does not match URL slug.',
+                'errors'  => [ 'slug' => [ 'Slug in the request body must match the URL slug.' ] ],
+            ], 422 );
+        }
+
+        $attributes         = $this->normalizeAttributes( $theme, $validated );
         $attributes['slug'] = $slug;
 
         $part = TemplatePart::updateOrCreate(
@@ -133,6 +154,26 @@ class TemplatePartsController extends Controller
         $theme = $this->themeManager->getActiveTheme();
 
         return null !== $theme && ! empty( $theme['slug'] ) ? (string) $theme['slug'] : null;
+    }
+
+    /**
+     * Detect a unique-constraint violation on a {@see QueryException}.
+     *
+     * MySQL/MariaDB report SQLSTATE 23000 + driver code 1062; PostgreSQL
+     * reports SQLSTATE 23505; SQLite (used in tests) raises 23000 with
+     * 'UNIQUE constraint failed' in the message.
+     *
+     * @since 1.2.0
+     */
+    protected function isUniqueViolation( QueryException $e ): bool
+    {
+        $sqlState = $e->getCode();
+
+        if ( '23000' === $sqlState || '23505' === $sqlState ) {
+            return true;
+        }
+
+        return str_contains( strtolower( $e->getMessage() ), 'unique' );
     }
 
     /**

--- a/src/Modules/SiteEditor/Http/Controllers/TemplatesController.php
+++ b/src/Modules/SiteEditor/Http/Controllers/TemplatesController.php
@@ -120,13 +120,29 @@ class TemplatesController extends Controller
             ], 422 );
         }
 
-        $attributes         = $this->normalizeAttributes( $theme, $validated );
-        $attributes['slug'] = $slug;
+        // Strip slug from the validated attributes — the route slug is
+        // canonical for both branches below.
+        unset( $validated['slug'] );
 
-        $template = Template::updateOrCreate(
-            [ 'theme' => $theme, 'slug' => $slug ],
-            $attributes,
-        );
+        $existing = Template::query()
+            ->where( 'theme', $theme )
+            ->where( 'slug', $slug )
+            ->first();
+
+        if ( null !== $existing ) {
+            // Update path: apply only the fields the client supplied. Don't
+            // run normalizeAttributes — its `author_id` and `is_custom`
+            // defaults would silently overwrite values the client didn't
+            // intend to change. Matches WP REST `/wp/v2/templates` PUT
+            // semantics (omitted fields keep their existing values).
+            $existing->update( $validated );
+            $template = $existing->refresh();
+        } else {
+            // Create path: stamp theme + author + is_custom defaults.
+            $attributes         = $this->normalizeAttributes( $theme, $validated );
+            $attributes['slug'] = $slug;
+            $template           = Template::create( $attributes );
+        }
 
         $entity = $this->resolver->resolve( $template->slug );
 

--- a/src/Modules/SiteEditor/Http/Controllers/TemplatesController.php
+++ b/src/Modules/SiteEditor/Http/Controllers/TemplatesController.php
@@ -19,6 +19,7 @@ use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Models\Template;
 use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Resolution\TemplateResolver;
 use ArtisanPackUI\CMSFramework\Modules\Themes\Managers\ThemeManager;
 use Dedoc\Scramble\Attributes\Group;
+use Illuminate\Database\QueryException;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Routing\Controller;
 
@@ -76,7 +77,18 @@ class TemplatesController extends Controller
             return response()->json( [ 'message' => 'No active theme.' ], 409 );
         }
 
-        $template = Template::create( $this->normalizeAttributes( $theme, $request->validated() ) );
+        try {
+            $template = Template::create( $this->normalizeAttributes( $theme, $request->validated() ) );
+        } catch ( QueryException $e ) {
+            if ( $this->isUniqueViolation( $e ) ) {
+                return response()->json( [
+                    'message' => 'A template with this slug already exists for the active theme.',
+                    'errors'  => [ 'slug' => [ 'Slug must be unique within the theme.' ] ],
+                ], 409 );
+            }
+
+            throw $e;
+        }
 
         $entity = $this->resolver->resolve( $template->slug );
 
@@ -96,9 +108,19 @@ class TemplatesController extends Controller
             return response()->json( [ 'message' => 'No active theme.' ], 409 );
         }
 
-        $attributes = $this->normalizeAttributes( $theme, $request->validated() );
-        // The slug from the route always wins over any slug in the payload —
-        // PUT identifies the resource.
+        $validated = $request->validated();
+
+        // PUT identifies the resource via the route slug. If the body also
+        // carries a slug it must match, so a client that mistakenly tries to
+        // rename the resource gets a 422 instead of silently being ignored.
+        if ( array_key_exists( 'slug', $validated ) && $validated['slug'] !== $slug ) {
+            return response()->json( [
+                'message' => 'Body slug does not match URL slug.',
+                'errors'  => [ 'slug' => [ 'Slug in the request body must match the URL slug.' ] ],
+            ], 422 );
+        }
+
+        $attributes         = $this->normalizeAttributes( $theme, $validated );
         $attributes['slug'] = $slug;
 
         $template = Template::updateOrCreate(
@@ -137,6 +159,26 @@ class TemplatesController extends Controller
         $theme = $this->themeManager->getActiveTheme();
 
         return null !== $theme && ! empty( $theme['slug'] ) ? (string) $theme['slug'] : null;
+    }
+
+    /**
+     * Detect a unique-constraint violation on a {@see QueryException}.
+     *
+     * MySQL/MariaDB report SQLSTATE 23000 + driver code 1062; PostgreSQL
+     * reports SQLSTATE 23505; SQLite (used in tests) raises 23000 with
+     * 'UNIQUE constraint failed' in the message.
+     *
+     * @since 1.2.0
+     */
+    protected function isUniqueViolation( QueryException $e ): bool
+    {
+        $sqlState = $e->getCode();
+
+        if ( '23000' === $sqlState || '23505' === $sqlState ) {
+            return true;
+        }
+
+        return str_contains( strtolower( $e->getMessage() ), 'unique' );
     }
 
     /**

--- a/src/Modules/SiteEditor/Http/Controllers/TemplatesController.php
+++ b/src/Modules/SiteEditor/Http/Controllers/TemplatesController.php
@@ -1,0 +1,163 @@
+<?php
+
+/**
+ * Templates Controller
+ *
+ * Implements the WordPress `/wp/v2/templates` REST shape against
+ * the cms-framework `TemplateResolver` + `Template` model.
+ *
+ * @since      1.2.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Modules\SiteEditor\Http\Controllers;
+
+use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Http\Requests\TemplateRequest;
+use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Http\Resources\TemplateResource;
+use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Models\Template;
+use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Resolution\TemplateResolver;
+use ArtisanPackUI\CMSFramework\Modules\Themes\Managers\ThemeManager;
+use Dedoc\Scramble\Attributes\Group;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Routing\Controller;
+
+/**
+ * @since 1.2.0
+ */
+#[Group( 'Site Editor / Templates', weight: 30 )]
+class TemplatesController extends Controller
+{
+    /**
+     * @since 1.2.0
+     */
+    public function __construct(
+        private TemplateResolver $resolver,
+        private ThemeManager $themeManager,
+    ) {
+    }
+
+    /**
+     * GET /api/v1/templates — list resolved templates for the active theme.
+     *
+     * @since 1.2.0
+     */
+    public function index(): JsonResponse
+    {
+        return response()->json( TemplateResource::collection( $this->resolver->all() ) );
+    }
+
+    /**
+     * GET /api/v1/templates/{slug} — show a single resolved template.
+     *
+     * @since 1.2.0
+     */
+    public function show( string $slug ): JsonResponse
+    {
+        $entity = $this->resolver->resolve( $slug );
+
+        if ( null === $entity ) {
+            return response()->json( [ 'message' => 'Template not found.' ], 404 );
+        }
+
+        return response()->json( TemplateResource::toArray( $entity ) );
+    }
+
+    /**
+     * POST /api/v1/templates — create a DB-stored template (custom or override).
+     *
+     * @since 1.2.0
+     */
+    public function store( TemplateRequest $request ): JsonResponse
+    {
+        $theme = $this->activeThemeSlug();
+
+        if ( null === $theme ) {
+            return response()->json( [ 'message' => 'No active theme.' ], 409 );
+        }
+
+        $template = Template::create( $this->normalizeAttributes( $theme, $request->validated() ) );
+
+        $entity = $this->resolver->resolve( $template->slug );
+
+        return response()->json( TemplateResource::toArray( $entity ), 201 );
+    }
+
+    /**
+     * PUT /api/v1/templates/{slug} — update or upsert a DB-stored template.
+     *
+     * @since 1.2.0
+     */
+    public function update( TemplateRequest $request, string $slug ): JsonResponse
+    {
+        $theme = $this->activeThemeSlug();
+
+        if ( null === $theme ) {
+            return response()->json( [ 'message' => 'No active theme.' ], 409 );
+        }
+
+        $attributes = $this->normalizeAttributes( $theme, $request->validated() );
+        // The slug from the route always wins over any slug in the payload —
+        // PUT identifies the resource.
+        $attributes['slug'] = $slug;
+
+        $template = Template::updateOrCreate(
+            [ 'theme' => $theme, 'slug' => $slug ],
+            $attributes,
+        );
+
+        $entity = $this->resolver->resolve( $template->slug );
+
+        return response()->json( TemplateResource::toArray( $entity ) );
+    }
+
+    /**
+     * DELETE /api/v1/templates/{slug} — revert to theme file by deleting the DB row.
+     *
+     * Returns 204 when a DB row was deleted, 404 when none existed.
+     *
+     * @since 1.2.0
+     */
+    public function destroy( string $slug ): JsonResponse
+    {
+        $deleted = $this->resolver->revert( $slug );
+
+        if ( ! $deleted ) {
+            return response()->json( [ 'message' => 'No template override to revert.' ], 404 );
+        }
+
+        return response()->json( null, 204 );
+    }
+
+    /**
+     * @since 1.2.0
+     */
+    protected function activeThemeSlug(): ?string
+    {
+        $theme = $this->themeManager->getActiveTheme();
+
+        return null !== $theme && ! empty( $theme['slug'] ) ? (string) $theme['slug'] : null;
+    }
+
+    /**
+     * Build the model attribute payload from validated request data,
+     * stamping the active theme.
+     *
+     * @since 1.2.0
+     *
+     * @param  array<string, mixed>  $validated
+     *
+     * @return array<string, mixed>
+     */
+    protected function normalizeAttributes( string $theme, array $validated ): array
+    {
+        $validated['theme']     = $theme;
+        $validated['author_id'] = $validated['author_id'] ?? auth()->id();
+
+        if ( ! array_key_exists( 'is_custom', $validated ) ) {
+            $validated['is_custom'] = false;
+        }
+
+        return $validated;
+    }
+}

--- a/src/Modules/SiteEditor/Http/Controllers/TemplatesController.php
+++ b/src/Modules/SiteEditor/Http/Controllers/TemplatesController.php
@@ -17,6 +17,7 @@ use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Http\Requests\TemplateRequest;
 use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Http\Resources\TemplateResource;
 use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Models\Template;
 use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Resolution\TemplateResolver;
+use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Support\SlugValidator;
 use ArtisanPackUI\CMSFramework\Modules\Themes\Managers\ThemeManager;
 use Dedoc\Scramble\Attributes\Group;
 use Illuminate\Database\QueryException;
@@ -108,6 +109,18 @@ class TemplatesController extends Controller
             return response()->json( [ 'message' => 'No active theme.' ], 409 );
         }
 
+        // The Form Request only validates `slug` when present in the payload.
+        // For PUT, the route slug is canonical and may be the only slug in
+        // play, so guard it directly against the same canonical pattern.
+        // Without this, a PUT to /api/v1/templates/Invalid_Slug! with no body
+        // slug would create a DB row the resolver subsequently can't read.
+        if ( ! SlugValidator::isValid( $slug ) ) {
+            return response()->json( [
+                'message' => 'URL slug is not in canonical kebab-case form.',
+                'errors'  => [ 'slug' => [ 'Slug must be lowercase letters, numbers, and hyphens only.' ] ],
+            ], 422 );
+        }
+
         $validated = $request->validated();
 
         // PUT identifies the resource via the route slug. If the body also
@@ -124,25 +137,7 @@ class TemplatesController extends Controller
         // canonical for both branches below.
         unset( $validated['slug'] );
 
-        $existing = Template::query()
-            ->where( 'theme', $theme )
-            ->where( 'slug', $slug )
-            ->first();
-
-        if ( null !== $existing ) {
-            // Update path: apply only the fields the client supplied. Don't
-            // run normalizeAttributes — its `author_id` and `is_custom`
-            // defaults would silently overwrite values the client didn't
-            // intend to change. Matches WP REST `/wp/v2/templates` PUT
-            // semantics (omitted fields keep their existing values).
-            $existing->update( $validated );
-            $template = $existing->refresh();
-        } else {
-            // Create path: stamp theme + author + is_custom defaults.
-            $attributes         = $this->normalizeAttributes( $theme, $validated );
-            $attributes['slug'] = $slug;
-            $template           = Template::create( $attributes );
-        }
+        $template = $this->upsertForTheme( $theme, $slug, $validated );
 
         $entity = $this->resolver->resolve( $template->slug );
 
@@ -165,6 +160,57 @@ class TemplatesController extends Controller
         }
 
         return response()->json( null, 204 );
+    }
+
+    /**
+     * Race-safe upsert for the active theme + route slug.
+     *
+     * Splits create vs. update so omitted `is_custom` and `author_id` keep
+     * their existing values on update (matching WP REST PUT semantics, where
+     * `normalizeAttributes` only stamps create-time defaults).
+     *
+     * Concurrent PUTs can race between the existence check and the create —
+     * one wins the unique-index, the loser raises a `QueryException` which we
+     * recover from by re-fetching the now-existing row and falling through to
+     * the update branch. The race window is narrow but the recovery is
+     * deterministic so neither caller sees a 500.
+     *
+     * @since 1.2.0
+     *
+     * @param  array<string, mixed>  $validated
+     */
+    protected function upsertForTheme( string $theme, string $slug, array $validated ): Template
+    {
+        $existing = Template::query()
+            ->where( 'theme', $theme )
+            ->where( 'slug', $slug )
+            ->first();
+
+        if ( null !== $existing ) {
+            $existing->update( $validated );
+
+            return $existing->refresh();
+        }
+
+        $attributes         = $this->normalizeAttributes( $theme, $validated );
+        $attributes['slug'] = $slug;
+
+        try {
+            return Template::create( $attributes );
+        } catch ( QueryException $e ) {
+            if ( ! $this->isUniqueViolation( $e ) ) {
+                throw $e;
+            }
+
+            $existing = Template::query()
+                ->where( 'theme', $theme )
+                ->where( 'slug', $slug )
+                ->firstOrFail();
+
+            $existing->update( $validated );
+
+            return $existing->refresh();
+        }
     }
 
     /**

--- a/src/Modules/SiteEditor/Http/Requests/TemplatePartRequest.php
+++ b/src/Modules/SiteEditor/Http/Requests/TemplatePartRequest.php
@@ -1,0 +1,65 @@
+<?php
+
+/**
+ * Template Part Form Request
+ *
+ * Validates store/update payloads for `/api/v1/template-parts`.
+ *
+ * @since      1.2.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Modules\SiteEditor\Http\Requests;
+
+use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Models\TemplatePart;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+/**
+ * @since 1.2.0
+ */
+class TemplatePartRequest extends FormRequest
+{
+    /**
+     * @since 1.2.0
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @since 1.2.0
+     *
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'slug'          => [ 'required', 'string', 'max:255', 'regex:/^[a-z0-9]+(?:-[a-z0-9]+)*$/' ],
+            'title'         => [ 'required', 'string', 'max:255' ],
+            'description'   => [ 'nullable', 'string' ],
+            'area'          => [ 'required', 'string', Rule::in( TemplatePart::AREAS ) ],
+            'status'        => [ 'nullable', 'string', 'in:auto-draft,publish,draft' ],
+            'is_custom'     => [ 'nullable', 'boolean' ],
+            'block_content' => [ 'nullable', 'array' ],
+        ];
+    }
+
+    /**
+     * @since 1.2.0
+     *
+     * @return array<string, string>
+     */
+    public function messages(): array
+    {
+        return [
+            'slug.required'  => __( 'The template part slug is required.' ),
+            'slug.regex'     => __( 'The slug must be lowercase letters, numbers, and hyphens only.' ),
+            'title.required' => __( 'The template part title is required.' ),
+            'area.required'  => __( 'The template part area is required.' ),
+            'area.in'        => __( 'The area must be one of: header, footer, sidebar, general.' ),
+        ];
+    }
+}

--- a/src/Modules/SiteEditor/Http/Requests/TemplatePartRequest.php
+++ b/src/Modules/SiteEditor/Http/Requests/TemplatePartRequest.php
@@ -36,8 +36,13 @@ class TemplatePartRequest extends FormRequest
      */
     public function rules(): array
     {
+        // POST identifies the resource by payload — slug required.
+        // PUT identifies the resource by route — slug optional, but if present
+        // the controller enforces it equals the route slug.
+        $slugPresence = $this->isMethod( 'post' ) ? 'required' : 'sometimes';
+
         return [
-            'slug'          => [ 'required', 'string', 'max:255', 'regex:/^[a-z0-9]+(?:-[a-z0-9]+)*$/' ],
+            'slug'          => [ $slugPresence, 'string', 'max:255', 'regex:/^[a-z0-9]+(?:-[a-z0-9]+)*$/' ],
             'title'         => [ 'required', 'string', 'max:255' ],
             'description'   => [ 'nullable', 'string' ],
             'area'          => [ 'required', 'string', Rule::in( TemplatePart::AREAS ) ],

--- a/src/Modules/SiteEditor/Http/Requests/TemplatePartRequest.php
+++ b/src/Modules/SiteEditor/Http/Requests/TemplatePartRequest.php
@@ -13,6 +13,7 @@ declare( strict_types=1 );
 namespace ArtisanPackUI\CMSFramework\Modules\SiteEditor\Http\Requests;
 
 use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Models\TemplatePart;
+use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Support\SlugValidator;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
 
@@ -42,7 +43,7 @@ class TemplatePartRequest extends FormRequest
         $slugPresence = $this->isMethod( 'post' ) ? 'required' : 'sometimes';
 
         return [
-            'slug'          => [ $slugPresence, 'string', 'max:255', 'regex:/^[a-z0-9]+(?:-[a-z0-9]+)*$/' ],
+            'slug'          => [ $slugPresence, 'string', 'max:255', 'regex:' . SlugValidator::PATTERN ],
             'title'         => [ 'required', 'string', 'max:255' ],
             'description'   => [ 'nullable', 'string' ],
             'area'          => [ 'required', 'string', Rule::in( TemplatePart::AREAS ) ],

--- a/src/Modules/SiteEditor/Http/Requests/TemplateRequest.php
+++ b/src/Modules/SiteEditor/Http/Requests/TemplateRequest.php
@@ -34,8 +34,13 @@ class TemplateRequest extends FormRequest
      */
     public function rules(): array
     {
+        // POST identifies the resource by payload — slug required.
+        // PUT identifies the resource by route — slug optional, but if present
+        // the controller enforces it equals the route slug.
+        $slugPresence = $this->isMethod( 'post' ) ? 'required' : 'sometimes';
+
         return [
-            'slug'          => [ 'required', 'string', 'max:255', 'regex:/^[a-z0-9]+(?:-[a-z0-9]+)*$/' ],
+            'slug'          => [ $slugPresence, 'string', 'max:255', 'regex:/^[a-z0-9]+(?:-[a-z0-9]+)*$/' ],
             'title'         => [ 'required', 'string', 'max:255' ],
             'description'   => [ 'nullable', 'string' ],
             'status'        => [ 'nullable', 'string', 'in:auto-draft,publish,draft' ],

--- a/src/Modules/SiteEditor/Http/Requests/TemplateRequest.php
+++ b/src/Modules/SiteEditor/Http/Requests/TemplateRequest.php
@@ -1,0 +1,60 @@
+<?php
+
+/**
+ * Template Form Request
+ *
+ * Validates store/update payloads for `/api/v1/templates`.
+ *
+ * @since      1.2.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Modules\SiteEditor\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+/**
+ * @since 1.2.0
+ */
+class TemplateRequest extends FormRequest
+{
+    /**
+     * @since 1.2.0
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @since 1.2.0
+     *
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'slug'          => [ 'required', 'string', 'max:255', 'regex:/^[a-z0-9]+(?:-[a-z0-9]+)*$/' ],
+            'title'         => [ 'required', 'string', 'max:255' ],
+            'description'   => [ 'nullable', 'string' ],
+            'status'        => [ 'nullable', 'string', 'in:auto-draft,publish,draft' ],
+            'is_custom'     => [ 'nullable', 'boolean' ],
+            'block_content' => [ 'nullable', 'array' ],
+        ];
+    }
+
+    /**
+     * @since 1.2.0
+     *
+     * @return array<string, string>
+     */
+    public function messages(): array
+    {
+        return [
+            'slug.required'  => __( 'The template slug is required.' ),
+            'slug.regex'     => __( 'The slug must be lowercase letters, numbers, and hyphens only.' ),
+            'title.required' => __( 'The template title is required.' ),
+        ];
+    }
+}

--- a/src/Modules/SiteEditor/Http/Requests/TemplateRequest.php
+++ b/src/Modules/SiteEditor/Http/Requests/TemplateRequest.php
@@ -12,6 +12,7 @@ declare( strict_types=1 );
 
 namespace ArtisanPackUI\CMSFramework\Modules\SiteEditor\Http\Requests;
 
+use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Support\SlugValidator;
 use Illuminate\Foundation\Http\FormRequest;
 
 /**
@@ -40,7 +41,7 @@ class TemplateRequest extends FormRequest
         $slugPresence = $this->isMethod( 'post' ) ? 'required' : 'sometimes';
 
         return [
-            'slug'          => [ $slugPresence, 'string', 'max:255', 'regex:/^[a-z0-9]+(?:-[a-z0-9]+)*$/' ],
+            'slug'          => [ $slugPresence, 'string', 'max:255', 'regex:' . SlugValidator::PATTERN ],
             'title'         => [ 'required', 'string', 'max:255' ],
             'description'   => [ 'nullable', 'string' ],
             'status'        => [ 'nullable', 'string', 'in:auto-draft,publish,draft' ],

--- a/src/Modules/SiteEditor/Http/Resources/TemplateResource.php
+++ b/src/Modules/SiteEditor/Http/Resources/TemplateResource.php
@@ -30,20 +30,24 @@ final class TemplateResource
      */
     public static function toArray( ResolvedEntity $entity ): array
     {
-        $wpId = $entity->wpId();
-        $id   = $wpId > 0 && ! $entity->hasThemeFile
-            ? (string) $wpId
-            : $entity->theme . '//' . $entity->slug;
-
         $payload = [
-            'id'             => $id,
+            // `id` is always `theme//slug` form, matching WP REST behavior. The integer
+            // DB row id (when one exists) is exposed separately as `wp_id`.
+            'id'             => $entity->theme . '//' . $entity->slug,
             'slug'           => $entity->slug,
             'theme'          => $entity->theme,
             'type'           => 'wp_template',
             'source'         => $entity->source,
             'origin'         => null,
             'content'        => [
-                'raw'           => $entity->content,
+                // `raw` is populated for theme files (the file contents) and empty
+                // for DB-stored entities — cms-framework's HasBlockContent trait stores
+                // only the parsed block array, never a raw HTML mirror. Consumers
+                // requiring HTML render through the matching renderer package; consumers
+                // requiring blocks read from `content.blocks`. Mirrors the existing
+                // visual-editor adapter convention (`Adapters\CmsFramework\WpEntityResource`).
+                'raw'           => $entity->raw,
+                'blocks'        => $entity->blocks,
                 'block_version' => 1,
             ],
             'title'          => [
@@ -52,7 +56,7 @@ final class TemplateResource
             ],
             'description'    => $entity->description ?? '',
             'status'         => $entity->status,
-            'wp_id'          => $wpId,
+            'wp_id'          => $entity->wpId(),
             'has_theme_file' => $entity->hasThemeFile,
             'is_custom'      => $entity->isCustom,
             'author'         => null !== $entity->model ? (int) ( $entity->model->author_id ?? 0 ) : 0,

--- a/src/Modules/SiteEditor/Http/Resources/TemplateResource.php
+++ b/src/Modules/SiteEditor/Http/Resources/TemplateResource.php
@@ -1,0 +1,83 @@
+<?php
+
+/**
+ * Template Resource
+ *
+ * Transforms a {@see ResolvedEntity} into a WordPress `/wp/v2/templates`
+ * shaped response array.
+ *
+ * @since      1.2.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Modules\SiteEditor\Http\Resources;
+
+use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Resolution\ResolvedEntity;
+
+/**
+ * @since 1.2.0
+ */
+final class TemplateResource
+{
+    /**
+     * Convert a ResolvedEntity into the WP-shape array used by both
+     * `/wp/v2/templates` and (with `area` added) `/wp/v2/template-parts`.
+     *
+     * @since 1.2.0
+     *
+     * @return array<string, mixed>
+     */
+    public static function toArray( ResolvedEntity $entity ): array
+    {
+        $wpId = $entity->wpId();
+        $id   = $wpId > 0 && ! $entity->hasThemeFile
+            ? (string) $wpId
+            : $entity->theme . '//' . $entity->slug;
+
+        $payload = [
+            'id'             => $id,
+            'slug'           => $entity->slug,
+            'theme'          => $entity->theme,
+            'type'           => 'wp_template',
+            'source'         => $entity->source,
+            'origin'         => null,
+            'content'        => [
+                'raw'           => $entity->content,
+                'block_version' => 1,
+            ],
+            'title'          => [
+                'raw'      => $entity->title ?? '',
+                'rendered' => $entity->title ?? '',
+            ],
+            'description'    => $entity->description ?? '',
+            'status'         => $entity->status,
+            'wp_id'          => $wpId,
+            'has_theme_file' => $entity->hasThemeFile,
+            'is_custom'      => $entity->isCustom,
+            'author'         => null !== $entity->model ? (int) ( $entity->model->author_id ?? 0 ) : 0,
+            'modified'       => null !== $entity->model
+                ? optional( $entity->model->updated_at )->toIso8601String()
+                : null,
+        ];
+
+        if ( null !== $entity->area ) {
+            $payload['type'] = 'wp_template_part';
+            $payload['area'] = $entity->area;
+        }
+
+        return $payload;
+    }
+
+    /**
+     * @since 1.2.0
+     *
+     * @param  array<int, ResolvedEntity>  $entities
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    public static function collection( array $entities ): array
+    {
+        return array_map( static fn ( ResolvedEntity $e ) => self::toArray( $e ), $entities );
+    }
+}

--- a/src/Modules/SiteEditor/Models/Template.php
+++ b/src/Modules/SiteEditor/Models/Template.php
@@ -1,0 +1,87 @@
+<?php
+
+/**
+ * Template Model
+ *
+ * Represents a site-editor template — either a DB-stored override of a theme
+ * file, or a fully custom template authored in the admin.
+ *
+ * @since      1.2.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Modules\SiteEditor\Models;
+
+use ArtisanPackUI\VisualEditor\Concerns\HasBlockContent;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Carbon;
+
+/**
+ * @property int $id
+ * @property string $theme
+ * @property string $slug
+ * @property string $title
+ * @property string|null $description
+ * @property string $status
+ * @property bool $is_custom
+ * @property array<int, array<string, mixed>>|null $block_content
+ * @property int|null $author_id
+ * @property Carbon $created_at
+ * @property Carbon $updated_at
+ */
+class Template extends Model
+{
+    use HasBlockContent;
+    use HasFactory;
+
+    /**
+     * @since 1.2.0
+     */
+    protected $table = 'templates';
+
+    /**
+     * The column that stores the visual editor block tree JSON.
+     *
+     * @since 1.2.0
+     */
+    protected string $blockContentColumn = 'block_content';
+
+    /**
+     * @since 1.2.0
+     *
+     * @var array<int, string>
+     */
+    protected $fillable = [
+        'theme',
+        'slug',
+        'title',
+        'description',
+        'status',
+        'is_custom',
+        'block_content',
+        'author_id',
+    ];
+
+    /**
+     * The user who last authored or edited this template.
+     *
+     * @since 1.2.0
+     */
+    public function author(): BelongsTo
+    {
+        return $this->belongsTo( config( 'artisanpack.cms-framework.user_model' ), 'author_id' );
+    }
+
+    /**
+     * @since 1.2.0
+     */
+    protected function casts(): array
+    {
+        return [
+            'is_custom' => 'boolean',
+        ];
+    }
+}

--- a/src/Modules/SiteEditor/Models/TemplatePart.php
+++ b/src/Modules/SiteEditor/Models/TemplatePart.php
@@ -1,0 +1,105 @@
+<?php
+
+/**
+ * TemplatePart Model
+ *
+ * Represents a site-editor template part — a reusable chunk of a template
+ * (header, footer, sidebar, or general). Either a DB-stored override of a
+ * theme file, or a fully custom part authored in the admin.
+ *
+ * @since      1.2.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Modules\SiteEditor\Models;
+
+use ArtisanPackUI\VisualEditor\Concerns\HasBlockContent;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Carbon;
+
+/**
+ * @property int $id
+ * @property string $theme
+ * @property string $slug
+ * @property string $title
+ * @property string|null $description
+ * @property string $area
+ * @property string $status
+ * @property bool $is_custom
+ * @property array<int, array<string, mixed>>|null $block_content
+ * @property int|null $author_id
+ * @property Carbon $created_at
+ * @property Carbon $updated_at
+ */
+class TemplatePart extends Model
+{
+    use HasBlockContent;
+    use HasFactory;
+
+    /**
+     * Closed list of template-part areas allowed in V1.
+     *
+     * Matches WordPress's default template-part areas. Open-ended user-defined
+     * areas are deferred to V1.1 per plan 14 §8.
+     *
+     * @since 1.2.0
+     */
+    public const AREAS = [
+        'header',
+        'footer',
+        'sidebar',
+        'general',
+    ];
+
+    /**
+     * @since 1.2.0
+     */
+    protected $table = 'template_parts';
+
+    /**
+     * The column that stores the visual editor block tree JSON.
+     *
+     * @since 1.2.0
+     */
+    protected string $blockContentColumn = 'block_content';
+
+    /**
+     * @since 1.2.0
+     *
+     * @var array<int, string>
+     */
+    protected $fillable = [
+        'theme',
+        'slug',
+        'title',
+        'description',
+        'area',
+        'status',
+        'is_custom',
+        'block_content',
+        'author_id',
+    ];
+
+    /**
+     * The user who last authored or edited this template part.
+     *
+     * @since 1.2.0
+     */
+    public function author(): BelongsTo
+    {
+        return $this->belongsTo( config( 'artisanpack.cms-framework.user_model' ), 'author_id' );
+    }
+
+    /**
+     * @since 1.2.0
+     */
+    protected function casts(): array
+    {
+        return [
+            'is_custom' => 'boolean',
+        ];
+    }
+}

--- a/src/Modules/SiteEditor/Providers/SiteEditorServiceProvider.php
+++ b/src/Modules/SiteEditor/Providers/SiteEditorServiceProvider.php
@@ -1,0 +1,52 @@
+<?php
+
+/**
+ * Site Editor Service Provider
+ *
+ * Registers the SiteEditor module's resolvers, REST routes, and migrations.
+ *
+ * Permissions for site-editor entities (`visual_editor.templates.edit`,
+ * `visual_editor.template-parts.edit`, etc.) are seeded by the parent
+ * {@see \ArtisanPackUI\CMSFramework\CMSFrameworkServiceProvider} via the
+ * G5 (#98) bridge. SiteEditor relies on those slugs being present without
+ * registering its own.
+ *
+ * @since      1.2.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Modules\SiteEditor\Providers;
+
+use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Resolution\TemplatePartResolver;
+use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Resolution\TemplateResolver;
+use ArtisanPackUI\CMSFramework\Modules\Themes\Managers\ThemeManager;
+use Illuminate\Support\ServiceProvider;
+
+/**
+ * @since 1.2.0
+ */
+class SiteEditorServiceProvider extends ServiceProvider
+{
+    /**
+     * @since 1.2.0
+     */
+    public function register(): void
+    {
+        $this->app->singleton( TemplateResolver::class, function ( $app ) {
+            return new TemplateResolver( $app->make( ThemeManager::class ) );
+        } );
+
+        $this->app->singleton( TemplatePartResolver::class, function ( $app ) {
+            return new TemplatePartResolver( $app->make( ThemeManager::class ) );
+        } );
+    }
+
+    /**
+     * @since 1.2.0
+     */
+    public function boot(): void
+    {
+        $this->loadRoutesFrom( __DIR__ . '/../routes/api.php' );
+    }
+}

--- a/src/Modules/SiteEditor/Resolution/EntityResolver.php
+++ b/src/Modules/SiteEditor/Resolution/EntityResolver.php
@@ -1,0 +1,56 @@
+<?php
+
+/**
+ * Entity Resolver Contract
+ *
+ * Site-editor entities (templates, template parts, patterns, global styles,
+ * navigation menus) are resolved through implementations of this interface.
+ * Each implementation merges DB overrides with theme-file fallbacks per
+ * plan 14 §4.2 — DB row wins when present.
+ *
+ * @since      1.2.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Modules\SiteEditor\Resolution;
+
+/**
+ * @since 1.2.0
+ */
+interface EntityResolver
+{
+    /**
+     * Resolve an entity by slug for the active theme.
+     *
+     * Returns the merged authoritative content: DB row if one exists for
+     * the active theme + slug, otherwise the theme file. Returns null
+     * when neither source has the slug.
+     *
+     * @since 1.2.0
+     */
+    public function resolve( string $slug ): ?ResolvedEntity;
+
+    /**
+     * List all entities for the active theme (file + DB merged).
+     *
+     * Returns one ResolvedEntity per unique slug, with DB rows taking
+     * precedence over theme files for slugs present in both.
+     *
+     * @since 1.2.0
+     *
+     * @return array<int, ResolvedEntity>
+     */
+    public function all(): array;
+
+    /**
+     * Revert an entity to its theme-file source by deleting the DB override.
+     *
+     * Returns true when a DB row was deleted, false when no DB row existed.
+     * For purely custom entities (no theme-file backing), this deletes the
+     * entity entirely.
+     *
+     * @since 1.2.0
+     */
+    public function revert( string $slug ): bool;
+}

--- a/src/Modules/SiteEditor/Resolution/ResolvedEntity.php
+++ b/src/Modules/SiteEditor/Resolution/ResolvedEntity.php
@@ -28,7 +28,8 @@ final class ResolvedEntity
      * @param  string  $slug  The entity slug.
      * @param  string  $theme  The active theme slug at resolution time.
      * @param  'db'|'theme'  $source  Whether the resolved content came from a DB row or a theme file.
-     * @param  string  $content  The block-content as a serialized block string (raw `<!-- wp:... /-->` markup).
+     * @param  string  $raw  The raw block markup string. Populated for theme files (the file contents) and empty for DB rows — cms-framework stores only the parsed block array, never a raw HTML mirror, to match the visual-editor adapter convention (`Adapters\CmsFramework\WpEntityResource`).
+     * @param  array<int, array<string, mixed>>  $blocks  The parsed block tree. Populated for DB rows; empty for theme files (we don't parse `.html` on the fly in V1).
      * @param  string|null  $title  Display title; null when only a theme file exists and the file has no title metadata.
      * @param  string|null  $description  Display description.
      * @param  string  $status  WP status (`'publish'` by default).
@@ -41,7 +42,8 @@ final class ResolvedEntity
         public readonly string $slug,
         public readonly string $theme,
         public readonly string $source,
-        public readonly string $content,
+        public readonly string $raw,
+        public readonly array $blocks,
         public readonly ?string $title,
         public readonly ?string $description,
         public readonly string $status,

--- a/src/Modules/SiteEditor/Resolution/ResolvedEntity.php
+++ b/src/Modules/SiteEditor/Resolution/ResolvedEntity.php
@@ -1,0 +1,66 @@
+<?php
+
+/**
+ * Resolved Entity DTO
+ *
+ * Carries the result of an {@see EntityResolver::resolve()} call: the merged
+ * source-of-truth content for a slug, plus enough metadata to reconstruct
+ * a WP-shape REST response.
+ *
+ * @since      1.2.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Modules\SiteEditor\Resolution;
+
+use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Models\Template;
+use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Models\TemplatePart;
+
+/**
+ * @since 1.2.0
+ */
+final class ResolvedEntity
+{
+    /**
+     * @since 1.2.0
+     *
+     * @param  string  $slug  The entity slug.
+     * @param  string  $theme  The active theme slug at resolution time.
+     * @param  'db'|'theme'  $source  Whether the resolved content came from a DB row or a theme file.
+     * @param  string  $content  The block-content as a serialized block string (raw `<!-- wp:... /-->` markup).
+     * @param  string|null  $title  Display title; null when only a theme file exists and the file has no title metadata.
+     * @param  string|null  $description  Display description.
+     * @param  string  $status  WP status (`'publish'` by default).
+     * @param  bool  $hasThemeFile  True when a theme file backs this slug (regardless of whether a DB override exists).
+     * @param  bool  $isCustom  True when the entity was authored in the admin with no theme-file backing.
+     * @param  string|null  $area  Template-part area (`'header' | 'footer' | 'sidebar' | 'general'`); null for templates.
+     * @param  Template|TemplatePart|null  $model  The DB row when `$source === 'db'`; null otherwise.
+     */
+    public function __construct(
+        public readonly string $slug,
+        public readonly string $theme,
+        public readonly string $source,
+        public readonly string $content,
+        public readonly ?string $title,
+        public readonly ?string $description,
+        public readonly string $status,
+        public readonly bool $hasThemeFile,
+        public readonly bool $isCustom,
+        public readonly ?string $area,
+        public readonly Template|TemplatePart|null $model,
+    ) {
+    }
+
+    /**
+     * The integer ID of the backing DB row, or 0 when none exists.
+     *
+     * Maps to WP's `wp_id` field on template / template-part responses.
+     *
+     * @since 1.2.0
+     */
+    public function wpId(): int
+    {
+        return null !== $this->model ? (int) $this->model->id : 0;
+    }
+}

--- a/src/Modules/SiteEditor/Resolution/TemplatePartResolver.php
+++ b/src/Modules/SiteEditor/Resolution/TemplatePartResolver.php
@@ -1,0 +1,217 @@
+<?php
+
+/**
+ * Template Part Resolver
+ *
+ * Resolves template-part entities for the active theme by merging DB-stored
+ * parts with theme-file parts from `themes/{active}/parts/{slug}.html`.
+ * DB rows win when present.
+ *
+ * @since      1.2.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Modules\SiteEditor\Resolution;
+
+use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Models\TemplatePart;
+use ArtisanPackUI\CMSFramework\Modules\Themes\Managers\ThemeManager;
+use Illuminate\Support\Facades\File;
+
+/**
+ * @since 1.2.0
+ */
+class TemplatePartResolver implements EntityResolver
+{
+    /**
+     * @since 1.2.0
+     */
+    public function __construct(
+        private ThemeManager $themeManager,
+    ) {
+    }
+
+    /**
+     * @since 1.2.0
+     */
+    public function resolve( string $slug ): ?ResolvedEntity
+    {
+        $theme = $this->activeThemeSlug();
+
+        if ( null === $theme ) {
+            return null;
+        }
+
+        $row          = TemplatePart::query()->where( 'theme', $theme )->where( 'slug', $slug )->first();
+        $themeFile    = $this->themeFilePath( $theme, $slug );
+        $hasThemeFile = null !== $themeFile;
+
+        if ( null !== $row ) {
+            return new ResolvedEntity(
+                slug         : $row->slug,
+                theme        : $row->theme,
+                source       : 'db',
+                content      : $this->blockContentToString( $row->block_content ),
+                title        : $row->title,
+                description  : $row->description,
+                status       : $row->status,
+                hasThemeFile : $hasThemeFile,
+                isCustom     : (bool) $row->is_custom && ! $hasThemeFile,
+                area         : $row->area,
+                model        : $row,
+            );
+        }
+
+        if ( null === $themeFile ) {
+            return null;
+        }
+
+        $content = File::get( $themeFile );
+
+        return new ResolvedEntity(
+            slug         : $slug,
+            theme        : $theme,
+            source       : 'theme',
+            content      : $content,
+            title        : $this->humanizeSlug( $slug ),
+            description  : null,
+            status       : 'publish',
+            hasThemeFile : true,
+            isCustom     : false,
+            area         : $this->guessAreaFromSlug( $slug ),
+            model        : null,
+        );
+    }
+
+    /**
+     * @since 1.2.0
+     *
+     * @return array<int, ResolvedEntity>
+     */
+    public function all(): array
+    {
+        $theme = $this->activeThemeSlug();
+
+        if ( null === $theme ) {
+            return [];
+        }
+
+        $themeFileSlugs = $this->themeFileSlugs( $theme );
+        $rows           = TemplatePart::query()->where( 'theme', $theme )->get()->keyBy( 'slug' );
+
+        $allSlugs = array_unique( array_merge( $themeFileSlugs, $rows->keys()->all() ) );
+        sort( $allSlugs );
+
+        $resolved = [];
+
+        foreach ( $allSlugs as $slug ) {
+            $entity = $this->resolve( $slug );
+
+            if ( null !== $entity ) {
+                $resolved[] = $entity;
+            }
+        }
+
+        return $resolved;
+    }
+
+    /**
+     * @since 1.2.0
+     */
+    public function revert( string $slug ): bool
+    {
+        $theme = $this->activeThemeSlug();
+
+        if ( null === $theme ) {
+            return false;
+        }
+
+        return TemplatePart::query()->where( 'theme', $theme )->where( 'slug', $slug )->delete() > 0;
+    }
+
+    /**
+     * @since 1.2.0
+     */
+    protected function activeThemeSlug(): ?string
+    {
+        $theme = $this->themeManager->getActiveTheme();
+
+        return null !== $theme && ! empty( $theme['slug'] ) ? (string) $theme['slug'] : null;
+    }
+
+    /**
+     * @since 1.2.0
+     */
+    protected function themeFilePath( string $theme, string $slug ): ?string
+    {
+        $directory = config( 'cms.themes.directory', 'themes' );
+        $path      = base_path( $directory ) . '/' . $theme . '/parts/' . $slug . '.html';
+
+        return File::exists( $path ) ? $path : null;
+    }
+
+    /**
+     * @since 1.2.0
+     *
+     * @return array<int, string>
+     */
+    protected function themeFileSlugs( string $theme ): array
+    {
+        $directory = config( 'cms.themes.directory', 'themes' );
+        $dir       = base_path( $directory ) . '/' . $theme . '/parts';
+
+        if ( ! File::isDirectory( $dir ) ) {
+            return [];
+        }
+
+        $slugs = [];
+
+        foreach ( File::files( $dir ) as $file ) {
+            if ( 'html' === $file->getExtension() ) {
+                $slugs[] = $file->getFilenameWithoutExtension();
+            }
+        }
+
+        return $slugs;
+    }
+
+    /**
+     * @since 1.2.0
+     *
+     * @param  array<int, array<string, mixed>>|null  $blockContent
+     */
+    protected function blockContentToString( ?array $blockContent ): string
+    {
+        if ( null === $blockContent || [] === $blockContent ) {
+            return '';
+        }
+
+        return (string) json_encode( $blockContent );
+    }
+
+    /**
+     * @since 1.2.0
+     */
+    protected function humanizeSlug( string $slug ): string
+    {
+        return ucwords( str_replace( ['-', '_'], ' ', $slug ) );
+    }
+
+    /**
+     * Guess a template-part area from the slug for theme-file parts that
+     * carry no metadata: e.g. `header`, `header-large` → `'header'`,
+     * `footer` → `'footer'`, anything else → `'general'`.
+     *
+     * @since 1.2.0
+     */
+    protected function guessAreaFromSlug( string $slug ): string
+    {
+        foreach ( ['header', 'footer', 'sidebar'] as $area ) {
+            if ( $slug === $area || str_starts_with( $slug, $area . '-' ) ) {
+                return $area;
+            }
+        }
+
+        return 'general';
+    }
+}

--- a/src/Modules/SiteEditor/Resolution/TemplatePartResolver.php
+++ b/src/Modules/SiteEditor/Resolution/TemplatePartResolver.php
@@ -36,6 +36,10 @@ class TemplatePartResolver implements EntityResolver
      */
     public function resolve( string $slug ): ?ResolvedEntity
     {
+        if ( ! $this->isValidSlug( $slug ) ) {
+            return null;
+        }
+
         $theme = $this->activeThemeSlug();
 
         if ( null === $theme ) {
@@ -120,6 +124,10 @@ class TemplatePartResolver implements EntityResolver
      */
     public function revert( string $slug ): bool
     {
+        if ( ! $this->isValidSlug( $slug ) ) {
+            return false;
+        }
+
         $theme = $this->activeThemeSlug();
 
         if ( null === $theme ) {
@@ -127,6 +135,21 @@ class TemplatePartResolver implements EntityResolver
         }
 
         return TemplatePart::query()->where( 'theme', $theme )->where( 'slug', $slug )->delete() > 0;
+    }
+
+    /**
+     * Validate a slug against the canonical pattern enforced at the request
+     * layer. Mirrors the regex in `TemplatePartRequest::rules()` so any input
+     * that could not have been written through the API is rejected here too —
+     * blocks path-traversal segments (`..`), separators (`/`, `\`), null
+     * bytes, and any character outside the kebab-case alphanumeric set
+     * before the slug is interpolated into a filesystem path.
+     *
+     * @since 1.2.0
+     */
+    protected function isValidSlug( string $slug ): bool
+    {
+        return (bool) preg_match( '/^[a-z0-9]+(?:-[a-z0-9]+)*$/', $slug );
     }
 
     /**

--- a/src/Modules/SiteEditor/Resolution/TemplatePartResolver.php
+++ b/src/Modules/SiteEditor/Resolution/TemplatePartResolver.php
@@ -15,6 +15,7 @@ declare( strict_types=1 );
 namespace ArtisanPackUI\CMSFramework\Modules\SiteEditor\Resolution;
 
 use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Models\TemplatePart;
+use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Support\SlugValidator;
 use ArtisanPackUI\CMSFramework\Modules\Themes\Managers\ThemeManager;
 use Illuminate\Support\Facades\File;
 
@@ -138,18 +139,13 @@ class TemplatePartResolver implements EntityResolver
     }
 
     /**
-     * Validate a slug against the canonical pattern enforced at the request
-     * layer. Mirrors the regex in `TemplatePartRequest::rules()` so any input
-     * that could not have been written through the API is rejected here too —
-     * blocks path-traversal segments (`..`), separators (`/`, `\`), null
-     * bytes, and any character outside the kebab-case alphanumeric set
-     * before the slug is interpolated into a filesystem path.
+     * Defense-in-depth slug guard, delegating to {@see SlugValidator}.
      *
      * @since 1.2.0
      */
     protected function isValidSlug( string $slug ): bool
     {
-        return (bool) preg_match( '/^[a-z0-9]+(?:-[a-z0-9]+)*$/', $slug );
+        return SlugValidator::isValid( $slug );
     }
 
     /**

--- a/src/Modules/SiteEditor/Resolution/TemplatePartResolver.php
+++ b/src/Modules/SiteEditor/Resolution/TemplatePartResolver.php
@@ -51,7 +51,8 @@ class TemplatePartResolver implements EntityResolver
                 slug         : $row->slug,
                 theme        : $row->theme,
                 source       : 'db',
-                content      : $this->blockContentToString( $row->block_content ),
+                raw          : '',
+                blocks       : is_array( $row->block_content ) ? $row->block_content : [],
                 title        : $row->title,
                 description  : $row->description,
                 status       : $row->status,
@@ -66,13 +67,12 @@ class TemplatePartResolver implements EntityResolver
             return null;
         }
 
-        $content = File::get( $themeFile );
-
         return new ResolvedEntity(
             slug         : $slug,
             theme        : $theme,
             source       : 'theme',
-            content      : $content,
+            raw          : File::get( $themeFile ),
+            blocks       : [],
             title        : $this->humanizeSlug( $slug ),
             description  : null,
             status       : 'publish',
@@ -173,20 +173,6 @@ class TemplatePartResolver implements EntityResolver
         }
 
         return $slugs;
-    }
-
-    /**
-     * @since 1.2.0
-     *
-     * @param  array<int, array<string, mixed>>|null  $blockContent
-     */
-    protected function blockContentToString( ?array $blockContent ): string
-    {
-        if ( null === $blockContent || [] === $blockContent ) {
-            return '';
-        }
-
-        return (string) json_encode( $blockContent );
     }
 
     /**

--- a/src/Modules/SiteEditor/Resolution/TemplateResolver.php
+++ b/src/Modules/SiteEditor/Resolution/TemplateResolver.php
@@ -15,6 +15,7 @@ declare( strict_types=1 );
 namespace ArtisanPackUI\CMSFramework\Modules\SiteEditor\Resolution;
 
 use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Models\Template;
+use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Support\SlugValidator;
 use ArtisanPackUI\CMSFramework\Modules\Themes\Managers\ThemeManager;
 use Illuminate\Support\Facades\File;
 
@@ -138,18 +139,15 @@ class TemplateResolver implements EntityResolver
     }
 
     /**
-     * Validate a slug against the canonical pattern enforced at the request
-     * layer. Mirrors the regex in `TemplateRequest::rules()` so any input that
-     * could not have been written through the API is rejected here too —
-     * blocks path-traversal segments (`..`), separators (`/`, `\`), null
-     * bytes, and any character outside the kebab-case alphanumeric set
-     * before the slug is interpolated into a filesystem path.
+     * Defense-in-depth slug guard, delegating to {@see SlugValidator} so the
+     * pattern lives in one place across resolvers, controllers, and Form
+     * Requests.
      *
      * @since 1.2.0
      */
     protected function isValidSlug( string $slug ): bool
     {
-        return (bool) preg_match( '/^[a-z0-9]+(?:-[a-z0-9]+)*$/', $slug );
+        return SlugValidator::isValid( $slug );
     }
 
     /**

--- a/src/Modules/SiteEditor/Resolution/TemplateResolver.php
+++ b/src/Modules/SiteEditor/Resolution/TemplateResolver.php
@@ -1,0 +1,221 @@
+<?php
+
+/**
+ * Template Resolver
+ *
+ * Resolves template entities for the active theme by merging DB-stored
+ * templates with theme-file templates from `themes/{active}/templates/{slug}.html`.
+ * DB rows win when present.
+ *
+ * @since      1.2.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Modules\SiteEditor\Resolution;
+
+use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Models\Template;
+use ArtisanPackUI\CMSFramework\Modules\Themes\Managers\ThemeManager;
+use Illuminate\Support\Facades\File;
+
+/**
+ * @since 1.2.0
+ */
+class TemplateResolver implements EntityResolver
+{
+    /**
+     * @since 1.2.0
+     */
+    public function __construct(
+        private ThemeManager $themeManager,
+    ) {
+    }
+
+    /**
+     * @since 1.2.0
+     */
+    public function resolve( string $slug ): ?ResolvedEntity
+    {
+        $theme = $this->activeThemeSlug();
+
+        if ( null === $theme ) {
+            return null;
+        }
+
+        $row          = Template::query()->where( 'theme', $theme )->where( 'slug', $slug )->first();
+        $themeFile    = $this->themeFilePath( $theme, $slug );
+        $hasThemeFile = null !== $themeFile;
+
+        if ( null !== $row ) {
+            return new ResolvedEntity(
+                slug         : $row->slug,
+                theme        : $row->theme,
+                source       : 'db',
+                content      : $this->blockContentToString( $row->block_content ),
+                title        : $row->title,
+                description  : $row->description,
+                status       : $row->status,
+                hasThemeFile : $hasThemeFile,
+                isCustom     : (bool) $row->is_custom && ! $hasThemeFile,
+                area         : null,
+                model        : $row,
+            );
+        }
+
+        if ( null === $themeFile ) {
+            return null;
+        }
+
+        $content = File::get( $themeFile );
+
+        return new ResolvedEntity(
+            slug         : $slug,
+            theme        : $theme,
+            source       : 'theme',
+            content      : $content,
+            title        : $this->humanizeSlug( $slug ),
+            description  : null,
+            status       : 'publish',
+            hasThemeFile : true,
+            isCustom     : false,
+            area         : null,
+            model        : null,
+        );
+    }
+
+    /**
+     * @since 1.2.0
+     *
+     * @return array<int, ResolvedEntity>
+     */
+    public function all(): array
+    {
+        $theme = $this->activeThemeSlug();
+
+        if ( null === $theme ) {
+            return [];
+        }
+
+        $themeFileSlugs = $this->themeFileSlugs( $theme );
+        $rows           = Template::query()->where( 'theme', $theme )->get()->keyBy( 'slug' );
+
+        $allSlugs = array_unique( array_merge( $themeFileSlugs, $rows->keys()->all() ) );
+        sort( $allSlugs );
+
+        $resolved = [];
+
+        foreach ( $allSlugs as $slug ) {
+            $entity = $this->resolve( $slug );
+
+            if ( null !== $entity ) {
+                $resolved[] = $entity;
+            }
+        }
+
+        return $resolved;
+    }
+
+    /**
+     * @since 1.2.0
+     */
+    public function revert( string $slug ): bool
+    {
+        $theme = $this->activeThemeSlug();
+
+        if ( null === $theme ) {
+            return false;
+        }
+
+        return Template::query()->where( 'theme', $theme )->where( 'slug', $slug )->delete() > 0;
+    }
+
+    /**
+     * Returns the slug of the active theme, or null when no theme is active.
+     *
+     * @since 1.2.0
+     */
+    protected function activeThemeSlug(): ?string
+    {
+        $theme = $this->themeManager->getActiveTheme();
+
+        return null !== $theme && ! empty( $theme['slug'] ) ? (string) $theme['slug'] : null;
+    }
+
+    /**
+     * Returns the absolute path to the theme file for the given slug,
+     * or null when the file does not exist.
+     *
+     * @since 1.2.0
+     */
+    protected function themeFilePath( string $theme, string $slug ): ?string
+    {
+        $directory = config( 'cms.themes.directory', 'themes' );
+        $path      = base_path( $directory ) . '/' . $theme . '/templates/' . $slug . '.html';
+
+        return File::exists( $path ) ? $path : null;
+    }
+
+    /**
+     * Returns the list of template slugs the active theme provides on disk.
+     *
+     * @since 1.2.0
+     *
+     * @return array<int, string>
+     */
+    protected function themeFileSlugs( string $theme ): array
+    {
+        $directory = config( 'cms.themes.directory', 'themes' );
+        $dir       = base_path( $directory ) . '/' . $theme . '/templates';
+
+        if ( ! File::isDirectory( $dir ) ) {
+            return [];
+        }
+
+        $slugs = [];
+
+        foreach ( File::files( $dir ) as $file ) {
+            if ( 'html' === $file->getExtension() ) {
+                $slugs[] = $file->getFilenameWithoutExtension();
+            }
+        }
+
+        return $slugs;
+    }
+
+    /**
+     * Convert a stored block_content array back to its serialized
+     * `<!-- wp:... /-->` string form.
+     *
+     * cms-framework stores block trees as parsed arrays per HasBlockContent;
+     * the WP REST shape for `content.raw` is the raw string. When the array
+     * is empty or null, returns an empty string.
+     *
+     * @since 1.2.0
+     *
+     * @param  array<int, array<string, mixed>>|null  $blockContent
+     */
+    protected function blockContentToString( ?array $blockContent ): string
+    {
+        if ( null === $blockContent || [] === $blockContent ) {
+            return '';
+        }
+
+        // For V1 we round-trip the array as JSON in the content.raw field.
+        // V1.1 will introduce proper block-string serialization once the
+        // visual-editor renderer surface stabilizes.
+        return (string) json_encode( $blockContent );
+    }
+
+    /**
+     * Convert a slug like `home-archive` to a human title `Home Archive`.
+     *
+     * Used as the default title when a theme-file template has no
+     * accompanying metadata.
+     *
+     * @since 1.2.0
+     */
+    protected function humanizeSlug( string $slug ): string
+    {
+        return ucwords( str_replace( ['-', '_'], ' ', $slug ) );
+    }
+}

--- a/src/Modules/SiteEditor/Resolution/TemplateResolver.php
+++ b/src/Modules/SiteEditor/Resolution/TemplateResolver.php
@@ -36,6 +36,10 @@ class TemplateResolver implements EntityResolver
      */
     public function resolve( string $slug ): ?ResolvedEntity
     {
+        if ( ! $this->isValidSlug( $slug ) ) {
+            return null;
+        }
+
         $theme = $this->activeThemeSlug();
 
         if ( null === $theme ) {
@@ -120,6 +124,10 @@ class TemplateResolver implements EntityResolver
      */
     public function revert( string $slug ): bool
     {
+        if ( ! $this->isValidSlug( $slug ) ) {
+            return false;
+        }
+
         $theme = $this->activeThemeSlug();
 
         if ( null === $theme ) {
@@ -127,6 +135,21 @@ class TemplateResolver implements EntityResolver
         }
 
         return Template::query()->where( 'theme', $theme )->where( 'slug', $slug )->delete() > 0;
+    }
+
+    /**
+     * Validate a slug against the canonical pattern enforced at the request
+     * layer. Mirrors the regex in `TemplateRequest::rules()` so any input that
+     * could not have been written through the API is rejected here too —
+     * blocks path-traversal segments (`..`), separators (`/`, `\`), null
+     * bytes, and any character outside the kebab-case alphanumeric set
+     * before the slug is interpolated into a filesystem path.
+     *
+     * @since 1.2.0
+     */
+    protected function isValidSlug( string $slug ): bool
+    {
+        return (bool) preg_match( '/^[a-z0-9]+(?:-[a-z0-9]+)*$/', $slug );
     }
 
     /**

--- a/src/Modules/SiteEditor/Resolution/TemplateResolver.php
+++ b/src/Modules/SiteEditor/Resolution/TemplateResolver.php
@@ -51,7 +51,8 @@ class TemplateResolver implements EntityResolver
                 slug         : $row->slug,
                 theme        : $row->theme,
                 source       : 'db',
-                content      : $this->blockContentToString( $row->block_content ),
+                raw          : '',
+                blocks       : is_array( $row->block_content ) ? $row->block_content : [],
                 title        : $row->title,
                 description  : $row->description,
                 status       : $row->status,
@@ -66,13 +67,12 @@ class TemplateResolver implements EntityResolver
             return null;
         }
 
-        $content = File::get( $themeFile );
-
         return new ResolvedEntity(
             slug         : $slug,
             theme        : $theme,
             source       : 'theme',
-            content      : $content,
+            raw          : File::get( $themeFile ),
+            blocks       : [],
             title        : $this->humanizeSlug( $slug ),
             description  : null,
             status       : 'publish',
@@ -180,30 +180,6 @@ class TemplateResolver implements EntityResolver
         }
 
         return $slugs;
-    }
-
-    /**
-     * Convert a stored block_content array back to its serialized
-     * `<!-- wp:... /-->` string form.
-     *
-     * cms-framework stores block trees as parsed arrays per HasBlockContent;
-     * the WP REST shape for `content.raw` is the raw string. When the array
-     * is empty or null, returns an empty string.
-     *
-     * @since 1.2.0
-     *
-     * @param  array<int, array<string, mixed>>|null  $blockContent
-     */
-    protected function blockContentToString( ?array $blockContent ): string
-    {
-        if ( null === $blockContent || [] === $blockContent ) {
-            return '';
-        }
-
-        // For V1 we round-trip the array as JSON in the content.raw field.
-        // V1.1 will introduce proper block-string serialization once the
-        // visual-editor renderer surface stabilizes.
-        return (string) json_encode( $blockContent );
     }
 
     /**

--- a/src/Modules/SiteEditor/Support/SlugValidator.php
+++ b/src/Modules/SiteEditor/Support/SlugValidator.php
@@ -1,0 +1,51 @@
+<?php
+
+/**
+ * Slug Validator
+ *
+ * Single source of truth for the canonical kebab-case slug pattern used by
+ * SiteEditor entities. Mirrors the regex enforced in the Form Requests so any
+ * slug that could not have been written through the API is also rejected on
+ * read paths and at controller boundaries that bypass the Form Request (e.g.
+ * the route slug on PUT/DELETE).
+ *
+ * @since      1.2.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Modules\SiteEditor\Support;
+
+/**
+ * @since 1.2.0
+ */
+final class SlugValidator
+{
+    /**
+     * Canonical kebab-case slug regex: lowercase a-z, digits, and single
+     * hyphens between groups. Rejects path-traversal segments (`..`),
+     * separators (`/`, `\`), null bytes, uppercase, and any other character.
+     *
+     * @since 1.2.0
+     */
+    public const PATTERN = '/^[a-z0-9]+(?:-[a-z0-9]+)*$/';
+
+    /**
+     * @since 1.2.0
+     */
+    public static function isValid( string $slug ): bool
+    {
+        return (bool) preg_match( self::PATTERN, $slug );
+    }
+
+    /**
+     * Pattern fragment for use in Laravel validation rule strings
+     * (`'regex:' . SlugValidator::patternRule()`).
+     *
+     * @since 1.2.0
+     */
+    public static function patternRule(): string
+    {
+        return self::PATTERN;
+    }
+}

--- a/src/Modules/SiteEditor/routes/api.php
+++ b/src/Modules/SiteEditor/routes/api.php
@@ -1,0 +1,27 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Http\Controllers\TemplatePartsController;
+use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Http\Controllers\TemplatesController;
+use Illuminate\Support\Facades\Route;
+
+Route::prefix( 'api/v1' )
+    ->middleware( 'auth' )
+    ->group( function (): void {
+        Route::prefix( 'templates' )->group( function (): void {
+            Route::get( '/', [ TemplatesController::class, 'index' ] )->name( 'api.templates.index' );
+            Route::post( '/', [ TemplatesController::class, 'store' ] )->name( 'api.templates.store' );
+            Route::get( '{slug}', [ TemplatesController::class, 'show' ] )->name( 'api.templates.show' );
+            Route::put( '{slug}', [ TemplatesController::class, 'update' ] )->name( 'api.templates.update' );
+            Route::delete( '{slug}', [ TemplatesController::class, 'destroy' ] )->name( 'api.templates.destroy' );
+        } );
+
+        Route::prefix( 'template-parts' )->group( function (): void {
+            Route::get( '/', [ TemplatePartsController::class, 'index' ] )->name( 'api.template-parts.index' );
+            Route::post( '/', [ TemplatePartsController::class, 'store' ] )->name( 'api.template-parts.store' );
+            Route::get( '{slug}', [ TemplatePartsController::class, 'show' ] )->name( 'api.template-parts.show' );
+            Route::put( '{slug}', [ TemplatePartsController::class, 'update' ] )->name( 'api.template-parts.update' );
+            Route::delete( '{slug}', [ TemplatePartsController::class, 'destroy' ] )->name( 'api.template-parts.destroy' );
+        } );
+    } );

--- a/tests/Feature/SiteEditor/TemplatePartsApiTest.php
+++ b/tests/Feature/SiteEditor/TemplatePartsApiTest.php
@@ -95,6 +95,41 @@ describe( 'POST /api/v1/template-parts', function (): void {
             'title' => 'Orphan',
         ] )->assertStatus( 422 );
     } );
+
+    it( 'returns 409 when posting a duplicate (theme, slug)', function (): void {
+        TemplatePart::create( [
+            'theme' => $this->themeSlug,
+            'slug'  => 'header',
+            'title' => 'Existing Header',
+            'area'  => 'header',
+        ] );
+
+        $this->actingAs( $this->user );
+
+        $response = $this->postJson( '/api/v1/template-parts', [
+            'slug'  => 'header',
+            'title' => 'New Header',
+            'area'  => 'header',
+        ] );
+
+        $response->assertStatus( 409 );
+        expect( $response->json( 'errors.slug' ) )->not->toBeEmpty();
+    } );
+} );
+
+describe( 'PUT slug semantics for parts', function (): void {
+    it( 'returns 422 when body slug does not match URL slug', function (): void {
+        $this->actingAs( $this->user );
+
+        $response = $this->putJson( '/api/v1/template-parts/header', [
+            'slug'  => 'sidebar',
+            'title' => 'Header',
+            'area'  => 'header',
+        ] );
+
+        $response->assertStatus( 422 );
+        expect( $response->json( 'errors.slug' ) )->not->toBeEmpty();
+    } );
 } );
 
 describe( 'DELETE /api/v1/template-parts/{slug}', function (): void {

--- a/tests/Feature/SiteEditor/TemplatePartsApiTest.php
+++ b/tests/Feature/SiteEditor/TemplatePartsApiTest.php
@@ -130,6 +130,19 @@ describe( 'PUT slug semantics for parts', function (): void {
         $response->assertStatus( 422 );
         expect( $response->json( 'errors.slug' ) )->not->toBeEmpty();
     } );
+
+    it( 'returns 422 when the URL slug is not canonical kebab-case', function (): void {
+        $this->actingAs( $this->user );
+
+        $response = $this->putJson( '/api/v1/template-parts/Invalid_Slug', [
+            'title' => 'X',
+            'area'  => 'header',
+        ] );
+
+        $response->assertStatus( 422 );
+        expect( $response->json( 'errors.slug' ) )->not->toBeEmpty();
+        expect( TemplatePart::where( 'slug', 'Invalid_Slug' )->exists() )->toBeFalse();
+    } );
 } );
 
 describe( 'DELETE /api/v1/template-parts/{slug}', function (): void {

--- a/tests/Feature/SiteEditor/TemplatePartsApiTest.php
+++ b/tests/Feature/SiteEditor/TemplatePartsApiTest.php
@@ -1,0 +1,132 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Models\TemplatePart;
+use ArtisanPackUI\CMSFramework\Modules\Themes\Managers\ThemeManager;
+use ArtisanPackUI\CMSFramework\Tests\Support\TestUser;
+use Illuminate\Support\Facades\File;
+
+beforeEach( function (): void {
+    $this->user        = TestUser::factory()->create();
+    $this->themesPath  = base_path( 'themes' );
+    $this->themeSlug   = 'test-theme';
+    $this->themeParts  = $this->themesPath . '/' . $this->themeSlug . '/parts';
+
+    File::ensureDirectoryExists( $this->themeParts );
+    File::put(
+        $this->themesPath . '/' . $this->themeSlug . '/theme.json',
+        json_encode( [ 'name' => 'Test', 'slug' => $this->themeSlug, 'version' => '1.0.0' ] ),
+    );
+
+    config()->set( 'cms.themes.cacheEnabled', false );
+
+    $this->mock( ThemeManager::class, function ( $mock ): void {
+        $mock->shouldReceive( 'getActiveTheme' )->andReturn( [
+            'name' => 'Test',
+            'slug' => $this->themeSlug,
+        ] );
+    } );
+} );
+
+afterEach( function (): void {
+    File::deleteDirectory( $this->themesPath . '/' . $this->themeSlug );
+} );
+
+describe( 'GET /api/v1/template-parts', function (): void {
+    it( 'requires authentication', function (): void {
+        $this->getJson( '/api/v1/template-parts' )->assertUnauthorized();
+    } );
+
+    it( 'returns merged file + DB parts with area set', function (): void {
+        File::put( $this->themeParts . '/header.html', '<!-- file header -->' );
+
+        TemplatePart::create( [
+            'theme'     => $this->themeSlug,
+            'slug'      => 'sidebar-blog',
+            'title'     => 'Blog Sidebar',
+            'area'      => 'sidebar',
+            'is_custom' => true,
+        ] );
+
+        $this->actingAs( $this->user );
+
+        $response = $this->getJson( '/api/v1/template-parts' );
+
+        $response->assertOk();
+        $bySlug = collect( $response->json() )->keyBy( 'slug' );
+
+        expect( $bySlug->get( 'header' )['area'] )->toBe( 'header' );
+        expect( $bySlug->get( 'sidebar-blog' )['area'] )->toBe( 'sidebar' );
+        expect( $bySlug->get( 'header' )['type'] )->toBe( 'wp_template_part' );
+    } );
+} );
+
+describe( 'POST /api/v1/template-parts', function (): void {
+    it( 'creates a part with a valid area', function (): void {
+        $this->actingAs( $this->user );
+
+        $response = $this->postJson( '/api/v1/template-parts', [
+            'slug'      => 'site-footer',
+            'title'     => 'Site Footer',
+            'area'      => 'footer',
+            'is_custom' => true,
+        ] );
+
+        $response->assertCreated();
+        expect( TemplatePart::where( 'slug', 'site-footer' )->exists() )->toBeTrue();
+    } );
+
+    it( 'rejects an invalid area value', function (): void {
+        $this->actingAs( $this->user );
+
+        $this->postJson( '/api/v1/template-parts', [
+            'slug'  => 'banner',
+            'title' => 'Banner',
+            'area'  => 'banner', // not in closed list
+        ] )->assertStatus( 422 );
+    } );
+
+    it( 'rejects when area is missing', function (): void {
+        $this->actingAs( $this->user );
+
+        $this->postJson( '/api/v1/template-parts', [
+            'slug'  => 'orphan',
+            'title' => 'Orphan',
+        ] )->assertStatus( 422 );
+    } );
+} );
+
+describe( 'DELETE /api/v1/template-parts/{slug}', function (): void {
+    it( 'reverts a DB override and returns 204', function (): void {
+        TemplatePart::create( [
+            'theme' => $this->themeSlug,
+            'slug'  => 'header',
+            'title' => 'Header',
+            'area'  => 'header',
+        ] );
+
+        $this->actingAs( $this->user );
+
+        $this->deleteJson( '/api/v1/template-parts/header' )->assertNoContent();
+        expect( TemplatePart::where( 'slug', 'header' )->exists() )->toBeFalse();
+    } );
+} );
+
+describe( 'theme isolation', function (): void {
+    it( 'does not list parts from another theme', function (): void {
+        TemplatePart::create( [
+            'theme' => 'other-theme',
+            'slug'  => 'header',
+            'title' => 'Other Header',
+            'area'  => 'header',
+        ] );
+
+        $this->actingAs( $this->user );
+
+        $response = $this->getJson( '/api/v1/template-parts' );
+        $slugs    = collect( $response->json() )->pluck( 'slug' )->all();
+
+        expect( $slugs )->not->toContain( 'header' );
+    } );
+} );

--- a/tests/Feature/SiteEditor/TemplatesApiTest.php
+++ b/tests/Feature/SiteEditor/TemplatesApiTest.php
@@ -61,7 +61,7 @@ describe( 'GET /api/v1/templates', function (): void {
                 'theme',
                 'type',
                 'source',
-                'content' => [ 'raw', 'block_version' ],
+                'content' => [ 'raw', 'blocks', 'block_version' ],
                 'title'   => [ 'raw', 'rendered' ],
                 'has_theme_file',
                 'is_custom',
@@ -71,6 +71,23 @@ describe( 'GET /api/v1/templates', function (): void {
 
         $slugs = collect( $response->json() )->pluck( 'slug' )->all();
         expect( $slugs )->toContain( 'page' )->toContain( 'archive' );
+    } );
+
+    it( 'always emits id in theme//slug form (even for custom templates)', function (): void {
+        Template::create( [
+            'theme'     => $this->themeSlug,
+            'slug'      => 'custom-only',
+            'title'     => 'Custom Only',
+            'is_custom' => true,
+        ] );
+
+        $this->actingAs( $this->user );
+
+        $response = $this->getJson( '/api/v1/templates/custom-only' );
+
+        $response->assertOk();
+        expect( $response->json( 'id' ) )->toBe( $this->themeSlug . '//custom-only' );
+        expect( $response->json( 'wp_id' ) )->toBeInt()->toBeGreaterThan( 0 );
     } );
 } );
 
@@ -87,6 +104,25 @@ describe( 'GET /api/v1/templates/{slug}', function (): void {
         expect( $response->json( 'has_theme_file' ) )->toBeTrue();
         expect( $response->json( 'wp_id' ) )->toBe( 0 );
         expect( $response->json( 'content.raw' ) )->toContain( 'wp:heading' );
+        expect( $response->json( 'content.blocks' ) )->toBe( [] );
+    } );
+
+    it( 'returns DB-stored templates with empty content.raw and populated content.blocks', function (): void {
+        Template::create( [
+            'theme'         => $this->themeSlug,
+            'slug'          => 'db-only',
+            'title'         => 'DB Only',
+            'is_custom'     => true,
+            'block_content' => [ [ 'blockName' => 'core/paragraph' ] ],
+        ] );
+
+        $this->actingAs( $this->user );
+
+        $response = $this->getJson( '/api/v1/templates/db-only' );
+
+        $response->assertOk();
+        expect( $response->json( 'content.raw' ) )->toBe( '' );
+        expect( $response->json( 'content.blocks' ) )->toBe( [ [ 'blockName' => 'core/paragraph' ] ] );
     } );
 
     it( '404s when the slug exists in neither file nor DB', function (): void {
@@ -120,6 +156,48 @@ describe( 'POST /api/v1/templates', function (): void {
             'slug'  => 'Invalid Slug!',
             'title' => 'X',
         ] )->assertStatus( 422 );
+    } );
+
+    it( 'returns 409 when posting a duplicate (theme, slug)', function (): void {
+        Template::create( [
+            'theme' => $this->themeSlug,
+            'slug'  => 'page',
+            'title' => 'Existing',
+        ] );
+
+        $this->actingAs( $this->user );
+
+        $response = $this->postJson( '/api/v1/templates', [
+            'slug'  => 'page',
+            'title' => 'New',
+        ] );
+
+        $response->assertStatus( 409 );
+        expect( $response->json( 'errors.slug' ) )->not->toBeEmpty();
+    } );
+} );
+
+describe( 'PUT slug semantics', function (): void {
+    it( 'accepts a body without a slug (route slug is canonical)', function (): void {
+        File::put( $this->themeFiles . '/index.html', '<!-- file -->' );
+
+        $this->actingAs( $this->user );
+
+        $this->putJson( '/api/v1/templates/index', [
+            'title' => 'DB Index',
+        ] )->assertOk();
+    } );
+
+    it( 'returns 422 when the body slug does not match the URL slug', function (): void {
+        $this->actingAs( $this->user );
+
+        $response = $this->putJson( '/api/v1/templates/index', [
+            'slug'  => 'home',
+            'title' => 'DB Index',
+        ] );
+
+        $response->assertStatus( 422 );
+        expect( $response->json( 'errors.slug' ) )->not->toBeEmpty();
     } );
 } );
 

--- a/tests/Feature/SiteEditor/TemplatesApiTest.php
+++ b/tests/Feature/SiteEditor/TemplatesApiTest.php
@@ -199,6 +199,30 @@ describe( 'PUT slug semantics', function (): void {
         $response->assertStatus( 422 );
         expect( $response->json( 'errors.slug' ) )->not->toBeEmpty();
     } );
+
+    it( 'preserves omitted is_custom and author_id on partial updates', function (): void {
+        $existing = Template::create( [
+            'theme'     => $this->themeSlug,
+            'slug'      => 'page',
+            'title'     => 'Original',
+            'is_custom' => true,
+            'author_id' => $this->user->id,
+        ] );
+
+        $this->actingAs( $this->user );
+
+        // Update only the title — omitted fields should keep their values.
+        $response = $this->putJson( '/api/v1/templates/page', [
+            'title' => 'Renamed',
+        ] );
+
+        $response->assertOk();
+
+        $existing->refresh();
+        expect( $existing->title )->toBe( 'Renamed' )
+            ->and( $existing->is_custom )->toBeTrue()
+            ->and( $existing->author_id )->toBe( $this->user->id );
+    } );
 } );
 
 describe( 'PUT /api/v1/templates/{slug}', function (): void {

--- a/tests/Feature/SiteEditor/TemplatesApiTest.php
+++ b/tests/Feature/SiteEditor/TemplatesApiTest.php
@@ -1,0 +1,164 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Models\Template;
+use ArtisanPackUI\CMSFramework\Modules\Themes\Managers\ThemeManager;
+use ArtisanPackUI\CMSFramework\Tests\Support\TestUser;
+use Illuminate\Support\Facades\File;
+
+beforeEach( function (): void {
+    $this->user        = TestUser::factory()->create();
+    $this->themesPath  = base_path( 'themes' );
+    $this->themeSlug   = 'test-theme';
+    $this->themeFiles  = $this->themesPath . '/' . $this->themeSlug . '/templates';
+
+    File::ensureDirectoryExists( $this->themeFiles );
+    File::put(
+        $this->themesPath . '/' . $this->themeSlug . '/theme.json',
+        json_encode( [ 'name' => 'Test', 'slug' => $this->themeSlug, 'version' => '1.0.0' ] ),
+    );
+
+    config()->set( 'cms.themes.cacheEnabled', false );
+
+    // Stub ThemeManager so the controller resolves our test theme as active.
+    $this->mock( ThemeManager::class, function ( $mock ): void {
+        $mock->shouldReceive( 'getActiveTheme' )->andReturn( [
+            'name' => 'Test',
+            'slug' => $this->themeSlug,
+        ] );
+    } );
+} );
+
+afterEach( function (): void {
+    File::deleteDirectory( $this->themesPath . '/' . $this->themeSlug );
+} );
+
+describe( 'GET /api/v1/templates', function (): void {
+    it( 'requires authentication', function (): void {
+        $this->getJson( '/api/v1/templates' )->assertUnauthorized();
+    } );
+
+    it( 'returns merged file + DB templates in WP shape', function (): void {
+        File::put( $this->themeFiles . '/page.html', '<!-- file -->' );
+
+        Template::create( [
+            'theme'     => $this->themeSlug,
+            'slug'      => 'archive',
+            'title'     => 'Custom Archive',
+            'is_custom' => true,
+        ] );
+
+        $this->actingAs( $this->user );
+
+        $response = $this->getJson( '/api/v1/templates' );
+
+        $response->assertOk();
+        $response->assertJsonStructure( [
+            '*' => [
+                'id',
+                'slug',
+                'theme',
+                'type',
+                'source',
+                'content' => [ 'raw', 'block_version' ],
+                'title'   => [ 'raw', 'rendered' ],
+                'has_theme_file',
+                'is_custom',
+                'wp_id',
+            ],
+        ] );
+
+        $slugs = collect( $response->json() )->pluck( 'slug' )->all();
+        expect( $slugs )->toContain( 'page' )->toContain( 'archive' );
+    } );
+} );
+
+describe( 'GET /api/v1/templates/{slug}', function (): void {
+    it( 'returns the resolved template for a theme-file slug', function (): void {
+        File::put( $this->themeFiles . '/single.html', '<!-- wp:heading -->' );
+
+        $this->actingAs( $this->user );
+
+        $response = $this->getJson( '/api/v1/templates/single' );
+
+        $response->assertOk();
+        expect( $response->json( 'source' ) )->toBe( 'theme' );
+        expect( $response->json( 'has_theme_file' ) )->toBeTrue();
+        expect( $response->json( 'wp_id' ) )->toBe( 0 );
+        expect( $response->json( 'content.raw' ) )->toContain( 'wp:heading' );
+    } );
+
+    it( '404s when the slug exists in neither file nor DB', function (): void {
+        $this->actingAs( $this->user );
+
+        $this->getJson( '/api/v1/templates/missing' )->assertNotFound();
+    } );
+} );
+
+describe( 'POST /api/v1/templates', function (): void {
+    it( 'creates a custom template and returns 201', function (): void {
+        $this->actingAs( $this->user );
+
+        $response = $this->postJson( '/api/v1/templates', [
+            'slug'          => 'custom-page',
+            'title'         => 'Custom Page',
+            'is_custom'     => true,
+            'block_content' => [ [ 'blockName' => 'core/paragraph' ] ],
+        ] );
+
+        $response->assertStatus( 201 );
+        expect( $response->json( 'source' ) )->toBe( 'db' );
+        expect( $response->json( 'is_custom' ) )->toBeTrue();
+        expect( Template::where( 'theme', $this->themeSlug )->where( 'slug', 'custom-page' )->exists() )->toBeTrue();
+    } );
+
+    it( 'rejects an invalid slug format', function (): void {
+        $this->actingAs( $this->user );
+
+        $this->postJson( '/api/v1/templates', [
+            'slug'  => 'Invalid Slug!',
+            'title' => 'X',
+        ] )->assertStatus( 422 );
+    } );
+} );
+
+describe( 'PUT /api/v1/templates/{slug}', function (): void {
+    it( 'creates an override over a theme-file template', function (): void {
+        File::put( $this->themeFiles . '/index.html', '<!-- file -->' );
+
+        $this->actingAs( $this->user );
+
+        $response = $this->putJson( '/api/v1/templates/index', [
+            'slug'          => 'index',
+            'title'         => 'DB Index',
+            'block_content' => [ [ 'blockName' => 'core/heading' ] ],
+        ] );
+
+        $response->assertOk();
+        expect( $response->json( 'source' ) )->toBe( 'db' );
+        expect( $response->json( 'has_theme_file' ) )->toBeTrue();
+    } );
+} );
+
+describe( 'DELETE /api/v1/templates/{slug}', function (): void {
+    it( 'reverts a DB override and returns 204', function (): void {
+        Template::create( [
+            'theme' => $this->themeSlug,
+            'slug'  => 'page',
+            'title' => 'Page',
+        ] );
+
+        $this->actingAs( $this->user );
+
+        $this->deleteJson( '/api/v1/templates/page' )->assertNoContent();
+
+        expect( Template::where( 'theme', $this->themeSlug )->where( 'slug', 'page' )->exists() )->toBeFalse();
+    } );
+
+    it( '404s when no DB row exists for the slug', function (): void {
+        $this->actingAs( $this->user );
+
+        $this->deleteJson( '/api/v1/templates/never-existed' )->assertNotFound();
+    } );
+} );

--- a/tests/Feature/SiteEditor/TemplatesApiTest.php
+++ b/tests/Feature/SiteEditor/TemplatesApiTest.php
@@ -223,6 +223,18 @@ describe( 'PUT slug semantics', function (): void {
             ->and( $existing->is_custom )->toBeTrue()
             ->and( $existing->author_id )->toBe( $this->user->id );
     } );
+
+    it( 'returns 422 when the URL slug is not canonical kebab-case', function (): void {
+        $this->actingAs( $this->user );
+
+        $response = $this->putJson( '/api/v1/templates/Invalid_Slug', [
+            'title' => 'X',
+        ] );
+
+        $response->assertStatus( 422 );
+        expect( $response->json( 'errors.slug' ) )->not->toBeEmpty();
+        expect( Template::where( 'slug', 'Invalid_Slug' )->exists() )->toBeFalse();
+    } );
 } );
 
 describe( 'PUT /api/v1/templates/{slug}', function (): void {

--- a/tests/Unit/SiteEditor/TemplateResolverTest.php
+++ b/tests/Unit/SiteEditor/TemplateResolverTest.php
@@ -161,3 +161,46 @@ describe( 'theme isolation', function (): void {
         expect( $result )->toBeNull();
     } );
 } );
+
+describe( 'slug sanitization', function (): void {
+    it( 'rejects path-traversal slugs', function (): void {
+        // Drop a real file at the would-be traversal target so a missing-file
+        // null doesn't mask a successful traversal.
+        File::ensureDirectoryExists( $this->themesPath . '/' . $this->themeSlug );
+        File::put( $this->themesPath . '/' . $this->themeSlug . '/secret.html', '<!-- secret -->' );
+
+        $result = $this->resolver->resolve( '../secret' );
+
+        expect( $result )->toBeNull();
+    } );
+
+    it( 'rejects slugs containing slashes', function (): void {
+        expect( $this->resolver->resolve( 'a/b' ) )->toBeNull();
+        expect( $this->resolver->resolve( 'a\\b' ) )->toBeNull();
+    } );
+
+    it( 'rejects slugs containing null bytes', function (): void {
+        expect( $this->resolver->resolve( "page\0evil" ) )->toBeNull();
+    } );
+
+    it( 'rejects uppercase slugs', function (): void {
+        File::put( $this->themeFiles . '/lowercase.html', '<!-- ok -->' );
+
+        expect( $this->resolver->resolve( 'Lowercase' ) )->toBeNull();
+    } );
+
+    it( 'rejects empty slugs', function (): void {
+        expect( $this->resolver->resolve( '' ) )->toBeNull();
+    } );
+
+    it( 'returns false from revert() for invalid slugs without touching the database', function (): void {
+        Template::create( [
+            'theme' => $this->themeSlug,
+            'slug'  => 'page',
+            'title' => 'Page',
+        ] );
+
+        expect( $this->resolver->revert( '../page' ) )->toBeFalse()
+            ->and( Template::where( 'slug', 'page' )->exists() )->toBeTrue();
+    } );
+} );

--- a/tests/Unit/SiteEditor/TemplateResolverTest.php
+++ b/tests/Unit/SiteEditor/TemplateResolverTest.php
@@ -40,7 +40,7 @@ afterEach( function (): void {
 } );
 
 describe( 'TemplateResolver::resolve()', function (): void {
-    it( 'returns the theme file when only the file exists', function (): void {
+    it( 'returns the theme file with raw content populated and blocks empty', function (): void {
         File::put( $this->themeFiles . '/page.html', '<!-- wp:paragraph --><p>Page</p><!-- /wp:paragraph -->' );
 
         $result = $this->resolver->resolve( 'page' );
@@ -50,13 +50,14 @@ describe( 'TemplateResolver::resolve()', function (): void {
             ->and( $result->source )->toBe( 'theme' )
             ->and( $result->slug )->toBe( 'page' )
             ->and( $result->theme )->toBe( $this->themeSlug )
-            ->and( $result->content )->toContain( 'wp:paragraph' )
+            ->and( $result->raw )->toContain( 'wp:paragraph' )
+            ->and( $result->blocks )->toBe( [] )
             ->and( $result->hasThemeFile )->toBeTrue()
             ->and( $result->isCustom )->toBeFalse()
             ->and( $result->wpId() )->toBe( 0 );
     } );
 
-    it( 'returns the DB row when only a DB row exists (custom template)', function (): void {
+    it( 'returns the DB row with blocks populated and raw empty (custom template)', function (): void {
         $row = Template::create( [
             'theme'         => $this->themeSlug,
             'slug'          => 'custom-page',
@@ -70,6 +71,8 @@ describe( 'TemplateResolver::resolve()', function (): void {
         expect( $result->source )->toBe( 'db' )
             ->and( $result->isCustom )->toBeTrue()
             ->and( $result->hasThemeFile )->toBeFalse()
+            ->and( $result->raw )->toBe( '' )
+            ->and( $result->blocks )->toBe( [ [ 'blockName' => 'core/paragraph' ] ] )
             ->and( $result->wpId() )->toBe( $row->id );
     } );
 

--- a/tests/Unit/SiteEditor/TemplateResolverTest.php
+++ b/tests/Unit/SiteEditor/TemplateResolverTest.php
@@ -1,0 +1,160 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Models\Template;
+use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Resolution\ResolvedEntity;
+use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Resolution\TemplateResolver;
+use ArtisanPackUI\CMSFramework\Modules\Themes\Managers\ThemeManager;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\File;
+
+uses( RefreshDatabase::class );
+
+beforeEach( function (): void {
+    $this->themesPath  = base_path( 'themes' );
+    $this->themeSlug   = 'test-theme';
+    $this->themeFiles  = $this->themesPath . '/' . $this->themeSlug . '/templates';
+
+    File::ensureDirectoryExists( $this->themeFiles );
+    File::put(
+        $this->themesPath . '/' . $this->themeSlug . '/theme.json',
+        json_encode( [ 'name' => 'Test', 'slug' => $this->themeSlug, 'version' => '1.0.0' ] ),
+    );
+
+    config()->set( 'cms.themes.cacheEnabled', false );
+
+    // Stub ThemeManager::getActiveTheme() to return our test theme.
+    $themeManager = $this->mock( ThemeManager::class, function ( $mock ): void {
+        $mock->shouldReceive( 'getActiveTheme' )->andReturn( [
+            'name' => 'Test',
+            'slug' => $this->themeSlug,
+        ] );
+    } );
+
+    $this->resolver = new TemplateResolver( $themeManager );
+} );
+
+afterEach( function (): void {
+    File::deleteDirectory( $this->themesPath . '/' . $this->themeSlug );
+} );
+
+describe( 'TemplateResolver::resolve()', function (): void {
+    it( 'returns the theme file when only the file exists', function (): void {
+        File::put( $this->themeFiles . '/page.html', '<!-- wp:paragraph --><p>Page</p><!-- /wp:paragraph -->' );
+
+        $result = $this->resolver->resolve( 'page' );
+
+        expect( $result )
+            ->toBeInstanceOf( ResolvedEntity::class )
+            ->and( $result->source )->toBe( 'theme' )
+            ->and( $result->slug )->toBe( 'page' )
+            ->and( $result->theme )->toBe( $this->themeSlug )
+            ->and( $result->content )->toContain( 'wp:paragraph' )
+            ->and( $result->hasThemeFile )->toBeTrue()
+            ->and( $result->isCustom )->toBeFalse()
+            ->and( $result->wpId() )->toBe( 0 );
+    } );
+
+    it( 'returns the DB row when only a DB row exists (custom template)', function (): void {
+        $row = Template::create( [
+            'theme'         => $this->themeSlug,
+            'slug'          => 'custom-page',
+            'title'         => 'Custom Page',
+            'is_custom'     => true,
+            'block_content' => [ [ 'blockName' => 'core/paragraph' ] ],
+        ] );
+
+        $result = $this->resolver->resolve( 'custom-page' );
+
+        expect( $result->source )->toBe( 'db' )
+            ->and( $result->isCustom )->toBeTrue()
+            ->and( $result->hasThemeFile )->toBeFalse()
+            ->and( $result->wpId() )->toBe( $row->id );
+    } );
+
+    it( 'returns the DB row over the theme file when both exist (DB wins)', function (): void {
+        File::put( $this->themeFiles . '/index.html', '<!-- file content -->' );
+
+        $row = Template::create( [
+            'theme'         => $this->themeSlug,
+            'slug'          => 'index',
+            'title'         => 'DB Index',
+            'is_custom'     => false,
+            'block_content' => [ [ 'blockName' => 'core/heading' ] ],
+        ] );
+
+        $result = $this->resolver->resolve( 'index' );
+
+        expect( $result->source )->toBe( 'db' )
+            ->and( $result->isCustom )->toBeFalse() // DB row exists but theme file also backs it
+            ->and( $result->hasThemeFile )->toBeTrue()
+            ->and( $result->wpId() )->toBe( $row->id );
+    } );
+
+    it( 'returns null when neither DB nor file has the slug', function (): void {
+        expect( $this->resolver->resolve( 'missing' ) )->toBeNull();
+    } );
+} );
+
+describe( 'TemplateResolver::all()', function (): void {
+    it( 'merges file slugs and DB slugs, deduplicating with DB winning', function (): void {
+        File::put( $this->themeFiles . '/page.html', '<!-- page from file -->' );
+        File::put( $this->themeFiles . '/single.html', '<!-- single from file -->' );
+
+        Template::create( [
+            'theme'     => $this->themeSlug,
+            'slug'      => 'page',
+            'title'     => 'Page From DB',
+            'is_custom' => false,
+        ] );
+        Template::create( [
+            'theme'     => $this->themeSlug,
+            'slug'      => 'archive',
+            'title'     => 'Custom Archive',
+            'is_custom' => true,
+        ] );
+
+        $all = $this->resolver->all();
+
+        $bySlug = collect( $all )->keyBy( 'slug' );
+
+        expect( $bySlug->keys()->all() )->toEqual( [ 'archive', 'page', 'single' ] )
+            ->and( $bySlug->get( 'page' )->source )->toBe( 'db' )
+            ->and( $bySlug->get( 'single' )->source )->toBe( 'theme' )
+            ->and( $bySlug->get( 'archive' )->source )->toBe( 'db' );
+    } );
+} );
+
+describe( 'TemplateResolver::revert()', function (): void {
+    it( 'deletes the DB row and returns true', function (): void {
+        Template::create( [
+            'theme' => $this->themeSlug,
+            'slug'  => 'page',
+            'title' => 'Page',
+        ] );
+
+        $result = $this->resolver->revert( 'page' );
+
+        expect( $result )->toBeTrue()
+            ->and( Template::where( 'theme', $this->themeSlug )->where( 'slug', 'page' )->exists() )->toBeFalse();
+    } );
+
+    it( 'returns false when no DB row exists for the slug', function (): void {
+        expect( $this->resolver->revert( 'never-existed' ) )->toBeFalse();
+    } );
+} );
+
+describe( 'theme isolation', function (): void {
+    it( 'does not return a row from a different theme', function (): void {
+        Template::create( [
+            'theme' => 'other-theme',
+            'slug'  => 'page',
+            'title' => 'Other Theme Page',
+        ] );
+
+        $result = $this->resolver->resolve( 'page' );
+
+        expect( $result )->toBeNull();
+    } );
+} );


### PR DESCRIPTION
## Description

Implements **H1** of plan 14 (cms-framework site-editor integration). Adds a new `src/Modules/SiteEditor/` module with `Template` and `TemplatePart` models, migrations, REST API endpoints in WP `/wp/v2/templates` + `/wp/v2/template-parts` shape, and `EntityResolver` implementations that return file/DB merged content with DB rows winning when present.

H1 is the first of the four parallelizable cms-framework backends after H0. It unblocks visual-editor's `#407` (H5 — site-editor resource filters), which is gated on at least one H1–H4 backend being live.

**Closes:** #108

## Type of Change

- [x] New feature (adds new functionality)

## Related Issue

**Issue:** #108

## Motivation and Context

The visual editor needs `useEntityRecord('postType', 'wp_template', slug)` to resolve through cms-framework, just like Posts and Pages now do via G3. Templates and template parts are the foundation of the site editor surface — without them, visual-editor's H5 (`#407`) can't populate `addEntities()` at editor bootstrap.

Storage model is the WP-style hybrid: theme files (`themes/{active}/templates/{slug}.html`) provide defaults, the database stores user overrides, DB row wins when both exist, revert deletes the DB row to return authority to the theme file.

## Changes Made

**New module: `src/Modules/SiteEditor/`** — sibling to `Themes/` (not a sub-namespace). It owns its own models, REST routes, and migrations; H2/H3/H4 (patterns, global styles, menus) will extend the same module.

- **Migrations** — `templates` and `template_parts` tables, both with `(theme, slug)` unique index and `block_content` JSON column. Parts table adds `area` (string, defaults to `'general'`).
- **Models** — `Template` and `TemplatePart` adopt `HasBlockContent` (matching Post/Page convention from G1a). `TemplatePart::AREAS` constant declares the closed list `['header', 'footer', 'sidebar', 'general']`.
- **Resolver layer** — `EntityResolver` interface + `ResolvedEntity` value object in `Resolution/`. `TemplateResolver` and `TemplatePartResolver` implement file-fallback / DB-wins logic; `TemplatePartResolver` auto-categorizes theme-file parts into a known area when the slug starts with a known prefix (`header-large` → `header`), else `general`.
- **Resource transformer** — `TemplateResource::toArray(ResolvedEntity)` produces WP-shape responses for both `wp_template` and `wp_template_part` types. `id` uses the `theme//slug` form for theme-backed entities and the integer DB ID for purely custom ones.
- **Controllers + Form Requests** — `TemplatesController` + `TemplatePartsController` with full REST CRUD. `TemplatePartRequest` enforces the closed area list at the application layer (HTTP 422 on invalid).
- **Service provider** — `SiteEditorServiceProvider` registered from `CMSFrameworkServiceProvider` between Themes and Plugins. Permissions (`visual_editor.templates.edit`, `.template-parts.edit`) are already seeded by G5 (#98); routes use `auth` middleware (V1 baseline of "any authenticated user" per plan 12 §2.6).

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS 15.4
- PHP Version: 8.4.3
- Project Version: cms-framework 1.2.0 (this PR)

**Tests Performed:**
1. `./vendor/bin/pest tests/Unit/SiteEditor/ tests/Feature/SiteEditor/ --compact` → 24/24 pass.
2. `./vendor/bin/pest --compact` (full suite) → 685 passed, 4 skipped (pre-existing), 0 failures.
3. `./vendor/bin/php-cs-fixer fix` → clean on all touched files.
4. `coderabbit review --plain --base origin/release/1.2` — see review summary on this PR.

## Accessibility Tests Run

- [x] Not applicable — backend / REST work; no UI changes.

**Details:** Pure backend module. No UI surface affected; the consumer is visual-editor's editor shell (which has its own accessibility coverage).

## Tests Added

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] All tests passing

**Test details:**

- `tests/Unit/SiteEditor/TemplateResolverTest.php` — 8 tests covering: theme-file fallback when only file exists, DB-wins when both exist, custom-template behavior (`isCustom = true`, `hasThemeFile = false`), null on missing slug, `all()` merging file + DB slugs (DB winning on overlap), `revert()` deleting the DB row + returning false when no row exists, and theme isolation (rows from a different theme don't leak into the active theme's resolution).
- `tests/Feature/SiteEditor/TemplatesApiTest.php` — 6 tests covering: auth gate, GET list with WP-shape structure assertions, GET single (theme-source path), 404 on missing, POST creates with `source: 'db'`, POST validates slug regex, PUT upserts with `has_theme_file` true when file backs the slug, DELETE returns 204 + 404 paths.
- `tests/Feature/SiteEditor/TemplatePartsApiTest.php` — 6 tests covering: auth gate, GET list with `area` correctly set + `type: wp_template_part`, POST creates with valid area, POST rejects invalid area (422), POST rejects missing area (422), DELETE 204, theme isolation.

## Documentation

- [x] Inline code documentation added
- [x] Wiki updated (`docs/site-editor.md`)

**Documentation details:**

`docs/site-editor.md` is new and documents:
- Module placement rationale (sibling to Themes, not under it)
- Storage model (file + DB hybrid, DB wins)
- REST endpoint reference for both `/templates` and `/template-parts`
- Closed area list and how it's enforced
- The `EntityResolver` contract (foreshadowing H2–H4)
- Permissions handling (seeded by G5, V1 baseline of any authenticated user)

## Pre-Submission Checklist

- [x] Followed contributing guidelines
- [x] Checked for other open PRs for same update
- [x] Code passes all tests (685 pass, 4 pre-existing skips)
- [x] Code has been linted (PHP-CS-Fixer)
- [x] Accessibility tests completed (N/A — backend)
- [x] Code follows project style guide
- [x] Self-review completed
- [x] Comments added for complex code
- [x] No new warnings generated

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Site Editor module: authenticated REST APIs for templates and template-parts (list, view, create, update, delete), DB overrides with theme-file fallback, WP-shaped JSON responses (id as theme//slug, content.raw/blocks, source, has_theme_file, is_custom).
  * Template-parts support named areas (header, footer, sidebar, general) and slug validation.

* **Documentation**
  * Added comprehensive Site Editor usage and API documentation.

* **Tests**
  * Added unit and feature tests covering resolution, API flows, validation, conflict handling, and revert behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->