### PR TITLE
fix: add by-key settings save path that applies sanitizers & types

### DIFF
--- a/docs/settings/Retrieving-and-Updating.md
+++ b/docs/settings/Retrieving-and-Updating.md
@@ -39,6 +39,47 @@ public function update(SettingsManager $settings)
 }
 ```
 
+## REST API
+
+### Saving registered settings (recommended)
+
+To update registered settings over HTTP, use the by-key bulk endpoint. Every value is routed through `SettingsManager::updateSetting()`, so the registered sanitizer callback **and** `SettingType` are applied — exactly as if you had called `apUpdateSetting()` in PHP.
+
+```http
+PUT /api/v1/settings
+Content-Type: application/json
+
+{
+  "settings": {
+    "site.title": "  My Site  ",
+    "site.logo_id": "42"
+  }
+}
+```
+
+The response echoes the freshly-stored, sanitized and cast values:
+
+```json
+{
+  "settings": {
+    "site.title": "My Site",
+    "site.logo_id": 42
+  }
+}
+```
+
+Notes:
+
+- Authorization goes through `SettingPolicy` (`settings.manage` by default, via the `settings.update` capability filter).
+- Every key in the payload must be **registered** (`apRegisterSetting`/`SettingsManager::registerSetting`). Unregistered keys are rejected with a `422` validation error, since there would be no sanitizer or type to apply.
+- This is the natural fit for an admin settings page that saves a group of keys at once.
+
+### Generic CRUD caveat
+
+The resourceful endpoints — `POST /api/v1/settings`, `PUT /api/v1/settings/{key}`, etc. — write **directly to the `Setting` model** and therefore **bypass the registered sanitizer callback and `SettingType`**. They are intended for ad-hoc, unregistered key/value storage.
+
+> **Do not use the generic CRUD to save registered settings.** Use `PUT /api/v1/settings` (above) or `apUpdateSetting()` so sanitizers and types are always applied.
+
 ## Default Resolution Order
 
 When you request a setting value using `getSetting($key, $default)` or `apGetSetting($key, $default)`, the value is resolved in this order:

--- a/src/Modules/Settings/Http/Controllers/SettingController.php
+++ b/src/Modules/Settings/Http/Controllers/SettingController.php
@@ -24,6 +24,7 @@ use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
 use Illuminate\Http\Response;
 use Illuminate\Routing\Controller;
+use Illuminate\Support\Facades\DB;
 
 /**
  * API controller for managing setting.
@@ -90,10 +91,14 @@ class SettingController extends Controller
         $values  = $request->validated()['settings'];
         $applied = [];
 
-        foreach ( $values as $key => $value ) {
-            $this->settings->updateSetting( $key, $value );
-            $applied[ $key ] = $this->settings->getSetting( $key );
-        }
+        // Persist the whole group atomically: if any key fails, no partial
+        // write survives and the caller can safely retry the same payload.
+        DB::transaction( function () use ( $values, &$applied ): void {
+            foreach ( $values as $key => $value ) {
+                $this->settings->updateSetting( $key, $value );
+                $applied[ $key ] = $this->settings->getSetting( $key );
+            }
+        } );
 
         return response()->json( ['settings' => $applied] );
     }
@@ -181,7 +186,7 @@ class SettingController extends Controller
     public function destroy( string|int $id ): Response // Correct return type hint
     {
         $setting = Setting::findOrFail( $id );
-        $this->authorize( 'delete', $setting);
+        $this->authorize( 'delete', $setting );
         $setting->delete();
 
         return response()->noContent();

--- a/src/Modules/Settings/Http/Controllers/SettingController.php
+++ b/src/Modules/Settings/Http/Controllers/SettingController.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare( strict_types=1 );
 
 /**
  * Setting Controller for the CMS Framework Settings Module.
@@ -13,8 +13,10 @@ declare(strict_types=1);
 
 namespace ArtisanPackUI\CMSFramework\Modules\Settings\Http\Controllers;
 
+use ArtisanPackUI\CMSFramework\Modules\Settings\Http\Requests\RegisteredSettingsRequest;
 use ArtisanPackUI\CMSFramework\Modules\Settings\Http\Requests\SettingRequest;
 use ArtisanPackUI\CMSFramework\Modules\Settings\Http\Resources\SettingResource;
+use ArtisanPackUI\CMSFramework\Modules\Settings\Managers\SettingsManager;
 use ArtisanPackUI\CMSFramework\Modules\Settings\Models\Setting;
 use Dedoc\Scramble\Attributes\Group;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
@@ -31,10 +33,14 @@ use Illuminate\Routing\Controller;
  *
  * @since 1.0.0
  */
-#[Group('Settings', weight: 13)]
+#[Group( 'Settings', weight: 13 )]
 class SettingController extends Controller
 {
     use AuthorizesRequests;
+
+    public function __construct( protected SettingsManager $settings )
+    {
+    }
 
     /**
      * Display a listing of settings.
@@ -48,11 +54,48 @@ class SettingController extends Controller
      */
     public function index(): AnonymousResourceCollection
     {
-        $this->authorize('viewAny', Setting::class);
+        $this->authorize( 'viewAny', Setting::class );
 
-        $settings = Setting::paginate(15);
+        $settings = Setting::paginate( 15 );
 
-        return SettingResource::collection($settings);
+        return SettingResource::collection( $settings );
+    }
+
+    /**
+     * Bulk-update one or more registered settings by key.
+     *
+     * Each supplied value is routed through `SettingsManager::updateSetting()`
+     * so the per-key sanitizer callback and registered `SettingType` always
+     * apply — unlike {@see store()}/{@see update()}, which write to the model
+     * directly and bypass both. Use this path for saving registered settings
+     * (e.g. an admin settings page); the generic ID/key CRUD remains for
+     * ad-hoc, unregistered keys.
+     *
+     * Unknown keys are rejected by {@see RegisteredSettingsRequest}, so every
+     * key reaching this method is guaranteed to be registered. The response
+     * echoes the freshly-read values so callers observe exactly what was
+     * persisted (sanitized and cast).
+     *
+     * @since 1.2.0
+     *
+     * @param  RegisteredSettingsRequest  $request  The request carrying the `settings` key/value map.
+     *
+     * @return JsonResponse The sanitized, persisted values keyed by setting key.
+     */
+    public function bulkUpdate( RegisteredSettingsRequest $request ): JsonResponse
+    {
+        $this->authorize( 'update', Setting::class );
+
+        /** @var array<string, mixed> $values */
+        $values  = $request->validated()['settings'];
+        $applied = [];
+
+        foreach ( $values as $key => $value ) {
+            $this->settings->updateSetting( $key, $value );
+            $applied[ $key ] = $this->settings->getSetting( $key );
+        }
+
+        return response()->json( ['settings' => $applied] );
     }
 
     /**
@@ -68,15 +111,15 @@ class SettingController extends Controller
      *
      * @return JsonResponse The JSON response containing the created setting resource.
      */
-    public function store(SettingRequest $request): JsonResponse // Correct return type hint
+    public function store( SettingRequest $request ): JsonResponse // Correct return type hint
     {
-        $this->authorize('create', Setting::class);
+        $this->authorize( 'create', Setting::class );
 
         $validated = $request->validated();
-        $setting   = Setting::create($validated);
+        $setting   = Setting::create( $validated );
 
         // Return JsonResponse explicitly with 201 status
-        return response()->json(new SettingResource($setting), 201);
+        return response()->json( new SettingResource( $setting ), 201 );
     }
 
     /**
@@ -91,12 +134,12 @@ class SettingController extends Controller
      *
      * @return SettingResource The setting resource with loaded permissions.
      */
-    public function show(string|int $id): SettingResource
+    public function show( string|int $id ): SettingResource
     {
-        $setting = Setting::findOrFail($id);
-        $this->authorize('view', $setting);
+        $setting = Setting::findOrFail( $id );
+        $this->authorize( 'view', $setting );
 
-        return new SettingResource($setting);
+        return new SettingResource( $setting );
     }
 
     /**
@@ -112,14 +155,14 @@ class SettingController extends Controller
      *
      * @return SettingResource The updated setting resource with loaded permissions.
      */
-    public function update(SettingRequest $request, string|int $id): SettingResource
+    public function update( SettingRequest $request, string|int $id ): SettingResource
     {
-        $setting = Setting::findOrFail($id);
-        $this->authorize('update', $setting);
+        $setting = Setting::findOrFail( $id );
+        $this->authorize( 'update', $setting );
         $validated = $request->validated();
-        $setting->update($validated);
+        $setting->update( $validated );
 
-        return new SettingResource($setting);
+        return new SettingResource( $setting );
     }
 
     /**
@@ -135,10 +178,10 @@ class SettingController extends Controller
      *
      * @return Response A response with 204 status code.
      */
-    public function destroy(string|int $id): Response // Correct return type hint
+    public function destroy( string|int $id ): Response // Correct return type hint
     {
-        $setting = Setting::findOrFail($id);
-        $this->authorize('delete', $setting);
+        $setting = Setting::findOrFail( $id );
+        $this->authorize( 'delete', $setting);
         $setting->delete();
 
         return response()->noContent();

--- a/src/Modules/Settings/Http/Requests/RegisteredSettingsRequest.php
+++ b/src/Modules/Settings/Http/Requests/RegisteredSettingsRequest.php
@@ -1,0 +1,93 @@
+<?php
+
+declare( strict_types=1 );
+
+/**
+ * Registered Settings Request.
+ *
+ * Validates by-key bulk-update payloads for the `PUT /api/v1/settings`
+ * endpoint. The body is a `settings` map of `key => value` pairs; every
+ * key must correspond to a setting registered via
+ * `SettingsManager::registerSetting()` so the controller can route each
+ * write through the manager (applying the per-key sanitizer and type).
+ *
+ * @since   1.2.0
+ */
+
+namespace ArtisanPackUI\CMSFramework\Modules\Settings\Http\Requests;
+
+use Illuminate\Contracts\Validation\Validator;
+use Illuminate\Foundation\Http\FormRequest;
+
+/**
+ * Form request for the registered-settings bulk-update endpoint.
+ *
+ * Authorization is delegated to the controller's `SettingPolicy` check;
+ * this request only guarantees the payload shape and that each supplied
+ * key is registered.
+ *
+ * @since 1.2.0
+ */
+class RegisteredSettingsRequest extends FormRequest
+{
+    /**
+     * Authorization is delegated to the controller's policy check.
+     *
+     * @since 1.2.0
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Validation rules for the bulk-update body.
+     *
+     * Per-key registration is enforced in {@see withValidator()} because
+     * setting keys are dynamic (and dotted, e.g. `site.title`), which the
+     * static rule array cannot express.
+     *
+     * @since 1.2.0
+     *
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'settings' => ['required', 'array', 'min:1'],
+        ];
+    }
+
+    /**
+     * Reject any keys in the payload that are not registered settings.
+     *
+     * Routing an unregistered key through `SettingsManager::updateSetting()`
+     * would store a raw, untyped value — the exact gap this endpoint exists
+     * to close — so unknown keys fail validation instead.
+     *
+     * @since 1.2.0
+     *
+     * @param  Validator  $validator  The validator instance for this request.
+     */
+    public function withValidator( Validator $validator ): void
+    {
+        $validator->after( function ( Validator $validator ): void {
+            $settings = $this->input( 'settings' );
+
+            if ( ! is_array( $settings ) ) {
+                return;
+            }
+
+            $registered = array_keys( applyFilters( 'ap.settings.registeredSettings', [] ) );
+
+            foreach ( array_keys( $settings ) as $key ) {
+                if ( ! in_array( $key, $registered, true ) ) {
+                    $validator->errors()->add(
+                        "settings.{$key}",
+                        __( 'The setting ":key" is not registered.', ['key' => $key] ),
+                    );
+                }
+            }
+        });
+    }
+}

--- a/src/Modules/Settings/routes/api.php
+++ b/src/Modules/Settings/routes/api.php
@@ -22,5 +22,11 @@ Route::middleware('auth')->group(function (): void {
     Route::get('settings/site', [SiteSettingController::class, 'show'])->name('settings.site.show');
     Route::put('settings/site', [SiteSettingController::class, 'update'])->name('settings.site.update');
 
+    // By-key bulk update. Registered before the apiResource so it is matched
+    // ahead of the ID/key-addressed `PUT settings/{setting}` update, and routes
+    // each value through SettingsManager (applying sanitizers + types) instead
+    // of writing to the model directly.
+    Route::put('settings', [SettingController::class, 'bulkUpdate'])->name('settings.bulk-update');
+
     Route::apiResource('settings', SettingController::class);
 });

--- a/tests/Feature/Settings/SettingsBulkUpdateApiTest.php
+++ b/tests/Feature/Settings/SettingsBulkUpdateApiTest.php
@@ -1,0 +1,186 @@
+<?php
+
+declare( strict_types=1 );
+
+/**
+ * Feature tests for the by-key bulk-update endpoint `PUT /api/v1/settings`.
+ *
+ * The generic ID/key CRUD writes straight to the model and skips the
+ * registered sanitizer + `SettingType`. This endpoint routes every value
+ * through `SettingsManager::updateSetting()` instead, so these tests assert
+ * the sanitizer runs, the type is serialized, unregistered keys are rejected,
+ * and the `SettingPolicy` gates access.
+ *
+ * @since 1.2.0
+ */
+
+namespace ArtisanPackUI\CMSFramework\Modules\Settings\Tests\Feature;
+
+use App\Models\User;
+use ArtisanPackUI\CMSFramework\Modules\Settings\Enums\SettingType;
+use ArtisanPackUI\CMSFramework\Modules\Settings\Managers\SettingsManager;
+use ArtisanPackUI\CMSFramework\Modules\Settings\Models\Setting;
+use ArtisanPackUI\CMSFramework\Modules\Users\Models\Role;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Gate;
+use function Pest\Laravel\actingAs;
+use function Pest\Laravel\putJson;
+
+uses( RefreshDatabase::class );
+
+beforeEach( function (): void {
+    $this->artisan( 'migrate', ['--database' => 'testing'] );
+
+    config( ['artisanpack.cms-framework.user_model' => 'App\\Models\\User'] );
+
+    if ( ! class_exists( 'App\\Models\\User' ) ) {
+        eval( '
+            namespace App\\Models {
+                use Illuminate\\Foundation\\Auth\\User as Authenticatable;
+                use ArtisanPackUI\\CMSFramework\\Modules\\Users\\Models\\Concerns\\HasRolesAndPermissions;
+
+                class User extends Authenticatable {
+                    use HasRolesAndPermissions;
+                    protected $table = "users";
+                    protected $fillable = ["name", "email", "password"];
+                    protected $hidden = ["password"];
+                }
+            }
+        ' );
+    }
+
+    $this->user = User::create( [
+        'name'     => 'Settings Admin',
+        'email'    => 'settings-admin@example.com',
+        'password' => bcrypt( 'password' ),
+    ] );
+
+    $role = Role::create( ['name' => 'Admin', 'slug' => 'admin'] );
+    $this->user->roles()->attach( $role );
+
+    $this->manager = app( SettingsManager::class );
+} );
+
+function grantBulkSettingsManage(): void
+{
+    Gate::define( 'settings.manage', fn ( User $user ) => true );
+}
+
+test( 'unauthenticated user cannot bulk-update settings', function (): void {
+    putJson( '/api/v1/settings', ['settings' => ['site.title' => 'Nope']] )
+        ->assertUnauthorized();
+} );
+
+test( 'user without permission cannot bulk-update settings', function (): void {
+    actingAs( $this->user )
+        ->putJson( '/api/v1/settings', ['settings' => ['site.title' => 'Nope']] )
+        ->assertForbidden();
+} );
+
+test( 'it applies the registered sanitizer callback', function (): void {
+    grantBulkSettingsManage();
+
+    $this->manager->registerSetting( 'blog.title', '', fn ( $value ) => trim( $value ), SettingType::String );
+
+    actingAs( $this->user )
+        ->putJson( '/api/v1/settings', ['settings' => ['blog.title' => '  Spaced Out  ']] )
+        ->assertOk()
+        ->assertJson( ['settings' => ['blog.title' => 'Spaced Out']] );
+
+    $this->assertDatabaseHas( 'settings', ['key' => 'blog.title', 'value' => 'Spaced Out'] );
+} );
+
+test( 'it serializes the value using the registered type', function (): void {
+    grantBulkSettingsManage();
+
+    $this->manager->registerSetting( 'blog.per_page', 10, 'sanitizeInt', SettingType::Integer );
+
+    $response = actingAs( $this->user )
+        ->putJson( '/api/v1/settings', ['settings' => ['blog.per_page' => '25']] )
+        ->assertOk();
+
+    // The response echoes the cast value, so the integer round-trips as an int.
+    // Index the literal dotted key rather than a dot-path lookup, which would
+    // otherwise read it as nested `settings.blog.per_page`.
+    expect( $response->json( 'settings' )['blog.per_page'] )->toBe( 25 );
+
+    $this->assertDatabaseHas( 'settings', [
+        'key'   => 'blog.per_page',
+        'value' => '25',
+        'type'  => 'integer',
+    ] );
+} );
+
+test( 'stored values match SettingsManager::updateSetting output', function (): void {
+    grantBulkSettingsManage();
+
+    $this->manager->registerSetting( 'blog.per_page', 10, 'sanitizeInt', SettingType::Integer );
+
+    actingAs( $this->user )
+        ->putJson( '/api/v1/settings', ['settings' => ['blog.per_page' => '42']] )
+        ->assertOk();
+
+    $viaEndpoint = Setting::where( 'key', 'blog.per_page' )->first();
+
+    // Drive the same key through the manager directly and confirm the stored
+    // representation is identical to what the endpoint produced.
+    $this->manager->updateSetting( 'blog.per_page', '42' );
+    $viaManager = Setting::where( 'key', 'blog.per_page' )->first();
+
+    expect( $viaManager->getRawOriginal( 'value' ) )->toBe( $viaEndpoint->getRawOriginal( 'value' ) );
+    expect( $viaManager->getRawOriginal( 'type' ) )->toBe( $viaEndpoint->getRawOriginal( 'type' ) );
+} );
+
+test( 'it updates several registered keys in one request', function (): void {
+    grantBulkSettingsManage();
+
+    $this->manager->registerSetting( 'blog.title', '', 'sanitizeText', SettingType::String );
+    $this->manager->registerSetting( 'blog.per_page', 10, 'sanitizeInt', SettingType::Integer );
+
+    actingAs( $this->user )
+        ->putJson( '/api/v1/settings', [
+            'settings' => [
+                'blog.title'    => 'My Blog',
+                'blog.per_page' => '15',
+            ],
+        ] )
+        ->assertOk()
+        ->assertJson( [
+            'settings' => [
+                'blog.title'    => 'My Blog',
+                'blog.per_page' => 15,
+            ],
+        ] );
+
+    $this->assertDatabaseHas( 'settings', ['key' => 'blog.title', 'value' => 'My Blog'] );
+    $this->assertDatabaseHas( 'settings', ['key' => 'blog.per_page', 'value' => '15'] );
+} );
+
+test( 'it rejects an unregistered key', function (): void {
+    grantBulkSettingsManage();
+
+    actingAs( $this->user )
+        ->putJson( '/api/v1/settings', ['settings' => ['totally.unregistered' => 'value']] )
+        ->assertStatus( 422 )
+        ->assertJsonValidationErrors( ['settings.totally.unregistered'] );
+
+    $this->assertDatabaseMissing( 'settings', ['key' => 'totally.unregistered'] );
+} );
+
+test( 'it rejects a request with no settings', function (): void {
+    grantBulkSettingsManage();
+
+    actingAs( $this->user )
+        ->putJson( '/api/v1/settings', ['settings' => []] )
+        ->assertStatus( 422 )
+        ->assertJsonValidationErrors( ['settings']);
+});
+
+test( 'it rejects a request missing the settings key entirely', function (): void {
+    grantBulkSettingsManage();
+
+    actingAs( $this->user)
+        ->putJson( '/api/v1/settings', [])
+        ->assertStatus( 422)
+        ->assertJsonValidationErrors( ['settings']);
+});


### PR DESCRIPTION
## Description

The generic `SettingController` REST CRUD (`apiResource` on `api/v1/settings`) writes setting values directly to the `Setting` model, bypassing `SettingsManager::updateSetting()`. As a result it never applies the per-key sanitizer callback or the registered `SettingType`, so consumers saving registered settings through those endpoints silently stored **unsanitized, untyped** values.

This adds a safe, by-key save path — `PUT /api/v1/settings` — that routes every value through `SettingsManager::updateSetting()` so sanitizers and types always apply. This is the natural fit for an admin settings page (e.g. Keystone) that saves a group of registered keys at once.

**Closes:** #137

## Type of Change

- [x] Bug fix (fixes an issue)

## Related Issue

**Issue:** #137

## Motivation and Context

Surfaced while wiring the Keystone admin Settings page. Only `SiteSettingController` and direct `SettingsManager::updateSetting()` calls applied sanitizers/types before; any consumer using the generic REST CRUD diverged from what `registerSetting()` promised — a data-integrity and security gap.

## Changes Made

- Add `SettingController::bulkUpdate()` handling `PUT /api/v1/settings` with a `{ "settings": { key: value, ... } }` body, routing each value through `SettingsManager::updateSetting()` (applies sanitizer + `SettingType`). Response echoes the freshly-read, sanitized/cast values.
- Add `RegisteredSettingsRequest`: validates the payload shape and rejects any **unregistered** key with a `422` (no sanitizer/type would exist to apply).
- Register the route before the `apiResource` so it is matched ahead of the ID/key-addressed `PUT settings/{setting}`.
- Authorization continues through `SettingPolicy` (`settings.manage`, via the `settings.update` capability filter). `SiteSettingController` and the generic CRUD are unchanged.
- Docs: new "REST API" section in `docs/settings/Retrieving-and-Updating.md` pointing consumers at the safe save path and noting the generic-CRUD caveat.

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS (Darwin 25.5.0)
- PHP Version: 8.4
- Project Version: release/1.2

**Tests Performed:**
1. New Pest feature suite for the endpoint (9 tests) — all passing.
2. Full package suite: 867 passed, 4 skipped, 0 failed.
3. Manual verification against the JMWD Keystone CMS admin Settings page — registered keys save sanitized + correctly typed.

## Accessibility Tests Run

- [ ] Keyboard navigation tested
- [ ] Screen reader tested
- [ ] Color contrast verified
- [ ] ARIA labels checked

**Details:** N/A — backend REST endpoint with no UI surface in this package.

## Tests Added

- [ ] Unit tests added/updated
- [x] Integration tests added/updated
- [x] All tests passing

**Test details:** `tests/Feature/Settings/SettingsBulkUpdateApiTest.php` covers: sanitizer applied, type serialized, parity with `SettingsManager::updateSetting()`, multi-key update, unregistered-key rejection (422), empty/missing payload (422), and auth/policy gating (401 + 403).

## Documentation

- [x] Inline code documentation added
- [ ] README updated
- [ ] Wiki updated
- [x] API documentation updated

**Documentation details:** Added a "REST API" section to `docs/settings/Retrieving-and-Updating.md` documenting the safe save path and the generic-CRUD caveat.

## Pre-Submission Checklist

- [x] Followed contributing guidelines
- [x] Checked for other open PRs for same update
- [x] Code passes all tests
- [x] Code has been linted
- [ ] Accessibility tests completed
- [x] Code follows project style guide
- [x] Self-review completed
- [x] Comments added for complex code
- [x] No new warnings generated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a bulk settings update API that lets clients update multiple settings in one request with validation, sanitization, and type casting.

* **Documentation**
  * Added REST API docs describing the bulk update endpoint, request/response examples, authorization behavior, and validation rules.

* **Tests**
  * Added comprehensive feature tests covering auth, validation, sanitization, type casting, and error cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ArtisanPack-UI/cms-framework/pull/139?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->