### PR TITLE
feat(global-styles): emit preset class bindings so picker choices actually apply (Keystone #53)

### DIFF
--- a/src/Modules/SiteEditor/Emission/GlobalStylesEmitter.php
+++ b/src/Modules/SiteEditor/Emission/GlobalStylesEmitter.php
@@ -43,6 +43,21 @@ class GlobalStylesEmitter
     private const CACHE_TTL = 86400;
 
     /**
+     * Emitter-output schema version. Bumped whenever the structure of
+     * the CSS this emitter produces changes (new rule families, removed
+     * rules, reformatted selectors). The version is part of the cache
+     * key so a deploy with a bumped emitter automatically invalidates
+     * every cached entry — no manual `php artisan cache:clear` needed
+     * to pick up the new output. Bump on any meaningful emission diff.
+     *
+     * v2: emit `.has-{slug}-color` / `-background-color` / `-border-color`
+     * / `-font-size` / `-gradient-background` preset class bindings
+     * (Keystone #53). Without these the picker swatch lights up but
+     * neither the canvas nor the front-end visually applies the color.
+     */
+    private const SCHEMA_VERSION = 'v2';
+
+    /**
      * @since 1.2.0
      */
     public function __construct(
@@ -106,7 +121,7 @@ class GlobalStylesEmitter
      */
     protected function cacheKey(ResolvedGlobalStyles $resolved): string
     {
-        return 'cms.global-styles.css.'.$resolved->theme.'.'.$resolved->contentHash();
+        return 'cms.global-styles.css.'.self::SCHEMA_VERSION.'.'.$resolved->theme.'.'.$resolved->contentHash();
     }
 
     /**
@@ -138,7 +153,100 @@ class GlobalStylesEmitter
             $blocks[] = $rule;
         }
 
+        // Preset class bindings — Gutenberg adds `has-{slug}-color`,
+        // `has-{slug}-background-color`, `has-{slug}-font-size` etc.
+        // when the author picks a preset from the palette / font-size
+        // picker. Without a CSS rule binding those classes to the
+        // matching `--wp--preset--*` custom property the choice never
+        // visually applies — the picker swatch lights up but neither
+        // the canvas nor the front-end shows the color change
+        // (Keystone #53).
+        foreach ($this->presetClassBindings($resolved->settings) as $rule) {
+            $blocks[] = $rule;
+        }
+
         return implode("\n\n", $blocks);
+    }
+
+    /**
+     * Emit `.has-{slug}-color`, `-background-color`, `-border-color`,
+     * `-font-size`, and `-gradient-background` rules that bind each
+     * preset slug to its matching `--wp--preset--*` custom property.
+     *
+     * `!important` mirrors WordPress core's emission so a preset
+     * selection always overrides cascading default styles, the way
+     * the upstream block editor and front-end already behave.
+     *
+     * @since 1.2.0
+     *
+     * @param  array<string, mixed>  $settings
+     *
+     * @return array<int, string>
+     */
+    protected function presetClassBindings(array $settings): array
+    {
+        $rules = [];
+
+        $palette = is_array($settings['color']['palette'] ?? null)
+            ? $settings['color']['palette']
+            : [];
+
+        foreach ($this->presetSlugs($palette) as $slug) {
+            $var = '--wp--preset--color--'.$slug;
+
+            $rules[] = '.has-'.$slug.'-color { color: var('.$var.') !important; }';
+            $rules[] = '.has-'.$slug.'-background-color { background-color: var('.$var.') !important; }';
+            $rules[] = '.has-'.$slug.'-border-color { border-color: var('.$var.') !important; }';
+        }
+
+        $fontSizes = is_array($settings['typography']['fontSizes'] ?? null)
+            ? $settings['typography']['fontSizes']
+            : [];
+
+        foreach ($this->presetSlugs($fontSizes) as $slug) {
+            $rules[] = '.has-'.$slug.'-font-size { font-size: var(--wp--preset--font-size--'.$slug.') !important; }';
+        }
+
+        $gradients = is_array($settings['color']['gradients'] ?? null)
+            ? $settings['color']['gradients']
+            : [];
+
+        foreach ($this->presetSlugs($gradients) as $slug) {
+            $rules[] = '.has-'.$slug.'-gradient-background { background: var(--wp--preset--gradient--'.$slug.') !important; }';
+        }
+
+        return $rules;
+    }
+
+    /**
+     * Extract the kebab-cased slug list from a presets array, skipping
+     * malformed entries the same way {@see presetCustomProperties()} does.
+     *
+     * @since 1.2.0
+     *
+     * @param  array<int, mixed>  $items
+     *
+     * @return array<int, string>
+     */
+    protected function presetSlugs(array $items): array
+    {
+        $slugs = [];
+
+        foreach ($items as $item) {
+            if (! is_array($item)) {
+                continue;
+            }
+
+            $slug = $item['slug'] ?? null;
+
+            if (! is_string($slug) || '' === $slug) {
+                continue;
+            }
+
+            $slugs[] = $this->kebab($slug);
+        }
+
+        return $slugs;
     }
 
     /**

--- a/src/Modules/SiteEditor/Emission/GlobalStylesEmitter.php
+++ b/src/Modules/SiteEditor/Emission/GlobalStylesEmitter.php
@@ -191,7 +191,7 @@ class GlobalStylesEmitter
             ? $settings['color']['palette']
             : [];
 
-        foreach ($this->presetSlugs($palette) as $slug) {
+        foreach ($this->presetSlugs($palette, 'color') as $slug) {
             $var = '--wp--preset--color--'.$slug;
 
             $rules[] = '.has-'.$slug.'-color { color: var('.$var.') !important; }';
@@ -203,7 +203,7 @@ class GlobalStylesEmitter
             ? $settings['typography']['fontSizes']
             : [];
 
-        foreach ($this->presetSlugs($fontSizes) as $slug) {
+        foreach ($this->presetSlugs($fontSizes, 'size') as $slug) {
             $rules[] = '.has-'.$slug.'-font-size { font-size: var(--wp--preset--font-size--'.$slug.') !important; }';
         }
 
@@ -211,7 +211,7 @@ class GlobalStylesEmitter
             ? $settings['color']['gradients']
             : [];
 
-        foreach ($this->presetSlugs($gradients) as $slug) {
+        foreach ($this->presetSlugs($gradients, 'gradient') as $slug) {
             $rules[] = '.has-'.$slug.'-gradient-background { background: var(--wp--preset--gradient--'.$slug.') !important; }';
         }
 
@@ -220,15 +220,20 @@ class GlobalStylesEmitter
 
     /**
      * Extract the kebab-cased slug list from a presets array, skipping
-     * malformed entries the same way {@see presetCustomProperties()} does.
+     * malformed entries the same way {@see presetCustomProperties()} does
+     * — a slug alone isn't enough; the matching `$valueKey`
+     * (`color` / `size` / `gradient` / `fontFamily`) has to be a usable
+     * scalar too. Without the value guard a malformed entry would still
+     * emit a `.has-{slug}-*` rule pointing at an undeclared CSS var.
      *
      * @since 1.2.0
      *
      * @param  array<int, mixed>  $items
+     * @param  string             $valueKey  The required-non-empty value key per preset family.
      *
      * @return array<int, string>
      */
-    protected function presetSlugs(array $items): array
+    protected function presetSlugs(array $items, string $valueKey): array
     {
         $slugs = [];
 
@@ -237,9 +242,10 @@ class GlobalStylesEmitter
                 continue;
             }
 
-            $slug = $item['slug'] ?? null;
+            $slug  = $item['slug'] ?? null;
+            $value = $item[$valueKey] ?? null;
 
-            if (! is_string($slug) || '' === $slug) {
+            if (! is_string($slug) || '' === $slug || ! is_scalar($value)) {
                 continue;
             }
 

--- a/tests/Unit/SiteEditor/GlobalStylesEmitterTest.php
+++ b/tests/Unit/SiteEditor/GlobalStylesEmitterTest.php
@@ -222,6 +222,54 @@ describe('GlobalStylesEmitter::emit()', function (): void {
             ->toContain('.has-sunset-gradient-background { background: var(--wp--preset--gradient--sunset) !important; }');
     });
 
+    it('skips preset class bindings for malformed entries missing the value key (CodeRabbit follow-up on #53)', function (): void {
+        // A slug alone isn't enough — without a usable `color` / `size`
+        // / `gradient` we'd emit a `.has-{slug}-*` rule pointing at an
+        // undeclared CSS var. Match `presetCustomProperties()`'s
+        // existing malformed-entry filter so both code paths stay in
+        // lockstep.
+        $resolved = makeResolved(
+            settings: [
+                'color' => [
+                    'palette' => [
+                        ['slug' => 'good', 'color' => '#abcdef'],
+                        ['slug' => 'no-color'],
+                        ['slug' => 'null-color', 'color' => null],
+                        ['slug' => 'array-color', 'color' => ['#fff']],
+                    ],
+                    'gradients' => [
+                        ['slug' => 'good-gradient', 'gradient' => 'linear-gradient(...)'],
+                        ['slug' => 'no-gradient'],
+                    ],
+                ],
+                'typography' => [
+                    'fontSizes' => [
+                        ['slug' => 'good-size', 'size' => '14px'],
+                        ['slug' => 'no-size'],
+                    ],
+                ],
+            ],
+        );
+
+        $this->resolver->shouldReceive('resolve')->andReturn($resolved);
+
+        $css = $this->emitter->emit();
+
+        // Valid entries still emit.
+        expect($css)
+            ->toContain('.has-good-color { color: var(--wp--preset--color--good) !important; }')
+            ->and($css)->toContain('.has-good-gradient-gradient-background')
+            ->and($css)->toContain('.has-good-size-font-size');
+
+        // Malformed entries skipped — no rules referencing undefined vars.
+        expect($css)
+            ->not->toContain('.has-no-color')
+            ->and($css)->not->toContain('.has-null-color')
+            ->and($css)->not->toContain('.has-array-color')
+            ->and($css)->not->toContain('.has-no-gradient')
+            ->and($css)->not->toContain('.has-no-size');
+    });
+
     it('skips preset class bindings when the palette / font-size / gradient list is empty (Keystone #53)', function (): void {
         $resolved = makeResolved();
 

--- a/tests/Unit/SiteEditor/GlobalStylesEmitterTest.php
+++ b/tests/Unit/SiteEditor/GlobalStylesEmitterTest.php
@@ -153,6 +153,87 @@ describe('GlobalStylesEmitter::emit()', function (): void {
         expect($css)->toContain('--wp--custom--spacing--gutter: 24px;')
             ->and($css)->toContain('--wp--custom--font-size--tiny: 10px;');
     });
+
+    it('emits `.has-{slug}-color` / `-background-color` / `-border-color` rules for each palette preset (Keystone #53)', function (): void {
+        // Without these class bindings the editor picker sets
+        // `textColor: "accent"` (which renders as `has-accent-color`)
+        // but neither the canvas nor the front-end applies the
+        // color — the var is declared on `:root` but nothing binds
+        // the class to it.
+        $resolved = makeResolved(
+            settings: [
+                'color' => [
+                    'palette' => [
+                        ['slug' => 'primary', 'color' => '#0f172a'],
+                        ['slug' => 'accent-soft', 'color' => '#dbeafe'],
+                    ],
+                ],
+            ],
+        );
+
+        $this->resolver->shouldReceive('resolve')->andReturn($resolved);
+
+        $css = $this->emitter->emit();
+
+        expect($css)
+            ->toContain('.has-primary-color { color: var(--wp--preset--color--primary) !important; }')
+            ->and($css)->toContain('.has-primary-background-color { background-color: var(--wp--preset--color--primary) !important; }')
+            ->and($css)->toContain('.has-primary-border-color { border-color: var(--wp--preset--color--primary) !important; }')
+            ->and($css)->toContain('.has-accent-soft-color { color: var(--wp--preset--color--accent-soft) !important; }');
+    });
+
+    it('emits `.has-{slug}-font-size` rules for each font-size preset (Keystone #53)', function (): void {
+        $resolved = makeResolved(
+            settings: [
+                'typography' => [
+                    'fontSizes' => [
+                        ['slug' => 'small',  'size' => '12px'],
+                        ['slug' => 'medium', 'size' => '16px'],
+                    ],
+                ],
+            ],
+        );
+
+        $this->resolver->shouldReceive('resolve')->andReturn($resolved);
+
+        $css = $this->emitter->emit();
+
+        expect($css)
+            ->toContain('.has-small-font-size { font-size: var(--wp--preset--font-size--small) !important; }')
+            ->and($css)->toContain('.has-medium-font-size { font-size: var(--wp--preset--font-size--medium) !important; }');
+    });
+
+    it('emits `.has-{slug}-gradient-background` rules for each gradient preset (Keystone #53)', function (): void {
+        $resolved = makeResolved(
+            settings: [
+                'color' => [
+                    'gradients' => [
+                        ['slug' => 'sunset', 'gradient' => 'linear-gradient(...)'],
+                    ],
+                ],
+            ],
+        );
+
+        $this->resolver->shouldReceive('resolve')->andReturn($resolved);
+
+        $css = $this->emitter->emit();
+
+        expect($css)
+            ->toContain('.has-sunset-gradient-background { background: var(--wp--preset--gradient--sunset) !important; }');
+    });
+
+    it('skips preset class bindings when the palette / font-size / gradient list is empty (Keystone #53)', function (): void {
+        $resolved = makeResolved();
+
+        $this->resolver->shouldReceive('resolve')->andReturn($resolved);
+
+        $css = $this->emitter->emit();
+
+        // No empty-slug rules slipped through.
+        expect($css)->not->toMatch('/\.has--color\b/');
+        expect($css)->not->toMatch('/\.has--font-size\b/');
+        expect($css)->not->toMatch('/\.has--gradient-background\b/');
+    });
 });
 
 describe('GlobalStylesEmitter cache', function (): void {
@@ -177,7 +258,10 @@ describe('GlobalStylesEmitter cache', function (): void {
 
         $this->emitter->emit();
 
-        $cacheKey = 'cms.global-styles.css.test-theme.'.$resolved->contentHash();
+        // Cache key carries the schema version so a deploy with a
+        // bumped emitter automatically busts every cached entry
+        // (Keystone #53). Mirror that here.
+        $cacheKey = 'cms.global-styles.css.v2.test-theme.'.$resolved->contentHash();
         expect(Cache::has($cacheKey))->toBeTrue();
 
         $this->emitter->invalidate();


### PR DESCRIPTION
Closes [Keystone #53](https://gitlab.com/jacob-martella-web-design/jacob-martella-web-design/jmwd-keystone-cms/jmwd-keystone-cms/-/work_items/53). Paired with visual-editor PR #462 and jmwd-keystone-cms MR.

## The bug

The emitter shipped \`--wp--preset--color--{slug}\` custom properties on \`:root\` but never the class bindings that turn a *preset selection* into a *visual change*. Picking "Accent" set \`textColor: "accent"\` (rendered as \`has-accent-color has-text-color\`), but with no \`.has-accent-color { color: var(...) !important; }\` rule anywhere, neither canvas nor front-end applied the color.

## The fix

\`buildCss()\` now also emits the class bindings WordPress core ships for every preset slug:

- \`.has-{slug}-color\` / \`-background-color\` / \`-border-color\` for each \`settings.color.palette\` entry
- \`.has-{slug}-font-size\` for each \`settings.typography.fontSizes\` entry
- \`.has-{slug}-gradient-background\` for each \`settings.color.gradients\` entry

\`!important\` mirrors core's emission so a preset selection overrides cascading default styles.

## Cache invalidation

Bumped the cache key to include a \`SCHEMA_VERSION\` constant (\`v2\`). Without it a deploy with a new emitter would keep serving the old CSS from the long-TTL cache until somebody ran \`php artisan cache:clear\` by hand — a real deployment trap. Future emission changes bump the version constant and existing entries automatically drop.

## Tests

4 new emitter tests cover palette / font-size / gradient class bindings plus the empty-list guard. Existing invalidate-cache test updated to assert the versioned key. 857/861 cms-framework tests green (4 pre-existing skips).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds CSS class patterns from presets: .has-{slug}-color, .has-{slug}-background-color, .has-{slug}-border-color, .has-{slug}-font-size, and .has-{slug}-gradient-background.

* **Bug Fixes**
  * CSS cache key updated to include a schema version segment so cached styles are invalidated when the emission format changes.

* **Tests**
  * Expanded tests covering preset class output, malformed preset handling, absence of empty classes, and updated cache-key expectations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ArtisanPack-UI/cms-framework/pull/135?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->