### PR TITLE
fix(updates): populate UpdateInfo->sha256 from GitLab releases

### DIFF
--- a/src/Modules/Core/Updates/Managers/ApplicationUpdateManager.php
+++ b/src/Modules/Core/Updates/Managers/ApplicationUpdateManager.php
@@ -90,10 +90,8 @@ class ApplicationUpdateManager
             // Step 3: Download update
             $zipPath = $this->getUpdateChecker()->downloadUpdate($targetVersion);
 
-            // Step 4: Verify checksum (if available)
-            if (config('cms.updates.verify_checksum', true) && $updateInfo->sha256) {
-                $this->verifyChecksum($zipPath, $updateInfo->sha256);
-            }
+            // Step 4: Verify checksum (or surface the silent skip)
+            $this->maybeVerifyChecksum($zipPath, $updateInfo, $targetVersion);
 
             // Step 5: Extract update
             $this->extractUpdate($zipPath);
@@ -369,6 +367,36 @@ class ApplicationUpdateManager
         if ($actualHash !== $expectedHash) {
             throw UpdateException::checksumMismatch($expectedHash, $actualHash);
         }
+    }
+
+    /**
+     * Verify the downloaded ZIP against its declared checksum, or surface that
+     * verification was skipped because the source did not advertise one.
+     *
+     * @since 2.0.0
+     *
+     * @param  string  $zipPath  Path to the downloaded ZIP.
+     * @param  UpdateInfo  $updateInfo  Update metadata from the source.
+     * @param  string  $targetVersion  Version being installed.
+     *
+     * @throws UpdateException When the checksum is present but does not match.
+     */
+    protected function maybeVerifyChecksum(string $zipPath, UpdateInfo $updateInfo, string $targetVersion): void
+    {
+        if (! config('cms.updates.verify_checksum', true)) {
+            return;
+        }
+
+        if ($updateInfo->sha256) {
+            $this->verifyChecksum($zipPath, $updateInfo->sha256);
+
+            return;
+        }
+
+        \Illuminate\Support\Facades\Log::warning('Skipping update integrity verification: update source did not advertise a SHA-256 checksum.', [
+            'target_version' => $targetVersion,
+            'source'         => $updateInfo->metadata['source'] ?? null,
+        ]);
     }
 
     /**

--- a/src/Modules/Core/Updates/Sources/GitLabUpdateSource.php
+++ b/src/Modules/Core/Updates/Sources/GitLabUpdateSource.php
@@ -9,7 +9,9 @@ use ArtisanPackUI\CMSFramework\Modules\Core\Updates\Exceptions\UpdateException;
 use ArtisanPackUI\CMSFramework\Modules\Core\Updates\ValueObjects\UpdateInfo;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
 use InvalidArgumentException;
+use Throwable;
 
 /**
  * GitLab Update Source
@@ -94,12 +96,22 @@ class GitLabUpdateSource implements UpdateSourceInterface
         // Get download link for source code
         $downloadUrl = "https://gitlab.com/api/v4/projects/{$this->projectId}/repository/archive.zip?sha={$latest['tag_name']}";
 
+        $sha256 = $this->extractChecksum($latest);
+
+        if (null === $sha256) {
+            Log::warning('GitLab release does not advertise a SHA-256 checksum; update integrity verification will be skipped.', [
+                'project_id' => $this->projectId,
+                'tag_name'   => $latest['tag_name'] ?? null,
+            ]);
+        }
+
         return new UpdateInfo(
             currentVersion: $this->currentVersion,
             latestVersion: ltrim($latest['tag_name'], 'v'),
             downloadUrl: $downloadUrl,
             changelog: $latest['description'] ?? null,
             releaseDate: $latest['created_at'] ?? null,
+            sha256: $sha256,
             metadata: [
                 'source'      => 'gitlab',
                 'release_url' => "https://gitlab.com/{$this->projectId}/-/releases/{$latest['tag_name']}",
@@ -294,5 +306,145 @@ class GitLabUpdateSource implements UpdateSourceInterface
         }
 
         return "https://gitlab.com/api/v4/projects/{$this->projectId}/repository/archive.zip?sha={$release['tag_name']}";
+    }
+
+    /**
+     * Extract a SHA-256 checksum from a GitLab release.
+     *
+     * Discovery order:
+     *   1. An asset link whose name or URL ends with `.sha256` (fetched and parsed).
+     *   2. A `SHA-256: <64-hex>` line embedded in the release description.
+     *
+     * @since 2.0.0
+     *
+     * @param  array<string, mixed>  $release  Release payload from the GitLab API.
+     *
+     * @return string|null Lowercase 64-character hex digest, or null when no checksum is published.
+     */
+    protected function extractChecksum(array $release): ?string
+    {
+        $sidecarHash = $this->extractChecksumFromSidecar($release);
+
+        if (null !== $sidecarHash) {
+            return $sidecarHash;
+        }
+
+        return $this->extractChecksumFromDescription($release['description'] ?? null);
+    }
+
+    /**
+     * Locate and fetch a `*.sha256` sidecar link from a release's asset links.
+     *
+     * @since 2.0.0
+     *
+     * @param  array<string, mixed>  $release  Release payload from the GitLab API.
+     *
+     * @return string|null Lowercase hex digest, or null if no usable sidecar is found.
+     */
+    protected function extractChecksumFromSidecar(array $release): ?string
+    {
+        $links = $release['assets']['links'] ?? [];
+
+        if (! is_array($links)) {
+            return null;
+        }
+
+        foreach ($links as $link) {
+            if (! is_array($link)) {
+                continue;
+            }
+
+            $name = isset($link['name']) && is_string($link['name']) ? $link['name'] : '';
+            $url  = isset($link['url']) && is_string($link['url']) ? $link['url'] : '';
+
+            if ('' === $url) {
+                continue;
+            }
+
+            if (! str_ends_with(strtolower($name), '.sha256') && ! str_ends_with(strtolower($url), '.sha256')) {
+                continue;
+            }
+
+            $hash = $this->fetchSidecarHash($url);
+
+            if (null !== $hash) {
+                return $hash;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Download a sidecar file and extract the first SHA-256 hex digest it contains.
+     *
+     * Accepts the common sidecar formats: a bare digest or a `<digest>  <filename>` line.
+     *
+     * @since 2.0.0
+     *
+     * @param  string  $url  URL of the `.sha256` sidecar.
+     *
+     * @return string|null Lowercase hex digest, or null on failure / unparseable contents.
+     */
+    protected function fetchSidecarHash(string $url): ?string
+    {
+        $headers = [];
+        if ($this->accessToken) {
+            $headers['PRIVATE-TOKEN'] = $this->accessToken;
+        }
+
+        try {
+            $response = Http::withHeaders($headers)
+                ->timeout(config('cms.updates.http_timeout', 15))
+                ->get($url);
+        } catch (Throwable $e) {
+            Log::warning('Failed to fetch GitLab SHA-256 sidecar.', [
+                'url'   => $url,
+                'error' => $e->getMessage(),
+            ]);
+
+            return null;
+        }
+
+        if (! $response->successful()) {
+            Log::warning('GitLab SHA-256 sidecar request returned a non-success status.', [
+                'url'    => $url,
+                'status' => $response->status(),
+            ]);
+
+            return null;
+        }
+
+        if (preg_match('/\b([a-f0-9]{64})\b/i', $response->body(), $matches)) {
+            return strtolower($matches[1]);
+        }
+
+        Log::warning('GitLab SHA-256 sidecar did not contain a 64-character hex digest.', [
+            'url' => $url,
+        ]);
+
+        return null;
+    }
+
+    /**
+     * Extract a `SHA-256: <hex>` line from a release description.
+     *
+     * @since 2.0.0
+     *
+     * @param  string|null  $description  Release description (Markdown allowed).
+     *
+     * @return string|null Lowercase hex digest, or null when no marker is present.
+     */
+    protected function extractChecksumFromDescription(?string $description): ?string
+    {
+        if (! is_string($description) || '' === $description) {
+            return null;
+        }
+
+        if (preg_match('/SHA-?256\s*[:=]\s*`?([a-f0-9]{64})`?/i', $description, $matches)) {
+            return strtolower($matches[1]);
+        }
+
+        return null;
     }
 }

--- a/tests/Unit/Updates/ApplicationUpdateManagerTest.php
+++ b/tests/Unit/Updates/ApplicationUpdateManagerTest.php
@@ -8,6 +8,7 @@ use ArtisanPackUI\CMSFramework\Modules\Core\Updates\Exceptions\UpdateException;
 use ArtisanPackUI\CMSFramework\Modules\Core\Updates\Managers\ApplicationUpdateManager;
 use ArtisanPackUI\CMSFramework\Modules\Core\Updates\UpdateChecker;
 use ArtisanPackUI\CMSFramework\Modules\Core\Updates\ValueObjects\UpdateInfo;
+use Illuminate\Support\Facades\Log;
 use Orchestra\Testbench\TestCase;
 use ReflectionClass;
 
@@ -170,6 +171,118 @@ class ApplicationUpdateManagerTest extends TestCase
         $result = $manager->checkForUpdate();
 
         $this->assertEquals('2.0.0', $result->latestVersion);
+    }
+
+    /**
+     * Test verifyChecksum throws on mismatch.
+     *
+     * @since 2.0.0
+     */
+    public function test_verify_checksum_throws_on_mismatch(): void
+    {
+        $manager = new ApplicationUpdateManager;
+
+        $zipPath = tempnam(sys_get_temp_dir(), 'cmsfw-update-');
+        file_put_contents($zipPath, 'fake zip contents');
+
+        try {
+            $reflection = new ReflectionClass($manager);
+            $method     = $reflection->getMethod('verifyChecksum');
+            $method->setAccessible(true);
+
+            $this->expectException(UpdateException::class);
+            $this->expectExceptionMessage('Checksum mismatch');
+
+            $method->invoke($manager, $zipPath, str_repeat('0', 64));
+        } finally {
+            @unlink($zipPath);
+        }
+    }
+
+    /**
+     * Test verifyChecksum passes when the digest matches.
+     *
+     * @since 2.0.0
+     */
+    public function test_verify_checksum_passes_when_digest_matches(): void
+    {
+        $manager = new ApplicationUpdateManager;
+
+        $zipPath = tempnam(sys_get_temp_dir(), 'cmsfw-update-');
+        file_put_contents($zipPath, 'matching zip contents');
+
+        try {
+            $reflection = new ReflectionClass($manager);
+            $method     = $reflection->getMethod('verifyChecksum');
+            $method->setAccessible(true);
+
+            $method->invoke($manager, $zipPath, hash_file('sha256', $zipPath));
+
+            $this->assertTrue(true); // No exception means success.
+        } finally {
+            @unlink($zipPath);
+        }
+    }
+
+    /**
+     * Test maybeVerifyChecksum logs a warning when the source omits a checksum.
+     *
+     * @since 2.0.0
+     */
+    public function test_maybe_verify_checksum_logs_warning_when_sha256_missing(): void
+    {
+        config(['cms.updates.verify_checksum' => true]);
+
+        $manager = new ApplicationUpdateManager;
+
+        $updateInfo = new UpdateInfo(
+            currentVersion: '1.0.0',
+            latestVersion: '2.0.0',
+            downloadUrl: 'https://example.com/update.zip',
+            sha256: null,
+            metadata: ['source' => 'gitlab'],
+        );
+
+        Log::shouldReceive('warning')
+            ->once()
+            ->withArgs(function (string $message, array $context): bool {
+                return str_contains($message, 'Skipping update integrity verification')
+                    && '2.0.0' === ($context['target_version'] ?? null)
+                    && 'gitlab' === ($context['source'] ?? null);
+            });
+
+        $reflection = new ReflectionClass($manager);
+        $method     = $reflection->getMethod('maybeVerifyChecksum');
+        $method->setAccessible(true);
+
+        $method->invoke($manager, '/does/not/matter.zip', $updateInfo, '2.0.0');
+    }
+
+    /**
+     * Test maybeVerifyChecksum does not warn when verification is disabled.
+     *
+     * @since 2.0.0
+     */
+    public function test_maybe_verify_checksum_is_silent_when_disabled(): void
+    {
+        config(['cms.updates.verify_checksum' => false]);
+
+        $manager = new ApplicationUpdateManager;
+
+        $updateInfo = new UpdateInfo(
+            currentVersion: '1.0.0',
+            latestVersion: '2.0.0',
+            downloadUrl: 'https://example.com/update.zip',
+            sha256: null,
+        );
+
+        Log::shouldReceive('warning')->never();
+
+        $reflection = new ReflectionClass($manager);
+        $method     = $reflection->getMethod('maybeVerifyChecksum');
+        $method->setAccessible(true);
+
+        $method->invoke($manager, '/does/not/matter.zip', $updateInfo, '2.0.0');
     }
 
     /**

--- a/tests/Unit/Updates/GitLabUpdateSourceTest.php
+++ b/tests/Unit/Updates/GitLabUpdateSourceTest.php
@@ -8,6 +8,7 @@ use ArtisanPackUI\CMSFramework\Modules\Core\Updates\Exceptions\UpdateException;
 use ArtisanPackUI\CMSFramework\Modules\Core\Updates\Sources\GitLabUpdateSource;
 use ArtisanPackUI\CMSFramework\Modules\Core\Updates\ValueObjects\UpdateInfo;
 use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
 use InvalidArgumentException;
 use Orchestra\Testbench\TestCase;
 
@@ -292,6 +293,174 @@ class GitLabUpdateSourceTest extends TestCase
 
         $this->assertEquals('gitlab', $updateInfo->metadata['source']);
         $this->assertArrayHasKey('release_url', $updateInfo->metadata);
+    }
+
+    /**
+     * Test GitLab source populates sha256 from a `.sha256` sidecar link.
+     *
+     * @since 2.0.0
+     */
+    public function test_populates_sha256_from_sidecar_link(): void
+    {
+        $expectedHash = str_repeat('a', 64);
+
+        Http::fake([
+            'gitlab.com/api/v4/projects/user%2Frepo/releases' => Http::response([
+                [
+                    'tag_name'    => 'v2.0.0',
+                    'description' => 'Release notes',
+                    'created_at'  => '2024-12-15T10:00:00.000Z',
+                    'assets'      => [
+                        'links' => [
+                            [
+                                'name' => 'source.zip',
+                                'url'  => 'https://gitlab.com/user/repo/-/releases/v2.0.0/source.zip',
+                            ],
+                            [
+                                'name' => 'source.zip.sha256',
+                                'url'  => 'https://example.com/releases/v2.0.0/source.zip.sha256',
+                            ],
+                        ],
+                    ],
+                ],
+            ], 200),
+            'example.com/releases/v2.0.0/source.zip.sha256' => Http::response(
+                $expectedHash."  source.zip\n",
+                200,
+            ),
+        ]);
+
+        $source     = new GitLabUpdateSource('https://gitlab.com/user/repo', '1.0.0');
+        $updateInfo = $source->checkForUpdate();
+
+        $this->assertSame($expectedHash, $updateInfo->sha256);
+    }
+
+    /**
+     * Test GitLab source populates sha256 from the release description.
+     *
+     * @since 2.0.0
+     */
+    public function test_populates_sha256_from_description_marker(): void
+    {
+        $expectedHash = str_repeat('b', 64);
+
+        Http::fake([
+            'gitlab.com/api/v4/projects/user%2Frepo/releases' => Http::response([
+                [
+                    'tag_name'    => 'v2.0.0',
+                    'description' => "Release notes\n\nSHA-256: {$expectedHash}\n",
+                    'created_at'  => '2024-12-15T10:00:00.000Z',
+                ],
+            ], 200),
+        ]);
+
+        $source     = new GitLabUpdateSource('https://gitlab.com/user/repo', '1.0.0');
+        $updateInfo = $source->checkForUpdate();
+
+        $this->assertSame($expectedHash, $updateInfo->sha256);
+    }
+
+    /**
+     * Test GitLab source logs a warning when no checksum is published.
+     *
+     * @since 2.0.0
+     */
+    public function test_logs_warning_and_leaves_sha256_null_when_absent(): void
+    {
+        Http::fake([
+            'gitlab.com/api/v4/projects/user%2Frepo/releases' => Http::response([
+                [
+                    'tag_name'    => 'v2.0.0',
+                    'description' => 'No checksum here.',
+                    'created_at'  => '2024-12-15T10:00:00.000Z',
+                ],
+            ], 200),
+        ]);
+
+        Log::shouldReceive('warning')
+            ->once()
+            ->withArgs(function (string $message, array $context): bool {
+                return str_contains($message, 'SHA-256')
+                    && 'v2.0.0' === ($context['tag_name'] ?? null);
+            });
+
+        $source     = new GitLabUpdateSource('https://gitlab.com/user/repo', '1.0.0');
+        $updateInfo = $source->checkForUpdate();
+
+        $this->assertNull($updateInfo->sha256);
+    }
+
+    /**
+     * Test GitLab source falls back when sidecar fetch fails and uses description.
+     *
+     * @since 2.0.0
+     */
+    public function test_falls_back_to_description_when_sidecar_fetch_fails(): void
+    {
+        $expectedHash = str_repeat('c', 64);
+
+        Http::fake([
+            'gitlab.com/api/v4/projects/user%2Frepo/releases' => Http::response([
+                [
+                    'tag_name'    => 'v2.0.0',
+                    'description' => "Notes\nSHA256: {$expectedHash}",
+                    'created_at'  => '2024-12-15T10:00:00.000Z',
+                    'assets'      => [
+                        'links' => [
+                            [
+                                'name' => 'source.zip.sha256',
+                                'url'  => 'https://example.com/missing.sha256',
+                            ],
+                        ],
+                    ],
+                ],
+            ], 200),
+            'example.com/missing.sha256' => Http::response('not found', 404),
+        ]);
+
+        // The sidecar fetch failure should be logged, but the source should still
+        // surface a checksum extracted from the description.
+        Log::shouldReceive('warning')->atLeast()->once();
+
+        $source     = new GitLabUpdateSource('https://gitlab.com/user/repo', '1.0.0');
+        $updateInfo = $source->checkForUpdate();
+
+        $this->assertSame($expectedHash, $updateInfo->sha256);
+    }
+
+    /**
+     * Test GitLab source returns null when sidecar body is not a hex digest.
+     *
+     * @since 2.0.0
+     */
+    public function test_returns_null_when_sidecar_body_is_not_hex(): void
+    {
+        Http::fake([
+            'gitlab.com/api/v4/projects/user%2Frepo/releases' => Http::response([
+                [
+                    'tag_name'    => 'v2.0.0',
+                    'description' => 'No description checksum.',
+                    'created_at'  => '2024-12-15T10:00:00.000Z',
+                    'assets'      => [
+                        'links' => [
+                            [
+                                'name' => 'source.zip.sha256',
+                                'url'  => 'https://example.com/bad.sha256',
+                            ],
+                        ],
+                    ],
+                ],
+            ], 200),
+            'example.com/bad.sha256' => Http::response('garbage payload without a hash', 200),
+        ]);
+
+        Log::shouldReceive('warning')->atLeast()->once();
+
+        $source     = new GitLabUpdateSource('https://gitlab.com/user/repo', '1.0.0');
+        $updateInfo = $source->checkForUpdate();
+
+        $this->assertNull($updateInfo->sha256);
     }
 
     /**


### PR DESCRIPTION
## Description

`GitLabUpdateSource::checkForUpdate()` previously constructed `UpdateInfo` without populating the `sha256` field, so the integrity-verification branch in `ApplicationUpdateManager::performUpdate()` (`if (verify_checksum && $updateInfo->sha256)`) always short-circuited for GitLab-sourced updates — silently, with no log entry. Operators believed `cms.updates.verify_checksum = true` (the default) was protecting them when it was not.

This PR adds checksum discovery for GitLab releases and makes the silent skip visible whenever a source omits a checksum.

**Closes:** #119

## Type of Change

- [x] Bug fix (fixes an issue)
- [x] Security fix

## Related Issue

**Issue:** #119

## Motivation and Context

Identified during the Phase 0 audit for `jmwd-keystone-cms` (issue #3). Tagged `Type/Security` because a silent verification skip on the update path is a meaningful integrity gap, even if not directly exploitable in isolation.

## Changes Made

- `GitLabUpdateSource` now discovers a SHA-256 digest by:
  1. Finding a `.sha256` sidecar in `release.assets.links[]`, fetching it (with auth headers reused), and parsing the first `[a-f0-9]{64}` token (supports `<digest>` or `<digest>  filename` formats).
  2. Falling back to a `SHA-256: <64-hex>` / `SHA256: <hex>` marker in the release description.
- When no checksum is discoverable, the source logs a warning with `project_id` + `tag_name`, and leaves `sha256` null.
- `ApplicationUpdateManager` step 4 now routes through a `maybeVerifyChecksum()` helper that:
  - Verifies when a digest is present.
  - Logs a warning (`target_version`, `source`) when verification is enabled but the source did not advertise a checksum.
  - Stays silent when `cms.updates.verify_checksum` is `false`.

Net: the silent skip is gone; either verification runs, or operators see a log line telling them it didn't.

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS (Darwin 25.5.0)
- Browser (if applicable): N/A
- PHP Version: 8.4 (test suite supports 8.2+)
- Project Version: cms-framework `release/2.0`

**Tests Performed:**
1. `./vendor/bin/pest tests/Unit/Updates tests/Feature/Updates --compact` — 74 passed (170 assertions).
2. `php -d memory_limit=1G ./vendor/bin/pest --compact` — full suite: 891 passed, 4 skipped, 0 failed.
3. `cr review --base release/2.0` — 0 findings.

## Accessibility Tests Run

- [x] N/A — backend/security change, no UI surface

**Details:** No user-facing UI was modified.

## Tests Added

- [x] Unit tests added/updated
- [x] All tests passing

**Test details:**

- `GitLabUpdateSourceTest`:
  - `test_populates_sha256_from_sidecar_link` — sidecar URL discovered + fetched + parsed.
  - `test_populates_sha256_from_description_marker` — `SHA-256:` line in description.
  - `test_logs_warning_and_leaves_sha256_null_when_absent` — both sources absent → warning + null.
  - `test_falls_back_to_description_when_sidecar_fetch_fails` — sidecar 404 → fall back to description.
  - `test_returns_null_when_sidecar_body_is_not_hex` — non-hex sidecar body → warning + null.
- `ApplicationUpdateManagerTest`:
  - `test_verify_checksum_throws_on_mismatch` — checksum mismatch.
  - `test_verify_checksum_passes_when_digest_matches` — checksum success.
  - `test_maybe_verify_checksum_logs_warning_when_sha256_missing` — null sha256 + enabled verification → warning.
  - `test_maybe_verify_checksum_is_silent_when_disabled` — disabled verification → no warning.

## Documentation

- [x] Inline code documentation added

**Documentation details:** New methods carry PHPDoc with `@since 2.0.0` and the discovery order is documented inline.

## Screenshots

N/A.

## Pre-Submission Checklist

- [x] Followed contributing guidelines
- [x] Checked for other open PRs for same update
- [x] Code passes all tests
- [x] Code has been linted (CodeRabbit review: 0 findings)
- [x] N/A — no UI surface for accessibility tests
- [x] Code follows project style guide
- [x] Self-review completed
- [x] Comments added for complex code
- [x] No new warnings generated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added SHA-256 checksum verification for application updates to ensure integrity and prevent corrupted installations.
  * Application now automatically discovers and extracts checksums from GitLab release sources.

* **Improvements**
  * Added warning logs when checksum verification is skipped due to missing or disabled checksums, improving transparency during update processes.
  * Enhanced fallback mechanisms to extract checksums from multiple sources (sidecar files and release descriptions).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ArtisanPack-UI/cms-framework/pull/144?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->