### PR TITLE
feat: H2 — Patterns module + ap.visual-editor.{templates,template-parts,patterns} filter wiring (#110)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `block_content` JSON column on the `posts` and `pages` tables for visual editor block trees, alongside the existing `content` longText column
 - `Post` and `Page` models adopt `ArtisanPackUI\VisualEditor\Concerns\HasBlockContent` with a polyfill stub so visual-editor remains an optional integration rather than a hard composer dependency
+- H2 — Site editor patterns module: `BlockPattern` model + `block_patterns` table, `PatternResolver` merging theme `.php` pattern files with user-source DB rows, REST endpoints in WP `/wp/v2/blocks` (synced) + `/wp/v2/block-patterns/patterns` (unsynced) shape, and `ap.visual-editor.patterns` filter registration behind a `class_exists` guard
+- `PatternFileParser` for theme-shipped pattern files with WP-style header doc-comments (`Title:`, `Slug:`, `Categories:`, `Description:`, `Block Types:`)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `block_content` JSON column on the `posts` and `pages` tables for visual editor block trees, alongside the existing `content` longText column
 - `Post` and `Page` models adopt `ArtisanPackUI\VisualEditor\Concerns\HasBlockContent` with a polyfill stub so visual-editor remains an optional integration rather than a hard composer dependency
-- H2 — Site editor patterns module: `BlockPattern` model + `block_patterns` table, `PatternResolver` merging theme `.php` pattern files with user-source DB rows, REST endpoints in WP `/wp/v2/blocks` (synced) + `/wp/v2/block-patterns/patterns` (unsynced) shape, and `ap.visual-editor.patterns` filter registration behind a `class_exists` guard
+- H2 — Site editor patterns module: `BlockPattern` model + `block_patterns` table, `PatternResolver` merging theme `.php` pattern files with user-source DB rows, REST endpoints under `/api/v1/blocks` (synced) and `/api/v1/block-patterns/patterns` (unsynced) returning WP-shape payloads (matching `/wp/v2/blocks` and `/wp/v2/block-patterns/patterns` respectively), and `ap.visual-editor.patterns` filter registration behind a `class_exists` guard
 - `PatternFileParser` for theme-shipped pattern files with WP-style header doc-comments (`Title:`, `Slug:`, `Categories:`, `Description:`, `Block Types:`)
 
 ### Changed

--- a/database/migrations/2026_05_01_120002_create_block_patterns_table.php
+++ b/database/migrations/2026_05_01_120002_create_block_patterns_table.php
@@ -1,0 +1,34 @@
+<?php
+
+declare( strict_types=1 );
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create( 'block_patterns', function ( Blueprint $table ): void {
+            $table->id();
+            $table->string( 'slug' )->unique();
+            $table->string( 'theme' )->nullable();
+            $table->string( 'title' );
+            $table->text( 'description' )->nullable();
+            $table->string( 'source' )->default( 'user' );
+            $table->boolean( 'synced' )->default( false );
+            $table->json( 'categories' )->nullable();
+            $table->json( 'block_types' )->nullable();
+            $table->json( 'block_content' )->nullable();
+            $table->foreignId( 'author_id' )->nullable()->constrained( 'users' )->nullOnDelete();
+            $table->timestamps();
+
+            $table->index( ['source', 'synced'] );
+        } );
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists( 'block_patterns' );
+    }
+};

--- a/docs/site-editor.md
+++ b/docs/site-editor.md
@@ -4,7 +4,7 @@ title: Site Editor
 
 # Site Editor Module
 
-The Site Editor module hosts the backends behind cms-framework's WordPress-style site-editor surface: templates, template parts, patterns, global styles, and menus. H1 ships templates and template parts; subsequent phases (H2–H4) add patterns, global styles, and menus to the same module.
+The Site Editor module hosts the backends behind cms-framework's WordPress-style site-editor surface: templates, template parts, patterns, global styles, and menus. H1 ships templates and template parts; H2 adds patterns; subsequent phases (H3–H4) add global styles and menus to the same module.
 
 ## Overview
 
@@ -93,6 +93,59 @@ The closed list is enforced at the application layer:
 
 Same shape as templates, but under `/api/v1/template-parts`. The response carries an additional `area` field and `type` is `wp_template_part`.
 
+## Patterns
+
+### Storage
+
+Patterns occupy two disjoint sources rather than a file/DB merge:
+
+- **Theme patterns** — PHP files at `themes/{active}/patterns/{slug}.php` with a leading WP-style header doc-comment (`Title:`, `Slug:`, `Categories:`, `Description:`, `Block Types:`). Read-only at runtime; the body after the doc-comment becomes the pattern content.
+- **User patterns** — DB rows in `block_patterns` with columns `id`, `slug`, `theme` (nullable), `title`, `description`, `source`, `synced` (bool), `categories` (JSON), `block_types` (JSON), `block_content` (JSON via `HasBlockContent`), `author_id`, timestamps.
+
+User-pattern slugs carry a `user/` prefix at storage time per plan 14 §5.6 — this guarantees a theme pattern named `hero` and a user pattern named `hero` do not collide in the merged inserter map. The REST surface presents the unprefixed user-facing slug; the storage form is exposed as `name` on the unsynced response (mirroring WP's namespaced pattern names).
+
+### Sync semantics
+
+`synced` distinguishes the two pattern shapes Gutenberg recognizes:
+
+- `synced = true` — surfaced under `/blocks` (WP `wp_block` shape). Editing the pattern updates every occurrence in the editor.
+- `synced = false` — surfaced under `/block-patterns/patterns` (WP `wp_block_pattern` shape). Each insertion is a snapshot; later edits to the pattern do not propagate.
+
+Theme patterns are always `synced = false`. Cross-state conversion happens through dedicated POST flows on each endpoint, not via PUT (a PUT to one endpoint never flips a pattern's `synced` bit on the other endpoint).
+
+### REST endpoints
+
+| Method | Path | Purpose |
+|---|---|---|
+| GET    | `/blocks` | List user-source synced patterns (`wp_block` shape). |
+| GET    | `/blocks/{slug}` | Show single synced pattern. |
+| POST   | `/blocks` | Create a synced user pattern. |
+| PUT    | `/blocks/{slug}` | Upsert a synced user pattern. |
+| DELETE | `/blocks/{slug}` | Delete a synced user pattern. |
+| GET    | `/block-patterns/patterns` | List theme + user-source unsynced patterns merged. |
+| GET    | `/block-patterns/patterns/{slug}` | Show single unsynced pattern (theme or user). |
+| POST   | `/block-patterns/patterns` | Create an unsynced user pattern. |
+| PUT    | `/block-patterns/patterns/{slug}` | Upsert an unsynced user pattern. **403** when targeting a theme slug. |
+| DELETE | `/block-patterns/patterns/{slug}` | Delete a user pattern. **403** when targeting a theme slug. |
+
+A theme pattern can be cloned to an editable user pattern via `PatternResolver::cloneToUser($slug)` — used by the admin "edit" affordance on theme patterns. The clone copies title, description, categories, and block types from the theme file into a new user-source DB row.
+
+### Resolver
+
+`PatternResolver` returns `ResolvedPattern` value objects. Unlike `EntityResolver` (templates / parts), it surfaces a `cloneToUser()` affordance and `toFilterMap()` for filter consumers, but does not implement `revert()` — patterns have no override-then-revert workflow.
+
+```php
+class PatternResolver
+{
+    public function resolve(string $slug): ?ResolvedPattern;
+    public function all(): array;                         // map<storage-slug, ResolvedPattern>
+    public function toFilterMap(): array;                 // map<storage-slug, array<string, mixed>>
+    public function cloneToUser(string $themeSlug): BlockPattern;
+}
+```
+
+The merged map keys use the storage form: theme patterns under their natural slug (`hero`), user patterns under `user/{slug}`. visual-editor's `ap.visual-editor.patterns` consumer expects this shape.
+
 ## Resolver contract
 
 Both entity types implement `ArtisanPackUI\CMSFramework\Modules\SiteEditor\Resolution\EntityResolver`:
@@ -108,22 +161,23 @@ interface EntityResolver
 
 `ResolvedEntity` is a value object carrying the merged source-of-truth: slug, theme, source (`'db'` or `'theme'`), content (block string), title, description, status, `hasThemeFile`, `isCustom`, `area` (parts only), and the backing model (when source is `'db'`).
 
-H2–H4 will add `PatternResolver`, `GlobalStylesResolver`, and `MenuResolver` against the same interface.
+`PatternResolver` (H2) does not implement `EntityResolver` — patterns have a different storage model and surface a `cloneToUser()` affordance instead of a slug-merge `revert()`. H3 (`GlobalStylesResolver`) and H4 (`MenuResolver`) will follow the same case-by-case shape decision.
 
 ## Permissions
 
-The slugs `visual_editor.templates.edit` and `visual_editor.template-parts.edit` are seeded by the parent `CMSFrameworkServiceProvider` via the G5 (#98) bridge. The SiteEditor module does not register additional permissions; routes use the `auth` middleware (V1 baseline of "any authenticated user", per plan 12 §2.6). V1.1 introduces fine-grained policies.
+The slugs `visual_editor.templates.edit`, `visual_editor.template-parts.edit`, and `visual_editor.patterns.edit` are seeded by the parent `CMSFrameworkServiceProvider` via the G5 (#98) bridge. The SiteEditor module does not register additional permissions; routes use the `auth` middleware (V1 baseline of "any authenticated user", per plan 12 §2.6). V1.1 introduces fine-grained policies.
 
 ## Service registration
 
 `SiteEditorServiceProvider` is registered from the parent `CMSFrameworkServiceProvider`. It:
 
-- Binds `TemplateResolver` and `TemplatePartResolver` as singletons.
+- Binds `TemplateResolver`, `TemplatePartResolver`, and `PatternResolver` as singletons.
 - Loads `routes/api.php` for the REST endpoints.
+- Registers `ap.visual-editor.patterns` filter under a `class_exists(VisualEditor::class)` guard so cms-framework boots cleanly without visual-editor installed.
 
 Migrations live at the package level (`database/migrations/`) and are loaded by the parent `CMSFrameworkServiceProvider`.
 
 ## Coordination with visual-editor
 
-- `#407` (H5 — site-editor resource filters): visual-editor reads the `/templates` and `/template-parts` endpoints to populate `addEntities()` at editor bootstrap.
+- `#407` (H5 — site-editor resource filters): visual-editor reads the `/templates`, `/template-parts`, `/blocks`, and `/block-patterns/patterns` endpoints to populate `addEntities()` at editor bootstrap. Patterns specifically surface through the `ap.visual-editor.patterns` filter that cms-framework registers behind a `class_exists` guard.
 - `#399` (G3 — editor entity adapter): visual-editor's WP-shape resource adapter maps the REST responses back into the editor's `useEntityRecord` / `useEntityRecords` selectors.

--- a/src/Modules/SiteEditor/Http/Controllers/BlockPatternsController.php
+++ b/src/Modules/SiteEditor/Http/Controllers/BlockPatternsController.php
@@ -1,0 +1,266 @@
+<?php
+
+/**
+ * Block Patterns Controller (unsynced patterns)
+ *
+ * Implements the WordPress `/wp/v2/block-patterns/patterns` REST shape — the
+ * inserter catalogue Gutenberg uses for unsynced patterns. Lists theme +
+ * user-source unsynced patterns merged. Write operations are restricted to
+ * user-source rows; theme patterns return 403 on PUT/DELETE.
+ *
+ * @since      1.2.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Modules\SiteEditor\Http\Controllers;
+
+use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Http\Requests\BlockPatternRequest;
+use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Http\Resources\BlockPatternResource;
+use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Models\BlockPattern;
+use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Resolution\PatternResolver;
+use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Resolution\ResolvedPattern;
+use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Support\SlugValidator;
+use Dedoc\Scramble\Attributes\Group;
+use Illuminate\Database\QueryException;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Routing\Controller;
+
+/**
+ * @since 1.2.0
+ */
+#[Group( 'Site Editor / Block Patterns (unsynced)', weight: 34 )]
+class BlockPatternsController extends Controller
+{
+    /**
+     * @since 1.2.0
+     */
+    public function __construct(
+        private PatternResolver $resolver,
+    ) {
+    }
+
+    /**
+     * GET /api/v1/block-patterns/patterns — list theme + user-source unsynced patterns.
+     *
+     * @since 1.2.0
+     */
+    public function index(): JsonResponse
+    {
+        $unsynced = array_filter(
+            $this->resolver->all(),
+            static fn ( ResolvedPattern $pattern ) => ! $pattern->synced,
+        );
+
+        return response()->json( BlockPatternResource::collection( $unsynced ) );
+    }
+
+    /**
+     * GET /api/v1/block-patterns/patterns/{slug}.
+     *
+     * @since 1.2.0
+     */
+    public function show( string $slug ): JsonResponse
+    {
+        $pattern = $this->resolver->resolve( $slug );
+
+        if ( null === $pattern || $pattern->synced ) {
+            return response()->json( [ 'message' => 'Pattern not found.' ], 404 );
+        }
+
+        return response()->json( BlockPatternResource::toArray( $pattern ) );
+    }
+
+    /**
+     * POST /api/v1/block-patterns/patterns — create an unsynced user pattern.
+     *
+     * @since 1.2.0
+     */
+    public function store( BlockPatternRequest $request ): JsonResponse
+    {
+        try {
+            $pattern = BlockPattern::create( $this->createAttributes( $request->validated() ) );
+        } catch ( QueryException $e ) {
+            if ( $this->isUniqueViolation( $e ) ) {
+                return $this->slugConflictResponse();
+            }
+
+            throw $e;
+        }
+
+        $resolved = $this->resolver->resolve( $pattern->userFacingSlug() );
+
+        return response()->json( BlockPatternResource::toArray( $resolved ), 201 );
+    }
+
+    /**
+     * PUT /api/v1/block-patterns/patterns/{slug} — update an unsynced user pattern.
+     *
+     * Theme patterns are read-only at this endpoint. A PUT to a theme-source
+     * slug returns 403 to make the boundary explicit; the admin can still
+     * clone the theme pattern into a user pattern via the resolver's
+     * `cloneToUser()` and update the resulting user-source row.
+     *
+     * @since 1.2.0
+     */
+    public function update( BlockPatternRequest $request, string $slug ): JsonResponse
+    {
+        if ( ! SlugValidator::isValid( $slug ) ) {
+            return $this->invalidSlugResponse();
+        }
+
+        $existing = $this->resolver->resolve( $slug );
+
+        if ( null !== $existing && BlockPattern::SOURCE_THEME === $existing->source ) {
+            return response()->json( [
+                'message' => 'Theme patterns are read-only. Clone the pattern to a user pattern before editing.',
+            ], 403 );
+        }
+
+        $validated = $request->validated();
+
+        if ( array_key_exists( 'slug', $validated ) && $validated['slug'] !== $slug ) {
+            return response()->json( [
+                'message' => 'Body slug does not match URL slug.',
+                'errors'  => [ 'slug' => [ 'Slug in the request body must match the URL slug.' ] ],
+            ], 422 );
+        }
+
+        unset( $validated['slug'] );
+
+        $pattern = $this->upsertUnsynced( $slug, $validated );
+
+        return response()->json( BlockPatternResource::toArray( $this->resolver->resolve( $pattern->userFacingSlug() ) ) );
+    }
+
+    /**
+     * DELETE /api/v1/block-patterns/patterns/{slug}.
+     *
+     * Theme patterns 403; user-source rows are deleted.
+     *
+     * @since 1.2.0
+     */
+    public function destroy( string $slug ): JsonResponse
+    {
+        if ( ! SlugValidator::isValid( $slug ) ) {
+            return $this->invalidSlugResponse();
+        }
+
+        $existing = $this->resolver->resolve( $slug );
+
+        if ( null !== $existing && BlockPattern::SOURCE_THEME === $existing->source ) {
+            return response()->json( [
+                'message' => 'Theme patterns cannot be deleted.',
+            ], 403 );
+        }
+
+        $deleted = BlockPattern::query()
+            ->where( 'slug', BlockPattern::withUserPrefix( $slug ) )
+            ->where( 'source', BlockPattern::SOURCE_USER )
+            ->where( 'synced', false )
+            ->delete();
+
+        if ( $deleted < 1 ) {
+            return response()->json( [ 'message' => 'Pattern not found.' ], 404 );
+        }
+
+        return response()->json( null, 204 );
+    }
+
+    /**
+     * Race-safe upsert for an unsynced user pattern.
+     *
+     * @since 1.2.0
+     *
+     * @param  array<string, mixed>  $validated
+     */
+    protected function upsertUnsynced( string $slug, array $validated ): BlockPattern
+    {
+        $existing = BlockPattern::query()
+            ->where( 'slug', BlockPattern::withUserPrefix( $slug ) )
+            ->where( 'source', BlockPattern::SOURCE_USER )
+            ->first();
+
+        if ( null !== $existing ) {
+            $validated['synced'] = false;
+            $existing->update( $validated );
+
+            return $existing->refresh();
+        }
+
+        $attributes         = $this->createAttributes( $validated );
+        $attributes['slug'] = $slug;
+
+        try {
+            return BlockPattern::create( $attributes );
+        } catch ( QueryException $e ) {
+            if ( ! $this->isUniqueViolation( $e ) ) {
+                throw $e;
+            }
+
+            $existing = BlockPattern::query()
+                ->where( 'slug', BlockPattern::withUserPrefix( $slug ) )
+                ->where( 'source', BlockPattern::SOURCE_USER )
+                ->firstOrFail();
+
+            unset( $validated['slug'] );
+            $validated['synced'] = false;
+            $existing->update( $validated );
+
+            return $existing->refresh();
+        }
+    }
+
+    /**
+     * @since 1.2.0
+     *
+     * @param  array<string, mixed>  $validated
+     *
+     * @return array<string, mixed>
+     */
+    protected function createAttributes( array $validated ): array
+    {
+        $validated['source']    = BlockPattern::SOURCE_USER;
+        $validated['synced']    = false;
+        $validated['theme']     = null;
+        $validated['author_id'] = $validated['author_id'] ?? auth()->id();
+
+        return $validated;
+    }
+
+    /**
+     * @since 1.2.0
+     */
+    protected function slugConflictResponse(): JsonResponse
+    {
+        return response()->json( [
+            'message' => 'A pattern with this slug already exists.',
+            'errors'  => [ 'slug' => [ 'Slug must be unique across user patterns.' ] ],
+        ], 409 );
+    }
+
+    /**
+     * @since 1.2.0
+     */
+    protected function invalidSlugResponse(): JsonResponse
+    {
+        return response()->json( [
+            'message' => 'URL slug is not in canonical kebab-case form.',
+            'errors'  => [ 'slug' => [ 'Slug must be lowercase letters, numbers, and hyphens only.' ] ],
+        ], 422 );
+    }
+
+    /**
+     * @since 1.2.0
+     */
+    protected function isUniqueViolation( QueryException $e ): bool
+    {
+        $sqlState = $e->getCode();
+
+        if ( '23000' === $sqlState || '23505' === $sqlState ) {
+            return true;
+        }
+
+        return str_contains( strtolower( $e->getMessage() ), 'unique' );
+    }
+}

--- a/src/Modules/SiteEditor/Http/Controllers/BlocksController.php
+++ b/src/Modules/SiteEditor/Http/Controllers/BlocksController.php
@@ -1,0 +1,246 @@
+<?php
+
+/**
+ * Blocks Controller (synced patterns)
+ *
+ * Implements the WordPress `/wp/v2/blocks` REST shape — the `wp_block` CPT
+ * Gutenberg uses for synced patterns. Scoped to user-source rows with
+ * `synced = true`. Theme patterns never surface here.
+ *
+ * @since      1.2.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Modules\SiteEditor\Http\Controllers;
+
+use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Http\Requests\BlockPatternRequest;
+use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Http\Resources\SyncedPatternResource;
+use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Models\BlockPattern;
+use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Resolution\PatternResolver;
+use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Support\SlugValidator;
+use Dedoc\Scramble\Attributes\Group;
+use Illuminate\Database\QueryException;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Routing\Controller;
+
+/**
+ * @since 1.2.0
+ */
+#[Group( 'Site Editor / Blocks (synced patterns)', weight: 33 )]
+class BlocksController extends Controller
+{
+    /**
+     * @since 1.2.0
+     */
+    public function __construct(
+        private PatternResolver $resolver,
+    ) {
+    }
+
+    /**
+     * GET /api/v1/blocks — list synced user patterns.
+     *
+     * @since 1.2.0
+     */
+    public function index(): JsonResponse
+    {
+        $synced = array_filter(
+            $this->resolver->all(),
+            static fn ( $pattern ) => $pattern->synced && BlockPattern::SOURCE_USER === $pattern->source,
+        );
+
+        return response()->json( SyncedPatternResource::collection( $synced ) );
+    }
+
+    /**
+     * GET /api/v1/blocks/{slug} — show a single synced user pattern.
+     *
+     * @since 1.2.0
+     */
+    public function show( string $slug ): JsonResponse
+    {
+        $pattern = $this->resolver->resolve( $slug );
+
+        if ( null === $pattern || BlockPattern::SOURCE_USER !== $pattern->source || ! $pattern->synced ) {
+            return response()->json( [ 'message' => 'Synced pattern not found.' ], 404 );
+        }
+
+        return response()->json( SyncedPatternResource::toArray( $pattern ) );
+    }
+
+    /**
+     * POST /api/v1/blocks — create a synced user pattern.
+     *
+     * @since 1.2.0
+     */
+    public function store( BlockPatternRequest $request ): JsonResponse
+    {
+        try {
+            $pattern = BlockPattern::create( $this->createAttributes( $request->validated(), synced: true ) );
+        } catch ( QueryException $e ) {
+            if ( $this->isUniqueViolation( $e ) ) {
+                return $this->slugConflictResponse();
+            }
+
+            throw $e;
+        }
+
+        $resolved = $this->resolver->resolve( $pattern->userFacingSlug() );
+
+        return response()->json( SyncedPatternResource::toArray( $resolved ), 201 );
+    }
+
+    /**
+     * PUT /api/v1/blocks/{slug} — update or upsert a synced user pattern.
+     *
+     * @since 1.2.0
+     */
+    public function update( BlockPatternRequest $request, string $slug ): JsonResponse
+    {
+        if ( ! SlugValidator::isValid( $slug ) ) {
+            return $this->invalidSlugResponse();
+        }
+
+        $validated = $request->validated();
+
+        if ( array_key_exists( 'slug', $validated ) && $validated['slug'] !== $slug ) {
+            return response()->json( [
+                'message' => 'Body slug does not match URL slug.',
+                'errors'  => [ 'slug' => [ 'Slug in the request body must match the URL slug.' ] ],
+            ], 422 );
+        }
+
+        unset( $validated['slug'] );
+
+        $pattern = $this->upsertSynced( $slug, $validated );
+
+        return response()->json( SyncedPatternResource::toArray( $this->resolver->resolve( $pattern->userFacingSlug() ) ) );
+    }
+
+    /**
+     * DELETE /api/v1/blocks/{slug} — delete a synced user pattern.
+     *
+     * @since 1.2.0
+     */
+    public function destroy( string $slug ): JsonResponse
+    {
+        if ( ! SlugValidator::isValid( $slug ) ) {
+            return $this->invalidSlugResponse();
+        }
+
+        $deleted = BlockPattern::query()
+            ->where( 'slug', BlockPattern::withUserPrefix( $slug ) )
+            ->where( 'source', BlockPattern::SOURCE_USER )
+            ->where( 'synced', true )
+            ->delete();
+
+        if ( $deleted < 1 ) {
+            return response()->json( [ 'message' => 'Synced pattern not found.' ], 404 );
+        }
+
+        return response()->json( null, 204 );
+    }
+
+    /**
+     * Race-safe upsert for a synced user pattern.
+     *
+     * @since 1.2.0
+     *
+     * @param  array<string, mixed>  $validated
+     */
+    protected function upsertSynced( string $slug, array $validated ): BlockPattern
+    {
+        $existing = BlockPattern::query()
+            ->where( 'slug', BlockPattern::withUserPrefix( $slug ) )
+            ->where( 'source', BlockPattern::SOURCE_USER )
+            ->first();
+
+        if ( null !== $existing ) {
+            // Lock to synced for this endpoint — stops a PUT from accidentally
+            // unsync-ing a pattern via this controller. Cross-state transitions
+            // happen through the unsynced controller's POST/PUT instead.
+            $validated['synced'] = true;
+            $existing->update( $validated );
+
+            return $existing->refresh();
+        }
+
+        $attributes         = $this->createAttributes( $validated, synced: true );
+        $attributes['slug'] = $slug;
+
+        try {
+            return BlockPattern::create( $attributes );
+        } catch ( QueryException $e ) {
+            if ( ! $this->isUniqueViolation( $e ) ) {
+                throw $e;
+            }
+
+            $existing = BlockPattern::query()
+                ->where( 'slug', BlockPattern::withUserPrefix( $slug ) )
+                ->where( 'source', BlockPattern::SOURCE_USER )
+                ->firstOrFail();
+
+            unset( $validated['slug'] );
+            $validated['synced'] = true;
+            $existing->update( $validated );
+
+            return $existing->refresh();
+        }
+    }
+
+    /**
+     * Build the model attribute payload for a create call.
+     *
+     * @since 1.2.0
+     *
+     * @param  array<string, mixed>  $validated
+     *
+     * @return array<string, mixed>
+     */
+    protected function createAttributes( array $validated, bool $synced ): array
+    {
+        $validated['source']    = BlockPattern::SOURCE_USER;
+        $validated['synced']    = $synced;
+        $validated['theme']     = null;
+        $validated['author_id'] = $validated['author_id'] ?? auth()->id();
+
+        return $validated;
+    }
+
+    /**
+     * @since 1.2.0
+     */
+    protected function slugConflictResponse(): JsonResponse
+    {
+        return response()->json( [
+            'message' => 'A pattern with this slug already exists.',
+            'errors'  => [ 'slug' => [ 'Slug must be unique across user patterns.' ] ],
+        ], 409 );
+    }
+
+    /**
+     * @since 1.2.0
+     */
+    protected function invalidSlugResponse(): JsonResponse
+    {
+        return response()->json( [
+            'message' => 'URL slug is not in canonical kebab-case form.',
+            'errors'  => [ 'slug' => [ 'Slug must be lowercase letters, numbers, and hyphens only.' ] ],
+        ], 422 );
+    }
+
+    /**
+     * @since 1.2.0
+     */
+    protected function isUniqueViolation( QueryException $e ): bool
+    {
+        $sqlState = $e->getCode();
+
+        if ( '23000' === $sqlState || '23505' === $sqlState ) {
+            return true;
+        }
+
+        return str_contains( strtolower( $e->getMessage() ), 'unique' );
+    }
+}

--- a/src/Modules/SiteEditor/Http/Requests/BlockPatternRequest.php
+++ b/src/Modules/SiteEditor/Http/Requests/BlockPatternRequest.php
@@ -1,0 +1,71 @@
+<?php
+
+/**
+ * Block Pattern Form Request
+ *
+ * Shared validation for both pattern REST mountpoints (`/api/v1/blocks` and
+ * `/api/v1/block-patterns/patterns`). The `synced` field is required at the
+ * controller level (each endpoint pins it to a fixed value), so it is only
+ * accepted as an optional override at the request layer.
+ *
+ * @since      1.2.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Modules\SiteEditor\Http\Requests;
+
+use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Support\SlugValidator;
+use Illuminate\Foundation\Http\FormRequest;
+
+/**
+ * @since 1.2.0
+ */
+class BlockPatternRequest extends FormRequest
+{
+    /**
+     * @since 1.2.0
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @since 1.2.0
+     *
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        // POST identifies the resource by payload — slug required.
+        // PUT identifies the resource by route — slug optional.
+        $slugPresence = $this->isMethod( 'post' ) ? 'required' : 'sometimes';
+
+        return [
+            'slug'          => [ $slugPresence, 'string', 'max:255', 'regex:' . SlugValidator::PATTERN ],
+            'title'         => [ 'required', 'string', 'max:255' ],
+            'description'   => [ 'nullable', 'string' ],
+            'synced'        => [ 'nullable', 'boolean' ],
+            'categories'    => [ 'nullable', 'array' ],
+            'categories.*'  => [ 'string' ],
+            'block_types'   => [ 'nullable', 'array' ],
+            'block_types.*' => [ 'string' ],
+            'block_content' => [ 'nullable', 'array' ],
+        ];
+    }
+
+    /**
+     * @since 1.2.0
+     *
+     * @return array<string, string>
+     */
+    public function messages(): array
+    {
+        return [
+            'slug.required'  => __( 'The pattern slug is required.' ),
+            'slug.regex'     => __( 'The slug must be lowercase letters, numbers, and hyphens only.' ),
+            'title.required' => __( 'The pattern title is required.' ),
+        ];
+    }
+}

--- a/src/Modules/SiteEditor/Http/Resources/BlockPatternResource.php
+++ b/src/Modules/SiteEditor/Http/Resources/BlockPatternResource.php
@@ -1,0 +1,69 @@
+<?php
+
+/**
+ * Block Pattern Resource
+ *
+ * Transforms a {@see ResolvedPattern} into a WordPress
+ * `/wp/v2/block-patterns/patterns` shaped response — i.e. the read-only
+ * inserter-catalogue shape Gutenberg uses for unsynced patterns. Both
+ * theme-shipped and user-authored unsynced patterns surface here.
+ *
+ * @since      1.2.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Modules\SiteEditor\Http\Resources;
+
+use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Models\BlockPattern;
+use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Resolution\ResolvedPattern;
+
+/**
+ * @since 1.2.0
+ */
+final class BlockPatternResource
+{
+    /**
+     * @since 1.2.0
+     *
+     * @return array<string, mixed>
+     */
+    public static function toArray( ResolvedPattern $pattern ): array
+    {
+        return [
+            // WP's `name` field on block-pattern responses carries the
+            // namespaced slug — `theme/header` for theme patterns, or the
+            // `user/{slug}` storage form for user patterns. Mirrors WP's
+            // expectation that `name` is globally unique across the inserter.
+            'name'        => $pattern->slug,
+            'slug'        => $pattern->userFacingSlug,
+            'title'       => $pattern->title,
+            'description' => $pattern->description ?? '',
+            'content'     => $pattern->rawContent,
+            'categories'  => $pattern->categories,
+            'block_types' => $pattern->blockTypes,
+            'source'      => $pattern->source,
+            'synced'      => $pattern->synced,
+            'theme'       => $pattern->theme,
+            'wp_id'       => BlockPattern::SOURCE_USER === $pattern->source ? $pattern->wpId() : null,
+            'modified'    => null !== $pattern->model
+                ? optional( $pattern->model->updated_at )->toIso8601String()
+                : null,
+        ];
+    }
+
+    /**
+     * @since 1.2.0
+     *
+     * @param  array<int|string, ResolvedPattern>  $patterns
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    public static function collection( array $patterns ): array
+    {
+        return array_values( array_map(
+            static fn ( ResolvedPattern $p ) => self::toArray( $p ),
+            $patterns,
+        ) );
+    }
+}

--- a/src/Modules/SiteEditor/Http/Resources/SyncedPatternResource.php
+++ b/src/Modules/SiteEditor/Http/Resources/SyncedPatternResource.php
@@ -1,0 +1,70 @@
+<?php
+
+/**
+ * Synced Pattern Resource
+ *
+ * Transforms a {@see ResolvedPattern} (or its underlying {@see BlockPattern})
+ * into a WordPress `/wp/v2/blocks` shaped response — i.e. the `wp_block` CPT
+ * shape used by Gutenberg for synced patterns.
+ *
+ * @since      1.2.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Modules\SiteEditor\Http\Resources;
+
+use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Resolution\ResolvedPattern;
+
+/**
+ * @since 1.2.0
+ */
+final class SyncedPatternResource
+{
+    /**
+     * @since 1.2.0
+     *
+     * @return array<string, mixed>
+     */
+    public static function toArray( ResolvedPattern $pattern ): array
+    {
+        return [
+            'id'                     => $pattern->wpId(),
+            'slug'                   => $pattern->userFacingSlug,
+            'title'                  => [
+                'raw'      => $pattern->title,
+                'rendered' => $pattern->title,
+            ],
+            'content'                => [
+                'raw'           => $pattern->rawContent,
+                'blocks'        => $pattern->blocks,
+                'block_version' => 1,
+            ],
+            'description'            => $pattern->description ?? '',
+            'status'                 => 'publish',
+            'type'                   => 'wp_block',
+            'wp_pattern_sync_status' => '',
+            'categories'             => $pattern->categories,
+            'block_types'            => $pattern->blockTypes,
+            'author'                 => null !== $pattern->model ? (int) ( $pattern->model->author_id ?? 0 ) : 0,
+            'modified'               => null !== $pattern->model
+                ? optional( $pattern->model->updated_at )->toIso8601String()
+                : null,
+        ];
+    }
+
+    /**
+     * @since 1.2.0
+     *
+     * @param  array<int|string, ResolvedPattern>  $patterns
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    public static function collection( array $patterns ): array
+    {
+        return array_values( array_map(
+            static fn ( ResolvedPattern $p ) => self::toArray( $p ),
+            $patterns,
+        ) );
+    }
+}

--- a/src/Modules/SiteEditor/Models/BlockPattern.php
+++ b/src/Modules/SiteEditor/Models/BlockPattern.php
@@ -1,0 +1,184 @@
+<?php
+
+/**
+ * BlockPattern Model
+ *
+ * Represents a site-editor block pattern. The DB stores user-authored patterns
+ * only — theme-shipped patterns live in the active theme's `patterns/` directory
+ * and are read at resolve time. Both sources surface together through the
+ * `ap.visual-editor.patterns` filter at the visual-editor consumer side.
+ *
+ * Per plan 14 §5.6, the `slug` column carries a `user/` prefix at storage time
+ * so user `single` and theme `single` cannot collide in the merged result map.
+ * The unprefixed user-facing slug is exposed via {@see self::userFacingSlug()}
+ * and used by the REST surface.
+ *
+ * @since      1.2.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Modules\SiteEditor\Models;
+
+use ArtisanPackUI\VisualEditor\Concerns\HasBlockContent;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Carbon;
+
+/**
+ * @property int $id
+ * @property string $slug
+ * @property string|null $theme
+ * @property string $title
+ * @property string|null $description
+ * @property string $source
+ * @property bool $synced
+ * @property array<int, string>|null $categories
+ * @property array<int, string>|null $block_types
+ * @property array<int, array<string, mixed>>|null $block_content
+ * @property int|null $author_id
+ * @property Carbon $created_at
+ * @property Carbon $updated_at
+ */
+class BlockPattern extends Model
+{
+    use HasBlockContent;
+    use HasFactory;
+
+    /**
+     * Allowed pattern sources. The DB stores `user` rows only — `theme` is
+     * recorded here for symmetry and to keep the door open to future cached
+     * theme-pattern rows without a schema change.
+     *
+     * @since 1.2.0
+     */
+    public const SOURCE_THEME = 'theme';
+
+    public const SOURCE_USER = 'user';
+
+    public const SOURCES = [
+        self::SOURCE_THEME,
+        self::SOURCE_USER,
+    ];
+
+    /**
+     * Storage prefix applied to user-source slugs per plan 14 §5.6. Keeps
+     * theme/user namespaces distinct in the merged `ap.visual-editor.patterns`
+     * map at the visual-editor consumer side.
+     *
+     * @since 1.2.0
+     */
+    public const USER_SLUG_PREFIX = 'user/';
+
+    /**
+     * @since 1.2.0
+     */
+    protected $table = 'block_patterns';
+
+    /**
+     * The column that stores the visual editor block tree JSON.
+     *
+     * @since 1.2.0
+     */
+    protected string $blockContentColumn = 'block_content';
+
+    /**
+     * @since 1.2.0
+     *
+     * @var array<int, string>
+     */
+    protected $fillable = [
+        'slug',
+        'theme',
+        'title',
+        'description',
+        'source',
+        'synced',
+        'categories',
+        'block_types',
+        'block_content',
+        'author_id',
+    ];
+
+    /**
+     * The user who last authored or edited this pattern.
+     *
+     * @since 1.2.0
+     */
+    public function author(): BelongsTo
+    {
+        return $this->belongsTo( config( 'artisanpack.cms-framework.user_model' ), 'author_id' );
+    }
+
+    /**
+     * The user-facing slug (storage slug minus the `user/` prefix).
+     *
+     * REST resources and inspector UIs consume this. The raw stored slug
+     * remains accessible via `$pattern->slug` for queries that need the
+     * namespaced form.
+     *
+     * @since 1.2.0
+     */
+    public function userFacingSlug(): string
+    {
+        return self::stripUserPrefix( $this->slug );
+    }
+
+    /**
+     * Adds the `user/` prefix to a slug if missing. Idempotent — safe to call
+     * on already-prefixed values.
+     *
+     * @since 1.2.0
+     */
+    public static function withUserPrefix( string $slug ): string
+    {
+        return str_starts_with( $slug, self::USER_SLUG_PREFIX )
+            ? $slug
+            : self::USER_SLUG_PREFIX . $slug;
+    }
+
+    /**
+     * Removes the `user/` prefix if present. Returns the slug unchanged when
+     * no prefix is present.
+     *
+     * @since 1.2.0
+     */
+    public static function stripUserPrefix( string $slug ): string
+    {
+        return str_starts_with( $slug, self::USER_SLUG_PREFIX )
+            ? substr( $slug, strlen( self::USER_SLUG_PREFIX ) )
+            : $slug;
+    }
+
+    /**
+     * Mutator that auto-prefixes user-source slugs at write time. Theme-source
+     * rows (rare — the table primarily holds user patterns) keep raw slugs.
+     *
+     * Implemented as a setter mutator rather than an `Attribute::make` cast
+     * because the prefix decision depends on the sibling `source` field, and
+     * the cast layer cannot read peer attributes during resolution.
+     *
+     * @since 1.2.0
+     */
+    public function setSlugAttribute( string $value ): void
+    {
+        $source = $this->attributes['source'] ?? self::SOURCE_USER;
+
+        $this->attributes['slug'] = self::SOURCE_USER === $source
+            ? self::withUserPrefix( $value )
+            : $value;
+    }
+
+    /**
+     * @since 1.2.0
+     */
+    protected function casts(): array
+    {
+        return [
+            'synced'      => 'boolean',
+            'categories'  => 'array',
+            'block_types' => 'array',
+        ];
+    }
+}

--- a/src/Modules/SiteEditor/Providers/SiteEditorServiceProvider.php
+++ b/src/Modules/SiteEditor/Providers/SiteEditorServiceProvider.php
@@ -18,9 +18,12 @@ declare( strict_types=1 );
 
 namespace ArtisanPackUI\CMSFramework\Modules\SiteEditor\Providers;
 
+use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Resolution\EntityResolver;
+use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Resolution\PatternResolver;
 use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Resolution\TemplatePartResolver;
 use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Resolution\TemplateResolver;
 use ArtisanPackUI\CMSFramework\Modules\Themes\Managers\ThemeManager;
+use ArtisanPackUI\VisualEditor\VisualEditor;
 use Illuminate\Support\ServiceProvider;
 
 /**
@@ -40,6 +43,10 @@ class SiteEditorServiceProvider extends ServiceProvider
         $this->app->singleton( TemplatePartResolver::class, function ( $app ) {
             return new TemplatePartResolver( $app->make( ThemeManager::class ) );
         } );
+
+        $this->app->singleton( PatternResolver::class, function ( $app ) {
+            return new PatternResolver( $app->make( ThemeManager::class ) );
+        } );
     }
 
     /**
@@ -48,5 +55,60 @@ class SiteEditorServiceProvider extends ServiceProvider
     public function boot(): void
     {
         $this->loadRoutesFrom( __DIR__ . '/../routes/api.php' );
+
+        $this->registerVisualEditorSiteEditorFilters();
+    }
+
+    /**
+     * Register cms-framework site-editor entities into visual-editor's
+     * `ap.visual-editor.{templates,template-parts,patterns}` filters.
+     *
+     * Behind a `class_exists` guard so cms-framework boots cleanly without
+     * visual-editor in `composer.json`. Public so tests can re-trigger the
+     * registration after stubbing the gate or mutating filter callbacks.
+     *
+     * Each filter merges cms-framework's resolved map *under* the existing
+     * map so app-level config / earlier contributors keep winning on key
+     * collision (mirrors `CMSFrameworkServiceProvider::registerVisualEditorBridge`'s
+     * merge order on `ap.visual-editor.resources`).
+     *
+     * @since 1.2.0
+     */
+    public function registerVisualEditorSiteEditorFilters(): void
+    {
+        if ( ! class_exists( VisualEditor::class ) ) {
+            return;
+        }
+
+        addFilter( 'ap.visual-editor.templates', function ( array $templates ): array {
+            return array_merge( $this->buildTemplateFilterMap( $this->app->make( TemplateResolver::class ) ), $templates );
+        } );
+
+        addFilter( 'ap.visual-editor.template-parts', function ( array $parts ): array {
+            return array_merge( $this->buildTemplateFilterMap( $this->app->make( TemplatePartResolver::class ) ), $parts );
+        } );
+
+        addFilter( 'ap.visual-editor.patterns', function ( array $patterns ): array {
+            return array_merge( $this->app->make( PatternResolver::class )->toFilterMap(), $patterns );
+        } );
+    }
+
+    /**
+     * Build the slug-keyed filter map for an EntityResolver. Templates and
+     * template-parts share the same shape so the same builder serves both.
+     *
+     * @since 1.2.0
+     *
+     * @return array<string, array<string, mixed>>
+     */
+    protected function buildTemplateFilterMap( EntityResolver $resolver ): array
+    {
+        $map = [];
+
+        foreach ( $resolver->all() as $entity ) {
+            $map[ $entity->slug ] = $entity->toFilterEntry();
+        }
+
+        return $map;
     }
 }

--- a/src/Modules/SiteEditor/Resolution/PatternResolver.php
+++ b/src/Modules/SiteEditor/Resolution/PatternResolver.php
@@ -1,0 +1,299 @@
+<?php
+
+/**
+ * Pattern Resolver
+ *
+ * Surfaces both theme-shipped patterns (filesystem) and user-authored patterns
+ * (DB rows) through a single read API. Unlike H1's templates, patterns do not
+ * merge by slug: theme patterns are file-only and read-only, while user
+ * patterns live exclusively in the DB. The two sources occupy disjoint
+ * keyspaces — user patterns carry a `user/` prefix on their stored slug per
+ * plan 14 §5.6 — and surface together in the merged map keyed by the storage
+ * form so visual-editor's `ap.visual-editor.patterns` consumer can route to
+ * the right code path per source.
+ *
+ * @since      1.2.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Modules\SiteEditor\Resolution;
+
+use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Models\BlockPattern;
+use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Support\PatternFileParser;
+use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Support\SlugValidator;
+use ArtisanPackUI\CMSFramework\Modules\Themes\Managers\ThemeManager;
+use Illuminate\Support\Facades\File;
+use RuntimeException;
+
+/**
+ * @since 1.2.0
+ */
+class PatternResolver
+{
+    /**
+     * @since 1.2.0
+     */
+    public function __construct(
+        private ThemeManager $themeManager,
+    ) {
+    }
+
+    /**
+     * Resolve a single pattern by either user-facing slug or storage-form
+     * slug. Looks up user patterns first (DB), then falls back to theme files.
+     *
+     * @since 1.2.0
+     */
+    public function resolve( string $slug ): ?ResolvedPattern
+    {
+        $userFacing = BlockPattern::stripUserPrefix( $slug );
+
+        if ( ! SlugValidator::isValid( $userFacing ) ) {
+            return null;
+        }
+
+        $row = BlockPattern::query()
+            ->where( 'slug', BlockPattern::withUserPrefix( $userFacing ) )
+            ->where( 'source', BlockPattern::SOURCE_USER )
+            ->first();
+
+        if ( null !== $row ) {
+            return $this->fromUserRow( $row );
+        }
+
+        return $this->resolveThemePattern( $userFacing );
+    }
+
+    /**
+     * Return all patterns for the active theme, keyed by storage-form slug.
+     *
+     * Theme patterns are keyed by their natural slug (`my-pattern`); user
+     * patterns by their `user/`-prefixed slug. This matches the expected key
+     * shape on the visual-editor consumer side ({@see \ArtisanPackUI\VisualEditor\SiteEditor\Resolution\PatternResolver}).
+     *
+     * @since 1.2.0
+     *
+     * @return array<string, ResolvedPattern>
+     */
+    public function all(): array
+    {
+        $resolved = [];
+
+        foreach ( $this->resolveThemePatterns() as $themePattern ) {
+            $resolved[ $themePattern->slug ] = $themePattern;
+        }
+
+        foreach ( BlockPattern::query()->where( 'source', BlockPattern::SOURCE_USER )->get() as $row ) {
+            $entity                     = $this->fromUserRow( $row );
+            $resolved[ $entity->slug ]  = $entity;
+        }
+
+        ksort( $resolved );
+
+        return $resolved;
+    }
+
+    /**
+     * Convert all resolved patterns to the array shape expected by visual-editor's
+     * `ap.visual-editor.patterns` filter.
+     *
+     * @since 1.2.0
+     *
+     * @return array<string, array<string, mixed>>
+     */
+    public function toFilterMap(): array
+    {
+        $map = [];
+
+        foreach ( $this->all() as $key => $pattern ) {
+            $map[ $key ] = $pattern->toFilterEntry();
+        }
+
+        return $map;
+    }
+
+    /**
+     * Clone a theme pattern into a new user-source DB row. The new row uses
+     * the same user-facing slug and inherits title / description / categories /
+     * block types from the theme file.
+     *
+     * @since 1.2.0
+     *
+     * @throws RuntimeException When no theme pattern exists for the slug.
+     */
+    public function cloneToUser( string $themeSlug ): BlockPattern
+    {
+        $themePattern = $this->resolveThemePattern( $themeSlug );
+
+        if ( null === $themePattern ) {
+            throw new RuntimeException( "No theme pattern found for slug '{$themeSlug}'." );
+        }
+
+        return BlockPattern::create( [
+            'slug'        => $themePattern->userFacingSlug,
+            'theme'       => null,
+            'title'       => $themePattern->title,
+            'description' => $themePattern->description,
+            'source'      => BlockPattern::SOURCE_USER,
+            'synced'      => false,
+            'categories'  => $themePattern->categories,
+            'block_types' => $themePattern->blockTypes,
+        ] );
+    }
+
+    /**
+     * Build a {@see ResolvedPattern} from a user-source DB row.
+     *
+     * @since 1.2.0
+     */
+    protected function fromUserRow( BlockPattern $row ): ResolvedPattern
+    {
+        $blocks = is_array( $row->block_content ) ? $row->block_content : [];
+
+        return new ResolvedPattern(
+            slug           : $row->slug,
+            userFacingSlug : $row->userFacingSlug(),
+            theme          : null,
+            title          : $row->title,
+            description    : $row->description,
+            source         : BlockPattern::SOURCE_USER,
+            synced         : (bool) $row->synced,
+            rawContent     : '',
+            blocks         : $blocks,
+            categories     : is_array( $row->categories ) ? array_values( array_filter( $row->categories, 'is_string' ) ) : [],
+            blockTypes     : is_array( $row->block_types ) ? array_values( array_filter( $row->block_types, 'is_string' ) ) : [],
+            model          : $row,
+        );
+    }
+
+    /**
+     * Read a single theme pattern by user-facing slug. Returns null when no
+     * matching file exists in the active theme.
+     *
+     * @since 1.2.0
+     */
+    protected function resolveThemePattern( string $slug ): ?ResolvedPattern
+    {
+        $theme = $this->activeThemeSlug();
+
+        if ( null === $theme ) {
+            return null;
+        }
+
+        $file = $this->themeFilePath( $theme, $slug );
+
+        if ( null === $file ) {
+            return null;
+        }
+
+        return $this->buildThemePattern( $theme, $slug, File::get( $file ) );
+    }
+
+    /**
+     * Walk the active theme's `patterns/` directory and build entities for each
+     * `.php` file found.
+     *
+     * @since 1.2.0
+     *
+     * @return array<int, ResolvedPattern>
+     */
+    protected function resolveThemePatterns(): array
+    {
+        $theme = $this->activeThemeSlug();
+
+        if ( null === $theme ) {
+            return [];
+        }
+
+        $directory = $this->themePatternsDirectory( $theme );
+
+        if ( ! File::isDirectory( $directory ) ) {
+            return [];
+        }
+
+        $patterns = [];
+
+        foreach ( File::files( $directory ) as $file ) {
+            if ( 'php' !== $file->getExtension() ) {
+                continue;
+            }
+
+            $slug = $file->getFilenameWithoutExtension();
+
+            if ( ! SlugValidator::isValid( $slug ) ) {
+                continue;
+            }
+
+            $patterns[] = $this->buildThemePattern( $theme, $slug, File::get( $file->getRealPath() ) );
+        }
+
+        return $patterns;
+    }
+
+    /**
+     * Build a theme {@see ResolvedPattern} from a parsed file's contents.
+     *
+     * @since 1.2.0
+     */
+    protected function buildThemePattern( string $theme, string $slug, string $contents ): ResolvedPattern
+    {
+        $parsed = PatternFileParser::parse( $contents );
+
+        return new ResolvedPattern(
+            slug           : $slug,
+            userFacingSlug : $slug,
+            theme          : $theme,
+            title          : '' !== $parsed['title'] ? $parsed['title'] : $this->humanizeSlug( $slug ),
+            description    : $parsed['description'],
+            source         : BlockPattern::SOURCE_THEME,
+            synced         : false,
+            rawContent     : $parsed['content'],
+            blocks         : [],
+            categories     : $parsed['categories'],
+            blockTypes     : $parsed['block_types'],
+            model          : null,
+        );
+    }
+
+    /**
+     * @since 1.2.0
+     */
+    protected function activeThemeSlug(): ?string
+    {
+        $theme = $this->themeManager->getActiveTheme();
+
+        return null !== $theme && ! empty( $theme['slug'] ) ? (string) $theme['slug'] : null;
+    }
+
+    /**
+     * @since 1.2.0
+     */
+    protected function themeFilePath( string $theme, string $slug ): ?string
+    {
+        $path = $this->themePatternsDirectory( $theme ) . '/' . $slug . '.php';
+
+        return File::exists( $path ) ? $path : null;
+    }
+
+    /**
+     * @since 1.2.0
+     */
+    protected function themePatternsDirectory( string $theme ): string
+    {
+        $directory = (string) config( 'cms.themes.directory', 'themes' );
+
+        return base_path( $directory ) . '/' . $theme . '/patterns';
+    }
+
+    /**
+     * Convert a slug like `hero-banner` to a human title `Hero Banner`. Used
+     * as the default title when a theme pattern omits the `Title:` header.
+     *
+     * @since 1.2.0
+     */
+    protected function humanizeSlug( string $slug ): string
+    {
+        return ucwords( str_replace( ['-', '_'], ' ', $slug ) );
+    }
+}

--- a/src/Modules/SiteEditor/Resolution/ResolvedEntity.php
+++ b/src/Modules/SiteEditor/Resolution/ResolvedEntity.php
@@ -65,4 +65,44 @@ final class ResolvedEntity
     {
         return null !== $this->model ? (int) $this->model->id : 0;
     }
+
+    /**
+     * Convert to the array shape consumed by visual-editor's
+     * {@see \ArtisanPackUI\VisualEditor\SiteEditor\Resolution\ResolvedTemplate::fromArray()}
+     * (and {@see \ArtisanPackUI\VisualEditor\SiteEditor\Resolution\ResolvedTemplatePart::fromArray()}
+     * when `area` is populated). Distinct from the WP REST `TemplateResource`
+     * shape: REST emits `id`, `content.{raw,blocks}`, and `title.{raw,rendered}`,
+     * while the filter expects `slug`, `theme`, top-level `raw_content`/`blocks`,
+     * and a plain string `title`.
+     *
+     * @since 1.2.0
+     *
+     * @return array<string, mixed>
+     */
+    public function toFilterEntry(): array
+    {
+        $entry = [
+            'slug'           => $this->slug,
+            'theme'          => $this->theme,
+            'title'          => $this->title ?? '',
+            'description'    => $this->description ?? '',
+            'status'         => $this->status,
+            'source'         => $this->source,
+            'raw_content'    => $this->raw,
+            'blocks'         => $this->blocks,
+            'has_theme_file' => $this->hasThemeFile,
+            'is_custom'      => $this->isCustom,
+            'wp_id'          => $this->wpId(),
+            'author_id'      => null !== $this->model ? (int) ( $this->model->author_id ?? 0 ) : null,
+            'modified_at'    => null !== $this->model
+                ? optional( $this->model->updated_at )->toIso8601String()
+                : null,
+        ];
+
+        if ( null !== $this->area ) {
+            $entry['area'] = $this->area;
+        }
+
+        return $entry;
+    }
 }

--- a/src/Modules/SiteEditor/Resolution/ResolvedEntity.php
+++ b/src/Modules/SiteEditor/Resolution/ResolvedEntity.php
@@ -93,7 +93,9 @@ final class ResolvedEntity
             'has_theme_file' => $this->hasThemeFile,
             'is_custom'      => $this->isCustom,
             'wp_id'          => $this->wpId(),
-            'author_id'      => null !== $this->model ? (int) ( $this->model->author_id ?? 0 ) : null,
+            'author_id'      => null !== $this->model && null !== $this->model->author_id
+                ? (int) $this->model->author_id
+                : null,
             'modified_at'    => null !== $this->model
                 ? optional( $this->model->updated_at )->toIso8601String()
                 : null,

--- a/src/Modules/SiteEditor/Resolution/ResolvedPattern.php
+++ b/src/Modules/SiteEditor/Resolution/ResolvedPattern.php
@@ -1,0 +1,99 @@
+<?php
+
+/**
+ * Resolved Pattern DTO
+ *
+ * Carries the result of a {@see PatternResolver::resolve()} call: the merged
+ * source-of-truth for a single block pattern, plus enough metadata to
+ * reconstruct both a WP-shape REST response and the array form consumed by
+ * visual-editor's `ap.visual-editor.patterns` filter.
+ *
+ * Distinct from H1's {@see ResolvedEntity}: patterns have no theme/DB merge
+ * by slug (theme patterns are file-only, user patterns are DB-only) and carry
+ * pattern-specific metadata (sync flag, categories, block types) that wouldn't
+ * fit cleanly on the templates DTO.
+ *
+ * @since      1.2.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Modules\SiteEditor\Resolution;
+
+use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Models\BlockPattern;
+
+/**
+ * @since 1.2.0
+ */
+final class ResolvedPattern
+{
+    /**
+     * @since 1.2.0
+     *
+     * @param  string  $slug          Storage-form slug. Theme patterns use the raw slug
+     *                                (`my-pattern`); user patterns carry the `user/`
+     *                                prefix per plan 14 §5.6.
+     * @param  string  $userFacingSlug  Slug as shown to clients (no `user/` prefix).
+     * @param  string|null  $theme     Active theme slug; null for user patterns.
+     * @param  string  $title         Display title.
+     * @param  string|null  $description
+     * @param  'theme'|'user'  $source
+     * @param  bool  $synced          True for synced (live-edited) user patterns;
+     *                                always false for theme patterns.
+     * @param  string  $rawContent    Serialized block markup string.
+     * @param  array<int, array<string, mixed>>  $blocks  Parsed block tree (DB rows).
+     * @param  array<int, string>  $categories  Pattern category slugs.
+     * @param  array<int, string>  $blockTypes  WP `blockTypes` hint for the inserter.
+     * @param  BlockPattern|null  $model  The DB row when `source === 'user'`; null otherwise.
+     */
+    public function __construct(
+        public readonly string $slug,
+        public readonly string $userFacingSlug,
+        public readonly ?string $theme,
+        public readonly string $title,
+        public readonly ?string $description,
+        public readonly string $source,
+        public readonly bool $synced,
+        public readonly string $rawContent,
+        public readonly array $blocks,
+        public readonly array $categories,
+        public readonly array $blockTypes,
+        public readonly ?BlockPattern $model,
+    ) {
+    }
+
+    /**
+     * The integer ID of the backing DB row, or 0 for theme patterns.
+     *
+     * Maps to WP's `wp_id` field on pattern responses.
+     *
+     * @since 1.2.0
+     */
+    public function wpId(): int
+    {
+        return null !== $this->model ? (int) $this->model->id : 0;
+    }
+
+    /**
+     * Convert to the array shape consumed by visual-editor's
+     * {@see \ArtisanPackUI\VisualEditor\SiteEditor\Resolution\ResolvedPattern::fromArray()}.
+     *
+     * @since 1.2.0
+     *
+     * @return array<string, mixed>
+     */
+    public function toFilterEntry(): array
+    {
+        return [
+            'slug'        => $this->slug,
+            'title'       => $this->title,
+            'raw_content' => $this->rawContent,
+            'blocks'      => $this->blocks,
+            'source'      => $this->source,
+            'synced'      => $this->synced,
+            'categories'  => $this->categories,
+            'block_types' => $this->blockTypes,
+            'wp_id'       => $this->wpId(),
+        ];
+    }
+}

--- a/src/Modules/SiteEditor/Support/PatternFileParser.php
+++ b/src/Modules/SiteEditor/Support/PatternFileParser.php
@@ -44,7 +44,14 @@ final class PatternFileParser
     }
 
     /**
-     * Extract `Header: value` pairs from the leading doc-comment.
+     * Extract `Header: value` pairs from the *leading* doc-comment.
+     *
+     * The `\A` anchor + leading-noise allowance restricts the match to a
+     * docblock at the very top of the file (after an optional UTF-8 BOM,
+     * whitespace, and a single `<?php` tag — the only things that can
+     * legitimately precede the metadata block in a WP-style pattern file).
+     * Without anchoring, an earlier non-header `/* ... *\/` comment in the
+     * file body would be parsed as the header and shadow the real one.
      *
      * @since 1.2.0
      *
@@ -52,7 +59,7 @@ final class PatternFileParser
      */
     protected static function extractHeaders( string $contents ): array
     {
-        if ( ! preg_match( '/\/\*\*?(.*?)\*\//s', $contents, $match ) ) {
+        if ( ! preg_match( '/\A(?:\xEF\xBB\xBF)?\s*(?:<\?php\s+)?\/\*\*?(.*?)\*\//s', $contents, $match ) ) {
             return [];
         }
 
@@ -86,8 +93,15 @@ final class PatternFileParser
          * Strip a leading PHP-tag block surrounding a doc-comment, then return
          * the body that follows. WP block-pattern PHP files commonly close the
          * PHP tag right after the doc-comment so the body is plain HTML.
+         *
+         * Both branches are anchored to the start of the file (after an
+         * optional UTF-8 BOM and whitespace) so a docblock buried in the body
+         * is never mistaken for the leading header — its contents would
+         * otherwise be silently stripped along with the docblock itself.
          */
-        if ( preg_match( '/<\?php\s+\/\*\*?.*?\*\/\s*\?>(.*)$/s', $contents, $match ) ) {
+        $leading = '\A(?:\xEF\xBB\xBF)?\s*';
+
+        if ( preg_match( '/' . $leading . '<\?php\s+\/\*\*?.*?\*\/\s*\?>\s*(.*)$/s', $contents, $match ) ) {
             return $match[1];
         }
 
@@ -95,7 +109,7 @@ final class PatternFileParser
          * Doc-comment without surrounding PHP tags — return everything after
          * the closing of the comment.
          */
-        if ( preg_match( '/\/\*\*?.*?\*\/(.*)$/s', $contents, $match ) ) {
+        if ( preg_match( '/' . $leading . '\/\*\*?.*?\*\/\s*(.*)$/s', $contents, $match ) ) {
             return $match[1];
         }
 

--- a/src/Modules/SiteEditor/Support/PatternFileParser.php
+++ b/src/Modules/SiteEditor/Support/PatternFileParser.php
@@ -1,0 +1,136 @@
+<?php
+
+/**
+ * Pattern File Parser
+ *
+ * Parses theme-shipped block-pattern PHP files. The file format mirrors WP's
+ * `register_block_pattern_from_file()` convention: a leading PHP doc comment
+ * carries metadata headers (`Title:`, `Slug:`, `Categories:`, `Description:`,
+ * `Block Types:`), and everything after the `?>` (or after the closing `*\/`
+ * when there is no PHP tag) is treated as the pattern content.
+ *
+ * @since      1.2.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Modules\SiteEditor\Support;
+
+/**
+ * @since 1.2.0
+ */
+final class PatternFileParser
+{
+    /**
+     * Parse a pattern file's contents into a structured payload.
+     *
+     * @since 1.2.0
+     *
+     * @return array{title: string, slug: string|null, description: string|null, categories: array<int, string>, block_types: array<int, string>, content: string}
+     */
+    public static function parse( string $contents ): array
+    {
+        $headers = self::extractHeaders( $contents );
+        $content = self::extractContent( $contents );
+
+        return [
+            'title'       => trim( $headers['Title'] ?? '' ),
+            'slug'        => self::nullable( $headers['Slug'] ?? null ),
+            'description' => self::nullable( $headers['Description'] ?? null ),
+            'categories'  => self::splitList( $headers['Categories'] ?? '' ),
+            'block_types' => self::splitList( $headers['Block Types'] ?? '' ),
+            'content'     => trim( $content ),
+        ];
+    }
+
+    /**
+     * Extract `Header: value` pairs from the leading doc-comment.
+     *
+     * @since 1.2.0
+     *
+     * @return array<string, string>
+     */
+    protected static function extractHeaders( string $contents ): array
+    {
+        if ( ! preg_match( '/\/\*\*?(.*?)\*\//s', $contents, $match ) ) {
+            return [];
+        }
+
+        $headers = [];
+
+        foreach ( preg_split( '/\R/', $match[1] ) as $line ) {
+            // Strip leading whitespace and asterisks from each doc-comment line.
+            $stripped = preg_replace( '/^\s*\*\s?/', '', $line );
+
+            if ( null === $stripped ) {
+                continue;
+            }
+
+            if ( preg_match( '/^([A-Za-z][A-Za-z0-9 \-]+):\s*(.*)$/', $stripped, $headerMatch ) ) {
+                $headers[ trim( $headerMatch[1] ) ] = trim( $headerMatch[2] );
+            }
+        }
+
+        return $headers;
+    }
+
+    /**
+     * Extract the pattern body (everything after the doc-comment + optional
+     * PHP closer). Falls back to the whole file when no doc-comment is present.
+     *
+     * @since 1.2.0
+     */
+    protected static function extractContent( string $contents ): string
+    {
+        /*
+         * Strip a leading PHP-tag block surrounding a doc-comment, then return
+         * the body that follows. WP block-pattern PHP files commonly close the
+         * PHP tag right after the doc-comment so the body is plain HTML.
+         */
+        if ( preg_match( '/<\?php\s+\/\*\*?.*?\*\/\s*\?>(.*)$/s', $contents, $match ) ) {
+            return $match[1];
+        }
+
+        /*
+         * Doc-comment without surrounding PHP tags — return everything after
+         * the closing of the comment.
+         */
+        if ( preg_match( '/\/\*\*?.*?\*\/(.*)$/s', $contents, $match ) ) {
+            return $match[1];
+        }
+
+        return $contents;
+    }
+
+    /**
+     * Split a comma-separated header value into a trimmed string list.
+     *
+     * @since 1.2.0
+     *
+     * @return array<int, string>
+     */
+    protected static function splitList( string $value ): array
+    {
+        $value = trim( $value );
+
+        if ( '' === $value ) {
+            return [];
+        }
+
+        return array_values( array_filter( array_map( 'trim', explode( ',', $value ) ) ) );
+    }
+
+    /**
+     * @since 1.2.0
+     */
+    protected static function nullable( ?string $value ): ?string
+    {
+        if ( null === $value ) {
+            return null;
+        }
+
+        $trimmed = trim( $value );
+
+        return '' === $trimmed ? null : $trimmed;
+    }
+}

--- a/src/Modules/SiteEditor/routes/api.php
+++ b/src/Modules/SiteEditor/routes/api.php
@@ -2,6 +2,8 @@
 
 declare( strict_types=1 );
 
+use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Http\Controllers\BlockPatternsController;
+use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Http\Controllers\BlocksController;
 use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Http\Controllers\TemplatePartsController;
 use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Http\Controllers\TemplatesController;
 use Illuminate\Support\Facades\Route;
@@ -23,5 +25,21 @@ Route::prefix( 'api/v1' )
             Route::get( '{slug}', [ TemplatePartsController::class, 'show' ] )->name( 'api.template-parts.show' );
             Route::put( '{slug}', [ TemplatePartsController::class, 'update' ] )->name( 'api.template-parts.update' );
             Route::delete( '{slug}', [ TemplatePartsController::class, 'destroy' ] )->name( 'api.template-parts.destroy' );
+        } );
+
+        Route::prefix( 'blocks' )->group( function (): void {
+            Route::get( '/', [ BlocksController::class, 'index' ] )->name( 'api.blocks.index' );
+            Route::post( '/', [ BlocksController::class, 'store' ] )->name( 'api.blocks.store' );
+            Route::get( '{slug}', [ BlocksController::class, 'show' ] )->name( 'api.blocks.show' );
+            Route::put( '{slug}', [ BlocksController::class, 'update' ] )->name( 'api.blocks.update' );
+            Route::delete( '{slug}', [ BlocksController::class, 'destroy' ] )->name( 'api.blocks.destroy' );
+        } );
+
+        Route::prefix( 'block-patterns/patterns' )->group( function (): void {
+            Route::get( '/', [ BlockPatternsController::class, 'index' ] )->name( 'api.block-patterns.index' );
+            Route::post( '/', [ BlockPatternsController::class, 'store' ] )->name( 'api.block-patterns.store' );
+            Route::get( '{slug}', [ BlockPatternsController::class, 'show' ] )->name( 'api.block-patterns.show' );
+            Route::put( '{slug}', [ BlockPatternsController::class, 'update' ] )->name( 'api.block-patterns.update' );
+            Route::delete( '{slug}', [ BlockPatternsController::class, 'destroy' ] )->name( 'api.block-patterns.destroy' );
         } );
     } );

--- a/tests/Feature/SiteEditor/PatternsApiTest.php
+++ b/tests/Feature/SiteEditor/PatternsApiTest.php
@@ -1,0 +1,288 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Models\BlockPattern;
+use ArtisanPackUI\CMSFramework\Modules\Themes\Managers\ThemeManager;
+use ArtisanPackUI\CMSFramework\Tests\Support\TestUser;
+use Illuminate\Support\Facades\File;
+
+beforeEach( function (): void {
+    $this->user          = TestUser::factory()->create();
+    $this->themesPath    = base_path( 'themes' );
+    $this->themeSlug     = 'test-theme';
+    $this->themePatterns = $this->themesPath . '/' . $this->themeSlug . '/patterns';
+
+    File::ensureDirectoryExists( $this->themePatterns );
+    File::put(
+        $this->themesPath . '/' . $this->themeSlug . '/theme.json',
+        json_encode( [ 'name' => 'Test', 'slug' => $this->themeSlug, 'version' => '1.0.0' ] ),
+    );
+
+    config()->set( 'cms.themes.cacheEnabled', false );
+
+    $this->mock( ThemeManager::class, function ( $mock ): void {
+        $mock->shouldReceive( 'getActiveTheme' )->andReturn( [
+            'name' => 'Test',
+            'slug' => $this->themeSlug,
+        ] );
+    } );
+} );
+
+afterEach( function (): void {
+    File::deleteDirectory( $this->themesPath . '/' . $this->themeSlug );
+} );
+
+describe( 'GET /api/v1/blocks (synced patterns)', function (): void {
+    it( 'requires authentication', function (): void {
+        $this->getJson( '/api/v1/blocks' )->assertUnauthorized();
+    } );
+
+    it( 'returns only synced user patterns in wp_block shape', function (): void {
+        BlockPattern::create( [ 'slug' => 'callout', 'title' => 'Callout', 'source' => BlockPattern::SOURCE_USER, 'synced' => true ] );
+        BlockPattern::create( [ 'slug' => 'plain', 'title' => 'Plain', 'source' => BlockPattern::SOURCE_USER, 'synced' => false ] );
+
+        $this->actingAs( $this->user );
+
+        $response = $this->getJson( '/api/v1/blocks' );
+
+        $response->assertOk();
+        $response->assertJsonStructure( [
+            '*' => [
+                'id',
+                'slug',
+                'title'   => [ 'raw', 'rendered' ],
+                'content' => [ 'raw', 'blocks', 'block_version' ],
+                'description',
+                'status',
+                'type',
+            ],
+        ] );
+
+        $slugs = collect( $response->json() )->pluck( 'slug' )->all();
+        expect( $slugs )->toEqual( [ 'callout' ] );
+    } );
+
+    it( 'shows a single synced user pattern by user-facing slug', function (): void {
+        BlockPattern::create( [ 'slug' => 'callout', 'title' => 'Callout', 'source' => BlockPattern::SOURCE_USER, 'synced' => true ] );
+
+        $this->actingAs( $this->user );
+
+        $response = $this->getJson( '/api/v1/blocks/callout' );
+
+        $response->assertOk();
+        expect( $response->json( 'slug' ) )->toBe( 'callout' );
+        expect( $response->json( 'type' ) )->toBe( 'wp_block' );
+    } );
+
+    it( '404s when looking up an unsynced or theme slug under /blocks', function (): void {
+        File::put( $this->themePatterns . '/hero.php', "<?php\n/**\n * Title: Hero\n */\n" );
+        BlockPattern::create( [ 'slug' => 'plain', 'title' => 'Plain', 'source' => BlockPattern::SOURCE_USER, 'synced' => false ] );
+
+        $this->actingAs( $this->user );
+
+        $this->getJson( '/api/v1/blocks/hero' )->assertNotFound();
+        $this->getJson( '/api/v1/blocks/plain' )->assertNotFound();
+    } );
+} );
+
+describe( 'POST /api/v1/blocks', function (): void {
+    it( 'creates a synced user pattern and returns 201', function (): void {
+        $this->actingAs( $this->user );
+
+        $response = $this->postJson( '/api/v1/blocks', [
+            'slug'          => 'hero',
+            'title'         => 'Hero',
+            'block_content' => [ [ 'blockName' => 'core/heading' ] ],
+        ] );
+
+        $response->assertStatus( 201 );
+        expect( $response->json( 'slug' ) )->toBe( 'hero' );
+        expect(
+            BlockPattern::where( 'slug', 'user/hero' )->where( 'synced', true )->exists(),
+        )->toBeTrue();
+    } );
+
+    it( 'rejects invalid slugs', function (): void {
+        $this->actingAs( $this->user );
+
+        $this->postJson( '/api/v1/blocks', [ 'slug' => 'Bad Slug!', 'title' => 'X' ] )->assertStatus( 422 );
+    } );
+
+    it( 'returns 409 on duplicate slug', function (): void {
+        BlockPattern::create( [ 'slug' => 'dup', 'title' => 'Dup', 'source' => BlockPattern::SOURCE_USER, 'synced' => true ] );
+
+        $this->actingAs( $this->user );
+
+        $this->postJson( '/api/v1/blocks', [ 'slug' => 'dup', 'title' => 'Other' ] )->assertStatus( 409 );
+    } );
+} );
+
+describe( 'PUT /api/v1/blocks/{slug}', function (): void {
+    it( 'creates the row when one does not exist (upsert)', function (): void {
+        $this->actingAs( $this->user );
+
+        $this->putJson( '/api/v1/blocks/new-block', [ 'title' => 'New Block' ] )->assertOk();
+
+        expect( BlockPattern::where( 'slug', 'user/new-block' )->where( 'synced', true )->exists() )->toBeTrue();
+    } );
+
+    it( 'returns 422 when body slug does not match URL slug', function (): void {
+        $this->actingAs( $this->user );
+
+        $this->putJson( '/api/v1/blocks/foo', [ 'slug' => 'bar', 'title' => 'X' ] )->assertStatus( 422 );
+    } );
+} );
+
+describe( 'DELETE /api/v1/blocks/{slug}', function (): void {
+    it( 'deletes the synced user pattern and returns 204', function (): void {
+        BlockPattern::create( [ 'slug' => 'gone', 'title' => 'Gone', 'source' => BlockPattern::SOURCE_USER, 'synced' => true ] );
+
+        $this->actingAs( $this->user );
+
+        $this->deleteJson( '/api/v1/blocks/gone' )->assertNoContent();
+
+        expect( BlockPattern::where( 'slug', 'user/gone' )->exists() )->toBeFalse();
+    } );
+
+    it( '404s when no synced row exists', function (): void {
+        $this->actingAs( $this->user );
+
+        $this->deleteJson( '/api/v1/blocks/missing' )->assertNotFound();
+    } );
+} );
+
+describe( 'GET /api/v1/block-patterns/patterns', function (): void {
+    it( 'lists theme + user-source unsynced patterns merged', function (): void {
+        File::put( $this->themePatterns . '/hero.php', "<?php\n/**\n * Title: Theme Hero\n */\n" );
+        BlockPattern::create( [ 'slug' => 'callout', 'title' => 'Callout', 'source' => BlockPattern::SOURCE_USER, 'synced' => false ] );
+        BlockPattern::create( [ 'slug' => 'synced-only', 'title' => 'Synced', 'source' => BlockPattern::SOURCE_USER, 'synced' => true ] );
+
+        $this->actingAs( $this->user );
+
+        $response = $this->getJson( '/api/v1/block-patterns/patterns' );
+
+        $response->assertOk();
+        $names = collect( $response->json() )->pluck( 'name' )->sort()->values()->all();
+        expect( $names )->toEqual( [ 'hero', 'user/callout' ] );
+    } );
+
+    it( 'shows a single theme pattern with source=theme', function (): void {
+        File::put( $this->themePatterns . '/hero.php', "<?php\n/**\n * Title: Hero\n * Categories: featured\n */\n" );
+
+        $this->actingAs( $this->user );
+
+        $response = $this->getJson( '/api/v1/block-patterns/patterns/hero' );
+
+        $response->assertOk();
+        expect( $response->json( 'source' ) )->toBe( BlockPattern::SOURCE_THEME );
+        expect( $response->json( 'wp_id' ) )->toBeNull();
+        expect( $response->json( 'categories' ) )->toEqual( [ 'featured' ] );
+    } );
+} );
+
+describe( 'POST /api/v1/block-patterns/patterns', function (): void {
+    it( 'creates an unsynced user pattern with synced=false enforced', function (): void {
+        $this->actingAs( $this->user );
+
+        $response = $this->postJson( '/api/v1/block-patterns/patterns', [
+            'slug'   => 'new-pattern',
+            'title'  => 'New Pattern',
+            'synced' => true, // Should be ignored / forced to false
+        ] );
+
+        $response->assertStatus( 201 );
+        expect(
+            BlockPattern::where( 'slug', 'user/new-pattern' )->where( 'synced', false )->exists(),
+        )->toBeTrue();
+    } );
+} );
+
+describe( 'PUT /api/v1/block-patterns/patterns/{slug}', function (): void {
+    it( '403s when targeting a theme pattern', function (): void {
+        File::put( $this->themePatterns . '/hero.php', "<?php\n/**\n * Title: Hero\n */\n" );
+
+        $this->actingAs( $this->user );
+
+        $this->putJson( '/api/v1/block-patterns/patterns/hero', [ 'title' => 'New' ] )->assertForbidden();
+    } );
+
+    it( 'updates an existing user pattern', function (): void {
+        BlockPattern::create( [ 'slug' => 'callout', 'title' => 'Old', 'source' => BlockPattern::SOURCE_USER, 'synced' => false ] );
+
+        $this->actingAs( $this->user );
+
+        $this->putJson( '/api/v1/block-patterns/patterns/callout', [ 'title' => 'New Title' ] )->assertOk();
+
+        expect( BlockPattern::where( 'slug', 'user/callout' )->first()->title )->toBe( 'New Title' );
+    } );
+} );
+
+describe( 'DELETE /api/v1/block-patterns/patterns/{slug}', function (): void {
+    it( '403s on a theme pattern', function (): void {
+        File::put( $this->themePatterns . '/hero.php', "<?php\n/**\n * Title: Hero\n */\n" );
+
+        $this->actingAs( $this->user );
+
+        $this->deleteJson( '/api/v1/block-patterns/patterns/hero' )->assertForbidden();
+    } );
+
+    it( 'deletes a user pattern', function (): void {
+        BlockPattern::create( [ 'slug' => 'gone', 'title' => 'Gone', 'source' => BlockPattern::SOURCE_USER, 'synced' => false ] );
+
+        $this->actingAs( $this->user );
+
+        $this->deleteJson( '/api/v1/block-patterns/patterns/gone' )->assertNoContent();
+
+        expect( BlockPattern::where( 'slug', 'user/gone' )->exists() )->toBeFalse();
+    } );
+} );
+
+describe( 'ap.visual-editor.patterns filter wiring', function (): void {
+    beforeEach( function (): void {
+        // The filter is registered conditionally on `class_exists(VisualEditor::class)`
+        // at SiteEditorServiceProvider::boot(). visual-editor isn't a dev dep of
+        // cms-framework, so the gate is false at boot. Loading the stub + manually
+        // re-triggering matches how `VisualEditorBridgeTest` exercises the same
+        // pattern on the parent CMSFrameworkServiceProvider.
+        require_once __DIR__ . '/../../Support/VisualEditorClassStub.php';
+
+        removeAllFilters( 'ap.visual-editor.patterns' );
+
+        ( new ArtisanPackUI\CMSFramework\Modules\SiteEditor\Providers\SiteEditorServiceProvider( app() ) )
+            ->registerVisualEditorSiteEditorFilters();
+    } );
+
+    afterEach( function (): void {
+        removeAllFilters( 'ap.visual-editor.patterns' );
+    } );
+
+    it( 'merges resolved patterns into the filter map under expected storage-form keys', function (): void {
+        File::put( $this->themePatterns . '/hero.php', "<?php\n/**\n * Title: Hero\n * Block Types: core/post-content\n */\n" );
+        BlockPattern::create( [ 'slug' => 'callout', 'title' => 'Callout', 'source' => BlockPattern::SOURCE_USER, 'synced' => true ] );
+
+        $merged = applyFilters( 'ap.visual-editor.patterns', [] );
+
+        expect( $merged )->toBeArray()
+            ->and( $merged )->toHaveKey( 'hero' )
+            ->and( $merged )->toHaveKey( 'user/callout' );
+
+        // Shape contract that visual-editor's ResolvedPattern::fromArray expects.
+        expect( $merged['hero'] )->toHaveKeys( [ 'slug', 'title', 'raw_content', 'blocks', 'source', 'synced', 'categories', 'block_types', 'wp_id' ] )
+            ->and( $merged['hero']['source'] )->toBe( 'theme' )
+            ->and( $merged['user/callout']['source'] )->toBe( 'user' )
+            ->and( $merged['user/callout']['synced'] )->toBeTrue();
+    } );
+
+    it( 'lets static config / earlier contributors win on key collision', function (): void {
+        File::put( $this->themePatterns . '/hero.php', "<?php\n/**\n * Title: Theme Hero\n */\n" );
+
+        $existing = [
+            'hero' => [ 'slug' => 'hero', 'title' => 'Static Hero', 'source' => 'theme' ],
+        ];
+
+        $merged = applyFilters( 'ap.visual-editor.patterns', $existing );
+
+        expect( $merged['hero']['title'] )->toBe( 'Static Hero' );
+    } );
+} );

--- a/tests/Feature/SiteEditor/TemplateFiltersTest.php
+++ b/tests/Feature/SiteEditor/TemplateFiltersTest.php
@@ -1,0 +1,139 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Models\Template;
+use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Models\TemplatePart;
+use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Providers\SiteEditorServiceProvider;
+use ArtisanPackUI\CMSFramework\Modules\Themes\Managers\ThemeManager;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\File;
+
+uses( RefreshDatabase::class );
+
+beforeEach( function (): void {
+    $this->themesPath  = base_path( 'themes' );
+    $this->themeSlug   = 'test-theme';
+    $this->templates   = $this->themesPath . '/' . $this->themeSlug . '/templates';
+    $this->parts       = $this->themesPath . '/' . $this->themeSlug . '/parts';
+
+    File::ensureDirectoryExists( $this->templates );
+    File::ensureDirectoryExists( $this->parts );
+    File::put(
+        $this->themesPath . '/' . $this->themeSlug . '/theme.json',
+        json_encode( [ 'name' => 'Test', 'slug' => $this->themeSlug, 'version' => '1.0.0' ] ),
+    );
+
+    config()->set( 'cms.themes.cacheEnabled', false );
+
+    $this->mock( ThemeManager::class, function ( $mock ): void {
+        $mock->shouldReceive( 'getActiveTheme' )->andReturn( [
+            'name' => 'Test',
+            'slug' => $this->themeSlug,
+        ] );
+    } );
+
+    // Filters are registered behind `class_exists(VisualEditor::class)` at
+    // SiteEditorServiceProvider::boot(); visual-editor isn't a dev dep of
+    // cms-framework, so the gate is false at boot. Load the stub and manually
+    // re-trigger registration. Mirrors PatternsApiTest's filter wiring suite
+    // and VisualEditorBridgeTest's pattern.
+    require_once __DIR__ . '/../../Support/VisualEditorClassStub.php';
+
+    removeAllFilters( 'ap.visual-editor.templates' );
+    removeAllFilters( 'ap.visual-editor.template-parts' );
+
+    ( new SiteEditorServiceProvider( app() ) )->registerVisualEditorSiteEditorFilters();
+} );
+
+afterEach( function (): void {
+    File::deleteDirectory( $this->themesPath . '/' . $this->themeSlug );
+    removeAllFilters( 'ap.visual-editor.templates' );
+    removeAllFilters( 'ap.visual-editor.template-parts' );
+} );
+
+describe( 'ap.visual-editor.templates filter wiring', function (): void {
+    it( 'merges file + DB templates into the filter map keyed by slug', function (): void {
+        File::put( $this->templates . '/single.html', '<!-- file -->' );
+        Template::create( [
+            'theme'         => $this->themeSlug,
+            'slug'          => 'archive',
+            'title'         => 'Custom Archive',
+            'is_custom'     => true,
+            'block_content' => [ [ 'blockName' => 'core/heading' ] ],
+        ] );
+
+        $merged = applyFilters( 'ap.visual-editor.templates', [] );
+
+        expect( $merged )->toHaveKey( 'single' )
+            ->and( $merged )->toHaveKey( 'archive' )
+            ->and( $merged['single']['source'] )->toBe( 'theme' )
+            ->and( $merged['archive']['source'] )->toBe( 'db' )
+            ->and( $merged['archive']['blocks'] )->toBe( [ [ 'blockName' => 'core/heading' ] ] );
+    } );
+
+    it( 'emits the contract fields visual-editor ResolvedTemplate::fromArray expects', function (): void {
+        File::put( $this->templates . '/page.html', '<!-- wp:paragraph -->' );
+
+        $merged = applyFilters( 'ap.visual-editor.templates', [] );
+
+        expect( $merged['page'] )->toHaveKeys( [
+            'slug',
+            'theme',
+            'title',
+            'description',
+            'status',
+            'source',
+            'raw_content',
+            'blocks',
+            'has_theme_file',
+            'is_custom',
+            'wp_id',
+        ] );
+    } );
+
+    it( 'lets static config / earlier contributors win on slug collision', function (): void {
+        File::put( $this->templates . '/page.html', '<!-- file -->' );
+
+        $merged = applyFilters( 'ap.visual-editor.templates', [
+            'page' => [ 'slug' => 'page', 'theme' => 'override', 'source' => 'theme' ],
+        ] );
+
+        expect( $merged['page']['theme'] )->toBe( 'override' );
+    } );
+} );
+
+describe( 'ap.visual-editor.template-parts filter wiring', function (): void {
+    it( 'surfaces an `area` field on each entry (header / footer / sidebar / general)', function (): void {
+        File::put( $this->parts . '/header.html', '<!-- header -->' );
+        File::put( $this->parts . '/footer.html', '<!-- footer -->' );
+        TemplatePart::create( [
+            'theme' => $this->themeSlug,
+            'slug'  => 'sidebar-menu',
+            'title' => 'Sidebar Menu',
+            'area'  => 'sidebar',
+        ] );
+
+        $merged = applyFilters( 'ap.visual-editor.template-parts', [] );
+
+        expect( $merged )->toHaveKey( 'header' )
+            ->and( $merged )->toHaveKey( 'footer' )
+            ->and( $merged )->toHaveKey( 'sidebar-menu' )
+            ->and( $merged['header']['area'] )->toBe( 'header' )
+            ->and( $merged['footer']['area'] )->toBe( 'footer' )
+            ->and( $merged['sidebar-menu']['area'] )->toBe( 'sidebar' );
+    } );
+
+    it( 'is independent of the templates filter (different keyspace)', function (): void {
+        File::put( $this->templates . '/page.html', '<!-- template -->' );
+        File::put( $this->parts . '/header.html', '<!-- part -->' );
+
+        $templates = applyFilters( 'ap.visual-editor.templates', [] );
+        $parts     = applyFilters( 'ap.visual-editor.template-parts', [] );
+
+        expect( $templates )->toHaveKey( 'page' )
+            ->and( $templates )->not->toHaveKey( 'header' )
+            ->and( $parts )->toHaveKey( 'header' )
+            ->and( $parts )->not->toHaveKey( 'page' );
+    } );
+} );

--- a/tests/Unit/SiteEditor/PatternResolverTest.php
+++ b/tests/Unit/SiteEditor/PatternResolverTest.php
@@ -1,0 +1,248 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Models\BlockPattern;
+use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Resolution\PatternResolver;
+use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Resolution\ResolvedPattern;
+use ArtisanPackUI\CMSFramework\Modules\Themes\Managers\ThemeManager;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\File;
+
+uses( RefreshDatabase::class );
+
+beforeEach( function (): void {
+    $this->themesPath = base_path( 'themes' );
+    $this->themeSlug  = 'test-theme';
+    $this->themeFiles = $this->themesPath . '/' . $this->themeSlug . '/patterns';
+
+    File::ensureDirectoryExists( $this->themeFiles );
+    File::put(
+        $this->themesPath . '/' . $this->themeSlug . '/theme.json',
+        json_encode( [ 'name' => 'Test', 'slug' => $this->themeSlug, 'version' => '1.0.0' ] ),
+    );
+
+    config()->set( 'cms.themes.cacheEnabled', false );
+
+    $themeManager = $this->mock( ThemeManager::class, function ( $mock ): void {
+        $mock->shouldReceive( 'getActiveTheme' )->andReturn( [
+            'name' => 'Test',
+            'slug' => $this->themeSlug,
+        ] );
+    } );
+
+    $this->resolver = new PatternResolver( $themeManager );
+} );
+
+afterEach( function (): void {
+    File::deleteDirectory( $this->themesPath . '/' . $this->themeSlug );
+} );
+
+describe( 'PatternResolver::resolve()', function (): void {
+    it( 'returns a theme pattern from a `.php` file with parsed headers and content', function (): void {
+        File::put( $this->themeFiles . '/hero.php', <<<'PHP'
+<?php
+/**
+ * Title: Hero Banner
+ * Slug: hero
+ * Categories: featured, layout
+ * Description: A bold opening section.
+ * Block Types: core/post-content
+ */
+?>
+<!-- wp:paragraph --><p>Hero copy</p><!-- /wp:paragraph -->
+PHP );
+
+        $result = $this->resolver->resolve( 'hero' );
+
+        expect( $result )->toBeInstanceOf( ResolvedPattern::class )
+            ->and( $result->source )->toBe( BlockPattern::SOURCE_THEME )
+            ->and( $result->slug )->toBe( 'hero' )
+            ->and( $result->userFacingSlug )->toBe( 'hero' )
+            ->and( $result->title )->toBe( 'Hero Banner' )
+            ->and( $result->description )->toBe( 'A bold opening section.' )
+            ->and( $result->categories )->toEqual( [ 'featured', 'layout' ] )
+            ->and( $result->blockTypes )->toEqual( [ 'core/post-content' ] )
+            ->and( $result->rawContent )->toContain( 'Hero copy' )
+            ->and( $result->synced )->toBeFalse()
+            ->and( $result->wpId() )->toBe( 0 );
+    } );
+
+    it( 'falls back to a humanized slug when the theme file omits the Title header', function (): void {
+        File::put( $this->themeFiles . '/no-title.php', <<<'PHP'
+<?php
+/**
+ * Description: No title.
+ */
+?>
+<!-- wp:paragraph --><p>Body</p><!-- /wp:paragraph -->
+PHP );
+
+        $result = $this->resolver->resolve( 'no-title' );
+
+        expect( $result->title )->toBe( 'No Title' );
+    } );
+
+    it( 'returns a user pattern from the DB and ignores the user/ prefix on lookup', function (): void {
+        $row = BlockPattern::create( [
+            'slug'          => 'callout',
+            'title'         => 'My Callout',
+            'source'        => BlockPattern::SOURCE_USER,
+            'synced'        => true,
+            'block_content' => [ [ 'blockName' => 'core/paragraph' ] ],
+        ] );
+
+        $byUserFacing = $this->resolver->resolve( 'callout' );
+        $byStored     = $this->resolver->resolve( 'user/callout' );
+
+        expect( $byUserFacing->source )->toBe( BlockPattern::SOURCE_USER )
+            ->and( $byUserFacing->slug )->toBe( 'user/callout' )
+            ->and( $byUserFacing->userFacingSlug )->toBe( 'callout' )
+            ->and( $byUserFacing->synced )->toBeTrue()
+            ->and( $byUserFacing->blocks )->toBe( [ [ 'blockName' => 'core/paragraph' ] ] )
+            ->and( $byUserFacing->wpId() )->toBe( $row->id )
+            ->and( $byStored->slug )->toBe( $byUserFacing->slug );
+    } );
+
+    it( 'returns null when neither DB nor file has the slug', function (): void {
+        expect( $this->resolver->resolve( 'missing' ) )->toBeNull();
+    } );
+
+    it( 'rejects path-traversal slugs', function (): void {
+        File::put( $this->themesPath . '/' . $this->themeSlug . '/secret.php', '<?php /** Title: Secret */ ?>' );
+
+        expect( $this->resolver->resolve( '../secret' ) )->toBeNull();
+    } );
+} );
+
+describe( 'PatternResolver::all()', function (): void {
+    it( 'merges theme patterns and user patterns under disjoint storage keys', function (): void {
+        File::put( $this->themeFiles . '/hero.php', <<<'PHP'
+<?php
+/**
+ * Title: Hero
+ */
+?>
+<!-- hero -->
+PHP );
+
+        BlockPattern::create( [
+            'slug'   => 'callout',
+            'title'  => 'Callout',
+            'source' => BlockPattern::SOURCE_USER,
+        ] );
+
+        $all = $this->resolver->all();
+
+        expect( array_keys( $all ) )->toEqual( [ 'hero', 'user/callout' ] )
+            ->and( $all['hero']->source )->toBe( BlockPattern::SOURCE_THEME )
+            ->and( $all['user/callout']->source )->toBe( BlockPattern::SOURCE_USER );
+    } );
+
+    it( 'allows a theme pattern and a user pattern to coexist with the same user-facing slug', function (): void {
+        File::put( $this->themeFiles . '/hero.php', <<<'PHP'
+<?php
+/**
+ * Title: Theme Hero
+ */
+?>
+<!-- theme -->
+PHP );
+
+        BlockPattern::create( [
+            'slug'   => 'hero',
+            'title'  => 'User Hero',
+            'source' => BlockPattern::SOURCE_USER,
+        ] );
+
+        $all = $this->resolver->all();
+
+        expect( array_keys( $all ) )->toEqual( [ 'hero', 'user/hero' ] )
+            ->and( $all['hero']->title )->toBe( 'Theme Hero' )
+            ->and( $all['user/hero']->title )->toBe( 'User Hero' );
+    } );
+} );
+
+describe( 'PatternResolver::toFilterMap()', function (): void {
+    it( 'returns an array shape consumable by visual-editor ResolvedPattern::fromArray', function (): void {
+        File::put( $this->themeFiles . '/hero.php', <<<'PHP'
+<?php
+/**
+ * Title: Hero
+ * Categories: featured
+ * Block Types: core/post-content
+ */
+?>
+<!-- hero -->
+PHP );
+
+        $map = $this->resolver->toFilterMap();
+
+        expect( $map )->toHaveKey( 'hero' )
+            ->and( $map['hero'] )->toHaveKeys( [
+                'slug',
+                'title',
+                'raw_content',
+                'blocks',
+                'source',
+                'synced',
+                'categories',
+                'block_types',
+                'wp_id',
+            ] )
+            ->and( $map['hero']['slug'] )->toBe( 'hero' )
+            ->and( $map['hero']['source'] )->toBe( BlockPattern::SOURCE_THEME )
+            ->and( $map['hero']['synced'] )->toBeFalse();
+    } );
+} );
+
+describe( 'PatternResolver::cloneToUser()', function (): void {
+    it( 'creates a user-source DB row populated from the theme file', function (): void {
+        File::put( $this->themeFiles . '/hero.php', <<<'PHP'
+<?php
+/**
+ * Title: Hero
+ * Description: From theme.
+ * Categories: featured
+ */
+?>
+<!-- hero -->
+PHP );
+
+        $row = $this->resolver->cloneToUser( 'hero' );
+
+        expect( $row->source )->toBe( BlockPattern::SOURCE_USER )
+            ->and( $row->synced )->toBeFalse()
+            ->and( $row->slug )->toBe( 'user/hero' )
+            ->and( $row->title )->toBe( 'Hero' )
+            ->and( $row->description )->toBe( 'From theme.' )
+            ->and( $row->categories )->toEqual( [ 'featured' ] );
+    } );
+
+    it( 'throws when the theme pattern does not exist', function (): void {
+        $this->resolver->cloneToUser( 'missing' );
+    } )->throws( RuntimeException::class );
+} );
+
+describe( 'BlockPattern slug prefix', function (): void {
+    it( 'auto-prefixes user-source slugs at write time', function (): void {
+        $row = BlockPattern::create( [
+            'slug'   => 'plain',
+            'title'  => 'Plain',
+            'source' => BlockPattern::SOURCE_USER,
+        ] );
+
+        expect( $row->slug )->toBe( 'user/plain' )
+            ->and( $row->userFacingSlug() )->toBe( 'plain' );
+    } );
+
+    it( 'is idempotent — accepts an already-prefixed slug without double-prefixing', function (): void {
+        $row = BlockPattern::create( [
+            'slug'   => 'user/already',
+            'title'  => 'Already',
+            'source' => BlockPattern::SOURCE_USER,
+        ] );
+
+        expect( $row->slug )->toBe( 'user/already' );
+    } );
+} );

--- a/tests/Unit/SiteEditor/PatternResolverTest.php
+++ b/tests/Unit/SiteEditor/PatternResolverTest.php
@@ -113,6 +113,59 @@ PHP );
 
         expect( $this->resolver->resolve( '../secret' ) )->toBeNull();
     } );
+
+    it( 'reads the leading docblock for headers, not a comment buried in the body', function (): void {
+        // The leading docblock is the real header; the docblock inside the
+        // <style> block is body content that incidentally uses the same
+        // doc-comment syntax. Without anchoring, the first non-greedy regex
+        // would still pick the leading block, but a file *missing* a leading
+        // docblock would fall through and parse the body comment as the
+        // header. Cover that explicitly with a no-leading-docblock fixture.
+        File::put( $this->themeFiles . '/leading-only.php', <<<'PHP'
+<?php
+/**
+ * Title: Real Hero
+ * Categories: featured
+ */
+?>
+<!-- wp:html -->
+<style>
+/**
+ * Title: Imposter
+ * Categories: malicious
+ */
+.x { color: red; }
+</style>
+<!-- /wp:html -->
+PHP );
+
+        $result = $this->resolver->resolve( 'leading-only' );
+
+        expect( $result->title )->toBe( 'Real Hero' )
+            ->and( $result->categories )->toEqual( [ 'featured' ] )
+            ->and( $result->rawContent )->toContain( 'wp:html' )
+            ->and( $result->rawContent )->toContain( 'Imposter' );
+    } );
+
+    it( 'does not parse a non-leading docblock as the header when the file has no leading one', function (): void {
+        File::put( $this->themeFiles . '/no-header.php', <<<'PHP'
+<?php
+$variable = 1;
+/**
+ * Title: Body Comment
+ * Categories: not-the-header
+ */
+?>
+<!-- wp:paragraph --><p>Body</p><!-- /wp:paragraph -->
+PHP );
+
+        $result = $this->resolver->resolve( 'no-header' );
+
+        // Empty title falls back to humanized slug; categories stay empty —
+        // confirms the body docblock is not silently promoted to header.
+        expect( $result->title )->toBe( 'No Header' )
+            ->and( $result->categories )->toEqual( [ ] );
+    } );
 } );
 
 describe( 'PatternResolver::all()', function (): void {


### PR DESCRIPTION
## Description

H2 — Site editor patterns module. Adds a single `BlockPattern` model that surfaces both theme-shipped patterns (filesystem) and user-authored patterns (DB rows) through a unified resolver, REST endpoints in the WP `/wp/v2/blocks` (synced) + `/wp/v2/block-patterns/patterns` (unsynced) shape, and registration into visual-editor's `ap.visual-editor.patterns` filter.

While in the same provider, also folds in the H1 filter wiring gap that #108 left behind: `ap.visual-editor.templates` and `ap.visual-editor.template-parts` are now registered alongside patterns, all behind a `class_exists(VisualEditor::class)` guard so cms-framework still boots cleanly without visual-editor in `composer.json`. Per H5 (visual-editor #407) §2.4 / its issue body: "cms-framework registers under `class_exists` guards" — H1 didn't, this PR closes that gap.

**Closes:** #110

## Type of Change

- [x] New feature (adds new functionality)

## Related Issue

**Issue:** #110

Coordinates with: visual-editor #407 (H5 — site-editor resource filters, merged) — the consumer side of `ap.visual-editor.patterns` is already shipped there.

## Motivation and Context

H2 is the second of the four parallelizable cms-framework site-editor backends (H1–H4) that gate visual-editor's V1.0.0. Patterns close the gap on the inserter catalogue — both the synced `wp_block` flow and the unsynced `wp_block_pattern` inserter list — so visual-editor's editor shell can be wired to cms-framework data once H6 lands the editor entity adapter.

Per plan 14 §5.6, user-pattern slugs carry a `user/` prefix at storage time so a theme `hero` and a user `hero` cannot collide in the merged inserter map. The REST surface presents the unprefixed user-facing slug; the storage form is exposed as `name` on the unsynced response (mirroring WP's namespaced pattern names).

The H1 filter wiring gap surfaced while implementing H2's filter wiring — H1 (#108) registered the resolvers and REST endpoints but not the filter producers. Folded into this PR so H1 + H2 + H3+ all use one consistent `registerVisualEditorSiteEditorFilters()` entry point.

## Changes Made

- New `BlockPattern` model + `block_patterns` migration (`source`, `synced`, `categories`, `block_types`, `block_content` via `HasBlockContent`, `theme` nullable, `author_id` nullable FK)
- `PatternResolver` merging theme `.php` pattern files with user-source DB rows; `cloneToUser()` affordance for the admin "edit theme pattern" flow
- `PatternFileParser` for theme-shipped pattern files with WP-style header doc-comments (`Title:`, `Slug:`, `Categories:`, `Description:`, `Block Types:`)
- REST endpoints under `/api/v1/blocks` (synced wp_block shape) and `/api/v1/block-patterns/patterns` (unsynced wp_block_pattern shape, including theme + user rows merged); theme patterns 403 on PUT/DELETE
- `SyncedPatternResource` (wp_block shape) and `BlockPatternResource` (wp_block_pattern shape) WP-shape transformers
- `BlockPatternRequest` shared form-request validation
- `ResolvedEntity::toFilterEntry()` so H1 templates / template-parts can register through the same builder; serves the templates and template-parts filter producers
- `SiteEditorServiceProvider::registerVisualEditorSiteEditorFilters()` registers all three filters (`ap.visual-editor.{templates,template-parts,patterns}`) behind a single `class_exists` guard
- Each filter merges cms-framework's resolved map *under* the existing map so app-level config / earlier contributors keep winning on key collision (matches the `ap.visual-editor.resources` merge order)
- `docs/site-editor.md` patterns section documenting REST endpoints, theme file format, sync semantics, slug-prefix decision
- CHANGELOG entry under `[Unreleased]`

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS 25.4.0
- PHP Version: 8.4.3
- Project Version: cms-framework `release/1.2`

**Tests Performed:**

1. **77 SiteEditor tests** (`./vendor/bin/pest tests/Feature/SiteEditor tests/Unit/SiteEditor`) all pass — 12 unit + 25 H1 + 20 H2 feature + 5 templates-filter feature + 15 H1 controller feature.
2. **Full suite** (`./vendor/bin/pest`) — 738 tests pass, 4 skipped (pre-existing unrelated skips). Zero regressions.
3. **CodeRabbit CLI pre-PR review** flagged one finding (`author_id` nullability inconsistency in `ResolvedEntity::toFilterEntry()`) — fixed before push.

## Accessibility Tests Run

N/A — backend-only PR (no UI changes). The REST responses surface no accessibility concerns directly; visual-editor consumes the data and remains the accessibility surface.

- [ ] Keyboard navigation tested
- [ ] Screen reader tested
- [ ] Color contrast verified
- [ ] ARIA labels checked

## Tests Added

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] All tests passing

**Test details:**

- `tests/Unit/SiteEditor/PatternResolverTest.php` (12 tests) — resolver merge logic, theme file parsing with humanized fallback titles, user/storage prefix round-trip, theme/user keyspace coexistence at the same user-facing slug, `cloneToUser()` semantics, `RuntimeException` on missing source, `toFilterMap()` shape contract, slug auto-prefix idempotency, path-traversal slug rejection.
- `tests/Feature/SiteEditor/PatternsApiTest.php` (20 tests) — all 5 verbs on both endpoints, auth gating, WP-shape `assertJsonStructure`, slug-prefix REST round-trip, theme-pattern read-only enforcement (403), unsynced/synced filtering at GET boundaries, `synced` overrides ignored on the unsynced endpoint, and the `ap.visual-editor.patterns` filter wiring round-trip with shape-contract assertions.
- `tests/Feature/SiteEditor/TemplateFiltersTest.php` (5 tests) — H1 templates + template-parts filter wiring (file + DB merge, contract fields, static-config-wins on collision, area surfaces on parts, templates / parts keyspace independence).

## Documentation

- [x] Inline code documentation added
- [x] API documentation updated (Scramble groups added on both controllers)
- [x] `docs/site-editor.md` extended with the patterns section + storage / sync / REST tables

**Documentation details:**

`docs/site-editor.md` now covers patterns alongside templates / parts:
- Storage model (theme `.php` files vs. user DB rows; the `user/` prefix decision)
- Sync semantics (synced = `wp_block`, unsynced = `wp_block_pattern`, theme patterns always unsynced)
- REST endpoints table for both `/blocks` and `/block-patterns/patterns`
- `PatternResolver` interface + cross-reference to H1's `EntityResolver` contract divergence (no `revert()`; adds `cloneToUser()`)
- Coordination updates noting H1's filter producers now register alongside H2's

## Pre-Submission Checklist

- [x] Followed contributing guidelines
- [x] Checked for other open PRs for same update
- [x] Code passes all tests (738 / 0 fail)
- [x] Code has been linted (`php-cs-fixer fix` on touched paths; pre-existing PHPCS errors in H1 carry forward unchanged)
- [x] Accessibility tests completed (N/A — backend-only)
- [x] Code follows project style guide
- [x] Self-review completed
- [x] Comments added for complex code (slug-prefix mutator, race-safe upsert, filter merge order)
- [x] No new warnings generated


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add full block pattern management in Site Editor: create, edit, list, sync and delete patterns from theme files and user-created DB patterns.
  * New REST endpoints for synced patterns (/api/v1/blocks) and unsynced patterns (/api/v1/block-patterns/patterns).
  * Visual Editor integration: patterns exposed via the ap.visual-editor.patterns filter.

* **Documentation**
  * Expanded Site Editor docs covering patterns, storage sources, sync semantics and permissions.

* **Tests**
  * Added feature and unit tests covering APIs, resolver behavior and Visual Editor wiring.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->