### PR TITLE
fix(site-editor): use auth:sanctum so REST clients can pass Bearer tokens

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,8 @@
     "artisanpack-ui/hooks": "^1.1",
     "artisanpack-ui/rbac": "^0.1@dev",
     "dedoc/scramble": "^0.12 || ^0.13",
-    "justinrainbow/json-schema": "^6.0"
+    "justinrainbow/json-schema": "^6.0",
+    "laravel/sanctum": "^4.0.8"
   },
   "require-dev": {
     "pestphp/pest": "^3.8",

--- a/src/Modules/SiteEditor/routes/api.php
+++ b/src/Modules/SiteEditor/routes/api.php
@@ -13,7 +13,7 @@ use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Http\Controllers\TemplatesCont
 use Illuminate\Support\Facades\Route;
 
 Route::prefix('api/v1')
-    ->middleware('auth')
+    ->middleware('auth:sanctum')
     ->group(function (): void {
         Route::prefix('templates')->group(function (): void {
             Route::get('/', [TemplatesController::class, 'index'])->name('api.templates.index');

--- a/tests/Feature/SiteEditor/TemplatesApiTest.php
+++ b/tests/Feature/SiteEditor/TemplatesApiTest.php
@@ -39,6 +39,26 @@ describe('GET /api/v1/templates', function (): void {
         $this->getJson('/api/v1/templates')->assertUnauthorized();
     });
 
+    it('accepts a Sanctum personal access token via Authorization header', function (): void {
+        File::put($this->themeFiles.'/page.html', '<!-- file -->');
+
+        $token = $this->user->createToken('test-token')->plainTextToken;
+
+        $this->getJson('/api/v1/templates', [
+            'Authorization' => 'Bearer '.$token,
+        ])->assertOk();
+    });
+
+    it('accepts a session-cookie authenticated user (browser editor flow)', function (): void {
+        File::put($this->themeFiles.'/page.html', '<!-- file -->');
+
+        // actingAs() on the default web guard simulates the browser session
+        // cookie path that the site editor UI uses today.
+        $this->actingAs($this->user);
+
+        $this->getJson('/api/v1/templates')->assertOk();
+    });
+
     it('returns merged file + DB templates in WP shape', function (): void {
         File::put($this->themeFiles.'/page.html', '<!-- file -->');
 

--- a/tests/Support/TestUser.php
+++ b/tests/Support/TestUser.php
@@ -9,9 +9,11 @@ use ArtisanPackUI\CMSFramework\Modules\Users\Models\Concerns\HasRolesAndPermissi
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
+use Laravel\Sanctum\HasApiTokens;
 
 class TestUser extends Authenticatable
 {
+    use HasApiTokens;
     use HasFactory;
     use HasNotifications;
     use HasRolesAndPermissions;

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -17,6 +17,7 @@ use ArtisanPackUI\Rbac\RbacServiceProvider;
 use ArtisanPackUI\Security\SecurityServiceProvider;
 use Dedoc\Scramble\ScrambleServiceProvider;
 use Illuminate\Foundation\Application;
+use Laravel\Sanctum\SanctumServiceProvider;
 
 /**
  * Provides the base application for all package tests.
@@ -31,6 +32,15 @@ class TestCase extends \Orchestra\Testbench\TestCase
 
         // Load the package's migrations (includes users, roles, permissions, settings, etc.)
         $this->loadMigrationsFrom(__DIR__.'/../database/migrations');
+
+        // Sanctum ships its own personal-access-tokens table; load it so
+        // `auth:sanctum` HTTP tests can mint bearer tokens. Resolve the path
+        // defensively so a missing vendor install doesn't crash bootstrap.
+        $sanctumMigrations = realpath(__DIR__.'/../vendor/laravel/sanctum/database/migrations');
+
+        if (false !== $sanctumMigrations) {
+            $this->loadMigrationsFrom($sanctumMigrations);
+        }
     }
 
     /**
@@ -46,6 +56,7 @@ class TestCase extends \Orchestra\Testbench\TestCase
             SecurityServiceProvider::class,
             ScrambleServiceProvider::class,
             RbacServiceProvider::class,
+            SanctumServiceProvider::class,
             CMSFrameworkServiceProvider::class,
             HooksServiceProvider::class,
         ];


### PR DESCRIPTION
## Description

The site-editor REST surface was guarded by the bare `auth` middleware,
which resolves to the `web` (session) guard under Laravel's default
auth config and rejects Sanctum personal access tokens with `401
Unauthenticated`. The themes (`auth:sanctum`) and notifications
(`auth:sanctum`) modules already agree on Sanctum, so this brings the
site-editor module into line — REST clients (curl/Postman/Insomnia)
can now exercise `api/v1/*` with a Bearer token, and the browser
editor's cookie/session path is preserved because `auth:sanctum`
accepts both.

**Closes:** #133

## Type of Change

- [x] Bug fix (fixes an issue)
- [ ] New feature (adds new functionality)
- [ ] Enhancement (improves existing functionality)
- [ ] Refactoring (code improvement, no behavior change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Security fix
- [ ] Breaking change (breaks backward compatibility)

## Related Issue

**Issue:** #133

## Motivation and Context

Discovered while running the H8 smoke flow
([visual-editor #433](https://github.com/ArtisanPack-UI/visual-editor/issues/433)) —
the doc's ad-hoc curl checks against templates / parts / global-styles /
menus all 401'd because the guard chain couldn't see Sanctum's Bearer
header. Without this fix, every REST-client integration test has to
fall back to a cookie + CSRF dance, which defeats the purpose of having
a token API.

## Changes Made

- Switch the `api/v1` group in `src/Modules/SiteEditor/routes/api.php`
  from `'auth'` → `'auth:sanctum'`.
- Promote `laravel/sanctum: ^4.0.8` to `require` (the package now
  references Sanctum's guard at runtime, so it can't live in dev-only).
- Add `HasApiTokens` to `tests/Support/TestUser` and register
  `SanctumServiceProvider` + Sanctum's `personal_access_tokens`
  migration in `tests/TestCase` so HTTP tests can mint Bearer tokens
  end-to-end.
- Cover both **Bearer-token** and **session-cookie** auth on
  `TemplatesController::index` in `TemplatesApiTest`.

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS (Darwin 25.5.0)
- Browser (if applicable): n/a (curl)
- PHP Version: 8.4.3
- Project Version: release/2.0

**Tests Performed:**

1. Full package suite: `869 passed (2281 assertions), 4 skipped` —
   no regressions in the existing site-editor / themes / notifications
   suites.
2. New `TemplatesApiTest` cases pass against the live `auth:sanctum`
   guard: Bearer header → 200, `actingAs` (session) → 200.
3. Manually curled the live route in the consuming dev app:
   - `Authorization: Bearer <token>` → `200` with the template list.
   - No auth → `401 Unauthenticated`.
4. Loaded the browser site editor in the dev app — still works via
   the existing session cookie (no regression for the editor UI).

## Accessibility Tests Run

- [ ] Keyboard navigation tested
- [ ] Screen reader tested
- [ ] Color contrast verified
- [ ] ARIA labels checked

**Details:** N/A — backend-only change, no UI surface affected.

## Tests Added

- [ ] Unit tests added/updated
- [x] Integration tests added/updated
- [x] All tests passing

**Test details:**
- `tests/Feature/SiteEditor/TemplatesApiTest.php`:
  - `it('accepts a Sanctum personal access token via Authorization header')`
  - `it('accepts a session-cookie authenticated user (browser editor flow)')`

## Documentation

- [ ] Inline code documentation added
- [ ] README updated
- [ ] Wiki updated
- [ ] API documentation updated

**Documentation details:** No public API change — the route URIs,
verbs, and shapes are unchanged. Only the accepted auth method
broadens (Bearer tokens now accepted in addition to the existing
session path).

## Screenshots

N/A — backend-only.

## Pre-Submission Checklist

- [x] Followed contributing guidelines
- [x] Checked for other open PRs for same update
- [x] Code passes all tests
- [x] Code has been linted
- [ ] Accessibility tests completed (N/A — backend)
- [x] Code follows project style guide
- [x] Self-review completed
- [x] Comments added for complex code
- [x] No new warnings generated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * API authentication updated to use Laravel Sanctum
  * Added personal access token support for API endpoints
  * Personal access tokens can be passed via Authorization header

* **Tests**
  * Added tests verifying personal access token authentication for API endpoints
  * Added tests verifying session-based authentication continues to work

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ArtisanPack-UI/cms-framework/pull/142?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->