### PR TITLE
feat: H4 — Menus module (Menu + MenuItem models, locations, REST)

### DIFF
--- a/database/migrations/2026_05_03_120000_create_menus_table.php
+++ b/database/migrations/2026_05_03_120000_create_menus_table.php
@@ -1,0 +1,30 @@
+<?php
+
+declare( strict_types=1 );
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create( 'menus', function ( Blueprint $table ): void {
+            $table->id();
+            $table->string( 'theme' );
+            $table->string( 'slug' );
+            $table->string( 'name' );
+            $table->text( 'description' )->nullable();
+            $table->boolean( 'auto_add_pages' )->default( false );
+            $table->foreignId( 'author_id' )->nullable()->constrained( 'users' )->nullOnDelete();
+            $table->timestamps();
+
+            $table->unique( ['theme', 'slug'] );
+        } );
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists( 'menus' );
+    }
+};

--- a/database/migrations/2026_05_03_120001_create_menu_items_table.php
+++ b/database/migrations/2026_05_03_120001_create_menu_items_table.php
@@ -1,0 +1,38 @@
+<?php
+
+declare( strict_types=1 );
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create( 'menu_items', function ( Blueprint $table ): void {
+            $table->id();
+            $table->foreignId( 'menu_id' )->constrained( 'menus' )->cascadeOnDelete();
+            $table->foreignId( 'parent_id' )->nullable()->constrained( 'menu_items' )->cascadeOnDelete();
+            $table->unsignedInteger( 'position' )->default( 0 );
+            $table->string( 'type' )->default( 'link' );
+            $table->string( 'label' );
+            $table->string( 'url' )->nullable();
+            $table->string( 'target' )->default( '_self' );
+            $table->string( 'rel' )->nullable();
+            $table->string( 'classes' )->nullable();
+            $table->text( 'description' )->nullable();
+            $table->string( 'object_type' )->nullable();
+            $table->unsignedBigInteger( 'object_id' )->nullable();
+            $table->string( 'kind' )->nullable();
+            $table->timestamps();
+
+            $table->index( ['menu_id', 'parent_id', 'position'] );
+            $table->index( ['object_type', 'object_id'] );
+        } );
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists( 'menu_items' );
+    }
+};

--- a/database/migrations/2026_05_03_120002_create_menu_location_assignments_table.php
+++ b/database/migrations/2026_05_03_120002_create_menu_location_assignments_table.php
@@ -1,0 +1,27 @@
+<?php
+
+declare( strict_types=1 );
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create( 'menu_location_assignments', function ( Blueprint $table ): void {
+            $table->id();
+            $table->string( 'theme' );
+            $table->string( 'location' );
+            $table->foreignId( 'menu_id' )->constrained( 'menus' )->cascadeOnDelete();
+            $table->timestamps();
+
+            $table->unique( ['theme', 'location'] );
+        } );
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists( 'menu_location_assignments' );
+    }
+};

--- a/docs/site-editor.md
+++ b/docs/site-editor.md
@@ -4,7 +4,7 @@ title: Site Editor
 
 # Site Editor Module
 
-The Site Editor module hosts the backends behind cms-framework's WordPress-style site-editor surface: templates, template parts, patterns, global styles, and menus. H1 ships templates and template parts; H2 adds patterns; subsequent phases (H3–H4) add global styles and menus to the same module.
+The Site Editor module hosts the backends behind cms-framework's WordPress-style site-editor surface: templates, template parts, patterns, global styles, and menus. H1 ships templates and template parts; H2 adds patterns; H3 adds global styles + CSS emission; H4 adds menus and the locations API.
 
 ## Overview
 
@@ -250,9 +250,130 @@ class GlobalStylesResolver
 
 `ResolvedGlobalStyles` carries `theme`, `settings`, `styles`, `variation`, `hasUserCustomization`, `model` (when DB-backed), plus a `contentHash()` accessor that the emitter uses for cache keying and a `toFilterEntry()` accessor that produces the `ap.visual-editor.global-styles` shape.
 
+## Menus
+
+H4 introduces navigation menus and the locations API. Unlike templates / parts / patterns / global styles, menus are **DB-only** — themes contribute *location names* via `theme.json` `menus.locations`, but never menu *content*. Switching themes leaves prior menus untouched (data preservation per plan 14 §5.5).
+
+### Storage
+
+- DB tables:
+  - `menus` — `id`, `theme`, `slug`, `name`, `description`, `auto_add_pages`, `author_id`, timestamps. Unique constraint on `(theme, slug)`.
+  - `menu_items` — `id`, `menu_id` (FK), `parent_id` (nullable, self-FK), `position`, `type` (`link` / `submenu` / `page-list`), `label`, `url`, `target`, `rel`, `classes`, `description`, `object_type`, `object_id`, `kind`, timestamps.
+  - `menu_location_assignments` — `id`, `theme`, `location`, `menu_id` (FK), timestamps. Unique constraint on `(theme, location)`.
+
+A separate `menu_location_assignments` table (rather than a `location` column on `menus`) lets one menu satisfy multiple locations and keeps location keys theme-scoped — switching themes leaves a menu unassigned without orphaning the menu itself.
+
+### Locations resolution
+
+Locations resolve through `ArtisanPackUI\CMSFramework\Modules\SiteEditor\Support\Menus`:
+
+```php
+Menus::locations();                    // array<string, string>
+Menus::assign( 'primary', $menuId );   // upsert assignment
+Menus::unassign( 'primary' );          // delete assignment
+Menus::assigned( 'primary' );          // ?Menu
+```
+
+Order:
+
+1. App default — `config('cms.menus.locations')`, e.g. `['primary' => 'Primary', 'footer' => 'Footer']`.
+2. Theme override — the active theme's `theme.json` `menus.locations` keys override the app defaults by key (theme wins per plan 14 §5.4); a warning is logged so app authors aren't confused.
+
+Themes that need a location no app has registered can declare it in `theme.json` and the location appears with the theme-provided label.
+
+### REST endpoints
+
+All endpoints live under `/api/v1/` and require authentication.
+
+| Method | Path | Purpose |
+|---|---|---|
+| GET | `/menus` | List menus for the active theme |
+| POST | `/menus` | Create a menu |
+| GET | `/menus/{id_or_slug}` | Show one menu |
+| PUT | `/menus/{id_or_slug}` | Update menu metadata (slug renames not supported) |
+| DELETE | `/menus/{id_or_slug}` | Delete the menu (cascades to items and assignments) |
+| GET | `/menu-items?menus={id}` | List items for a menu, ordered by `(parent_id, position)` |
+| POST | `/menu-items` | Create item under a menu (`menus` field required) |
+| GET | `/menu-items/{id}` | Show one item |
+| PUT | `/menu-items/{id}` | Update item (the `menus` field is prohibited — items can't be reparented across menus) |
+| DELETE | `/menu-items/{id}` | Delete item (cascades to children) |
+| GET | `/menu-locations` | List declared locations + their assignments (`menu` is `0` when unassigned) |
+| PUT | `/menu-locations/{location}` | Assign a menu to a location (body: `{ "menu": <id> }`) |
+| DELETE | `/menu-locations/{location}` | Unassign |
+
+Menu response shape mirrors WP `/wp/v2/menus`:
+
+```json
+{
+    "id": 1,
+    "name": "Main Navigation",
+    "slug": "main",
+    "description": "",
+    "meta": [],
+    "locations": [ "primary" ],
+    "auto_add_pages": false,
+    "theme": "digital-shopfront"
+}
+```
+
+Menu-item response shape mirrors WP `/wp/v2/menu-items`. Note that `type` carries the WP-side vocabulary (`custom` / `post_type` / `taxonomy` derived from the model `kind`), while `link_type` carries the cms-side flag (`link` / `submenu` / `page-list`) for visual-editor's adapter:
+
+```json
+{
+    "id": 4,
+    "title":  { "raw": "Home", "rendered": "Home" },
+    "url":    "/",
+    "menus":  1,
+    "parent": 0,
+    "menu_order": 0,
+    "target": "_self",
+    "type":       "custom",
+    "type_label": "Custom Link",
+    "link_type":  "link",
+    "object":     "",
+    "object_id":  0,
+    "classes":    [],
+    "xfn":        [],
+    "attr_title": "",
+    "description": "",
+    "meta":       []
+}
+```
+
+### Resolver
+
+`MenuResolver::all()` powers the `ap.visual-editor.navigation` filter. It returns `array<string, ResolvedMenu>` keyed by location key. Locations the active theme declares but no menu is assigned to still appear with `wp_id => null` and an empty `items` array, so editor surfaces can render empty slots.
+
+The `items` field projects `MenuItem` rows into the upstream `core/navigation-link` / `core/navigation-submenu` / `core/page-list` shapes — children nest under parents by `(parent_id, position)`. Page-list items render as a dynamic placeholder (`'dynamic' => 'page-list'`) — the resolver does not enumerate pages here so cms-framework stays decoupled from Phase G content types. The navigation block performs the page enumeration at render time.
+
+```php
+class MenuResolver
+{
+    /** @return array<string, array{location: string, name: string, items: array, wp_id: int|null}> */
+    public function all(): array;
+
+    public function resolve( string $location ): ?array;
+    public function revert( string $location ): bool; // unassigns, preserves Menu
+}
+```
+
+### Item link types (kickoff decision)
+
+H4 ships all three link types per plan 14 §8 H4 row:
+
+- **`link`** — direct URL link (`core/navigation-link`).
+- **`submenu`** — container for nested items (`core/navigation-submenu`).
+- **`page-list`** — dynamic page enumeration at render time (`core/page-list`).
+
+The `(object_type, object_id)` pair is a soft polymorphic reference; items survive deletion of the linked resource and continue rendering with the stored `label` + `url`. Pruning dead links is deferred to V1.1.
+
+### Cascade behavior
+
+Deleting a `Menu` cascades to its `MenuItem`s and `MenuLocationAssignment`s; deleting a `MenuItem` cascades to its children. Cascade is implemented at the Eloquent layer (in each model's `booted()` method) on top of the migration's `cascadeOnDelete()` foreign-key declarations, so behavior is consistent regardless of whether the database driver enforces FK constraints (notably SQLite needs `PRAGMA foreign_keys`).
+
 ## Resolver contract
 
-Both entity types implement `ArtisanPackUI\CMSFramework\Modules\SiteEditor\Resolution\EntityResolver`:
+Templates and template parts implement `ArtisanPackUI\CMSFramework\Modules\SiteEditor\Resolution\EntityResolver`:
 
 ```php
 interface EntityResolver
@@ -265,19 +386,19 @@ interface EntityResolver
 
 `ResolvedEntity` is a value object carrying the merged source-of-truth: slug, theme, source (`'db'` or `'theme'`), content (block string), title, description, status, `hasThemeFile`, `isCustom`, `area` (parts only), and the backing model (when source is `'db'`).
 
-`PatternResolver` (H2) and `GlobalStylesResolver` (H3) do not implement `EntityResolver` — patterns surface `cloneToUser()` instead of slug-merge `revert()`, and global styles are a singleton-per-theme without a slug keyspace at all. H4 (`MenuResolver`) will follow the same case-by-case shape decision.
+`PatternResolver` (H2), `GlobalStylesResolver` (H3), and `MenuResolver` (H4) do not implement `EntityResolver` — patterns surface `cloneToUser()` instead of slug-merge `revert()`, global styles are a singleton-per-theme without a slug keyspace, and menus are keyed by location (not slug) and have no theme-file fallback.
 
 ## Permissions
 
-The slugs `visual_editor.templates.edit`, `visual_editor.template-parts.edit`, `visual_editor.patterns.edit`, and `visual_editor.global-styles.edit` are seeded by the parent `CMSFrameworkServiceProvider` via the G5 (#98) bridge. The SiteEditor module does not register additional permissions; routes use the `auth` middleware (V1 baseline of "any authenticated user", per plan 12 §2.6). V1.1 introduces fine-grained policies.
+The slugs `visual_editor.templates.edit`, `visual_editor.template-parts.edit`, `visual_editor.patterns.edit`, `visual_editor.global-styles.edit`, and `visual_editor.navigation.edit` are seeded by the parent `CMSFrameworkServiceProvider` via the G5 (#98) bridge. The SiteEditor module does not register additional permissions; routes use the `auth` middleware (V1 baseline of "any authenticated user", per plan 12 §2.6). V1.1 introduces fine-grained policies.
 
 ## Service registration
 
 `SiteEditorServiceProvider` is registered from the parent `CMSFrameworkServiceProvider`. It:
 
-- Binds `TemplateResolver`, `TemplatePartResolver`, `PatternResolver`, `GlobalStylesResolver`, and `GlobalStylesEmitter` as singletons.
+- Binds `TemplateResolver`, `TemplatePartResolver`, `PatternResolver`, `GlobalStylesResolver`, `GlobalStylesEmitter`, and `MenuResolver` as singletons.
 - Loads `routes/api.php` for the REST endpoints.
-- Registers `ap.visual-editor.{templates,template-parts,patterns,global-styles}` filters under a `class_exists(VisualEditor::class)` guard so cms-framework boots cleanly without visual-editor installed. The `global-styles` filter is a singleton (`?ResolvedGlobalStyles` array shape, not a keyed map).
+- Registers `ap.visual-editor.{templates,template-parts,patterns,global-styles,navigation}` filters under a `class_exists(VisualEditor::class)` guard so cms-framework boots cleanly without visual-editor installed. The `global-styles` filter is a singleton (`?ResolvedGlobalStyles` array shape); the others are keyed maps. cms-framework's resolved map merges *under* the existing map so app-level config / earlier filter contributors win on key collision.
 - Registers the `@cmsGlobalStyles` Blade directive.
 - Wires a `GlobalStyles` model observer that invalidates the emitter cache on save and delete.
 
@@ -285,5 +406,5 @@ Migrations live at the package level (`database/migrations/`) and are loaded by 
 
 ## Coordination with visual-editor
 
-- `#407` (H5 — site-editor resource filters): visual-editor reads the `/templates`, `/template-parts`, `/blocks`, and `/block-patterns/patterns` endpoints to populate `addEntities()` at editor bootstrap. Patterns specifically surface through the `ap.visual-editor.patterns` filter that cms-framework registers behind a `class_exists` guard.
+- `#407` (H5 — site-editor resource filters): visual-editor reads the `/templates`, `/template-parts`, `/blocks`, `/block-patterns/patterns`, `/global-styles`, `/menus`, `/menu-items`, and `/menu-locations` endpoints to populate `addEntities()` at editor bootstrap. Each entity surfaces through its corresponding `ap.visual-editor.*` filter that cms-framework registers behind a `class_exists` guard.
 - `#399` (G3 — editor entity adapter): visual-editor's WP-shape resource adapter maps the REST responses back into the editor's `useEntityRecord` / `useEntityRecords` selectors.

--- a/src/Modules/SiteEditor/Http/Controllers/MenuItemsController.php
+++ b/src/Modules/SiteEditor/Http/Controllers/MenuItemsController.php
@@ -9,6 +9,10 @@
  * required on `store` and prohibited on `update` (items cannot be
  * reparented across menus — delete and recreate instead).
  *
+ * All read and write operations are scoped to menus belonging to the
+ * active theme — items in other themes' menus are unreachable through
+ * this controller (404 instead of cross-theme leakage).
+ *
  * @since      1.2.0
  */
 
@@ -20,7 +24,9 @@ use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Http\Requests\MenuItemRequest;
 use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Http\Resources\MenuItemResource;
 use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Models\Menu;
 use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Models\MenuItem;
+use ArtisanPackUI\CMSFramework\Modules\Themes\Managers\ThemeManager;
 use Dedoc\Scramble\Attributes\Group;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
@@ -32,25 +38,40 @@ use Illuminate\Routing\Controller;
 class MenuItemsController extends Controller
 {
     /**
+     * @since 1.2.0
+     */
+    public function __construct(
+        private ThemeManager $themeManager,
+    ) {
+    }
+
+    /**
      * GET /api/v1/menu-items?menus={id} — list items for a menu, ordered
-     * by `(parent_id, position)` so consumers receive a deterministic flat
-     * list ready to nest.
+     * by `(parent_id, position, id)` so consumers receive a deterministic
+     * flat list ready to nest. The `id` tiebreaker keeps ordering stable
+     * when two siblings share `position`.
      *
      * @since 1.2.0
      */
     public function index( Request $request ): JsonResponse
     {
-        $query = MenuItem::query()
-            ->orderBy( 'parent_id' )
-            ->orderBy( 'position' );
+        $query = $this->themeScopedQuery();
+
+        if ( null === $query ) {
+            return response()->json( [] );
+        }
+
+        $query->orderBy( 'parent_id' )
+            ->orderBy( 'position' )
+            ->orderBy( 'id' );
 
         $menusFilter = $request->query( 'menus' );
 
         if ( null !== $menusFilter ) {
-            if ( ! is_numeric( $menusFilter ) ) {
+            if ( ! self::isPositiveIntegerString( $menusFilter ) ) {
                 return response()->json( [
                     'message' => 'Invalid menus filter.',
-                    'errors'  => [ 'menus' => [ 'menus must be an integer menu id.' ] ],
+                    'errors'  => [ 'menus' => [ 'menus must be a positive integer menu id.' ] ],
                 ], 422 );
             }
 
@@ -67,7 +88,7 @@ class MenuItemsController extends Controller
      */
     public function show( int $id ): JsonResponse
     {
-        $item = MenuItem::query()->find( $id );
+        $item = $this->findItemForActiveTheme( $id );
 
         if ( null === $item ) {
             return response()->json( [ 'message' => 'Menu item not found.' ], 404 );
@@ -77,15 +98,24 @@ class MenuItemsController extends Controller
     }
 
     /**
-     * POST /api/v1/menu-items — create an item under a menu.
+     * POST /api/v1/menu-items — create an item under a menu in the active
+     * theme. Returns 404 when the menu belongs to another theme so this
+     * endpoint cannot be used to write into other themes' menus.
      *
      * @since 1.2.0
      */
     public function store( MenuItemRequest $request ): JsonResponse
     {
-        $validated = $request->validated();
+        $theme = $this->activeThemeSlug();
 
-        $menu = Menu::query()->find( (int) $validated['menus'] );
+        if ( null === $theme ) {
+            return response()->json( [ 'message' => 'No active theme.' ], 409 );
+        }
+
+        $validated = $request->validated();
+        $menu      = Menu::query()
+            ->where( 'theme', $theme )
+            ->find( (int) $validated['menus'] );
 
         if ( null === $menu ) {
             return response()->json( [ 'message' => 'Menu not found.' ], 404 );
@@ -97,13 +127,13 @@ class MenuItemsController extends Controller
     }
 
     /**
-     * PUT /api/v1/menu-items/{id} — update an item.
+     * PUT /api/v1/menu-items/{id} — update an item in the active theme.
      *
      * @since 1.2.0
      */
     public function update( MenuItemRequest $request, int $id ): JsonResponse
     {
-        $item = MenuItem::query()->find( $id );
+        $item = $this->findItemForActiveTheme( $id );
 
         if ( null === $item ) {
             return response()->json( [ 'message' => 'Menu item not found.' ], 404 );
@@ -124,7 +154,7 @@ class MenuItemsController extends Controller
      */
     public function destroy( int $id ): JsonResponse
     {
-        $item = MenuItem::query()->find( $id );
+        $item = $this->findItemForActiveTheme( $id );
 
         if ( null === $item ) {
             return response()->json( [ 'message' => 'Menu item not found.' ], 404 );
@@ -133,6 +163,65 @@ class MenuItemsController extends Controller
         $item->delete();
 
         return response()->json( null, 204 );
+    }
+
+    /**
+     * Build a base query that only sees items whose parent menu belongs to
+     * the active theme. Returns null when there is no active theme so the
+     * caller can short-circuit (typically by returning an empty list).
+     *
+     * @since 1.2.0
+     */
+    protected function themeScopedQuery(): ?Builder
+    {
+        $theme = $this->activeThemeSlug();
+
+        if ( null === $theme ) {
+            return null;
+        }
+
+        return MenuItem::query()->whereHas( 'menu', static function ( Builder $menu ) use ( $theme ): void {
+            $menu->where( 'theme', $theme );
+        } );
+    }
+
+    /**
+     * Look up a single item, verifying its parent menu belongs to the
+     * active theme.
+     *
+     * @since 1.2.0
+     */
+    protected function findItemForActiveTheme( int $id ): ?MenuItem
+    {
+        $query = $this->themeScopedQuery();
+
+        if ( null === $query ) {
+            return null;
+        }
+
+        return $query->find( $id );
+    }
+
+    /**
+     * @since 1.2.0
+     */
+    protected function activeThemeSlug(): ?string
+    {
+        $theme = $this->themeManager->getActiveTheme();
+
+        return null !== $theme && ! empty( $theme['slug'] ) ? (string) $theme['slug'] : null;
+    }
+
+    /**
+     * Strict positive-integer-string check. Rejects `is_numeric` edge cases
+     * like `"1e3"` (which casts to 1, not 1000) and `"01"` (which casts to
+     * 1, masking the leading zero).
+     *
+     * @since 1.2.0
+     */
+    protected static function isPositiveIntegerString( mixed $value ): bool
+    {
+        return is_string( $value ) && '' !== $value && ctype_digit( $value );
     }
 
     /**

--- a/src/Modules/SiteEditor/Http/Controllers/MenuItemsController.php
+++ b/src/Modules/SiteEditor/Http/Controllers/MenuItemsController.php
@@ -47,9 +47,11 @@ class MenuItemsController extends Controller
 
     /**
      * GET /api/v1/menu-items?menus={id} — list items for a menu, ordered
-     * by `(parent_id, position, id)` so consumers receive a deterministic
-     * flat list ready to nest. The `id` tiebreaker keeps ordering stable
-     * when two siblings share `position`.
+     * by `(COALESCE(parent_id, 0), position, id)` so consumers receive a
+     * deterministic flat list ready to nest. The `COALESCE` normalizes
+     * NULL ordering across SQL engines (MySQL/SQLite default NULLs first,
+     * PostgreSQL defaults NULLs last); the `id` tiebreaker keeps ordering
+     * stable when two siblings share `position`.
      *
      * @since 1.2.0
      */
@@ -61,7 +63,7 @@ class MenuItemsController extends Controller
             return response()->json( [] );
         }
 
-        $query->orderBy( 'parent_id' )
+        $query->orderByRaw( 'COALESCE(parent_id, 0)' )
             ->orderBy( 'position' )
             ->orderBy( 'id' );
 
@@ -213,15 +215,23 @@ class MenuItemsController extends Controller
     }
 
     /**
-     * Strict positive-integer-string check. Rejects `is_numeric` edge cases
-     * like `"1e3"` (which casts to 1, not 1000) and `"01"` (which casts to
-     * 1, masking the leading zero).
+     * Strict positive-integer-string check. Rejects:
+     *
+     * - `is_numeric` edge cases like `"1e3"` (would cast to 1, not 1000).
+     * - `"0"` (menu ids are 1-based; rejecting at the boundary surfaces
+     *   the bad input as 422 instead of an empty result set).
+     * - Leading-zero strings like `"01"` (would cast to 1, masking the
+     *   client's intent — surface as 422 so misformatted ids aren't
+     *   silently coerced).
      *
      * @since 1.2.0
      */
     protected static function isPositiveIntegerString( mixed $value ): bool
     {
-        return is_string( $value ) && '' !== $value && ctype_digit( $value );
+        return is_string( $value )
+            && '' !== $value
+            && ctype_digit( $value )
+            && '0' !== $value[0];
     }
 
     /**

--- a/src/Modules/SiteEditor/Http/Controllers/MenuItemsController.php
+++ b/src/Modules/SiteEditor/Http/Controllers/MenuItemsController.php
@@ -1,0 +1,190 @@
+<?php
+
+/**
+ * Menu Items Controller
+ *
+ * Implements the WordPress `/wp/v2/menu-items` REST shape against the
+ * cms-framework `MenuItem` model. Items are scoped to a parent `Menu`
+ * via the `?menus={id}` query param on `index`; the `menus` field is
+ * required on `store` and prohibited on `update` (items cannot be
+ * reparented across menus — delete and recreate instead).
+ *
+ * @since      1.2.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Modules\SiteEditor\Http\Controllers;
+
+use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Http\Requests\MenuItemRequest;
+use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Http\Resources\MenuItemResource;
+use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Models\Menu;
+use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Models\MenuItem;
+use Dedoc\Scramble\Attributes\Group;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Routing\Controller;
+
+/**
+ * @since 1.2.0
+ */
+#[Group( 'Site Editor / Menu Items', weight: 61 )]
+class MenuItemsController extends Controller
+{
+    /**
+     * GET /api/v1/menu-items?menus={id} — list items for a menu, ordered
+     * by `(parent_id, position)` so consumers receive a deterministic flat
+     * list ready to nest.
+     *
+     * @since 1.2.0
+     */
+    public function index( Request $request ): JsonResponse
+    {
+        $query = MenuItem::query()
+            ->orderBy( 'parent_id' )
+            ->orderBy( 'position' );
+
+        $menusFilter = $request->query( 'menus' );
+
+        if ( null !== $menusFilter ) {
+            if ( ! is_numeric( $menusFilter ) ) {
+                return response()->json( [
+                    'message' => 'Invalid menus filter.',
+                    'errors'  => [ 'menus' => [ 'menus must be an integer menu id.' ] ],
+                ], 422 );
+            }
+
+            $query->where( 'menu_id', (int) $menusFilter );
+        }
+
+        return response()->json( MenuItemResource::collection( $query->get() ) );
+    }
+
+    /**
+     * GET /api/v1/menu-items/{id} — show a single menu item.
+     *
+     * @since 1.2.0
+     */
+    public function show( int $id ): JsonResponse
+    {
+        $item = MenuItem::query()->find( $id );
+
+        if ( null === $item ) {
+            return response()->json( [ 'message' => 'Menu item not found.' ], 404 );
+        }
+
+        return response()->json( MenuItemResource::toArray( $item ) );
+    }
+
+    /**
+     * POST /api/v1/menu-items — create an item under a menu.
+     *
+     * @since 1.2.0
+     */
+    public function store( MenuItemRequest $request ): JsonResponse
+    {
+        $validated = $request->validated();
+
+        $menu = Menu::query()->find( (int) $validated['menus'] );
+
+        if ( null === $menu ) {
+            return response()->json( [ 'message' => 'Menu not found.' ], 404 );
+        }
+
+        $item = MenuItem::create( $this->mapPayload( $validated, $menu->id ) );
+
+        return response()->json( MenuItemResource::toArray( $item ), 201 );
+    }
+
+    /**
+     * PUT /api/v1/menu-items/{id} — update an item.
+     *
+     * @since 1.2.0
+     */
+    public function update( MenuItemRequest $request, int $id ): JsonResponse
+    {
+        $item = MenuItem::query()->find( $id );
+
+        if ( null === $item ) {
+            return response()->json( [ 'message' => 'Menu item not found.' ], 404 );
+        }
+
+        $validated = $request->validated();
+
+        $item->update( $this->mapPayload( $validated, (int) $item->menu_id, $item ) );
+
+        return response()->json( MenuItemResource::toArray( $item->refresh() ) );
+    }
+
+    /**
+     * DELETE /api/v1/menu-items/{id} — delete an item (cascades to
+     * children).
+     *
+     * @since 1.2.0
+     */
+    public function destroy( int $id ): JsonResponse
+    {
+        $item = MenuItem::query()->find( $id );
+
+        if ( null === $item ) {
+            return response()->json( [ 'message' => 'Menu item not found.' ], 404 );
+        }
+
+        $item->delete();
+
+        return response()->json( null, 204 );
+    }
+
+    /**
+     * Translate the WP-shape request payload into model attributes.
+     *
+     * Only fields present in the validated payload are mapped — omitted
+     * fields keep their existing values on update, matching WP REST PUT
+     * semantics.
+     *
+     * @since 1.2.0
+     *
+     * @param  array<string, mixed>  $validated
+     *
+     * @return array<string, mixed>
+     */
+    protected function mapPayload( array $validated, int $menuId, ?MenuItem $existing = null ): array
+    {
+        $attributes = [ 'menu_id' => $menuId ];
+
+        $map = [
+            'title'       => 'label',
+            'url'         => 'url',
+            'target'      => 'target',
+            'classes'     => 'classes',
+            'description' => 'description',
+            'menu_order'  => 'position',
+            'parent'      => 'parent_id',
+            'object'      => 'object_type',
+            'object_id'   => 'object_id',
+            'kind'        => 'kind',
+            'type'        => 'type',
+            'xfn'         => 'rel',
+        ];
+
+        foreach ( $map as $payloadKey => $modelKey ) {
+            if ( array_key_exists( $payloadKey, $validated ) ) {
+                $attributes[ $modelKey ] = $validated[ $payloadKey ];
+            }
+        }
+
+        if ( null === $existing && ! array_key_exists( 'position', $attributes ) ) {
+            $attributes['position'] = 0;
+        }
+
+        if ( null === $existing && ! array_key_exists( 'target', $attributes ) ) {
+            $attributes['target'] = '_self';
+        }
+
+        if ( null === $existing && ! array_key_exists( 'type', $attributes ) ) {
+            $attributes['type'] = MenuItem::TYPE_LINK;
+        }
+
+        return $attributes;
+    }
+}

--- a/src/Modules/SiteEditor/Http/Controllers/MenuLocationsController.php
+++ b/src/Modules/SiteEditor/Http/Controllers/MenuLocationsController.php
@@ -1,0 +1,129 @@
+<?php
+
+/**
+ * Menu Locations Controller
+ *
+ * `GET /api/v1/menu-locations` — list theme-declared locations + their
+ * current assignments. `PUT /api/v1/menu-locations/{location}` — assign
+ * a menu. `DELETE /api/v1/menu-locations/{location}` — unassign.
+ *
+ * Locations are resolved through {@see Menus::locations()} (app config +
+ * theme.json `menus.locations`, theme wins on collision).
+ *
+ * @since      1.2.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Modules\SiteEditor\Http\Controllers;
+
+use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Http\Requests\MenuLocationAssignmentRequest;
+use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Http\Resources\MenuLocationResource;
+use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Models\Menu;
+use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Models\MenuLocationAssignment;
+use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Support\Menus;
+use ArtisanPackUI\CMSFramework\Modules\Themes\Managers\ThemeManager;
+use Dedoc\Scramble\Attributes\Group;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Routing\Controller;
+
+/**
+ * @since 1.2.0
+ */
+#[Group( 'Site Editor / Menu Locations', weight: 62 )]
+class MenuLocationsController extends Controller
+{
+    /**
+     * @since 1.2.0
+     */
+    public function __construct(
+        private ThemeManager $themeManager,
+    ) {
+    }
+
+    /**
+     * GET /api/v1/menu-locations — list locations + assignments.
+     *
+     * @since 1.2.0
+     */
+    public function index(): JsonResponse
+    {
+        $locations = Menus::locations();
+
+        $theme = $this->activeThemeSlug();
+
+        $assignments = null !== $theme
+            ? MenuLocationAssignment::query()
+                ->where( 'theme', $theme )
+                ->pluck( 'menu_id', 'location' )
+                ->map( static fn ( $id ): int => (int) $id )
+                ->all()
+            : [];
+
+        return response()->json( MenuLocationResource::collection( $locations, $assignments ) );
+    }
+
+    /**
+     * PUT /api/v1/menu-locations/{location} — assign a menu.
+     *
+     * @since 1.2.0
+     */
+    public function update( MenuLocationAssignmentRequest $request, string $location ): JsonResponse
+    {
+        $theme = $this->activeThemeSlug();
+
+        if ( null === $theme ) {
+            return response()->json( [ 'message' => 'No active theme.' ], 409 );
+        }
+
+        $locations = Menus::locations();
+
+        if ( ! array_key_exists( $location, $locations ) ) {
+            return response()->json( [
+                'message' => 'Location is not declared by the active theme or app config.',
+            ], 404 );
+        }
+
+        $menuId = (int) $request->validated()['menu'];
+        $menu   = Menu::query()->where( 'theme', $theme )->find( $menuId );
+
+        if ( null === $menu ) {
+            return response()->json( [
+                'message' => 'Menu does not belong to the active theme.',
+                'errors'  => [ 'menu' => [ 'Menu must be authored against the active theme.' ] ],
+            ], 422 );
+        }
+
+        Menus::assign( $location, $menuId );
+
+        return response()->json(
+            MenuLocationResource::toArray( $location, $locations[ $location ], $menuId ),
+        );
+    }
+
+    /**
+     * DELETE /api/v1/menu-locations/{location} — unassign.
+     *
+     * @since 1.2.0
+     */
+    public function destroy( string $location ): JsonResponse
+    {
+        $deleted = Menus::unassign( $location );
+
+        if ( ! $deleted ) {
+            return response()->json( [ 'message' => 'No assignment to unassign.' ], 404 );
+        }
+
+        return response()->json( null, 204 );
+    }
+
+    /**
+     * @since 1.2.0
+     */
+    protected function activeThemeSlug(): ?string
+    {
+        $theme = $this->themeManager->getActiveTheme();
+
+        return null !== $theme && ! empty( $theme['slug'] ) ? (string) $theme['slug'] : null;
+    }
+}

--- a/src/Modules/SiteEditor/Http/Controllers/MenusController.php
+++ b/src/Modules/SiteEditor/Http/Controllers/MenusController.php
@@ -1,0 +1,230 @@
+<?php
+
+/**
+ * Menus Controller
+ *
+ * Implements the WordPress `/wp/v2/menus` REST shape against the
+ * cms-framework `Menu` model. Menus are theme-scoped — listing returns
+ * only menus authored against the active theme.
+ *
+ * @since      1.2.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Modules\SiteEditor\Http\Controllers;
+
+use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Http\Requests\MenuRequest;
+use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Http\Resources\MenuResource;
+use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Models\Menu;
+use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Support\SlugValidator;
+use ArtisanPackUI\CMSFramework\Modules\Themes\Managers\ThemeManager;
+use Dedoc\Scramble\Attributes\Group;
+use Illuminate\Database\QueryException;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Routing\Controller;
+
+/**
+ * @since 1.2.0
+ */
+#[Group( 'Site Editor / Menus', weight: 60 )]
+class MenusController extends Controller
+{
+    /**
+     * @since 1.2.0
+     */
+    public function __construct(
+        private ThemeManager $themeManager,
+    ) {
+    }
+
+    /**
+     * GET /api/v1/menus — list menus for the active theme.
+     *
+     * @since 1.2.0
+     */
+    public function index(): JsonResponse
+    {
+        $theme = $this->activeThemeSlug();
+
+        if ( null === $theme ) {
+            return response()->json( [] );
+        }
+
+        $menus = Menu::query()
+            ->where( 'theme', $theme )
+            ->with( 'locationAssignments' )
+            ->orderBy( 'name' )
+            ->get();
+
+        return response()->json( MenuResource::collection( $menus ) );
+    }
+
+    /**
+     * GET /api/v1/menus/{id_or_slug} — show a single menu.
+     *
+     * @since 1.2.0
+     */
+    public function show( string $idOrSlug ): JsonResponse
+    {
+        $menu = $this->resolveMenu( $idOrSlug );
+
+        if ( null === $menu ) {
+            return response()->json( [ 'message' => 'Menu not found.' ], 404 );
+        }
+
+        return response()->json( MenuResource::toArray( $menu ) );
+    }
+
+    /**
+     * POST /api/v1/menus — create a menu against the active theme.
+     *
+     * @since 1.2.0
+     */
+    public function store( MenuRequest $request ): JsonResponse
+    {
+        $theme = $this->activeThemeSlug();
+
+        if ( null === $theme ) {
+            return response()->json( [ 'message' => 'No active theme.' ], 409 );
+        }
+
+        $validated = $request->validated();
+
+        try {
+            $menu = Menu::create( $this->normalizeAttributes( $theme, $validated ) );
+        } catch ( QueryException $e ) {
+            if ( $this->isUniqueViolation( $e ) ) {
+                return response()->json( [
+                    'message' => 'A menu with this slug already exists for the active theme.',
+                    'errors'  => [ 'slug' => [ 'Slug must be unique within the theme.' ] ],
+                ], 409 );
+            }
+
+            throw $e;
+        }
+
+        $menu->load( 'locationAssignments' );
+
+        return response()->json( MenuResource::toArray( $menu ), 201 );
+    }
+
+    /**
+     * PUT /api/v1/menus/{id_or_slug} — update menu metadata.
+     *
+     * @since 1.2.0
+     */
+    public function update( MenuRequest $request, string $idOrSlug ): JsonResponse
+    {
+        $menu = $this->resolveMenu( $idOrSlug );
+
+        if ( null === $menu ) {
+            return response()->json( [ 'message' => 'Menu not found.' ], 404 );
+        }
+
+        $validated = $request->validated();
+
+        if ( array_key_exists( 'slug', $validated ) && $validated['slug'] !== $menu->slug ) {
+            return response()->json( [
+                'message' => 'Body slug does not match the menu slug.',
+                'errors'  => [ 'slug' => [ 'Slug renames are not supported.' ] ],
+            ], 422 );
+        }
+
+        unset( $validated['slug'] );
+
+        $menu->update( $validated );
+
+        $menu->load( 'locationAssignments' );
+
+        return response()->json( MenuResource::toArray( $menu->refresh() ) );
+    }
+
+    /**
+     * DELETE /api/v1/menus/{id_or_slug} — delete the menu (cascades to
+     * items and assignments).
+     *
+     * @since 1.2.0
+     */
+    public function destroy( string $idOrSlug ): JsonResponse
+    {
+        $menu = $this->resolveMenu( $idOrSlug );
+
+        if ( null === $menu ) {
+            return response()->json( [ 'message' => 'Menu not found.' ], 404 );
+        }
+
+        $menu->delete();
+
+        return response()->json( null, 204 );
+    }
+
+    /**
+     * Resolve `{id_or_slug}` to a {@see Menu} for the active theme.
+     *
+     * @since 1.2.0
+     */
+    protected function resolveMenu( string $idOrSlug ): ?Menu
+    {
+        $theme = $this->activeThemeSlug();
+
+        if ( null === $theme ) {
+            return null;
+        }
+
+        $query = Menu::query()->where( 'theme', $theme )->with( 'locationAssignments' );
+
+        if ( ctype_digit( $idOrSlug ) ) {
+            return $query->find( (int) $idOrSlug );
+        }
+
+        if ( ! SlugValidator::isValid( $idOrSlug ) ) {
+            return null;
+        }
+
+        return $query->where( 'slug', $idOrSlug )->first();
+    }
+
+    /**
+     * @since 1.2.0
+     */
+    protected function activeThemeSlug(): ?string
+    {
+        $theme = $this->themeManager->getActiveTheme();
+
+        return null !== $theme && ! empty( $theme['slug'] ) ? (string) $theme['slug'] : null;
+    }
+
+    /**
+     * @since 1.2.0
+     *
+     * @param  array<string, mixed>  $validated
+     *
+     * @return array<string, mixed>
+     */
+    protected function normalizeAttributes( string $theme, array $validated ): array
+    {
+        $validated['theme']     = $theme;
+        $validated['author_id'] = $validated['author_id'] ?? auth()->id();
+
+        if ( ! array_key_exists( 'auto_add_pages', $validated ) ) {
+            $validated['auto_add_pages'] = false;
+        }
+
+        return $validated;
+    }
+
+    /**
+     * @since 1.2.0
+     */
+    protected function isUniqueViolation( QueryException $e ): bool
+    {
+        $sqlState = $e->getCode();
+
+        if ( '23000' === $sqlState || '23505' === $sqlState ) {
+            return true;
+        }
+
+        return str_contains( strtolower( $e->getMessage() ), 'unique' );
+    }
+}

--- a/src/Modules/SiteEditor/Http/Controllers/MenusController.php
+++ b/src/Modules/SiteEditor/Http/Controllers/MenusController.php
@@ -162,6 +162,12 @@ class MenusController extends Controller
     /**
      * Resolve `{id_or_slug}` to a {@see Menu} for the active theme.
      *
+     * Tries slug match first, then falls back to integer-id lookup. Slug-first
+     * order matters for numeric-only slugs (e.g. `"123"`), which `SlugValidator`
+     * accepts and which would otherwise be unreachable: an ID-first resolver
+     * would always shadow them with the row whose `id = 123`, which may belong
+     * to a different menu (or another theme).
+     *
      * @since 1.2.0
      */
     protected function resolveMenu( string $idOrSlug ): ?Menu
@@ -174,15 +180,19 @@ class MenusController extends Controller
 
         $query = Menu::query()->where( 'theme', $theme )->with( 'locationAssignments' );
 
+        if ( SlugValidator::isValid( $idOrSlug ) ) {
+            $bySlug = ( clone $query )->where( 'slug', $idOrSlug )->first();
+
+            if ( null !== $bySlug ) {
+                return $bySlug;
+            }
+        }
+
         if ( ctype_digit( $idOrSlug ) ) {
             return $query->find( (int) $idOrSlug );
         }
 
-        if ( ! SlugValidator::isValid( $idOrSlug ) ) {
-            return null;
-        }
-
-        return $query->where( 'slug', $idOrSlug )->first();
+        return null;
     }
 
     /**

--- a/src/Modules/SiteEditor/Http/Requests/MenuItemRequest.php
+++ b/src/Modules/SiteEditor/Http/Requests/MenuItemRequest.php
@@ -1,0 +1,158 @@
+<?php
+
+/**
+ * Menu Item Form Request
+ *
+ * Validates store/update payloads for `/api/v1/menu-items`. Enforces:
+ *
+ * - `type` ∈ {link, submenu, page-list}
+ * - `(object_type, object_id)` paired (both present or both absent)
+ * - `parent_id` references a `MenuItem` belonging to the same `Menu`
+ *
+ * @since      1.2.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Modules\SiteEditor\Http\Requests;
+
+use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Models\MenuItem;
+use Closure;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+/**
+ * @since 1.2.0
+ */
+class MenuItemRequest extends FormRequest
+{
+    /**
+     * @since 1.2.0
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @since 1.2.0
+     *
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        $isPost   = $this->isMethod( 'post' );
+        $required = $isPost ? 'required' : 'sometimes';
+
+        return [
+            'menus'       => [ $isPost ? 'required' : 'prohibited', 'integer', 'exists:menus,id' ],
+            'parent'      => [ 'nullable', 'integer', 'exists:menu_items,id' ],
+            'menu_order'  => [ 'nullable', 'integer', 'min:0' ],
+            'type'        => [ $required, 'string', Rule::in( MenuItem::TYPES ) ],
+            'title'       => [ $required, 'string', 'max:255' ],
+            'url'         => [ 'nullable', 'string', 'max:2048' ],
+            'target'      => [ 'nullable', 'string', Rule::in( [ '_self', '_blank' ] ) ],
+            'xfn'         => [ 'nullable', 'string', 'max:255' ],
+            'classes'     => [ 'nullable', 'string', 'max:255' ],
+            'description' => [ 'nullable', 'string' ],
+            'object'      => [ 'nullable', 'string', 'max:64', $this->objectPairing() ],
+            'object_id'   => [ 'nullable', 'integer', $this->objectPairing() ],
+            'kind'        => [ 'nullable', 'string', 'max:32' ],
+        ];
+    }
+
+    /**
+     * @since 1.2.0
+     *
+     * @return array<string, string>
+     */
+    public function messages(): array
+    {
+        return [
+            'menus.required'    => __( 'A parent menu id is required.' ),
+            'menus.prohibited'  => __( 'The parent menu cannot be reassigned via update.' ),
+            'type.in'           => __( 'Type must be one of link, submenu, or page-list.' ),
+            'target.in'         => __( 'Target must be _self or _blank.' ),
+        ];
+    }
+
+    /**
+     * Closure rule that enforces the `(object, object_id)` pairing — both
+     * fields must be present together, or both absent.
+     *
+     * @since 1.2.0
+     */
+    protected function objectPairing(): Closure
+    {
+        return function ( string $attribute, mixed $value, Closure $fail ): void {
+            $other = 'object' === $attribute ? 'object_id' : 'object';
+
+            $thisFilled  = null !== $value && '' !== $value;
+            $otherFilled = $this->filled( $other );
+
+            if ( $thisFilled !== $otherFilled ) {
+                $fail( __( 'object and object_id must be provided together.' ) );
+            }
+        };
+    }
+
+    /**
+     * @since 1.2.0
+     */
+    protected function passedValidation(): void
+    {
+        // After validation, enforce parent-belongs-to-same-menu. Done here
+        // (rather than in `rules()`) so we have both the validated parent
+        // and the menu_id together, including the existing item's menu on
+        // updates where `menus` is prohibited.
+        $parentId = $this->input( 'parent' );
+
+        if ( null === $parentId ) {
+            return;
+        }
+
+        $menuId = $this->resolvedMenuId();
+
+        if ( null === $menuId ) {
+            return;
+        }
+
+        $parent = MenuItem::query()->find( $parentId );
+
+        if ( null !== $parent && (int) $parent->menu_id !== (int) $menuId ) {
+            $this->failedValidation(
+                tap( validator( $this->all(), [] ), function ( $validator ): void {
+                    $validator->errors()->add(
+                        'parent',
+                        __( 'parent must reference an item belonging to the same menu.' ),
+                    );
+                } ),
+            );
+        }
+    }
+
+    /**
+     * Resolve the effective menu id for the current request: the `menus`
+     * input on POST, or the existing item's `menu_id` on update.
+     *
+     * @since 1.2.0
+     */
+    protected function resolvedMenuId(): ?int
+    {
+        if ( $this->isMethod( 'post' ) ) {
+            $menuId = $this->input( 'menus' );
+
+            return is_numeric( $menuId ) ? (int) $menuId : null;
+        }
+
+        $itemId = $this->route( 'id' );
+
+        if ( null === $itemId ) {
+            return null;
+        }
+
+        $item = MenuItem::query()->find( $itemId );
+
+        return null !== $item ? (int) $item->menu_id : null;
+    }
+}

--- a/src/Modules/SiteEditor/Http/Requests/MenuItemRequest.php
+++ b/src/Modules/SiteEditor/Http/Requests/MenuItemRequest.php
@@ -22,7 +22,9 @@ declare( strict_types=1 );
 namespace ArtisanPackUI\CMSFramework\Modules\SiteEditor\Http\Requests;
 
 use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Http\Resources\MenuItemResource;
+use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Models\Menu;
 use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Models\MenuItem;
+use ArtisanPackUI\CMSFramework\Modules\Themes\Managers\ThemeManager;
 use Closure;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
@@ -51,8 +53,8 @@ class MenuItemRequest extends FormRequest
         $required = $isPost ? 'required' : 'sometimes';
 
         return [
-            'menus'       => [ $isPost ? 'required' : 'prohibited', 'integer', 'exists:menus,id' ],
-            'parent'      => [ 'nullable', 'integer', 'exists:menu_items,id' ],
+            'menus'       => [ $isPost ? 'required' : 'prohibited', 'integer', $this->menuExistsRule() ],
+            'parent'      => [ 'nullable', 'integer', $this->parentExistsRule() ],
             'menu_order'  => [ 'nullable', 'integer', 'min:0' ],
             'type'        => [ $required, 'string', Rule::in( MenuItem::TYPES ) ],
             'title'       => [ $required, 'string', 'max:255' ],
@@ -130,6 +132,67 @@ class MenuItemRequest extends FormRequest
     protected static function isZeroSentinel( mixed $value ): bool
     {
         return 0 === $value || '0' === $value;
+    }
+
+    /**
+     * Theme-scoped existence rule for the `menus` field. Falls back to
+     * an unscoped `exists` when no theme is active so the `exists` step
+     * still rejects truly nonexistent ids consistently — the controller
+     * will surface the no-active-theme case as 409 once validation
+     * reaches it.
+     *
+     * Scoped existence prevents cross-theme leakage: `menus: <id>` for
+     * an id that lives in another theme now yields the same 422 as a
+     * truly-nonexistent id, instead of distinguishing the two through
+     * controller-level 404 vs validation-level 422.
+     *
+     * @since 1.2.0
+     */
+    protected function menuExistsRule(): mixed
+    {
+        $themeSlug = $this->activeThemeSlug();
+
+        if ( null === $themeSlug ) {
+            return 'exists:menus,id';
+        }
+
+        return Rule::exists( 'menus', 'id' )->where( static function ( $query ) use ( $themeSlug ): void {
+            $query->where( 'theme', $themeSlug );
+        } );
+    }
+
+    /**
+     * Theme-scoped existence rule for the `parent` field. The parent
+     * must reference a `menu_item` whose owning `Menu` belongs to the
+     * active theme. The further "same menu" constraint runs in
+     * {@see passedValidation()}.
+     *
+     * @since 1.2.0
+     */
+    protected function parentExistsRule(): mixed
+    {
+        $themeSlug = $this->activeThemeSlug();
+
+        if ( null === $themeSlug ) {
+            return 'exists:menu_items,id';
+        }
+
+        return Rule::exists( 'menu_items', 'id' )->where( static function ( $query ) use ( $themeSlug ): void {
+            $query->whereIn(
+                'menu_id',
+                Menu::query()->where( 'theme', $themeSlug )->select( 'id' ),
+            );
+        } );
+    }
+
+    /**
+     * @since 1.2.0
+     */
+    protected function activeThemeSlug(): ?string
+    {
+        $theme = app( ThemeManager::class )->getActiveTheme();
+
+        return null !== $theme && ! empty( $theme['slug'] ) ? (string) $theme['slug'] : null;
     }
 
     /**

--- a/src/Modules/SiteEditor/Http/Requests/MenuItemRequest.php
+++ b/src/Modules/SiteEditor/Http/Requests/MenuItemRequest.php
@@ -6,8 +6,13 @@
  * Validates store/update payloads for `/api/v1/menu-items`. Enforces:
  *
  * - `type` ∈ {link, submenu, page-list}
+ * - `kind` ∈ {post-type, taxonomy, custom} when present (allow-list)
  * - `(object_type, object_id)` paired (both present or both absent)
  * - `parent_id` references a `MenuItem` belonging to the same `Menu`
+ *
+ * Normalizes WP REST sentinel values (`parent: 0`, `object: ""` paired
+ * with `object_id: 0`) to nulls in {@see prepareForValidation()} so
+ * upstream WP-shape clients pass without rewriting their payloads.
  *
  * @since      1.2.0
  */
@@ -16,6 +21,7 @@ declare( strict_types=1 );
 
 namespace ArtisanPackUI\CMSFramework\Modules\SiteEditor\Http\Requests;
 
+use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Http\Resources\MenuItemResource;
 use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Models\MenuItem;
 use Closure;
 use Illuminate\Foundation\Http\FormRequest;
@@ -57,7 +63,7 @@ class MenuItemRequest extends FormRequest
             'description' => [ 'nullable', 'string' ],
             'object'      => [ 'nullable', 'string', 'max:64', $this->objectPairing() ],
             'object_id'   => [ 'nullable', 'integer', $this->objectPairing() ],
-            'kind'        => [ 'nullable', 'string', 'max:32' ],
+            'kind'        => [ 'nullable', 'string', 'max:32', Rule::in( array_keys( MenuItemResource::KIND_TO_TYPE ) ) ],
         ];
     }
 
@@ -74,6 +80,56 @@ class MenuItemRequest extends FormRequest
             'type.in'           => __( 'Type must be one of link, submenu, or page-list.' ),
             'target.in'         => __( 'Target must be _self or _blank.' ),
         ];
+    }
+
+    /**
+     * Normalize WP REST sentinel values before validation runs:
+     *
+     * - `parent: 0` → `parent: null` (WP marks root items with id `0`,
+     *   which fails `exists:menu_items,id` since no item has id 0).
+     * - `object: ""` paired with `object_id: 0` → both null (WP marks
+     *   non-typed items this way; the pairing rule treats `""` as empty
+     *   on one side but `0` as filled on the other, raising a spurious
+     *   "must be provided together" error).
+     *
+     * @since 1.2.0
+     */
+    protected function prepareForValidation(): void
+    {
+        $merge = [];
+
+        if ( $this->has( 'parent' ) && self::isZeroSentinel( $this->input( 'parent' ) ) ) {
+            $merge['parent'] = null;
+        }
+
+        $object   = $this->input( 'object' );
+        $objectId = $this->input( 'object_id' );
+
+        if (
+            ( '' === $object || null === $object )
+            && ( null === $objectId || self::isZeroSentinel( $objectId ) )
+        ) {
+            $merge['object']    = null;
+            $merge['object_id'] = null;
+        }
+
+        if ( ! empty( $merge ) ) {
+            $this->merge( $merge );
+        }
+    }
+
+    /**
+     * Identify the WP sentinel zero (sent as `0` or `"0"`) without
+     * matching the literal string `"0"` other code paths might intend
+     * (e.g. an `object` whose value is the string `"0"`, which is not
+     * a sentinel — `object` is a non-numeric type vocabulary). Used by
+     * {@see prepareForValidation()} on integer-typed fields only.
+     *
+     * @since 1.2.0
+     */
+    protected static function isZeroSentinel( mixed $value ): bool
+    {
+        return 0 === $value || '0' === $value;
     }
 
     /**

--- a/src/Modules/SiteEditor/Http/Requests/MenuLocationAssignmentRequest.php
+++ b/src/Modules/SiteEditor/Http/Requests/MenuLocationAssignmentRequest.php
@@ -1,0 +1,55 @@
+<?php
+
+/**
+ * Menu Location Assignment Form Request
+ *
+ * Validates `PUT /api/v1/menu-locations/{location}` — assigning a menu to
+ * a theme-declared location.
+ *
+ * @since      1.2.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Modules\SiteEditor\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+/**
+ * @since 1.2.0
+ */
+class MenuLocationAssignmentRequest extends FormRequest
+{
+    /**
+     * @since 1.2.0
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @since 1.2.0
+     *
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'menu' => [ 'required', 'integer', 'exists:menus,id' ],
+        ];
+    }
+
+    /**
+     * @since 1.2.0
+     *
+     * @return array<string, string>
+     */
+    public function messages(): array
+    {
+        return [
+            'menu.required' => __( 'The menu id is required.' ),
+            'menu.exists'   => __( 'The menu id does not match an existing menu.' ),
+        ];
+    }
+}

--- a/src/Modules/SiteEditor/Http/Requests/MenuRequest.php
+++ b/src/Modules/SiteEditor/Http/Requests/MenuRequest.php
@@ -1,0 +1,61 @@
+<?php
+
+/**
+ * Menu Form Request
+ *
+ * Validates store/update payloads for `/api/v1/menus`.
+ *
+ * @since      1.2.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Modules\SiteEditor\Http\Requests;
+
+use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Support\SlugValidator;
+use Illuminate\Foundation\Http\FormRequest;
+
+/**
+ * @since 1.2.0
+ */
+class MenuRequest extends FormRequest
+{
+    /**
+     * @since 1.2.0
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @since 1.2.0
+     *
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        $slugPresence = $this->isMethod( 'post' ) ? 'required' : 'sometimes';
+
+        return [
+            'slug'           => [ $slugPresence, 'string', 'max:255', 'regex:' . SlugValidator::PATTERN ],
+            'name'           => [ 'required', 'string', 'max:255' ],
+            'description'    => [ 'nullable', 'string' ],
+            'auto_add_pages' => [ 'nullable', 'boolean' ],
+        ];
+    }
+
+    /**
+     * @since 1.2.0
+     *
+     * @return array<string, string>
+     */
+    public function messages(): array
+    {
+        return [
+            'slug.required' => __( 'The menu slug is required.' ),
+            'slug.regex'    => __( 'The slug must be lowercase letters, numbers, and hyphens only.' ),
+            'name.required' => __( 'The menu name is required.' ),
+        ];
+    }
+}

--- a/src/Modules/SiteEditor/Http/Resources/MenuItemResource.php
+++ b/src/Modules/SiteEditor/Http/Resources/MenuItemResource.php
@@ -1,0 +1,105 @@
+<?php
+
+/**
+ * Menu Item Resource
+ *
+ * Transforms a {@see MenuItem} into a WordPress `/wp/v2/menu-items`-shaped
+ * response array. The `type` field uses the WP-side vocabulary (`custom` /
+ * `post_type` / `taxonomy`) derived from the model's `kind`; the cms-side
+ * link-style flag (`link` / `submenu` / `page-list`) lives on `link_type`
+ * for visual-editor's adapter to consume.
+ *
+ * @since      1.2.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Modules\SiteEditor\Http\Resources;
+
+use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Models\MenuItem;
+
+/**
+ * @since 1.2.0
+ */
+final class MenuItemResource
+{
+    /**
+     * Map model `kind` ('post-type' | 'taxonomy' | 'custom' | null) to
+     * the WP `type` vocabulary.
+     *
+     * @since 1.2.0
+     */
+    protected const KIND_TO_TYPE = [
+        'post-type' => 'post_type',
+        'taxonomy'  => 'taxonomy',
+        'custom'    => 'custom',
+    ];
+
+    /**
+     * @since 1.2.0
+     *
+     * @return array<string, mixed>
+     */
+    public static function toArray( MenuItem $item ): array
+    {
+        $kind = $item->kind ?? 'custom';
+        $type = self::KIND_TO_TYPE[ $kind ] ?? 'custom';
+
+        return [
+            'id'         => (int) $item->id,
+            'title'      => [
+                'raw'      => $item->label,
+                'rendered' => $item->label,
+            ],
+            'url'        => $item->url ?? '',
+            'attr_title' => $item->description ?? '',
+            'classes'    => null !== $item->classes && '' !== $item->classes
+                ? explode( ' ', $item->classes )
+                : [],
+            'description' => $item->description ?? '',
+            'menu_order'  => (int) $item->position,
+            'menus'       => (int) $item->menu_id,
+            'parent'      => null !== $item->parent_id ? (int) $item->parent_id : 0,
+            'target'      => $item->target ?? '_self',
+            'type'        => $type,
+            'type_label'  => self::typeLabel( $type ),
+            'object'      => $item->object_type ?? '',
+            'object_id'   => null !== $item->object_id ? (int) $item->object_id : 0,
+            'xfn'         => null !== $item->rel && '' !== $item->rel
+                ? explode( ' ', $item->rel )
+                : [],
+            'link_type'  => $item->type,
+            'meta'       => [],
+        ];
+    }
+
+    /**
+     * @since 1.2.0
+     *
+     * @param  iterable<int, MenuItem>  $items
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    public static function collection( iterable $items ): array
+    {
+        $out = [];
+
+        foreach ( $items as $item ) {
+            $out[] = self::toArray( $item );
+        }
+
+        return $out;
+    }
+
+    /**
+     * @since 1.2.0
+     */
+    protected static function typeLabel( string $type ): string
+    {
+        return match ( $type ) {
+            'post_type' => 'Post Type',
+            'taxonomy'  => 'Taxonomy',
+            default     => 'Custom Link',
+        };
+    }
+}

--- a/src/Modules/SiteEditor/Http/Resources/MenuItemResource.php
+++ b/src/Modules/SiteEditor/Http/Resources/MenuItemResource.php
@@ -27,9 +27,15 @@ final class MenuItemResource
      * Map model `kind` ('post-type' | 'taxonomy' | 'custom' | null) to
      * the WP `type` vocabulary.
      *
+     * Public so {@see \ArtisanPackUI\CMSFramework\Modules\SiteEditor\Http\Requests\MenuItemRequest}
+     * can pin its `kind` allow-list to the same set of keys without
+     * duplicating the vocabulary.
+     *
      * @since 1.2.0
+     *
+     * @var array<string, string>
      */
-    protected const KIND_TO_TYPE = [
+    public const KIND_TO_TYPE = [
         'post-type' => 'post_type',
         'taxonomy'  => 'taxonomy',
         'custom'    => 'custom',
@@ -46,16 +52,14 @@ final class MenuItemResource
         $type = self::KIND_TO_TYPE[ $kind ] ?? 'custom';
 
         return [
-            'id'         => (int) $item->id,
-            'title'      => [
+            'id'          => (int) $item->id,
+            'title'       => [
                 'raw'      => $item->label,
                 'rendered' => $item->label,
             ],
-            'url'        => $item->url ?? '',
-            'attr_title' => $item->description ?? '',
-            'classes'    => null !== $item->classes && '' !== $item->classes
-                ? explode( ' ', $item->classes )
-                : [],
+            'url'         => $item->url ?? '',
+            'attr_title'  => $item->description ?? '',
+            'classes'     => self::splitTokens( $item->classes ),
             'description' => $item->description ?? '',
             'menu_order'  => (int) $item->position,
             'menus'       => (int) $item->menu_id,
@@ -65,11 +69,9 @@ final class MenuItemResource
             'type_label'  => self::typeLabel( $type ),
             'object'      => $item->object_type ?? '',
             'object_id'   => null !== $item->object_id ? (int) $item->object_id : 0,
-            'xfn'         => null !== $item->rel && '' !== $item->rel
-                ? explode( ' ', $item->rel )
-                : [],
-            'link_type'  => $item->type,
-            'meta'       => [],
+            'xfn'         => self::splitTokens( $item->rel ),
+            'link_type'   => $item->type,
+            'meta'        => [],
         ];
     }
 
@@ -89,6 +91,32 @@ final class MenuItemResource
         }
 
         return $out;
+    }
+
+    /**
+     * Split a space-separated token string (CSS class list, XFN rels) into
+     * a list, collapsing runs of whitespace and dropping empty tokens.
+     * Returns `[]` for null or whitespace-only input.
+     *
+     * @since 1.2.0
+     *
+     * @return array<int, string>
+     */
+    protected static function splitTokens( ?string $value ): array
+    {
+        if ( null === $value ) {
+            return [];
+        }
+
+        $trimmed = trim( $value );
+
+        if ( '' === $trimmed ) {
+            return [];
+        }
+
+        $parts = preg_split( '/\s+/', $trimmed );
+
+        return false === $parts ? [] : array_values( array_filter( $parts, static fn ( string $p ): bool => '' !== $p ) );
     }
 
     /**

--- a/src/Modules/SiteEditor/Http/Resources/MenuLocationResource.php
+++ b/src/Modules/SiteEditor/Http/Resources/MenuLocationResource.php
@@ -1,0 +1,55 @@
+<?php
+
+/**
+ * Menu Location Resource
+ *
+ * Shapes a single resolved location for `/api/v1/menu-locations`. Mirrors
+ * the response shape of WP's `/wp/v2/menu-locations`: a `name` (the key),
+ * a `description` (the human label), and the assigned `menu` id (or 0
+ * when nothing is assigned).
+ *
+ * @since      1.2.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Modules\SiteEditor\Http\Resources;
+
+/**
+ * @since 1.2.0
+ */
+final class MenuLocationResource
+{
+    /**
+     * @since 1.2.0
+     *
+     * @return array<string, mixed>
+     */
+    public static function toArray( string $location, string $label, ?int $menuId ): array
+    {
+        return [
+            'name'        => $location,
+            'description' => $label,
+            'menu'        => null !== $menuId ? $menuId : 0,
+        ];
+    }
+
+    /**
+     * @since 1.2.0
+     *
+     * @param  array<string, string>  $locations  Keyed location → label.
+     * @param  array<string, int>     $assignments  Keyed location → menu id.
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    public static function collection( array $locations, array $assignments ): array
+    {
+        $out = [];
+
+        foreach ( $locations as $location => $label ) {
+            $out[] = self::toArray( $location, $label, $assignments[ $location ] ?? null );
+        }
+
+        return $out;
+    }
+}

--- a/src/Modules/SiteEditor/Http/Resources/MenuResource.php
+++ b/src/Modules/SiteEditor/Http/Resources/MenuResource.php
@@ -1,0 +1,63 @@
+<?php
+
+/**
+ * Menu Resource
+ *
+ * Transforms a {@see Menu} into a WordPress `/wp/v2/menus`-shaped response
+ * array. The `locations` field lists the theme-declared location keys this
+ * menu is currently assigned to.
+ *
+ * @since      1.2.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Modules\SiteEditor\Http\Resources;
+
+use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Models\Menu;
+
+/**
+ * @since 1.2.0
+ */
+final class MenuResource
+{
+    /**
+     * @since 1.2.0
+     *
+     * @return array<string, mixed>
+     */
+    public static function toArray( Menu $menu ): array
+    {
+        return [
+            'id'             => (int) $menu->id,
+            'description'    => $menu->description ?? '',
+            'name'           => $menu->name,
+            'slug'           => $menu->slug,
+            'meta'           => [],
+            'locations'      => $menu->locationAssignments
+                ->pluck( 'location' )
+                ->values()
+                ->all(),
+            'auto_add_pages' => (bool) $menu->auto_add_pages,
+            'theme'          => $menu->theme,
+        ];
+    }
+
+    /**
+     * @since 1.2.0
+     *
+     * @param  iterable<int, Menu>  $menus
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    public static function collection( iterable $menus ): array
+    {
+        $out = [];
+
+        foreach ( $menus as $menu ) {
+            $out[] = self::toArray( $menu );
+        }
+
+        return $out;
+    }
+}

--- a/src/Modules/SiteEditor/Models/Menu.php
+++ b/src/Modules/SiteEditor/Models/Menu.php
@@ -60,17 +60,25 @@ class Menu extends Model
     ];
 
     /**
-     * Items in this menu, ordered by `(parent_id, position, id)` so consumers
-     * receive a deterministic flat list ready to nest. The `id` tiebreaker
-     * keeps ordering stable when two siblings share `position` (which can
-     * happen mid-edit before the client has resequenced positions).
+     * Items in this menu, ordered by `(COALESCE(parent_id, 0), position, id)`.
+     *
+     * `COALESCE(parent_id, 0)` normalizes NULL parent_id (root items) to a
+     * concrete value before ordering — without it, NULL ordering varies by
+     * SQL engine (MySQL/SQLite default to NULLs first, PostgreSQL to NULLs
+     * last). Coercing to 0 keeps the relation deterministic across drivers
+     * and matches the resolver's `parent_id ?? 0` grouping convention in
+     * {@see \ArtisanPackUI\CMSFramework\Modules\SiteEditor\Resolution\MenuResolver::projectItems()}.
+     *
+     * The `id` tiebreaker keeps ordering stable when two siblings share
+     * `position` (which can happen mid-edit before the client has
+     * resequenced positions).
      *
      * @since 1.2.0
      */
     public function items(): HasMany
     {
         return $this->hasMany( MenuItem::class )
-            ->orderBy( 'parent_id' )
+            ->orderByRaw( 'COALESCE(parent_id, 0)' )
             ->orderBy( 'position' )
             ->orderBy( 'id' );
     }

--- a/src/Modules/SiteEditor/Models/Menu.php
+++ b/src/Modules/SiteEditor/Models/Menu.php
@@ -60,14 +60,19 @@ class Menu extends Model
     ];
 
     /**
-     * Items in this menu, ordered by `(parent_id, position)` so consumers
-     * receive a deterministic flat list ready to nest.
+     * Items in this menu, ordered by `(parent_id, position, id)` so consumers
+     * receive a deterministic flat list ready to nest. The `id` tiebreaker
+     * keeps ordering stable when two siblings share `position` (which can
+     * happen mid-edit before the client has resequenced positions).
      *
      * @since 1.2.0
      */
     public function items(): HasMany
     {
-        return $this->hasMany( MenuItem::class )->orderBy( 'parent_id' )->orderBy( 'position' );
+        return $this->hasMany( MenuItem::class )
+            ->orderBy( 'parent_id' )
+            ->orderBy( 'position' )
+            ->orderBy( 'id' );
     }
 
     /**

--- a/src/Modules/SiteEditor/Models/Menu.php
+++ b/src/Modules/SiteEditor/Models/Menu.php
@@ -1,0 +1,122 @@
+<?php
+
+/**
+ * Menu Model
+ *
+ * Represents a navigation menu — a named collection of {@see MenuItem}
+ * records that can be assigned to one or more theme-declared locations
+ * via {@see MenuLocationAssignment}.
+ *
+ * Menus are DB-only (per plan 14 §4.2): themes contribute location *names*
+ * via `theme.json` `menus.locations`, but never menu *content*. Switching
+ * themes leaves prior menus untouched (data preservation per §5.5);
+ * switching back surfaces the same menus and their assignments again.
+ *
+ * @since      1.2.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Modules\SiteEditor\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Support\Carbon;
+
+/**
+ * @property int $id
+ * @property string $theme
+ * @property string $slug
+ * @property string $name
+ * @property string|null $description
+ * @property bool $auto_add_pages
+ * @property int|null $author_id
+ * @property Carbon $created_at
+ * @property Carbon $updated_at
+ */
+class Menu extends Model
+{
+    use HasFactory;
+
+    /**
+     * @since 1.2.0
+     */
+    protected $table = 'menus';
+
+    /**
+     * @since 1.2.0
+     *
+     * @var array<int, string>
+     */
+    protected $fillable = [
+        'theme',
+        'slug',
+        'name',
+        'description',
+        'auto_add_pages',
+        'author_id',
+    ];
+
+    /**
+     * Items in this menu, ordered by `(parent_id, position)` so consumers
+     * receive a deterministic flat list ready to nest.
+     *
+     * @since 1.2.0
+     */
+    public function items(): HasMany
+    {
+        return $this->hasMany( MenuItem::class )->orderBy( 'parent_id' )->orderBy( 'position' );
+    }
+
+    /**
+     * Locations this menu is assigned to. A single menu can satisfy
+     * multiple locations within the same theme.
+     *
+     * @since 1.2.0
+     */
+    public function locationAssignments(): HasMany
+    {
+        return $this->hasMany( MenuLocationAssignment::class );
+    }
+
+    /**
+     * The user who created this menu.
+     *
+     * @since 1.2.0
+     */
+    public function author(): BelongsTo
+    {
+        return $this->belongsTo( config( 'artisanpack.cms-framework.user_model' ), 'author_id' );
+    }
+
+    /**
+     * @since 1.2.0
+     *
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'auto_add_pages' => 'boolean',
+        ];
+    }
+
+    /**
+     * Eloquent-level cascade for items + location assignments. Migrations
+     * also declare DB-level `cascadeOnDelete()`, but FK enforcement isn't
+     * universal across drivers (notably SQLite needs `PRAGMA foreign_keys`
+     * enabled). Cascading at the model layer keeps the behavior consistent
+     * regardless of how the connection is configured.
+     *
+     * @since 1.2.0
+     */
+    protected static function booted(): void
+    {
+        static::deleting( static function ( Menu $menu ): void {
+            $menu->items()->each( static fn ( MenuItem $item ): ?bool => $item->delete() );
+            $menu->locationAssignments()->delete();
+        } );
+    }
+}

--- a/src/Modules/SiteEditor/Models/MenuItem.php
+++ b/src/Modules/SiteEditor/Models/MenuItem.php
@@ -113,13 +113,14 @@ class MenuItem extends Model
     }
 
     /**
-     * Direct children of this item, ordered by position.
+     * Direct children of this item, ordered by `(position, id)`. The `id`
+     * tiebreaker keeps ordering stable when two siblings share `position`.
      *
      * @since 1.2.0
      */
     public function children(): HasMany
     {
-        return $this->hasMany( self::class, 'parent_id' )->orderBy( 'position' );
+        return $this->hasMany( self::class, 'parent_id' )->orderBy( 'position' )->orderBy( 'id' );
     }
 
     /**

--- a/src/Modules/SiteEditor/Models/MenuItem.php
+++ b/src/Modules/SiteEditor/Models/MenuItem.php
@@ -1,0 +1,151 @@
+<?php
+
+/**
+ * Menu Item Model
+ *
+ * Represents a single navigation entry within a {@see Menu}. Items support
+ * three link types — `link`, `submenu`, `page-list` — matching the upstream
+ * `core/navigation-link` / `core/navigation-submenu` / `core/page-list`
+ * blocks, so {@see \ArtisanPackUI\CMSFramework\Modules\SiteEditor\Resolution\MenuResolver}
+ * projects them into the navigation block shape without translation.
+ *
+ * The `(object_type, object_id)` pair is a soft polymorphic reference: items
+ * survive the deletion of the linked resource and continue rendering with the
+ * stored `label` + `url`. Pruning dead links is deferred to V1.1.
+ *
+ * @since      1.2.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Modules\SiteEditor\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Support\Carbon;
+
+/**
+ * @property int $id
+ * @property int $menu_id
+ * @property int|null $parent_id
+ * @property int $position
+ * @property string $type
+ * @property string $label
+ * @property string|null $url
+ * @property string $target
+ * @property string|null $rel
+ * @property string|null $classes
+ * @property string|null $description
+ * @property string|null $object_type
+ * @property int|null $object_id
+ * @property string|null $kind
+ * @property Carbon $created_at
+ * @property Carbon $updated_at
+ */
+class MenuItem extends Model
+{
+    use HasFactory;
+
+    /**
+     * Menu-item link types matching the upstream navigation block family.
+     *
+     * @since 1.2.0
+     */
+    public const TYPE_LINK = 'link';
+
+    public const TYPE_SUBMENU = 'submenu';
+
+    public const TYPE_PAGE_LIST = 'page-list';
+
+    /**
+     * @since 1.2.0
+     *
+     * @var array<int, string>
+     */
+    public const TYPES = [
+        self::TYPE_LINK,
+        self::TYPE_SUBMENU,
+        self::TYPE_PAGE_LIST,
+    ];
+
+    /**
+     * @since 1.2.0
+     */
+    protected $table = 'menu_items';
+
+    /**
+     * @since 1.2.0
+     *
+     * @var array<int, string>
+     */
+    protected $fillable = [
+        'menu_id',
+        'parent_id',
+        'position',
+        'type',
+        'label',
+        'url',
+        'target',
+        'rel',
+        'classes',
+        'description',
+        'object_type',
+        'object_id',
+        'kind',
+    ];
+
+    /**
+     * @since 1.2.0
+     */
+    public function menu(): BelongsTo
+    {
+        return $this->belongsTo( Menu::class );
+    }
+
+    /**
+     * @since 1.2.0
+     */
+    public function parent(): BelongsTo
+    {
+        return $this->belongsTo( self::class, 'parent_id' );
+    }
+
+    /**
+     * Direct children of this item, ordered by position.
+     *
+     * @since 1.2.0
+     */
+    public function children(): HasMany
+    {
+        return $this->hasMany( self::class, 'parent_id' )->orderBy( 'position' );
+    }
+
+    /**
+     * @since 1.2.0
+     *
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'position'  => 'integer',
+            'object_id' => 'integer',
+        ];
+    }
+
+    /**
+     * Eloquent-level cascade for child items so deletion behavior is
+     * consistent regardless of whether the underlying driver enforces the
+     * `parent_id` foreign key constraint declared in the migration.
+     *
+     * @since 1.2.0
+     */
+    protected static function booted(): void
+    {
+        static::deleting( static function ( MenuItem $item ): void {
+            $item->children()->each( static fn ( MenuItem $child ): ?bool => $child->delete() );
+        } );
+    }
+}

--- a/src/Modules/SiteEditor/Models/MenuLocationAssignment.php
+++ b/src/Modules/SiteEditor/Models/MenuLocationAssignment.php
@@ -1,0 +1,59 @@
+<?php
+
+/**
+ * Menu Location Assignment Model
+ *
+ * Joins a {@see Menu} to a theme-declared location key (e.g. `primary`,
+ * `footer`). Lives in its own table rather than as a column on `Menu`
+ * because (a) one menu can satisfy multiple locations, and (b) location
+ * names are theme-scoped — switching themes can leave a menu unassigned
+ * without orphaning the menu itself.
+ *
+ * @since      1.2.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Modules\SiteEditor\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Carbon;
+
+/**
+ * @property int $id
+ * @property string $theme
+ * @property string $location
+ * @property int $menu_id
+ * @property Carbon $created_at
+ * @property Carbon $updated_at
+ */
+class MenuLocationAssignment extends Model
+{
+    use HasFactory;
+
+    /**
+     * @since 1.2.0
+     */
+    protected $table = 'menu_location_assignments';
+
+    /**
+     * @since 1.2.0
+     *
+     * @var array<int, string>
+     */
+    protected $fillable = [
+        'theme',
+        'location',
+        'menu_id',
+    ];
+
+    /**
+     * @since 1.2.0
+     */
+    public function menu(): BelongsTo
+    {
+        return $this->belongsTo( Menu::class );
+    }
+}

--- a/src/Modules/SiteEditor/Providers/SiteEditorServiceProvider.php
+++ b/src/Modules/SiteEditor/Providers/SiteEditorServiceProvider.php
@@ -22,6 +22,7 @@ use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Emission\GlobalStylesEmitter;
 use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Models\GlobalStyles;
 use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Resolution\EntityResolver;
 use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Resolution\GlobalStylesResolver;
+use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Resolution\MenuResolver;
 use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Resolution\PatternResolver;
 use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Resolution\TemplatePartResolver;
 use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Resolution\TemplateResolver;
@@ -58,6 +59,10 @@ class SiteEditorServiceProvider extends ServiceProvider
 
         $this->app->singleton( GlobalStylesEmitter::class, function ( $app ) {
             return new GlobalStylesEmitter( $app->make( GlobalStylesResolver::class ) );
+        } );
+
+        $this->app->singleton( MenuResolver::class, function ( $app ) {
+            return new MenuResolver( $app->make( ThemeManager::class ) );
         } );
     }
 
@@ -114,6 +119,14 @@ class SiteEditorServiceProvider extends ServiceProvider
             $resolved = $this->app->make( GlobalStylesResolver::class )->resolve();
 
             return null !== $resolved ? $resolved->toFilterEntry() : $existing;
+        } );
+
+        // Navigation filter — `array<string, ResolvedMenu>` keyed by location.
+        // Same merge order as templates/parts/patterns: cms-framework's
+        // resolved map goes *under* the existing map so app-level config
+        // (or earlier filter contributors) wins on key collision.
+        addFilter( 'ap.visual-editor.navigation', function ( array $existing ): array {
+            return array_merge( $this->app->make( MenuResolver::class )->all(), $existing );
         } );
     }
 

--- a/src/Modules/SiteEditor/Resolution/MenuResolver.php
+++ b/src/Modules/SiteEditor/Resolution/MenuResolver.php
@@ -1,0 +1,217 @@
+<?php
+
+/**
+ * Menu Resolver
+ *
+ * Resolves theme-declared menu *locations* into the navigation shape that
+ * visual-editor's `ap.visual-editor.navigation` filter consumes:
+ * `array<string, ResolvedMenu>` keyed by location.
+ *
+ * Unlike H1/H2/H3, this resolver has no theme-file fallback — menus are
+ * DB-only per plan 14 §4.2. Themes contribute *location names* via
+ * `theme.json` `menus.locations`; menus and items live entirely in the
+ * database. Locations the active theme declares but no app has assigned a
+ * menu to still appear in the output with `wp_id = null` so editor
+ * surfaces can render empty slots.
+ *
+ * @since      1.2.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Modules\SiteEditor\Resolution;
+
+use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Models\Menu;
+use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Models\MenuItem;
+use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Models\MenuLocationAssignment;
+use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Support\Menus;
+use ArtisanPackUI\CMSFramework\Modules\Themes\Managers\ThemeManager;
+
+/**
+ * @since 1.2.0
+ */
+class MenuResolver
+{
+    /**
+     * @since 1.2.0
+     */
+    public function __construct(
+        private ThemeManager $themeManager,
+    ) {
+    }
+
+    /**
+     * Returns every theme-declared location for the active theme keyed by
+     * location key. Locations without an assigned menu still appear with
+     * `wp_id => null` and an empty `items` array.
+     *
+     * @since 1.2.0
+     *
+     * @return array<string, array{location: string, name: string, items: array<int, array<string, mixed>>, wp_id: int|null}>
+     */
+    public function all(): array
+    {
+        $theme = $this->activeThemeSlug();
+
+        if ( null === $theme ) {
+            return [];
+        }
+
+        $locations = Menus::locations();
+
+        if ( empty( $locations ) ) {
+            return [];
+        }
+
+        $assignments = MenuLocationAssignment::query()
+            ->where( 'theme', $theme )
+            ->with( [ 'menu', 'menu.items' ] )
+            ->get()
+            ->keyBy( 'location' );
+
+        $resolved = [];
+
+        foreach ( $locations as $location => $label ) {
+            $assignment = $assignments->get( $location );
+            $menu       = null !== $assignment ? $assignment->menu : null;
+
+            $resolved[ $location ] = [
+                'location' => $location,
+                'name'     => null !== $menu ? $menu->name : $label,
+                'items'    => null !== $menu ? $this->projectItems( $menu->items->all() ) : [],
+                'wp_id'    => null !== $menu ? (int) $menu->id : null,
+            ];
+        }
+
+        return $resolved;
+    }
+
+    /**
+     * Resolve a single location for the active theme. Returns null when
+     * the location key isn't declared (by app config or theme).
+     *
+     * @since 1.2.0
+     *
+     * @return array{location: string, name: string, items: array<int, array<string, mixed>>, wp_id: int|null}|null
+     */
+    public function resolve( string $location ): ?array
+    {
+        $all = $this->all();
+
+        return $all[ $location ] ?? null;
+    }
+
+    /**
+     * Revert (unassign) a location for the active theme. The underlying
+     * `Menu` is preserved — only the `MenuLocationAssignment` row is
+     * deleted.
+     *
+     * @since 1.2.0
+     */
+    public function revert( string $location ): bool
+    {
+        return Menus::unassign( $location );
+    }
+
+    /**
+     * Project a flat list of `MenuItem` rows into the upstream
+     * `core/navigation-link` / `core/navigation-submenu` / `core/page-list`
+     * shapes, with children nested under parents by `(parent_id, position)`.
+     *
+     * Page-list items render as a dynamic placeholder (`dynamic: 'page-list'`)
+     * — the resolver does not enumerate pages here so cms-framework stays
+     * decoupled from Phase G content types. The navigation block performs
+     * the page enumeration at render time.
+     *
+     * @since 1.2.0
+     *
+     * @param  array<int, MenuItem>  $items
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    protected function projectItems( array $items ): array
+    {
+        $byParent = [];
+
+        foreach ( $items as $item ) {
+            $byParent[ (int) ( $item->parent_id ?? 0 ) ][] = $item;
+        }
+
+        // Stable order within each parent bucket — items are pre-ordered by the
+        // Menu::items() relation, so rebuilding the tree just walks `$byParent`.
+        return $this->buildBranch( $byParent, 0 );
+    }
+
+    /**
+     * Recursive nesting helper for {@see projectItems()}.
+     *
+     * @since 1.2.0
+     *
+     * @param  array<int, array<int, MenuItem>>  $byParent
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    protected function buildBranch( array $byParent, int $parentId ): array
+    {
+        if ( ! isset( $byParent[ $parentId ] ) ) {
+            return [];
+        }
+
+        $branch = [];
+
+        foreach ( $byParent[ $parentId ] as $item ) {
+            $branch[] = $this->itemToShape( $item, $byParent );
+        }
+
+        return $branch;
+    }
+
+    /**
+     * Convert one `MenuItem` row into the upstream navigation shape, recursing
+     * into children for `submenu` items.
+     *
+     * @since 1.2.0
+     *
+     * @param  array<int, array<int, MenuItem>>  $byParent
+     *
+     * @return array<string, mixed>
+     */
+    protected function itemToShape( MenuItem $item, array $byParent ): array
+    {
+        $shape = [
+            'id'          => (int) $item->id,
+            'type'        => $item->type,
+            'label'       => $item->label,
+            'url'         => $item->url,
+            'target'      => $item->target,
+            'rel'         => $item->rel,
+            'classes'     => $item->classes,
+            'description' => $item->description,
+            'object_type' => $item->object_type,
+            'object_id'   => null !== $item->object_id ? (int) $item->object_id : null,
+            'kind'        => $item->kind,
+            'parent_id'   => null !== $item->parent_id ? (int) $item->parent_id : null,
+            'position'    => (int) $item->position,
+        ];
+
+        if ( MenuItem::TYPE_SUBMENU === $item->type ) {
+            $shape['children'] = $this->buildBranch( $byParent, (int) $item->id );
+        }
+
+        if ( MenuItem::TYPE_PAGE_LIST === $item->type ) {
+            $shape['dynamic'] = MenuItem::TYPE_PAGE_LIST;
+        }
+
+        return $shape;
+    }
+
+    /**
+     * @since 1.2.0
+     */
+    protected function activeThemeSlug(): ?string
+    {
+        $theme = $this->themeManager->getActiveTheme();
+
+        return null !== $theme && ! empty( $theme['slug'] ) ? (string) $theme['slug'] : null;
+    }
+}

--- a/src/Modules/SiteEditor/Support/Menus.php
+++ b/src/Modules/SiteEditor/Support/Menus.php
@@ -1,0 +1,189 @@
+<?php
+
+/**
+ * Menus Support Service
+ *
+ * Locations API for the SiteEditor menus subsystem. Apps register their
+ * default location set in `config('cms.menus.locations')`; themes can
+ * override or add entries via `theme.json` `menus.locations`. Per plan 14
+ * §5.4, the theme wins on key collision (themes are closer to user-visible
+ * behavior); a warning is logged so app authors aren't confused.
+ *
+ * @since      1.2.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Modules\SiteEditor\Support;
+
+use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Models\Menu;
+use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Models\MenuLocationAssignment;
+use ArtisanPackUI\CMSFramework\Modules\Themes\Managers\ThemeManager;
+
+/**
+ * @since 1.2.0
+ */
+class Menus
+{
+    /**
+     * Returns the resolved location map for the active theme. Order:
+     * app `config('cms.menus.locations')` defaults first, then the active
+     * theme's `theme.json` `menus.locations` (theme keys override app keys
+     * on collision; logs a warning per overridden key).
+     *
+     * Returns the app defaults alone when there is no active theme.
+     *
+     * @since 1.2.0
+     *
+     * @return array<string, string>
+     */
+    public static function locations(): array
+    {
+        $appLocations = self::normalizeStringMap( config( 'cms.menus.locations', [] ) );
+
+        $theme = self::activeThemeManifest();
+
+        if ( null === $theme ) {
+            return $appLocations;
+        }
+
+        $themeLocations = self::normalizeStringMap( $theme['menus']['locations'] ?? [] );
+
+        if ( empty( $themeLocations ) ) {
+            return $appLocations;
+        }
+
+        foreach ( array_keys( $themeLocations ) as $key ) {
+            if ( array_key_exists( $key, $appLocations ) && $appLocations[ $key ] !== $themeLocations[ $key ] ) {
+                logger()->warning(
+                    'Theme `theme.json` menus.locations key overrides app config(\'cms.menus.locations\').',
+                    [
+                        'location'   => $key,
+                        'app_label'  => $appLocations[ $key ],
+                        'theme_slug' => $theme['slug'] ?? null,
+                    ],
+                );
+            }
+        }
+
+        return array_merge( $appLocations, $themeLocations );
+    }
+
+    /**
+     * Assign a menu to a location for the active theme. Upserts the
+     * `MenuLocationAssignment` row — calling this for a location that is
+     * already assigned reassigns it.
+     *
+     * @since 1.2.0
+     *
+     * @return MenuLocationAssignment|null Null when there is no active theme.
+     */
+    public static function assign( string $location, int $menuId ): ?MenuLocationAssignment
+    {
+        $theme = self::activeThemeSlug();
+
+        if ( null === $theme ) {
+            return null;
+        }
+
+        return MenuLocationAssignment::query()->updateOrCreate(
+            [ 'theme' => $theme, 'location' => $location ],
+            [ 'menu_id' => $menuId ],
+        );
+    }
+
+    /**
+     * Unassign a location for the active theme. Returns true when an
+     * assignment row was deleted, false when none existed.
+     *
+     * @since 1.2.0
+     */
+    public static function unassign( string $location ): bool
+    {
+        $theme = self::activeThemeSlug();
+
+        if ( null === $theme ) {
+            return false;
+        }
+
+        return MenuLocationAssignment::query()
+            ->where( 'theme', $theme )
+            ->where( 'location', $location )
+            ->delete() > 0;
+    }
+
+    /**
+     * Returns the menu currently assigned to the given location for the
+     * active theme, or null when nothing is assigned (or no active theme).
+     *
+     * @since 1.2.0
+     */
+    public static function assigned( string $location ): ?Menu
+    {
+        $theme = self::activeThemeSlug();
+
+        if ( null === $theme ) {
+            return null;
+        }
+
+        $assignment = MenuLocationAssignment::query()
+            ->where( 'theme', $theme )
+            ->where( 'location', $location )
+            ->first();
+
+        return null !== $assignment ? $assignment->menu : null;
+    }
+
+    /**
+     * @since 1.2.0
+     */
+    protected static function activeThemeSlug(): ?string
+    {
+        $theme = self::activeThemeManifest();
+
+        return null !== $theme && ! empty( $theme['slug'] ) ? (string) $theme['slug'] : null;
+    }
+
+    /**
+     * @since 1.2.0
+     *
+     * @return array<string, mixed>|null
+     */
+    protected static function activeThemeManifest(): ?array
+    {
+        return app( ThemeManager::class )->getActiveTheme();
+    }
+
+    /**
+     * Coerce arbitrary input into a `array<string, string>` map, dropping
+     * entries with non-string keys or non-stringable values. Defends the
+     * locations contract from malformed config or theme.json input without
+     * raising during a request.
+     *
+     * @since 1.2.0
+     *
+     * @return array<string, string>
+     */
+    protected static function normalizeStringMap( mixed $input ): array
+    {
+        if ( ! is_array( $input ) ) {
+            return [];
+        }
+
+        $normalized = [];
+
+        foreach ( $input as $key => $value ) {
+            if ( ! is_string( $key ) || '' === $key ) {
+                continue;
+            }
+
+            if ( is_string( $value ) ) {
+                $normalized[ $key ] = $value;
+            } elseif ( is_scalar( $value ) ) {
+                $normalized[ $key ] = (string) $value;
+            }
+        }
+
+        return $normalized;
+    }
+}

--- a/src/Modules/SiteEditor/routes/api.php
+++ b/src/Modules/SiteEditor/routes/api.php
@@ -5,6 +5,9 @@ declare( strict_types=1 );
 use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Http\Controllers\BlockPatternsController;
 use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Http\Controllers\BlocksController;
 use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Http\Controllers\GlobalStylesController;
+use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Http\Controllers\MenuItemsController;
+use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Http\Controllers\MenuLocationsController;
+use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Http\Controllers\MenusController;
 use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Http\Controllers\TemplatePartsController;
 use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Http\Controllers\TemplatesController;
 use Illuminate\Support\Facades\Route;
@@ -50,5 +53,27 @@ Route::prefix( 'api/v1' )
             Route::get( '/', [ GlobalStylesController::class, 'show' ] )->name( 'api.global-styles.show' );
             Route::put( '/', [ GlobalStylesController::class, 'update' ] )->name( 'api.global-styles.update' );
             Route::delete( '/', [ GlobalStylesController::class, 'destroy' ] )->name( 'api.global-styles.destroy' );
+        } );
+
+        Route::prefix( 'menus' )->group( function (): void {
+            Route::get( '/', [ MenusController::class, 'index' ] )->name( 'api.menus.index' );
+            Route::post( '/', [ MenusController::class, 'store' ] )->name( 'api.menus.store' );
+            Route::get( '{idOrSlug}', [ MenusController::class, 'show' ] )->name( 'api.menus.show' );
+            Route::put( '{idOrSlug}', [ MenusController::class, 'update' ] )->name( 'api.menus.update' );
+            Route::delete( '{idOrSlug}', [ MenusController::class, 'destroy' ] )->name( 'api.menus.destroy' );
+        } );
+
+        Route::prefix( 'menu-items' )->group( function (): void {
+            Route::get( '/', [ MenuItemsController::class, 'index' ] )->name( 'api.menu-items.index' );
+            Route::post( '/', [ MenuItemsController::class, 'store' ] )->name( 'api.menu-items.store' );
+            Route::get( '{id}', [ MenuItemsController::class, 'show' ] )->name( 'api.menu-items.show' )->whereNumber( 'id' );
+            Route::put( '{id}', [ MenuItemsController::class, 'update' ] )->name( 'api.menu-items.update' )->whereNumber( 'id' );
+            Route::delete( '{id}', [ MenuItemsController::class, 'destroy' ] )->name( 'api.menu-items.destroy' )->whereNumber( 'id' );
+        } );
+
+        Route::prefix( 'menu-locations' )->group( function (): void {
+            Route::get( '/', [ MenuLocationsController::class, 'index' ] )->name( 'api.menu-locations.index' );
+            Route::put( '{location}', [ MenuLocationsController::class, 'update' ] )->name( 'api.menu-locations.update' );
+            Route::delete( '{location}', [ MenuLocationsController::class, 'destroy' ] )->name( 'api.menu-locations.destroy' );
         } );
     } );

--- a/tests/Feature/SiteEditor/MenuFiltersTest.php
+++ b/tests/Feature/SiteEditor/MenuFiltersTest.php
@@ -1,0 +1,106 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Models\Menu;
+use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Models\MenuItem;
+use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Models\MenuLocationAssignment;
+use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Providers\SiteEditorServiceProvider;
+use ArtisanPackUI\CMSFramework\Modules\Themes\Managers\ThemeManager;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses( RefreshDatabase::class );
+
+beforeEach( function (): void {
+    $this->themeSlug = 'test-theme';
+
+    config()->set( 'cms.menus.locations', [
+        'primary' => 'Primary Menu',
+        'footer'  => 'Footer Menu',
+    ] );
+
+    $this->mock( ThemeManager::class, function ( $mock ): void {
+        $mock->shouldReceive( 'getActiveTheme' )->andReturn( [
+            'slug' => $this->themeSlug,
+        ] );
+    } );
+
+    require_once __DIR__ . '/../../Support/VisualEditorClassStub.php';
+
+    removeAllFilters( 'ap.visual-editor.navigation' );
+
+    ( new SiteEditorServiceProvider( app() ) )->registerVisualEditorSiteEditorFilters();
+} );
+
+afterEach( function (): void {
+    removeAllFilters( 'ap.visual-editor.navigation' );
+} );
+
+describe( 'ap.visual-editor.navigation filter wiring', function (): void {
+    it( 'returns every declared location keyed by location key', function (): void {
+        $entries = applyFilters( 'ap.visual-editor.navigation', [] );
+
+        expect( $entries )->toBeArray()
+            ->and( array_keys( $entries ) )->toBe( [ 'primary', 'footer' ] )
+            ->and( $entries['primary']['wp_id'] )->toBeNull();
+    } );
+
+    it( 'fills wp_id and items for assigned locations', function (): void {
+        $menu = Menu::create( [
+            'theme' => $this->themeSlug,
+            'slug'  => 'main',
+            'name'  => 'Main',
+        ] );
+
+        MenuItem::create( [
+            'menu_id'  => $menu->id,
+            'position' => 0,
+            'type'     => MenuItem::TYPE_LINK,
+            'label'    => 'Home',
+            'url'      => '/',
+        ] );
+
+        MenuLocationAssignment::create( [
+            'theme'    => $this->themeSlug,
+            'location' => 'primary',
+            'menu_id'  => $menu->id,
+        ] );
+
+        $entries = applyFilters( 'ap.visual-editor.navigation', [] );
+
+        expect( $entries['primary']['wp_id'] )->toBe( $menu->id )
+            ->and( $entries['primary']['items'] )->toHaveCount( 1 )
+            ->and( $entries['primary']['items'][0]['label'] )->toBe( 'Home' );
+    } );
+
+    it( 'preserves prior contributors on key collision (static config wins)', function (): void {
+        $menu = Menu::create( [
+            'theme' => $this->themeSlug,
+            'slug'  => 'main',
+            'name'  => 'Main',
+        ] );
+
+        MenuLocationAssignment::create( [
+            'theme'    => $this->themeSlug,
+            'location' => 'primary',
+            'menu_id'  => $menu->id,
+        ] );
+
+        $static = [
+            'primary' => [
+                'location' => 'primary',
+                'name'     => 'Static Primary',
+                'items'    => [],
+                'wp_id'    => 999,
+            ],
+        ];
+
+        $entries = applyFilters( 'ap.visual-editor.navigation', $static );
+
+        // The cms-framework callback merges its map *under* `$static`, so
+        // the static entry wins on collision while still picking up the
+        // resolver's `footer` entry.
+        expect( $entries['primary']['wp_id'] )->toBe( 999 )
+            ->and( $entries )->toHaveKey( 'footer' );
+    } );
+} );

--- a/tests/Feature/SiteEditor/MenuItemsApiTest.php
+++ b/tests/Feature/SiteEditor/MenuItemsApiTest.php
@@ -1,0 +1,203 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Models\Menu;
+use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Models\MenuItem;
+use ArtisanPackUI\CMSFramework\Modules\Themes\Managers\ThemeManager;
+use ArtisanPackUI\CMSFramework\Tests\Support\TestUser;
+
+beforeEach( function (): void {
+    $this->user      = TestUser::factory()->create();
+    $this->themeSlug = 'test-theme';
+
+    $this->mock( ThemeManager::class, function ( $mock ): void {
+        $mock->shouldReceive( 'getActiveTheme' )->andReturn( [
+            'slug' => $this->themeSlug,
+        ] );
+    } );
+
+    $this->menu = Menu::create( [
+        'theme' => $this->themeSlug,
+        'slug'  => 'main',
+        'name'  => 'Main',
+    ] );
+} );
+
+describe( 'GET /api/v1/menu-items', function (): void {
+    it( 'requires authentication', function (): void {
+        $this->getJson( '/api/v1/menu-items' )->assertUnauthorized();
+    } );
+
+    it( 'orders results by (parent_id, position)', function (): void {
+        $about = MenuItem::create( [
+            'menu_id'  => $this->menu->id,
+            'position' => 1,
+            'type'     => MenuItem::TYPE_SUBMENU,
+            'label'    => 'About',
+        ] );
+
+        // Created out of order on purpose to verify ordering.
+        MenuItem::create( [
+            'menu_id'   => $this->menu->id,
+            'parent_id' => $about->id,
+            'position'  => 0,
+            'type'      => MenuItem::TYPE_LINK,
+            'label'     => 'Team',
+        ] );
+
+        MenuItem::create( [
+            'menu_id'  => $this->menu->id,
+            'position' => 0,
+            'type'     => MenuItem::TYPE_LINK,
+            'label'    => 'Home',
+            'url'      => '/',
+        ] );
+
+        $this->actingAs( $this->user );
+
+        $response = $this->getJson( '/api/v1/menu-items?menus=' . $this->menu->id );
+
+        $response->assertOk();
+
+        $labels = collect( $response->json() )->pluck( 'title.raw' )->all();
+
+        // Top-level (parent_id=null) sorted to the front by position; then
+        // children sorted under by position.
+        expect( $labels )->toBe( [ 'Home', 'About', 'Team' ] );
+    } );
+
+    it( 'rejects non-numeric ?menus filters', function (): void {
+        $this->actingAs( $this->user );
+
+        $this->getJson( '/api/v1/menu-items?menus=abc' )->assertStatus( 422 );
+    } );
+} );
+
+describe( 'POST /api/v1/menu-items', function (): void {
+    it( 'creates a link item', function (): void {
+        $this->actingAs( $this->user );
+
+        $response = $this->postJson( '/api/v1/menu-items', [
+            'menus' => $this->menu->id,
+            'title' => 'Home',
+            'url'   => '/',
+            'type'  => MenuItem::TYPE_LINK,
+        ] );
+
+        $response->assertCreated();
+        expect( $response->json( 'title.raw' ) )->toBe( 'Home' )
+            ->and( $response->json( 'menus' ) )->toBe( $this->menu->id )
+            ->and( $response->json( 'link_type' ) )->toBe( MenuItem::TYPE_LINK );
+    } );
+
+    it( 'rejects an invalid link type', function (): void {
+        $this->actingAs( $this->user );
+
+        $this->postJson( '/api/v1/menu-items', [
+            'menus' => $this->menu->id,
+            'title' => 'Home',
+            'type'  => 'invalid',
+        ] )->assertStatus( 422 );
+    } );
+
+    it( 'rejects unpaired (object, object_id) fields', function (): void {
+        $this->actingAs( $this->user );
+
+        $this->postJson( '/api/v1/menu-items', [
+            'menus'  => $this->menu->id,
+            'title'  => 'Post Link',
+            'type'   => MenuItem::TYPE_LINK,
+            'object' => 'post',
+        ] )->assertStatus( 422 );
+    } );
+
+    it( 'rejects parent referencing an item in a different menu', function (): void {
+        $other = Menu::create( [
+            'theme' => $this->themeSlug,
+            'slug'  => 'other',
+            'name'  => 'Other',
+        ] );
+
+        $alien = MenuItem::create( [
+            'menu_id'  => $other->id,
+            'position' => 0,
+            'type'     => MenuItem::TYPE_LINK,
+            'label'    => 'Alien',
+        ] );
+
+        $this->actingAs( $this->user );
+
+        $this->postJson( '/api/v1/menu-items', [
+            'menus'  => $this->menu->id,
+            'title'  => 'Bad Parent',
+            'type'   => MenuItem::TYPE_LINK,
+            'parent' => $alien->id,
+        ] )->assertStatus( 422 );
+    } );
+} );
+
+describe( 'PUT /api/v1/menu-items/{id}', function (): void {
+    it( 'updates fields without reassigning the parent menu', function (): void {
+        $item = MenuItem::create( [
+            'menu_id'  => $this->menu->id,
+            'position' => 0,
+            'type'     => MenuItem::TYPE_LINK,
+            'label'    => 'Old',
+            'url'      => '/old',
+        ] );
+
+        $this->actingAs( $this->user );
+
+        $response = $this->putJson( '/api/v1/menu-items/' . $item->id, [
+            'title' => 'New',
+            'url'   => '/new',
+        ] );
+
+        $response->assertOk();
+        expect( $response->json( 'title.raw' ) )->toBe( 'New' )
+            ->and( $response->json( 'url' ) )->toBe( '/new' );
+    } );
+
+    it( 'prohibits the menus field on update', function (): void {
+        $item = MenuItem::create( [
+            'menu_id'  => $this->menu->id,
+            'position' => 0,
+            'type'     => MenuItem::TYPE_LINK,
+            'label'    => 'Item',
+        ] );
+
+        $this->actingAs( $this->user );
+
+        $this->putJson( '/api/v1/menu-items/' . $item->id, [
+            'menus' => $this->menu->id,
+            'title' => 'Item',
+        ] )->assertStatus( 422 );
+    } );
+} );
+
+describe( 'DELETE /api/v1/menu-items/{id}', function (): void {
+    it( 'cascades to children', function (): void {
+        $parent = MenuItem::create( [
+            'menu_id'  => $this->menu->id,
+            'position' => 0,
+            'type'     => MenuItem::TYPE_SUBMENU,
+            'label'    => 'Parent',
+        ] );
+
+        $child = MenuItem::create( [
+            'menu_id'   => $this->menu->id,
+            'parent_id' => $parent->id,
+            'position'  => 0,
+            'type'      => MenuItem::TYPE_LINK,
+            'label'     => 'Child',
+        ] );
+
+        $this->actingAs( $this->user );
+
+        $this->deleteJson( '/api/v1/menu-items/' . $parent->id )->assertNoContent();
+
+        expect( MenuItem::query()->find( $parent->id ) )->toBeNull()
+            ->and( MenuItem::query()->find( $child->id ) )->toBeNull();
+    } );
+} );

--- a/tests/Feature/SiteEditor/MenuItemsApiTest.php
+++ b/tests/Feature/SiteEditor/MenuItemsApiTest.php
@@ -81,6 +81,20 @@ describe( 'GET /api/v1/menu-items', function (): void {
         $this->getJson( '/api/v1/menu-items?menus=1e3' )->assertStatus( 422 );
     } );
 
+    it( 'rejects ?menus=0 (menu ids are 1-based)', function (): void {
+        $this->actingAs( $this->user );
+
+        $this->getJson( '/api/v1/menu-items?menus=0' )->assertStatus( 422 );
+    } );
+
+    it( 'rejects leading-zero ?menus filters that would silently miscast', function (): void {
+        $this->actingAs( $this->user );
+
+        // `(int) "01"` is 1, masking the client's intent. Surface as 422
+        // instead of silently coercing.
+        $this->getJson( '/api/v1/menu-items?menus=01' )->assertStatus( 422 );
+    } );
+
     it( 'does not surface items from menus in other themes', function (): void {
         $foreign = Menu::create( [
             'theme' => 'other-theme',
@@ -202,7 +216,7 @@ describe( 'POST /api/v1/menu-items', function (): void {
         ] )->assertStatus( 422 );
     } );
 
-    it( 'rejects items targeting menus in other themes', function (): void {
+    it( 'rejects items targeting menus in other themes (validation layer)', function (): void {
         $foreign = Menu::create( [
             'theme' => 'other-theme',
             'slug'  => 'foreign',
@@ -211,11 +225,50 @@ describe( 'POST /api/v1/menu-items', function (): void {
 
         $this->actingAs( $this->user );
 
+        // Foreign-theme menus and truly-nonexistent menus both yield 422
+        // through the theme-scoped `exists` rule on the `menus` field —
+        // unifying the response so existence in other themes isn't
+        // distinguishable from non-existence.
         $this->postJson( '/api/v1/menu-items', [
             'menus' => $foreign->id,
             'title' => 'Sneaky',
             'type'  => MenuItem::TYPE_LINK,
-        ] )->assertNotFound();
+        ] )->assertJsonValidationErrors( [ 'menus' ] );
+    } );
+
+    it( 'returns the same 422 for a truly-nonexistent menus id', function (): void {
+        $this->actingAs( $this->user );
+
+        $this->postJson( '/api/v1/menu-items', [
+            'menus' => 999_999,
+            'title' => 'Item',
+            'type'  => MenuItem::TYPE_LINK,
+        ] )->assertJsonValidationErrors( [ 'menus' ] );
+    } );
+
+    it( 'rejects parent referencing an item in another theme', function (): void {
+        $foreign = Menu::create( [
+            'theme' => 'other-theme',
+            'slug'  => 'foreign',
+            'name'  => 'Foreign',
+        ] );
+
+        $alien = MenuItem::create( [
+            'menu_id'  => $foreign->id,
+            'position' => 0,
+            'type'     => MenuItem::TYPE_LINK,
+            'label'    => 'Alien',
+        ] );
+
+        $this->actingAs( $this->user );
+
+        // Same theme-scoped exists fix on the `parent` field.
+        $this->postJson( '/api/v1/menu-items', [
+            'menus'  => $this->menu->id,
+            'title'  => 'Bad Parent',
+            'type'   => MenuItem::TYPE_LINK,
+            'parent' => $alien->id,
+        ] )->assertJsonValidationErrors( [ 'parent' ] );
     } );
 
     it( 'normalizes WP sentinel parent=0 to a root item', function (): void {

--- a/tests/Feature/SiteEditor/MenuItemsApiTest.php
+++ b/tests/Feature/SiteEditor/MenuItemsApiTest.php
@@ -72,6 +72,72 @@ describe( 'GET /api/v1/menu-items', function (): void {
 
         $this->getJson( '/api/v1/menu-items?menus=abc' )->assertStatus( 422 );
     } );
+
+    it( 'rejects scientific-notation ?menus filters that pass is_numeric', function (): void {
+        $this->actingAs( $this->user );
+
+        // `is_numeric("1e3")` is true but `(int) "1e3"` is 1, not 1000.
+        // The strict positive-integer-string check rejects it.
+        $this->getJson( '/api/v1/menu-items?menus=1e3' )->assertStatus( 422 );
+    } );
+
+    it( 'does not surface items from menus in other themes', function (): void {
+        $foreign = Menu::create( [
+            'theme' => 'other-theme',
+            'slug'  => 'foreign',
+            'name'  => 'Foreign',
+        ] );
+
+        MenuItem::create( [
+            'menu_id'  => $foreign->id,
+            'position' => 0,
+            'type'     => MenuItem::TYPE_LINK,
+            'label'    => 'Foreign Item',
+        ] );
+
+        MenuItem::create( [
+            'menu_id'  => $this->menu->id,
+            'position' => 0,
+            'type'     => MenuItem::TYPE_LINK,
+            'label'    => 'Local Item',
+        ] );
+
+        $this->actingAs( $this->user );
+
+        $response = $this->getJson( '/api/v1/menu-items' );
+
+        $response->assertOk();
+
+        $labels = collect( $response->json() )->pluck( 'title.raw' )->all();
+
+        expect( $labels )->toBe( [ 'Local Item' ] );
+    } );
+
+    it( 'tiebreaks equal positions by id for deterministic order', function (): void {
+        // Two siblings with the same `position` — without the `id` tiebreaker
+        // the relative order would be implementation-defined.
+        $first = MenuItem::create( [
+            'menu_id'  => $this->menu->id,
+            'position' => 0,
+            'type'     => MenuItem::TYPE_LINK,
+            'label'    => 'First',
+        ] );
+
+        $second = MenuItem::create( [
+            'menu_id'  => $this->menu->id,
+            'position' => 0,
+            'type'     => MenuItem::TYPE_LINK,
+            'label'    => 'Second',
+        ] );
+
+        $this->actingAs( $this->user );
+
+        $response = $this->getJson( '/api/v1/menu-items?menus=' . $this->menu->id );
+
+        $ids = collect( $response->json() )->pluck( 'id' )->all();
+
+        expect( $ids )->toBe( [ $first->id, $second->id ] );
+    } );
 } );
 
 describe( 'POST /api/v1/menu-items', function (): void {
@@ -134,6 +200,99 @@ describe( 'POST /api/v1/menu-items', function (): void {
             'type'   => MenuItem::TYPE_LINK,
             'parent' => $alien->id,
         ] )->assertStatus( 422 );
+    } );
+
+    it( 'rejects items targeting menus in other themes', function (): void {
+        $foreign = Menu::create( [
+            'theme' => 'other-theme',
+            'slug'  => 'foreign',
+            'name'  => 'Foreign',
+        ] );
+
+        $this->actingAs( $this->user );
+
+        $this->postJson( '/api/v1/menu-items', [
+            'menus' => $foreign->id,
+            'title' => 'Sneaky',
+            'type'  => MenuItem::TYPE_LINK,
+        ] )->assertNotFound();
+    } );
+
+    it( 'normalizes WP sentinel parent=0 to a root item', function (): void {
+        $this->actingAs( $this->user );
+
+        // WP REST sends `parent: 0` for top-level items. Without the
+        // prepareForValidation() normalization, this would fail the
+        // `exists:menu_items,id` rule (no item has id 0).
+        $response = $this->postJson( '/api/v1/menu-items', [
+            'menus'  => $this->menu->id,
+            'title'  => 'Root',
+            'type'   => MenuItem::TYPE_LINK,
+            'parent' => 0,
+        ] );
+
+        $response->assertCreated();
+        expect( $response->json( 'parent' ) )->toBe( 0 );
+    } );
+
+    it( 'normalizes WP sentinel object="" + object_id=0 (custom-link payload)', function (): void {
+        $this->actingAs( $this->user );
+
+        // WP REST sends `object: ""` and `object_id: 0` for custom links.
+        // Without prepareForValidation() the pairing rule would fire
+        // because `0` is "filled" but `""` is not.
+        $response = $this->postJson( '/api/v1/menu-items', [
+            'menus'     => $this->menu->id,
+            'title'     => 'Custom',
+            'type'      => MenuItem::TYPE_LINK,
+            'object'    => '',
+            'object_id' => 0,
+        ] );
+
+        $response->assertCreated();
+        expect( $response->json( 'object' ) )->toBe( '' )
+            ->and( $response->json( 'object_id' ) )->toBe( 0 );
+    } );
+
+    it( 'rejects an unknown kind value', function (): void {
+        $this->actingAs( $this->user );
+
+        $this->postJson( '/api/v1/menu-items', [
+            'menus' => $this->menu->id,
+            'title' => 'Item',
+            'type'  => MenuItem::TYPE_LINK,
+            'kind'  => 'unknown-kind',
+        ] )->assertStatus( 422 );
+    } );
+
+    it( 'accepts known kind values', function (): void {
+        $this->actingAs( $this->user );
+
+        $response = $this->postJson( '/api/v1/menu-items', [
+            'menus' => $this->menu->id,
+            'title' => 'Post Link',
+            'type'  => MenuItem::TYPE_LINK,
+            'kind'  => 'post-type',
+        ] );
+
+        $response->assertCreated();
+        expect( $response->json( 'type' ) )->toBe( 'post_type' );
+    } );
+
+    it( 'normalizes whitespace in classes and xfn for the WP-shape response', function (): void {
+        $this->actingAs( $this->user );
+
+        $response = $this->postJson( '/api/v1/menu-items', [
+            'menus'   => $this->menu->id,
+            'title'   => 'Item',
+            'type'    => MenuItem::TYPE_LINK,
+            'classes' => 'foo  bar   baz',
+            'xfn'     => '  nofollow   noopener  ',
+        ] );
+
+        $response->assertCreated();
+        expect( $response->json( 'classes' ) )->toBe( [ 'foo', 'bar', 'baz' ] )
+            ->and( $response->json( 'xfn' ) )->toBe( [ 'nofollow', 'noopener' ] );
     } );
 } );
 

--- a/tests/Feature/SiteEditor/MenuLocationsApiTest.php
+++ b/tests/Feature/SiteEditor/MenuLocationsApiTest.php
@@ -1,0 +1,124 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Models\Menu;
+use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Models\MenuLocationAssignment;
+use ArtisanPackUI\CMSFramework\Modules\Themes\Managers\ThemeManager;
+use ArtisanPackUI\CMSFramework\Tests\Support\TestUser;
+
+beforeEach( function (): void {
+    $this->user      = TestUser::factory()->create();
+    $this->themeSlug = 'test-theme';
+
+    config()->set( 'cms.menus.locations', [
+        'primary' => 'Primary Menu',
+        'footer'  => 'Footer Menu',
+    ] );
+
+    $this->mock( ThemeManager::class, function ( $mock ): void {
+        $mock->shouldReceive( 'getActiveTheme' )->andReturn( [
+            'slug' => $this->themeSlug,
+        ] );
+    } );
+
+    $this->menu = Menu::create( [
+        'theme' => $this->themeSlug,
+        'slug'  => 'main',
+        'name'  => 'Main',
+    ] );
+} );
+
+describe( 'GET /api/v1/menu-locations', function (): void {
+    it( 'requires authentication', function (): void {
+        $this->getJson( '/api/v1/menu-locations' )->assertUnauthorized();
+    } );
+
+    it( 'lists every declared location with the assigned menu id (or 0 when none)', function (): void {
+        MenuLocationAssignment::create( [
+            'theme'    => $this->themeSlug,
+            'location' => 'primary',
+            'menu_id'  => $this->menu->id,
+        ] );
+
+        $this->actingAs( $this->user );
+
+        $response = $this->getJson( '/api/v1/menu-locations' );
+
+        $response->assertOk();
+        $response->assertJsonStructure( [ '*' => [ 'name', 'description', 'menu' ] ] );
+
+        $rows = collect( $response->json() )->keyBy( 'name' )->all();
+
+        expect( $rows['primary']['menu'] )->toBe( $this->menu->id )
+            ->and( $rows['primary']['description'] )->toBe( 'Primary Menu' )
+            ->and( $rows['footer']['menu'] )->toBe( 0 );
+    } );
+} );
+
+describe( 'PUT /api/v1/menu-locations/{location}', function (): void {
+    it( 'assigns a menu to a location', function (): void {
+        $this->actingAs( $this->user );
+
+        $response = $this->putJson( '/api/v1/menu-locations/primary', [
+            'menu' => $this->menu->id,
+        ] );
+
+        $response->assertOk();
+        expect( $response->json( 'name' ) )->toBe( 'primary' )
+            ->and( $response->json( 'menu' ) )->toBe( $this->menu->id );
+
+        $this->assertDatabaseHas( 'menu_location_assignments', [
+            'theme'    => $this->themeSlug,
+            'location' => 'primary',
+            'menu_id'  => $this->menu->id,
+        ] );
+    } );
+
+    it( 'rejects assignments to undeclared locations', function (): void {
+        $this->actingAs( $this->user );
+
+        $this->putJson( '/api/v1/menu-locations/sidebar', [
+            'menu' => $this->menu->id,
+        ] )->assertNotFound();
+    } );
+
+    it( 'rejects menus authored against another theme', function (): void {
+        $other = Menu::create( [
+            'theme' => 'other-theme',
+            'slug'  => 'other',
+            'name'  => 'Other',
+        ] );
+
+        $this->actingAs( $this->user );
+
+        $this->putJson( '/api/v1/menu-locations/primary', [
+            'menu' => $other->id,
+        ] )->assertStatus( 422 );
+    } );
+} );
+
+describe( 'DELETE /api/v1/menu-locations/{location}', function (): void {
+    it( 'unassigns a location', function (): void {
+        MenuLocationAssignment::create( [
+            'theme'    => $this->themeSlug,
+            'location' => 'primary',
+            'menu_id'  => $this->menu->id,
+        ] );
+
+        $this->actingAs( $this->user );
+
+        $this->deleteJson( '/api/v1/menu-locations/primary' )->assertNoContent();
+
+        $this->assertDatabaseMissing( 'menu_location_assignments', [
+            'theme'    => $this->themeSlug,
+            'location' => 'primary',
+        ] );
+    } );
+
+    it( 'returns 404 when nothing was assigned', function (): void {
+        $this->actingAs( $this->user );
+
+        $this->deleteJson( '/api/v1/menu-locations/primary' )->assertNotFound();
+    } );
+} );

--- a/tests/Feature/SiteEditor/MenusApiTest.php
+++ b/tests/Feature/SiteEditor/MenusApiTest.php
@@ -134,6 +134,34 @@ describe( 'GET /api/v1/menus/{id_or_slug}', function (): void {
 
         $this->getJson( '/api/v1/menus/main' )->assertNotFound();
     } );
+
+    it( 'prefers a slug match over a same-numbered id when both exist', function (): void {
+        // Two menus: one whose `id` happens to be 1, one whose `slug` is "1".
+        $first = Menu::create( [ 'theme' => $this->themeSlug, 'slug' => 'first', 'name' => 'First' ] );
+
+        $second = Menu::create( [ 'theme' => $this->themeSlug, 'slug' => (string) $first->id, 'name' => 'Slug Wins' ] );
+
+        $this->actingAs( $this->user );
+
+        $response = $this->getJson( '/api/v1/menus/' . $first->id );
+
+        // Slug match wins — `/menus/1` resolves to the menu with slug "1",
+        // not the menu with id 1, so a numeric-only slug stays reachable.
+        $response->assertOk();
+        expect( $response->json( 'id' ) )->toBe( $second->id )
+            ->and( $response->json( 'slug' ) )->toBe( (string) $first->id );
+    } );
+
+    it( 'falls back to id lookup when no slug matches', function (): void {
+        $menu = Menu::create( [ 'theme' => $this->themeSlug, 'slug' => 'main', 'name' => 'Main' ] );
+
+        $this->actingAs( $this->user );
+
+        $response = $this->getJson( '/api/v1/menus/' . $menu->id );
+
+        $response->assertOk();
+        expect( $response->json( 'id' ) )->toBe( $menu->id );
+    } );
 } );
 
 describe( 'PUT /api/v1/menus/{id_or_slug}', function (): void {

--- a/tests/Feature/SiteEditor/MenusApiTest.php
+++ b/tests/Feature/SiteEditor/MenusApiTest.php
@@ -1,0 +1,199 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Models\Menu;
+use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Models\MenuItem;
+use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Models\MenuLocationAssignment;
+use ArtisanPackUI\CMSFramework\Modules\Themes\Managers\ThemeManager;
+use ArtisanPackUI\CMSFramework\Tests\Support\TestUser;
+
+beforeEach( function (): void {
+    $this->user      = TestUser::factory()->create();
+    $this->themeSlug = 'test-theme';
+
+    $this->mock( ThemeManager::class, function ( $mock ): void {
+        $mock->shouldReceive( 'getActiveTheme' )->andReturn( [
+            'name' => 'Test',
+            'slug' => $this->themeSlug,
+        ] );
+    } );
+} );
+
+describe( 'GET /api/v1/menus', function (): void {
+    it( 'requires authentication', function (): void {
+        $this->getJson( '/api/v1/menus' )->assertUnauthorized();
+    } );
+
+    it( 'returns menus scoped to the active theme in WP shape', function (): void {
+        Menu::create( [ 'theme' => $this->themeSlug, 'slug' => 'main', 'name' => 'Main' ] );
+        Menu::create( [ 'theme' => 'other', 'slug' => 'other-main', 'name' => 'Other' ] );
+
+        $this->actingAs( $this->user );
+
+        $response = $this->getJson( '/api/v1/menus' );
+
+        $response->assertOk();
+        $response->assertJsonStructure( [ '*' => [ 'id', 'name', 'slug', 'description', 'meta', 'locations', 'auto_add_pages', 'theme' ] ] );
+
+        $slugs = collect( $response->json() )->pluck( 'slug' )->all();
+
+        expect( $slugs )->toBe( [ 'main' ] );
+    } );
+
+    it( 'surfaces assigned locations on each menu', function (): void {
+        $menu = Menu::create( [ 'theme' => $this->themeSlug, 'slug' => 'main', 'name' => 'Main' ] );
+
+        MenuLocationAssignment::create( [
+            'theme'    => $this->themeSlug,
+            'location' => 'primary',
+            'menu_id'  => $menu->id,
+        ] );
+
+        $this->actingAs( $this->user );
+
+        $response = $this->getJson( '/api/v1/menus' );
+
+        expect( $response->json( '0.locations' ) )->toBe( [ 'primary' ] );
+    } );
+} );
+
+describe( 'POST /api/v1/menus', function (): void {
+    it( 'creates a menu against the active theme', function (): void {
+        $this->actingAs( $this->user );
+
+        $response = $this->postJson( '/api/v1/menus', [
+            'slug' => 'main',
+            'name' => 'Main',
+        ] );
+
+        $response->assertCreated();
+
+        expect( $response->json( 'slug' ) )->toBe( 'main' )
+            ->and( $response->json( 'theme' ) )->toBe( $this->themeSlug );
+
+        $this->assertDatabaseHas( 'menus', [
+            'theme' => $this->themeSlug,
+            'slug'  => 'main',
+        ] );
+    } );
+
+    it( 'returns 409 on slug collision within the active theme', function (): void {
+        Menu::create( [ 'theme' => $this->themeSlug, 'slug' => 'main', 'name' => 'Existing' ] );
+
+        $this->actingAs( $this->user );
+
+        $response = $this->postJson( '/api/v1/menus', [
+            'slug' => 'main',
+            'name' => 'Duplicate',
+        ] );
+
+        $response->assertStatus( 409 );
+    } );
+
+    it( 'rejects invalid slugs (non kebab-case)', function (): void {
+        $this->actingAs( $this->user );
+
+        $response = $this->postJson( '/api/v1/menus', [
+            'slug' => 'Bad_Slug!',
+            'name' => 'Bad',
+        ] );
+
+        $response->assertStatus( 422 );
+        $response->assertJsonValidationErrors( [ 'slug' ] );
+    } );
+} );
+
+describe( 'GET /api/v1/menus/{id_or_slug}', function (): void {
+    it( 'shows a menu by integer id', function (): void {
+        $menu = Menu::create( [ 'theme' => $this->themeSlug, 'slug' => 'main', 'name' => 'Main' ] );
+
+        $this->actingAs( $this->user );
+
+        $response = $this->getJson( '/api/v1/menus/' . $menu->id );
+
+        $response->assertOk();
+        expect( $response->json( 'id' ) )->toBe( $menu->id );
+    } );
+
+    it( 'shows a menu by slug', function (): void {
+        Menu::create( [ 'theme' => $this->themeSlug, 'slug' => 'main', 'name' => 'Main' ] );
+
+        $this->actingAs( $this->user );
+
+        $response = $this->getJson( '/api/v1/menus/main' );
+
+        $response->assertOk();
+        expect( $response->json( 'slug' ) )->toBe( 'main' );
+    } );
+
+    it( 'returns 404 for menus belonging to other themes', function (): void {
+        Menu::create( [ 'theme' => 'other', 'slug' => 'main', 'name' => 'Other' ] );
+
+        $this->actingAs( $this->user );
+
+        $this->getJson( '/api/v1/menus/main' )->assertNotFound();
+    } );
+} );
+
+describe( 'PUT /api/v1/menus/{id_or_slug}', function (): void {
+    it( 'updates menu metadata', function (): void {
+        $menu = Menu::create( [ 'theme' => $this->themeSlug, 'slug' => 'main', 'name' => 'Old Name' ] );
+
+        $this->actingAs( $this->user );
+
+        $response = $this->putJson( '/api/v1/menus/' . $menu->id, [
+            'name'        => 'New Name',
+            'description' => 'Updated',
+        ] );
+
+        $response->assertOk();
+        expect( $response->json( 'name' ) )->toBe( 'New Name' )
+            ->and( $response->json( 'description' ) )->toBe( 'Updated' );
+    } );
+
+    it( 'rejects slug renames', function (): void {
+        $menu = Menu::create( [ 'theme' => $this->themeSlug, 'slug' => 'main', 'name' => 'Main' ] );
+
+        $this->actingAs( $this->user );
+
+        $this->putJson( '/api/v1/menus/' . $menu->id, [
+            'slug' => 'renamed',
+            'name' => 'Main',
+        ] )->assertStatus( 422 );
+    } );
+} );
+
+describe( 'DELETE /api/v1/menus/{id_or_slug}', function (): void {
+    it( 'cascades to items and location assignments', function (): void {
+        $menu = Menu::create( [ 'theme' => $this->themeSlug, 'slug' => 'main', 'name' => 'Main' ] );
+
+        $item = MenuItem::create( [
+            'menu_id'  => $menu->id,
+            'position' => 0,
+            'type'     => MenuItem::TYPE_LINK,
+            'label'    => 'Home',
+            'url'      => '/',
+        ] );
+
+        MenuLocationAssignment::create( [
+            'theme'    => $this->themeSlug,
+            'location' => 'primary',
+            'menu_id'  => $menu->id,
+        ] );
+
+        $this->actingAs( $this->user );
+
+        $this->deleteJson( '/api/v1/menus/' . $menu->id )->assertNoContent();
+
+        expect( Menu::query()->find( $menu->id ) )->toBeNull()
+            ->and( MenuItem::query()->find( $item->id ) )->toBeNull()
+            ->and( MenuLocationAssignment::query()->where( 'menu_id', $menu->id )->exists() )->toBeFalse();
+    } );
+
+    it( 'returns 404 for unknown menus', function (): void {
+        $this->actingAs( $this->user );
+
+        $this->deleteJson( '/api/v1/menus/9999' )->assertNotFound();
+    } );
+} );

--- a/tests/Unit/SiteEditor/MenuResolverTest.php
+++ b/tests/Unit/SiteEditor/MenuResolverTest.php
@@ -1,0 +1,219 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Models\Menu;
+use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Models\MenuItem;
+use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Models\MenuLocationAssignment;
+use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Resolution\MenuResolver;
+use ArtisanPackUI\CMSFramework\Modules\Themes\Managers\ThemeManager;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses( RefreshDatabase::class );
+
+beforeEach( function (): void {
+    $this->themeSlug = 'test-theme';
+
+    config()->set( 'cms.menus.locations', [
+        'primary' => 'Primary Menu',
+        'footer'  => 'Footer Menu',
+    ] );
+
+    $themeManager = $this->mock( ThemeManager::class, function ( $mock ): void {
+        $mock->shouldReceive( 'getActiveTheme' )->andReturn( [
+            'name' => 'Test',
+            'slug' => $this->themeSlug,
+        ] );
+    } );
+
+    $this->resolver = new MenuResolver( $themeManager );
+} );
+
+describe( 'MenuResolver::all()', function (): void {
+    it( 'returns every declared location, including unassigned, keyed by location', function (): void {
+        $resolved = $this->resolver->all();
+
+        expect( $resolved )->toHaveCount( 2 )
+            ->and( array_keys( $resolved ) )->toBe( [ 'primary', 'footer' ] );
+
+        expect( $resolved['primary']['wp_id'] )->toBeNull()
+            ->and( $resolved['primary']['items'] )->toBe( [] )
+            ->and( $resolved['primary']['name'] )->toBe( 'Primary Menu' )
+            ->and( $resolved['footer']['wp_id'] )->toBeNull();
+    } );
+
+    it( 'fills wp_id and the menu name when a location is assigned', function (): void {
+        $menu = Menu::create( [
+            'theme' => $this->themeSlug,
+            'slug'  => 'main',
+            'name'  => 'Main Navigation',
+        ] );
+
+        MenuLocationAssignment::create( [
+            'theme'    => $this->themeSlug,
+            'location' => 'primary',
+            'menu_id'  => $menu->id,
+        ] );
+
+        $resolved = $this->resolver->all();
+
+        expect( $resolved['primary']['wp_id'] )->toBe( $menu->id )
+            ->and( $resolved['primary']['name'] )->toBe( 'Main Navigation' );
+    } );
+
+    it( 'projects items into the navigation block shape with hierarchy reconstructed', function (): void {
+        $menu = Menu::create( [
+            'theme' => $this->themeSlug,
+            'slug'  => 'main',
+            'name'  => 'Main',
+        ] );
+
+        MenuLocationAssignment::create( [
+            'theme'    => $this->themeSlug,
+            'location' => 'primary',
+            'menu_id'  => $menu->id,
+        ] );
+
+        $home = MenuItem::create( [
+            'menu_id'  => $menu->id,
+            'position' => 0,
+            'type'     => MenuItem::TYPE_LINK,
+            'label'    => 'Home',
+            'url'      => '/',
+        ] );
+
+        $about = MenuItem::create( [
+            'menu_id'  => $menu->id,
+            'position' => 1,
+            'type'     => MenuItem::TYPE_SUBMENU,
+            'label'    => 'About',
+        ] );
+
+        MenuItem::create( [
+            'menu_id'   => $menu->id,
+            'parent_id' => $about->id,
+            'position'  => 0,
+            'type'      => MenuItem::TYPE_LINK,
+            'label'     => 'Team',
+            'url'       => '/about/team',
+        ] );
+
+        MenuItem::create( [
+            'menu_id'   => $menu->id,
+            'parent_id' => $about->id,
+            'position'  => 1,
+            'type'      => MenuItem::TYPE_LINK,
+            'label'     => 'Contact',
+            'url'       => '/about/contact',
+        ] );
+
+        $resolved = $this->resolver->all();
+
+        $items = $resolved['primary']['items'];
+
+        expect( $items )->toHaveCount( 2 )
+            ->and( $items[0]['label'] )->toBe( 'Home' )
+            ->and( $items[1]['label'] )->toBe( 'About' )
+            ->and( $items[1]['type'] )->toBe( MenuItem::TYPE_SUBMENU )
+            ->and( $items[1]['children'] )->toHaveCount( 2 )
+            ->and( $items[1]['children'][0]['label'] )->toBe( 'Team' )
+            ->and( $items[1]['children'][1]['label'] )->toBe( 'Contact' );
+    } );
+
+    it( 'flags page-list items as dynamic without enumerating pages', function (): void {
+        $menu = Menu::create( [
+            'theme' => $this->themeSlug,
+            'slug'  => 'main',
+            'name'  => 'Main',
+        ] );
+
+        MenuLocationAssignment::create( [
+            'theme'    => $this->themeSlug,
+            'location' => 'primary',
+            'menu_id'  => $menu->id,
+        ] );
+
+        MenuItem::create( [
+            'menu_id'  => $menu->id,
+            'position' => 0,
+            'type'     => MenuItem::TYPE_PAGE_LIST,
+            'label'    => 'Pages',
+        ] );
+
+        $resolved = $this->resolver->all();
+
+        $first = $resolved['primary']['items'][0];
+
+        expect( $first['type'] )->toBe( MenuItem::TYPE_PAGE_LIST )
+            ->and( $first['dynamic'] )->toBe( MenuItem::TYPE_PAGE_LIST );
+    } );
+
+    it( 'isolates assignments by theme — switching themes hides prior theme assignments', function (): void {
+        $menu = Menu::create( [
+            'theme' => 'other-theme',
+            'slug'  => 'main',
+            'name'  => 'Main',
+        ] );
+
+        MenuLocationAssignment::create( [
+            'theme'    => 'other-theme',
+            'location' => 'primary',
+            'menu_id'  => $menu->id,
+        ] );
+
+        $resolved = $this->resolver->all();
+
+        // Active theme is `test-theme`; the `other-theme` assignment must
+        // not surface.
+        expect( $resolved['primary']['wp_id'] )->toBeNull();
+    } );
+
+    it( 'returns an empty array when there is no active theme', function (): void {
+        $themeManager = $this->mock( ThemeManager::class, function ( $mock ): void {
+            $mock->shouldReceive( 'getActiveTheme' )->andReturn( null );
+        } );
+
+        $resolver = new MenuResolver( $themeManager );
+
+        expect( $resolver->all() )->toBe( [] );
+    } );
+} );
+
+describe( 'MenuResolver::resolve()', function (): void {
+    it( 'returns a single resolved location entry', function (): void {
+        $entry = $this->resolver->resolve( 'primary' );
+
+        expect( $entry )->toBeArray()
+            ->and( $entry['location'] )->toBe( 'primary' );
+    } );
+
+    it( 'returns null for an unknown location key', function (): void {
+        expect( $this->resolver->resolve( 'sidebar' ) )->toBeNull();
+    } );
+} );
+
+describe( 'MenuResolver::revert()', function (): void {
+    it( 'unassigns a location while preserving the underlying menu', function (): void {
+        $menu = Menu::create( [
+            'theme' => $this->themeSlug,
+            'slug'  => 'main',
+            'name'  => 'Main',
+        ] );
+
+        MenuLocationAssignment::create( [
+            'theme'    => $this->themeSlug,
+            'location' => 'primary',
+            'menu_id'  => $menu->id,
+        ] );
+
+        $reverted = $this->resolver->revert( 'primary' );
+
+        expect( $reverted )->toBeTrue()
+            ->and( Menu::query()->find( $menu->id ) )->not->toBeNull()
+            ->and( MenuLocationAssignment::query()->where( 'location', 'primary' )->exists() )->toBeFalse();
+    } );
+
+    it( 'returns false when no assignment exists', function (): void {
+        expect( $this->resolver->revert( 'primary' ) )->toBeFalse();
+    } );
+} );

--- a/tests/Unit/SiteEditor/MenusSupportTest.php
+++ b/tests/Unit/SiteEditor/MenusSupportTest.php
@@ -1,0 +1,175 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Models\Menu;
+use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Models\MenuLocationAssignment;
+use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Support\Menus;
+use ArtisanPackUI\CMSFramework\Modules\Themes\Managers\ThemeManager;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Log;
+
+uses( RefreshDatabase::class );
+
+beforeEach( function (): void {
+    $this->themeSlug = 'test-theme';
+
+    config()->set( 'cms.menus.locations', [
+        'primary' => 'Primary Menu',
+        'footer'  => 'Footer Menu',
+    ] );
+} );
+
+describe( 'Menus::locations()', function (): void {
+    it( 'returns app config defaults when there is no active theme', function (): void {
+        $this->mock( ThemeManager::class, function ( $mock ): void {
+            $mock->shouldReceive( 'getActiveTheme' )->andReturn( null );
+        } );
+
+        expect( Menus::locations() )->toBe( [
+            'primary' => 'Primary Menu',
+            'footer'  => 'Footer Menu',
+        ] );
+    } );
+
+    it( 'merges theme.json overrides on top of app defaults — theme wins on collision', function (): void {
+        $this->mock( ThemeManager::class, function ( $mock ): void {
+            $mock->shouldReceive( 'getActiveTheme' )->andReturn( [
+                'name'  => 'Test',
+                'slug'  => $this->themeSlug,
+                'menus' => [
+                    'locations' => [
+                        'primary' => 'Theme Primary',
+                        'sidebar' => 'Sidebar',
+                    ],
+                ],
+            ] );
+        } );
+
+        $resolved = Menus::locations();
+
+        expect( $resolved )->toBe( [
+            'primary' => 'Theme Primary',
+            'footer'  => 'Footer Menu',
+            'sidebar' => 'Sidebar',
+        ] );
+    } );
+
+    it( 'logs a warning when the theme overrides an app-config location key', function (): void {
+        $this->mock( ThemeManager::class, function ( $mock ): void {
+            $mock->shouldReceive( 'getActiveTheme' )->andReturn( [
+                'name'  => 'Test',
+                'slug'  => $this->themeSlug,
+                'menus' => [
+                    'locations' => [ 'primary' => 'Theme Primary' ],
+                ],
+            ] );
+        } );
+
+        Log::shouldReceive( 'warning' )
+            ->once()
+            ->with(
+                'Theme `theme.json` menus.locations key overrides app config(\'cms.menus.locations\').',
+                Mockery::on( static function ( array $context ): bool {
+                    return 'primary' === $context['location']
+                        && 'Primary Menu' === $context['app_label'];
+                } ),
+            );
+
+        Menus::locations();
+    } );
+
+    it( 'does not warn when theme adds a key the app does not provide', function (): void {
+        $this->mock( ThemeManager::class, function ( $mock ): void {
+            $mock->shouldReceive( 'getActiveTheme' )->andReturn( [
+                'slug'  => $this->themeSlug,
+                'menus' => [
+                    'locations' => [ 'sidebar' => 'Sidebar' ],
+                ],
+            ] );
+        } );
+
+        Log::shouldReceive( 'warning' )->never();
+
+        $resolved = Menus::locations();
+
+        expect( $resolved )->toHaveKey( 'sidebar', 'Sidebar' );
+    } );
+
+    it( 'ignores malformed locations entries (non-string keys or values)', function (): void {
+        $this->mock( ThemeManager::class, function ( $mock ): void {
+            $mock->shouldReceive( 'getActiveTheme' )->andReturn( [
+                'slug'  => $this->themeSlug,
+                'menus' => [
+                    'locations' => [
+                        ''        => 'Empty Key',
+                        'sidebar' => null,
+                        'banner'  => 42,
+                    ],
+                ],
+            ] );
+        } );
+
+        $resolved = Menus::locations();
+
+        expect( $resolved )->toHaveKey( 'banner', '42' )
+            ->and( $resolved )->not->toHaveKey( '' )
+            ->and( $resolved )->not->toHaveKey( 'sidebar' );
+    } );
+} );
+
+describe( 'Menus::assign() / unassign() / assigned()', function (): void {
+    beforeEach( function (): void {
+        $this->mock( ThemeManager::class, function ( $mock ): void {
+            $mock->shouldReceive( 'getActiveTheme' )->andReturn( [
+                'slug' => $this->themeSlug,
+            ] );
+        } );
+
+        $this->menu = Menu::create( [
+            'theme' => $this->themeSlug,
+            'slug'  => 'main',
+            'name'  => 'Main',
+        ] );
+    } );
+
+    it( 'creates an assignment row on first assign', function (): void {
+        Menus::assign( 'primary', $this->menu->id );
+
+        $row = MenuLocationAssignment::query()->where( 'theme', $this->themeSlug )->where( 'location', 'primary' )->first();
+
+        expect( $row )->not->toBeNull()
+            ->and( (int) $row->menu_id )->toBe( $this->menu->id );
+    } );
+
+    it( 'reassigns by upserting the row in place', function (): void {
+        $other = Menu::create( [
+            'theme' => $this->themeSlug,
+            'slug'  => 'alt',
+            'name'  => 'Alt',
+        ] );
+
+        Menus::assign( 'primary', $this->menu->id );
+        Menus::assign( 'primary', $other->id );
+
+        expect( MenuLocationAssignment::query()->where( 'theme', $this->themeSlug )->where( 'location', 'primary' )->count() )->toBe( 1 )
+            ->and( Menus::assigned( 'primary' )?->id )->toBe( $other->id );
+    } );
+
+    it( 'unassign removes the row and returns true', function (): void {
+        Menus::assign( 'primary', $this->menu->id );
+
+        expect( Menus::unassign( 'primary' ) )->toBeTrue()
+            ->and( Menus::assigned( 'primary' ) )->toBeNull();
+    } );
+
+    it( 'unassign returns false when nothing was assigned', function (): void {
+        expect( Menus::unassign( 'primary' ) )->toBeFalse();
+    } );
+
+    it( 'assigned returns the menu model when assigned', function (): void {
+        Menus::assign( 'primary', $this->menu->id );
+
+        expect( Menus::assigned( 'primary' )?->id )->toBe( $this->menu->id );
+    } );
+} );


### PR DESCRIPTION
## Description

Adds the fourth and final cms-framework backend in Phase H — site-editor menus. Menus are DB-only (themes contribute *location names* via `theme.json` `menus.locations`, but never menu *content*). Closing this issue unblocks visual-editor's H6 (WP-shape adapters / `addEntities` / sidebars) by providing `/menus` and `/menu-items` endpoints to wrap, and gives the `ap.visual-editor.navigation` filter a real backend (it currently has no producer behind it).

**Closes:** #114

## Type of Change

- [x] New feature (adds new functionality)

## Related Issue

**Issue:** #114

## Motivation and Context

H4 is the last of the four parallelizable cms-framework backends after H0 (#100). H1 (#108), H2 (#110), and H3 (#112) all merged on `release/1.2`. Per plan 14 §3, the editor surface phases (H5/H6/H7/H8 in visual-editor) need at least one of H1–H4 backends live before they can resolve resources; H5 (visual-editor #407) shipped against the H1/H2/H3 contracts. H4 completes the H1–H4 set so the menus filter has a producer behind it.

Per plan 14 §8 H4 row, all three menu-item link types (`link` / `submenu` / `page-list`) ship together — the plan called this out as needing extra time at kickoff and confirmed all three are needed for parity.

## Changes Made

- **Models (3):** `Menu`, `MenuItem`, `MenuLocationAssignment` with relations + Eloquent-level cascade so deletion behavior is consistent regardless of whether the driver enforces FK constraints (notably SQLite needs `PRAGMA foreign_keys`).
- **Migrations (3):** `menus`, `menu_items`, `menu_location_assignments` with `(theme, slug)` / `(menu_id, parent_id, position)` / `(theme, location)` indexes and FK declarations.
- **`MenuResolver`:** projects items into the upstream `core/navigation-link` / `core/navigation-submenu` / `core/page-list` shapes with hierarchy reconstructed by `(parent_id, position)`. Unassigned theme-declared locations surface with `wp_id => null` and an empty `items` array so editor surfaces can render empty slots. Page-list items render as a dynamic placeholder (`'dynamic' => 'page-list'`) — the resolver does not enumerate pages, keeping cms-framework decoupled from Phase G content types.
- **`Menus` support service:** `locations()` (config + theme.json merge, theme wins on key collision per §5.4, warning logged), `assign() / unassign() / assigned()`.
- **REST API (under `/api/v1/`):** `/menus`, `/menu-items?menus={id}`, `/menu-locations` in WP `/wp/v2/menus` + `/wp/v2/menu-items` shape. `MenuItemResource` exposes both the WP-side `type` (`custom` / `post_type` / `taxonomy`) and the cms-side `link_type` (`link` / `submenu` / `page-list`) for visual-editor's adapter.
- **`SiteEditorServiceProvider`:** binds `MenuResolver` as a singleton and registers the `ap.visual-editor.navigation` filter callback behind the existing `class_exists(VisualEditor::class)` guard with the same `array_merge` order as H1/H2/H3 — static config wins on key collision.

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS Darwin 25.4.0
- PHP Version: 8.4.3
- Project Version: 1.2.0-dev (release/1.2 branch)

**Tests Performed:**
1. Unit + Feature suite: `php -d memory_limit=512M ./vendor/bin/pest --compact` — 832 passed (4 pre-existing skips), 2,202 assertions.
2. SiteEditor-only: `./vendor/bin/pest tests/Feature/SiteEditor tests/Unit/SiteEditor` — 171 passed.
3. Linters: `./vendor/bin/php-cs-fixer fix --dry-run --diff` clean (0 fixable files).

## Accessibility Tests Run

Not applicable — backend-only change (REST API + service classes). No UI surface in this PR.

- [x] Keyboard navigation tested (n/a — no UI)
- [x] Screen reader tested (n/a — no UI)
- [x] Color contrast verified (n/a — no UI)
- [x] ARIA labels checked (n/a — no UI)

## Tests Added

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] All tests passing

**Test details:**

53 new tests across 6 files:

- `tests/Unit/SiteEditor/MenuResolverTest.php` — projection (link / submenu / page-list), hierarchy reconstruction, unassigned-location surfacing, theme isolation, `revert()` semantics.
- `tests/Unit/SiteEditor/MenusSupportTest.php` — locations merge order (config → theme.json), theme-wins precedence, warning emission on collision, malformed-input normalization, `assign()`/`unassign()`/`assigned()` round-trip.
- `tests/Feature/SiteEditor/MenusApiTest.php` — REST CRUD, theme-scoped listing, slug-collision 409, slug-rename rejection, cascade-on-delete (items + assignments).
- `tests/Feature/SiteEditor/MenuItemsApiTest.php` — `(parent_id, position)` ordering, link-type validation, `(object, object_id)` pairing, parent-belongs-to-same-menu enforcement, `menus` field prohibited on update, cascade to children.
- `tests/Feature/SiteEditor/MenuLocationsApiTest.php` — list + assign + unassign, undeclared-location 404, cross-theme-menu 422.
- `tests/Feature/SiteEditor/MenuFiltersTest.php` — `ap.visual-editor.navigation` round-trip and static-config-wins precedence on collision.

## Documentation

- [x] Inline code documentation added
- [x] README updated (n/a — section in `docs/site-editor.md` is the documentation surface)
- [ ] Wiki updated (deferred to release notes)
- [x] API documentation updated

**Documentation details:**

`docs/site-editor.md` gains a "Menus" section documenting the storage model, locations resolution order, all REST endpoints with WP-shape examples, the resolver projection contract, the kickoff link-types decision, and the cascade behavior. The "Resolver contract", "Permissions", "Service registration", and "Coordination with visual-editor" sections were updated to reflect the new resolver / filter / endpoints.

## Pre-Submission Checklist

- [x] Followed contributing guidelines
- [x] Checked for other open PRs for same update
- [x] Code passes all tests
- [x] Code has been linted (php-cs-fixer clean)
- [x] Accessibility tests completed (n/a — backend only)
- [x] Code follows project style guide
- [x] Self-review completed
- [x] Comments added for complex code
- [x] No new warnings generated (phpcs noise matches existing pre-existing baseline of 1,398 violations across the codebase; H4 files use the same `declare( strict_types=1 );` / `where()` / magic-method patterns as H1/H2/H3)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Full navigation menu system: create/manage menus, nested menu items, and assign menus to theme locations via REST APIs

* **Visual Editor**
  * Integration exposes resolved menus by location into the editor’s navigation map

* **Documentation**
  * Site Editor docs updated with a complete Menus specification and resolver behavior

* **Tests**
  * Added feature and unit tests covering APIs, resolver logic, support utilities, and editor filter wiring
<!-- end of auto-generated comment: release notes by coderabbit.ai -->