### PR TITLE
fix: schema-guard ap.visual-editor.* filter callbacks against missing tables

### DIFF
--- a/src/Modules/SiteEditor/Providers/SiteEditorServiceProvider.php
+++ b/src/Modules/SiteEditor/Providers/SiteEditorServiceProvider.php
@@ -29,6 +29,7 @@ use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Resolution\TemplateResolver;
 use ArtisanPackUI\CMSFramework\Modules\Themes\Managers\ThemeManager;
 use ArtisanPackUI\VisualEditor\VisualEditor;
 use Illuminate\Support\Facades\Blade;
+use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\ServiceProvider;
 
 /**
@@ -100,14 +101,26 @@ class SiteEditorServiceProvider extends ServiceProvider
         }
 
         addFilter( 'ap.visual-editor.templates', function ( array $templates ): array {
+            if ( ! Schema::hasTable( 'templates' ) ) {
+                return $templates;
+            }
+
             return array_merge( $this->buildTemplateFilterMap( $this->app->make( TemplateResolver::class ) ), $templates );
         } );
 
         addFilter( 'ap.visual-editor.template-parts', function ( array $parts ): array {
+            if ( ! Schema::hasTable( 'template_parts' ) ) {
+                return $parts;
+            }
+
             return array_merge( $this->buildTemplateFilterMap( $this->app->make( TemplatePartResolver::class ) ), $parts );
         } );
 
         addFilter( 'ap.visual-editor.patterns', function ( array $patterns ): array {
+            if ( ! Schema::hasTable( 'block_patterns' ) ) {
+                return $patterns;
+            }
+
             return array_merge( $this->app->make( PatternResolver::class )->toFilterMap(), $patterns );
         } );
 
@@ -116,6 +129,10 @@ class SiteEditorServiceProvider extends ServiceProvider
         // the prior value (typically null from the default callback) only
         // surfaces when there is no active theme.
         addFilter( 'ap.visual-editor.global-styles', function ( $existing ) {
+            if ( ! Schema::hasTable( 'global_styles' ) ) {
+                return $existing;
+            }
+
             $resolved = $this->app->make( GlobalStylesResolver::class )->resolve();
 
             return null !== $resolved ? $resolved->toFilterEntry() : $existing;
@@ -126,6 +143,10 @@ class SiteEditorServiceProvider extends ServiceProvider
         // resolved map goes *under* the existing map so app-level config
         // (or earlier filter contributors) wins on key collision.
         addFilter( 'ap.visual-editor.navigation', function ( array $existing ): array {
+            if ( ! Schema::hasTable( 'menus' ) ) {
+                return $existing;
+            }
+
             return array_merge( $this->app->make( MenuResolver::class )->all(), $existing );
         } );
     }

--- a/tests/Feature/SiteEditor/SchemaGuardFilterCallbacksTest.php
+++ b/tests/Feature/SiteEditor/SchemaGuardFilterCallbacksTest.php
@@ -1,0 +1,96 @@
+<?php
+
+/**
+ * Regression test for #116 — filter callbacks must not crash when their
+ * underlying SiteEditor tables are missing.
+ *
+ * The five `ap.visual-editor.*` filter callbacks registered by
+ * {@see SiteEditorServiceProvider::registerVisualEditorSiteEditorFilters()}
+ * eagerly query their primary tables. When visual-editor's H5 service
+ * provider applies these filters at `booted()` — which Laravel boots
+ * before host package migrations run — the un-guarded callbacks crashed
+ * with "no such table" `QueryException`s. The regression here drops the
+ * five tables, re-registers the filters, and asserts each callback
+ * returns its input value unchanged with no exception.
+ *
+ * @since      1.2.0
+ */
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Providers\SiteEditorServiceProvider;
+use Illuminate\Support\Facades\Schema;
+
+beforeEach( function (): void {
+	require_once __DIR__ . '/../../Support/VisualEditorClassStub.php';
+
+	// Drop the five SiteEditor tables to simulate boot-before-migrations.
+	// Each filter callback short-circuits via Schema::hasTable when its
+	// primary table is missing, so post-drop the filters must return the
+	// input value unchanged.
+	foreach ( [ 'menu_location_assignments', 'menu_items', 'menus', 'global_styles', 'block_patterns', 'template_parts', 'templates' ] as $table ) {
+		Schema::dropIfExists( $table );
+	}
+
+	foreach ( [
+		'ap.visual-editor.templates',
+		'ap.visual-editor.template-parts',
+		'ap.visual-editor.patterns',
+		'ap.visual-editor.global-styles',
+		'ap.visual-editor.navigation',
+	] as $filter ) {
+		removeAllFilters( $filter );
+	}
+
+	( new SiteEditorServiceProvider( app() ) )->registerVisualEditorSiteEditorFilters();
+} );
+
+afterEach( function (): void {
+	foreach ( [
+		'ap.visual-editor.templates',
+		'ap.visual-editor.template-parts',
+		'ap.visual-editor.patterns',
+		'ap.visual-editor.global-styles',
+		'ap.visual-editor.navigation',
+	] as $filter ) {
+		removeAllFilters( $filter );
+	}
+} );
+
+it( 'short-circuits ap.visual-editor.templates when the templates table is missing', function (): void {
+	$result = applyFilters( 'ap.visual-editor.templates', [ 'foo' => [ 'slug' => 'foo' ] ] );
+
+	expect( $result )->toBe( [ 'foo' => [ 'slug' => 'foo' ] ] );
+} );
+
+it( 'short-circuits ap.visual-editor.template-parts when the template_parts table is missing', function (): void {
+	$result = applyFilters( 'ap.visual-editor.template-parts', [ 'header' => [ 'slug' => 'header' ] ] );
+
+	expect( $result )->toBe( [ 'header' => [ 'slug' => 'header' ] ] );
+} );
+
+it( 'short-circuits ap.visual-editor.patterns when the block_patterns table is missing', function (): void {
+	$result = applyFilters( 'ap.visual-editor.patterns', [ 'hero' => [ 'slug' => 'hero' ] ] );
+
+	expect( $result )->toBe( [ 'hero' => [ 'slug' => 'hero' ] ] );
+} );
+
+it( 'short-circuits ap.visual-editor.global-styles when the global_styles table is missing', function (): void {
+	$existing = [ 'theme' => 'fallback', 'settings' => [], 'styles' => [], 'variations' => [] ];
+
+	$result = applyFilters( 'ap.visual-editor.global-styles', $existing );
+
+	expect( $result )->toBe( $existing );
+} );
+
+it( 'passes null through ap.visual-editor.global-styles when the table is missing and there is no prior value', function (): void {
+	$result = applyFilters( 'ap.visual-editor.global-styles', null );
+
+	expect( $result )->toBeNull();
+} );
+
+it( 'short-circuits ap.visual-editor.navigation when the menus table is missing', function (): void {
+	$result = applyFilters( 'ap.visual-editor.navigation', [ 'primary' => [ 'location' => 'primary' ] ] );
+
+	expect( $result )->toBe( [ 'primary' => [ 'location' => 'primary' ] ] );
+} );


### PR DESCRIPTION
## Description

Adds `Schema::hasTable()` guards to the five `ap.visual-editor.*` filter callbacks registered in `SiteEditorServiceProvider::registerVisualEditorSiteEditorFilters()`. Each callback short-circuits to its prior input value when its primary table is missing, which prevents boot from crashing in environments where filters fire before migrations finish.

**Closes:** #116

## Type of Change

- [x] Bug fix (fixes an issue)

## Related Issue

**Issue:** #116

## Motivation and Context

The five filter callbacks eagerly query their primary tables. When visual-editor's H5 service provider applies these filters at `booted()` — which Laravel runs **before** host package migrations in Orchestra Testbench — the un-guarded callbacks crashed with:

```
SQLSTATE[HY000]: General error: 1 no such table: block_patterns
in src/Modules/SiteEditor/Resolution/PatternResolver.php:87
```

The same crash will surface during a fresh `composer require artisanpack-ui/cms-framework` post-install hook (cache warm-up reads filters before migrations run) or in any multi-tenant boot path where the connection isn't ready when `booted()` fires.

## Changes Made

- `src/Modules/SiteEditor/Providers/SiteEditorServiceProvider.php`: imported `Illuminate\Support\Facades\Schema`; added `Schema::hasTable()` guards to all 5 filter callbacks
- `tests/Feature/SiteEditor/SchemaGuardFilterCallbacksTest.php`: 6 regression assertions covering each filter + a null-passthrough case for global-styles

## Tables guarded

| Filter | Table |
|---|---|
| `ap.visual-editor.templates` | `templates` |
| `ap.visual-editor.template-parts` | `template_parts` |
| `ap.visual-editor.patterns` | `block_patterns` |
| `ap.visual-editor.global-styles` | `global_styles` |
| `ap.visual-editor.navigation` | `menus` |

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS 25.4.0
- PHP Version: 8.4.3
- Project Version: cms-framework `release/1.2`

**Tests Performed:**
1. New regression test boots the provider, drops the SiteEditor tables, and asserts each `applyFilters` call returns the input unchanged with no exception (6 assertions, all pass)
2. Full `tests/Feature/SiteEditor/` suite re-run: 121 tests / 365 assertions pass — no happy-path regressions
3. Surfaced from visual-editor's H6 work (#431); confirmed visual-editor's `Tests\Feature\SiteEditor\CmsFrameworkBootstrapTest` now boots cleanly through the symlinked vendor

## Accessibility Tests Run

N/A — backend-only patch; no UI surface affected.

## Tests Added

- [x] Unit tests added/updated — Pest feature test under `tests/Feature/SiteEditor/SchemaGuardFilterCallbacksTest.php`
- [ ] Integration tests added/updated
- [x] All tests passing

**Test details:**
- 6 assertions in the new regression test (one per filter + null-passthrough)
- 121 existing SiteEditor feature tests still green

## Documentation

No public-API surface changed; the guards are an internal defensive layer. Inline code documentation on the new test file explains the regression scenario.

## Pre-Submission Checklist

- [x] Followed contributing guidelines
- [x] Checked for other open PRs for same update
- [x] Code passes all tests
- [x] Code has been linted (CodeRabbit local review pass: no findings)
- [x] Code follows project style guide
- [x] Self-review completed
- [x] Comments added for complex code
- [x] No new warnings generated

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness of site editor functionality by ensuring filters gracefully handle scenarios where underlying database components are unavailable.

* **Tests**
  * Added regression tests to verify site editor stability when expected database tables are missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->