### PR TITLE
fix(content-types): rewrite HasFeaturedImage to use the featureables pivot

### DIFF
--- a/src/Modules/ContentTypes/Models/Concerns/HasFeaturedImage.php
+++ b/src/Modules/ContentTypes/Models/Concerns/HasFeaturedImage.php
@@ -86,13 +86,14 @@ trait HasFeaturedImage
      */
     public function getFeaturedImageUrl(string $size = 'full'): ?string
     {
-        $media = $this->featuredImage()->first();
+        // Reuse the eager-loaded relation when available so callers that
+        // already loaded `featuredImage` (e.g. via API resources) don't
+        // get an N+1 query per row.
+        $media = $this->relationLoaded('featuredImage')
+            ? $this->featuredImage->first()
+            : $this->featuredImage()->first();
 
-        if (! $media) {
-            return null;
-        }
-
-        return $media->url ?? null;
+        return $media?->url;
     }
 
     /**

--- a/src/Modules/ContentTypes/Models/Concerns/HasFeaturedImage.php
+++ b/src/Modules/ContentTypes/Models/Concerns/HasFeaturedImage.php
@@ -63,6 +63,9 @@ trait HasFeaturedImage
     public function setFeaturedImage(int $mediaId): void
     {
         $this->featuredImage()->sync([sanitizeInt($mediaId)]);
+        // Drop any eager-loaded copy so getFeaturedImageUrl() — which
+        // reuses the loaded relation — does not return stale data.
+        $this->unsetRelation('featuredImage');
     }
 
     /**
@@ -75,6 +78,7 @@ trait HasFeaturedImage
     public function removeFeaturedImage(): void
     {
         $this->featuredImage()->detach();
+        $this->unsetRelation('featuredImage');
     }
 
     /**

--- a/src/Modules/ContentTypes/Models/Concerns/HasFeaturedImage.php
+++ b/src/Modules/ContentTypes/Models/Concerns/HasFeaturedImage.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /**
  * HasFeaturedImage Trait
  *
- * Provides featured image functionality for content types.
+ * Provides featured image functionality for any model via a polymorphic pivot.
  *
  * @since 1.0.0
  */
@@ -13,77 +13,100 @@ declare(strict_types=1);
 namespace ArtisanPackUI\CMSFramework\Modules\ContentTypes\Models\Concerns;
 
 use ArtisanPackUI\MediaLibrary\Models\Media;
-use Illuminate\Database\Eloquent\Relations\MorphOne;
+use Illuminate\Database\Eloquent\Relations\MorphToMany;
 
 /**
- * Trait for adding featured image support to models.
+ * Trait for attaching a single featured image to a host model via the
+ * `featureables` polymorphic pivot table shipped with the cms-framework.
+ *
+ * The trait does not add a column to the host model's table; the
+ * association is stored entirely in `featureables`. This lets the trait
+ * be applied to models the package does not own (for example, an
+ * application's `User` model) without requiring a schema change on the
+ * host table.
  *
  * @since 1.0.0
  */
 trait HasFeaturedImage
 {
     /**
-     * Get the featured image for the model.
+     * Get the featured image relation for the model.
+     *
+     * Returns a `MorphToMany` relation against the `featureables` pivot.
+     * `setFeaturedImage()` keeps this constrained to a single row, so
+     * `$model->featuredImage->first()` (or `getFeaturedImageUrl()`) is
+     * the typical way to read the attached media.
      *
      * @since 1.0.0
      */
-    public function featuredImage(): MorphOne
+    public function featuredImage(): MorphToMany
     {
-        return $this->morphOne(Media::class, 'featurable', 'featurable_type', 'featurable_id')
+        return $this->morphToMany(
+            $this->featuredImageMediaModel(),
+            'featurable',
+            'featureables',
+            null,
+            'media_id'
+        )
             ->withTimestamps();
     }
 
     /**
      * Set the featured image for the model.
      *
+     * Replaces any existing featured image with the given media row.
+     *
      * @since 1.0.0
      *
-     * @param  int  $mediaId  The ID of the media to set as featured image.
+     * @param  int  $mediaId  The ID of the media row to attach.
      */
     public function setFeaturedImage(int $mediaId): void
     {
-        // Remove existing featured image
-        $this->removeFeaturedImage();
-
-        // Create new featured image relationship
-        Media::where('id', sanitizeInt($mediaId))->update([
-            'featurable_type' => get_class($this),
-            'featurable_id'   => $this->id,
-        ]);
+        $this->featuredImage()->sync([sanitizeInt($mediaId)]);
     }
 
     /**
      * Remove the featured image from the model.
      *
+     * Detaches every featured image row for this model from the pivot.
+     *
      * @since 1.0.0
      */
     public function removeFeaturedImage(): void
     {
-        Media::where('featurable_type', get_class($this))
-            ->where('featurable_id', $this->id)
-            ->update([
-                'featurable_type' => null,
-                'featurable_id'   => null,
-            ]);
+        $this->featuredImage()->detach();
     }
 
     /**
-     * Get the featured image URL.
+     * Get the URL for the currently attached featured image.
      *
      * @since 1.0.0
      *
-     * @param  string  $size  The size of the image (full, thumbnail, medium, large).
+     * @param  string  $size  Reserved for size-aware Media implementations.
      */
     public function getFeaturedImageUrl(string $size = 'full'): ?string
     {
-        $featuredImage = $this->featuredImage;
+        $media = $this->featuredImage()->first();
 
-        if (! $featuredImage) {
+        if (! $media) {
             return null;
         }
 
-        // Return the appropriate URL based on size
-        // This will depend on how the Media model handles sizes
-        return $featuredImage->url ?? null;
+        return $media->url ?? null;
+    }
+
+    /**
+     * The FQCN of the Media model the trait should attach to.
+     *
+     * Override on the host model (or in test fixtures) to substitute a
+     * different Media implementation.
+     *
+     * @since 2.0.0
+     *
+     * @return class-string
+     */
+    protected function featuredImageMediaModel(): string
+    {
+        return Media::class;
     }
 }

--- a/tests/Support/TestFeaturedImageModel.php
+++ b/tests/Support/TestFeaturedImageModel.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Test fixture: a model that uses HasFeaturedImage against TestMedia.
+ *
+ * @since 2.0.0
+ */
+
+namespace ArtisanPackUI\CMSFramework\Tests\Support;
+
+use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Models\Concerns\HasFeaturedImage;
+use Illuminate\Database\Eloquent\Model;
+
+class TestFeaturedImageModel extends Model
+{
+    use HasFeaturedImage;
+
+    protected $table = 'test_featured_image_models';
+
+    protected $guarded = [];
+
+    protected function featuredImageMediaModel(): string
+    {
+        return TestMedia::class;
+    }
+}

--- a/tests/Support/TestMedia.php
+++ b/tests/Support/TestMedia.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Test fixture: a minimal Media model.
+ *
+ * Stands in for `\ArtisanPackUI\MediaLibrary\Models\Media` so that the
+ * cms-framework test suite can exercise media-aware traits without
+ * requiring the media-library package as a dev dependency.
+ *
+ * @since 2.0.0
+ */
+
+namespace ArtisanPackUI\CMSFramework\Tests\Support;
+
+use Illuminate\Database\Eloquent\Model;
+
+class TestMedia extends Model
+{
+    protected $table = 'media';
+
+    protected $guarded = [];
+}

--- a/tests/Unit/ContentTypes/HasFeaturedImageTest.php
+++ b/tests/Unit/ContentTypes/HasFeaturedImageTest.php
@@ -114,6 +114,22 @@ test('getFeaturedImageUrl returns the URL of the attached media row', function (
     expect($model->getFeaturedImageUrl())->toBe('https://example.test/a.jpg');
 });
 
+test('getFeaturedImageUrl reuses the eager-loaded relation without re-querying', function (): void {
+    $model = TestFeaturedImageModel::create(['name' => 'Subject']);
+    $media = TestMedia::create(['url' => 'https://example.test/a.jpg']);
+    $model->setFeaturedImage($media->id);
+
+    $reloaded = TestFeaturedImageModel::with('featuredImage')->find($model->id);
+
+    DB::enableQueryLog();
+    DB::flushQueryLog();
+
+    expect($reloaded->getFeaturedImageUrl())->toBe('https://example.test/a.jpg');
+    expect(DB::getQueryLog())->toBeEmpty();
+
+    DB::disableQueryLog();
+});
+
 test('setFeaturedImage isolates featured images per host model row', function (): void {
     $modelA = TestFeaturedImageModel::create(['name' => 'A']);
     $modelB = TestFeaturedImageModel::create(['name' => 'B']);

--- a/tests/Unit/ContentTypes/HasFeaturedImageTest.php
+++ b/tests/Unit/ContentTypes/HasFeaturedImageTest.php
@@ -1,0 +1,136 @@
+<?php
+
+declare(strict_types=1);
+
+use ArtisanPackUI\CMSFramework\Modules\Blog\Models\Post;
+use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Models\Concerns\HasFeaturedImage;
+use ArtisanPackUI\CMSFramework\Modules\Pages\Models\Page;
+use ArtisanPackUI\CMSFramework\Tests\Support\TestFeaturedImageModel;
+use ArtisanPackUI\CMSFramework\Tests\Support\TestMedia;
+use Illuminate\Database\Eloquent\Relations\MorphToMany;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+beforeEach(function (): void {
+    $this->artisan('migrate', ['--database' => 'testing']);
+
+    // The cms-framework migrations for `featureables`, `posts`, and `pages`
+    // reference a `media` table via foreign keys. SQLite accepts the FK
+    // definitions even when the referenced table is absent, so the
+    // package's own migrations pass; the host table just needs to exist
+    // before we attach rows in tests.
+    if (! Schema::hasTable('media')) {
+        Schema::create('media', function (Blueprint $table): void {
+            $table->id();
+            $table->string('url')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    if (! Schema::hasTable('test_featured_image_models')) {
+        Schema::create('test_featured_image_models', function (Blueprint $table): void {
+            $table->id();
+            $table->string('name')->nullable();
+            $table->timestamps();
+        });
+    }
+});
+
+test('featuredImage returns a MorphToMany relation against the featureables pivot', function (): void {
+    $model = TestFeaturedImageModel::create(['name' => 'Subject']);
+
+    $relation = $model->featuredImage();
+
+    expect($relation)->toBeInstanceOf(MorphToMany::class);
+    expect($relation->getTable())->toBe('featureables');
+});
+
+test('setFeaturedImage attaches a media row via the pivot table', function (): void {
+    $model = TestFeaturedImageModel::create(['name' => 'Subject']);
+    $media = TestMedia::create(['url' => 'https://example.test/a.jpg']);
+
+    $model->setFeaturedImage($media->id);
+
+    $row = DB::table('featureables')->first();
+
+    expect($row)->not->toBeNull();
+    expect((int) $row->media_id)->toBe($media->id);
+    expect((int) $row->featurable_id)->toBe($model->id);
+    expect($row->featurable_type)->toBe(TestFeaturedImageModel::class);
+    expect($model->featuredImage()->count())->toBe(1);
+});
+
+test('setFeaturedImage replaces the existing featured image rather than appending', function (): void {
+    $model = TestFeaturedImageModel::create(['name' => 'Subject']);
+    $first = TestMedia::create(['url' => 'https://example.test/first.jpg']);
+    $second = TestMedia::create(['url' => 'https://example.test/second.jpg']);
+
+    $model->setFeaturedImage($first->id);
+    $model->setFeaturedImage($second->id);
+
+    $rows = DB::table('featureables')
+        ->where('featurable_type', TestFeaturedImageModel::class)
+        ->where('featurable_id', $model->id)
+        ->get();
+
+    expect($rows)->toHaveCount(1);
+    expect((int) $rows->first()->media_id)->toBe($second->id);
+});
+
+test('removeFeaturedImage detaches every row for the host model', function (): void {
+    $model = TestFeaturedImageModel::create(['name' => 'Subject']);
+    $media = TestMedia::create(['url' => 'https://example.test/a.jpg']);
+
+    $model->setFeaturedImage($media->id);
+    expect($model->featuredImage()->count())->toBe(1);
+
+    $model->removeFeaturedImage();
+
+    expect($model->featuredImage()->count())->toBe(0);
+    expect(DB::table('featureables')->count())->toBe(0);
+});
+
+test('removeFeaturedImage on a model without a featured image is a no-op', function (): void {
+    $model = TestFeaturedImageModel::create(['name' => 'Subject']);
+
+    $model->removeFeaturedImage();
+
+    expect(DB::table('featureables')->count())->toBe(0);
+});
+
+test('getFeaturedImageUrl returns null when no featured image is attached', function (): void {
+    $model = TestFeaturedImageModel::create(['name' => 'Subject']);
+
+    expect($model->getFeaturedImageUrl())->toBeNull();
+});
+
+test('getFeaturedImageUrl returns the URL of the attached media row', function (): void {
+    $model = TestFeaturedImageModel::create(['name' => 'Subject']);
+    $media = TestMedia::create(['url' => 'https://example.test/a.jpg']);
+
+    $model->setFeaturedImage($media->id);
+
+    expect($model->getFeaturedImageUrl())->toBe('https://example.test/a.jpg');
+});
+
+test('setFeaturedImage isolates featured images per host model row', function (): void {
+    $modelA = TestFeaturedImageModel::create(['name' => 'A']);
+    $modelB = TestFeaturedImageModel::create(['name' => 'B']);
+    $mediaA = TestMedia::create(['url' => 'https://example.test/a.jpg']);
+    $mediaB = TestMedia::create(['url' => 'https://example.test/b.jpg']);
+
+    $modelA->setFeaturedImage($mediaA->id);
+    $modelB->setFeaturedImage($mediaB->id);
+
+    expect($modelA->featuredImage()->first()->id)->toBe($mediaA->id);
+    expect($modelB->featuredImage()->first()->id)->toBe($mediaB->id);
+});
+
+test('post model still uses HasFeaturedImage trait', function (): void {
+    expect(in_array(HasFeaturedImage::class, class_uses_recursive(Post::class), true))->toBeTrue();
+});
+
+test('page model still uses HasFeaturedImage trait', function (): void {
+    expect(in_array(HasFeaturedImage::class, class_uses_recursive(Page::class), true))->toBeTrue();
+});

--- a/tests/Unit/ContentTypes/HasFeaturedImageTest.php
+++ b/tests/Unit/ContentTypes/HasFeaturedImageTest.php
@@ -114,6 +114,33 @@ test('getFeaturedImageUrl returns the URL of the attached media row', function (
     expect($model->getFeaturedImageUrl())->toBe('https://example.test/a.jpg');
 });
 
+test('setFeaturedImage invalidates the eager-loaded relation so getFeaturedImageUrl is not stale', function (): void {
+    $model = TestFeaturedImageModel::create(['name' => 'Subject']);
+    $first = TestMedia::create(['url' => 'https://example.test/first.jpg']);
+    $second = TestMedia::create(['url' => 'https://example.test/second.jpg']);
+    $model->setFeaturedImage($first->id);
+
+    $reloaded = TestFeaturedImageModel::with('featuredImage')->find($model->id);
+    expect($reloaded->getFeaturedImageUrl())->toBe('https://example.test/first.jpg');
+
+    $reloaded->setFeaturedImage($second->id);
+
+    expect($reloaded->getFeaturedImageUrl())->toBe('https://example.test/second.jpg');
+});
+
+test('removeFeaturedImage invalidates the eager-loaded relation so getFeaturedImageUrl returns null', function (): void {
+    $model = TestFeaturedImageModel::create(['name' => 'Subject']);
+    $media = TestMedia::create(['url' => 'https://example.test/a.jpg']);
+    $model->setFeaturedImage($media->id);
+
+    $reloaded = TestFeaturedImageModel::with('featuredImage')->find($model->id);
+    expect($reloaded->getFeaturedImageUrl())->toBe('https://example.test/a.jpg');
+
+    $reloaded->removeFeaturedImage();
+
+    expect($reloaded->getFeaturedImageUrl())->toBeNull();
+});
+
 test('getFeaturedImageUrl reuses the eager-loaded relation without re-querying', function (): void {
     $model = TestFeaturedImageModel::create(['name' => 'Subject']);
     $media = TestMedia::create(['url' => 'https://example.test/a.jpg']);


### PR DESCRIPTION
## Description

`HasFeaturedImage` (`src/Modules/ContentTypes/Models/Concerns/HasFeaturedImage.php`) was pointing `morphOne` at `media.featurable_type` / `media.featurable_id` — columns that do not exist on the `media` table shipped by `artisanpack-ui/media-library`. The polymorphic columns actually live on the `featureables` pivot table the cms-framework already ships. The trait was effectively dead code: `setFeaturedImage()` / `removeFeaturedImage()` threw `QueryException` on MySQL/PG (or silently wrote nothing on SQLite), and `getFeaturedImageUrl()` always returned `null`.

This PR takes Option A from the issue: rewrite the trait to use the existing `featureables` pivot via `morphToMany`.

**Closes:** #141

## Type of Change

- [x] Bug fix (fixes an issue)
- [ ] New feature (adds new functionality)
- [ ] Enhancement (improves existing functionality)
- [ ] Refactoring (code improvement, no behavior change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Security fix
- [ ] Breaking change (breaks backward compatibility)

> Note: technically a breaking shape change for `$model->featuredImage` (now a `MorphToMany` relation instead of `MorphOne`), but the trait had no working callers — it was unusable on any supported DB. Calling it a bug fix in the spirit of the issue.

## Related Issue

**Issue:** #141

## Motivation and Context

The trait advertises a polymorphic featured-image pattern and the package even ships the `featureables` pivot to back it, but the relation and mutators all target the wrong table. Integrators following the trait's API hit either schema errors or silent no-ops. Fixing the trait to use the pivot it was designed for restores the "attach a featured image to any host model without adding a column to that model's table" capability — which is the trait's reason for existing alongside the `featured_image_id` FK pattern on `Post` / `Page`.

## Changes Made

- Rewrite `featuredImage()` as `MorphToMany` against the `featureables` pivot, explicitly passing `media_id` as the related pivot key so the relation is stable regardless of the bound Media FQCN.
- `setFeaturedImage(int $mediaId)` now uses `sync([…])` so re-assigning replaces the existing attachment instead of stacking rows.
- `removeFeaturedImage()` uses `detach()` against the pivot.
- `getFeaturedImageUrl(string $size = 'full')` reads via `featuredImage()->first()` so it correctly returns the URL when a media row is attached and `null` otherwise.
- Add a small protected `featuredImageMediaModel(): string` hook (defaults to `\ArtisanPackUI\MediaLibrary\Models\Media::class`) so host models — and the test suite — can substitute a different Media implementation without dragging media-library into the package's hard dependencies.
- New Pest fixtures `tests/Support/TestMedia.php` and `tests/Support/TestFeaturedImageModel.php` and a new test file `tests/Unit/ContentTypes/HasFeaturedImageTest.php`.

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS (Darwin 25.5.0)
- Browser (if applicable): N/A
- PHP Version: 8.4
- Project Version: `release/2.0` head

**Tests Performed:**
1. New unit tests (10) covering: `featuredImage()` returns a `MorphToMany` against `featureables`, `setFeaturedImage()` writes the pivot row, `setFeaturedImage()` replaces rather than appends, `removeFeaturedImage()` clears every row for the host, `removeFeaturedImage()` is a no-op when nothing is attached, `getFeaturedImageUrl()` returns null with no attachment and the URL otherwise, attachments isolate per host model row, and that `Post`/`Page` still apply the trait.
2. Full package test suite: `php -d memory_limit=512M ./vendor/bin/pest --compact` — 879 passed, 4 skipped, 0 failures.
3. CodeRabbit CLI review against `release/2.0`: 0 findings.

## Accessibility Tests Run

- [ ] Keyboard navigation tested
- [ ] Screen reader tested
- [ ] Color contrast verified
- [ ] ARIA labels checked

**Details:** N/A — back-end-only trait change, no UI surface.

## Tests Added

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] All tests passing

**Test details:** See `tests/Unit/ContentTypes/HasFeaturedImageTest.php` (10 tests) and the new `tests/Support/TestMedia.php` / `tests/Support/TestFeaturedImageModel.php` fixtures.

## Documentation

- [x] Inline code documentation added
- [ ] README updated
- [ ] Wiki updated
- [ ] API documentation updated

**Documentation details:** Trait docblocks updated to describe the new `MorphToMany` semantics, the `featureables` pivot, and the `featuredImageMediaModel()` override hook. No public README/wiki references the trait yet.

## Screenshots

N/A.

## Pre-Submission Checklist

- [x] Followed contributing guidelines
- [x] Checked for other open PRs for same update
- [x] Code passes all tests
- [x] Code has been linted
- [ ] Accessibility tests completed
- [x] Code follows project style guide
- [x] Self-review completed
- [x] Comments added for complex code
- [x] No new warnings generated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Redesigned featured-image handling to use a more flexible association with a configurable media model; setting a featured image now replaces the previous attachment, removal detaches it, and URL retrieval returns the current featured image (reusing already-loaded relation to avoid stale reads).

* **Tests**
  * Added comprehensive unit tests and test fixtures covering attach/replace/remove/URL behaviors and isolation across content types.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ArtisanPack-UI/cms-framework/pull/143?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->