### PR TITLE
feat(updates): GitLabUpdateSource release-asset download strategy

### DIFF
--- a/src/Modules/Core/Updates/Sources/GitLabUpdateSource.php
+++ b/src/Modules/Core/Updates/Sources/GitLabUpdateSource.php
@@ -326,10 +326,10 @@ class GitLabUpdateSource implements UpdateSourceInterface
      */
     protected function resolveDownloadUrl(array $release): string
     {
-        $strategy = config('cms.updates.gitlab_update_strategy', 'auto_archive');
+        $strategy = (string) config('cms.updates.gitlab_update_strategy', 'auto_archive');
 
         if ('release_asset' === $strategy) {
-            $pattern = (string) config('cms.updates.gitlab_release_asset_pattern', '*.tar.gz');
+            $pattern = (string) config('cms.updates.gitlab_release_asset_pattern', '*.zip');
             $assetUrl = $this->findReleaseAssetUrl($release, $pattern);
 
             if (null === $assetUrl) {
@@ -343,7 +343,14 @@ class GitLabUpdateSource implements UpdateSourceInterface
             return $assetUrl;
         }
 
-        return $this->buildAutoArchiveUrl($release['tag_name']);
+        if ('auto_archive' === $strategy) {
+            return $this->buildAutoArchiveUrl($release['tag_name']);
+        }
+
+        throw UpdateException::downloadFailed(
+            "Unsupported `cms.updates.gitlab_update_strategy` value '{$strategy}'. "
+            ."Expected 'auto_archive' or 'release_asset'.",
+        );
     }
 
     /**

--- a/src/Modules/Core/Updates/Sources/GitLabUpdateSource.php
+++ b/src/Modules/Core/Updates/Sources/GitLabUpdateSource.php
@@ -93,8 +93,7 @@ class GitLabUpdateSource implements UpdateSourceInterface
             throw UpdateException::versionCheckFailed('No stable releases found');
         }
 
-        // Get download link for source code
-        $downloadUrl = "https://gitlab.com/api/v4/projects/{$this->projectId}/repository/archive.zip?sha={$latest['tag_name']}";
+        $downloadUrl = $this->resolveDownloadUrl($latest);
 
         $sha256 = $this->extractChecksum($latest);
 
@@ -296,16 +295,123 @@ class GitLabUpdateSource implements UpdateSourceInterface
      *
      * @param  array  $release  Release data from GitLab API
      *
+     * @throws UpdateException
+     *
      * @return string Download URL
      */
     protected function extractDownloadUrl(array $release): string
     {
-        // Get download link for source code
         if (! isset($release['tag_name'])) {
             throw UpdateException::downloadFailed('No tag_name found in release');
         }
 
-        return "https://gitlab.com/api/v4/projects/{$this->projectId}/repository/archive.zip?sha={$release['tag_name']}";
+        return $this->resolveDownloadUrl($release);
+    }
+
+    /**
+     * Resolve the download URL for a release based on the configured strategy.
+     *
+     * Two strategies are supported:
+     *   - 'auto_archive' (default): returns the auto-generated GitLab source archive URL.
+     *   - 'release_asset': returns the URL of the first asset link matching
+     *     `cms.updates.gitlab_release_asset_pattern`; throws when no link matches.
+     *
+     * @since 2.0.0
+     *
+     * @param  array<string, mixed>  $release  Release payload from the GitLab API.
+     *
+     * @throws UpdateException When `release_asset` is selected but no asset link matches the pattern.
+     *
+     * @return string Resolved download URL.
+     */
+    protected function resolveDownloadUrl(array $release): string
+    {
+        $strategy = config('cms.updates.gitlab_update_strategy', 'auto_archive');
+
+        if ('release_asset' === $strategy) {
+            $pattern = (string) config('cms.updates.gitlab_release_asset_pattern', '*.tar.gz');
+            $assetUrl = $this->findReleaseAssetUrl($release, $pattern);
+
+            if (null === $assetUrl) {
+                throw UpdateException::downloadFailed(
+                    "No release asset link matched pattern '{$pattern}' for tag '{$release['tag_name']}'. "
+                    .'Either upload a matching asset, adjust `cms.updates.gitlab_release_asset_pattern`, '
+                    ."or set `cms.updates.gitlab_update_strategy` to 'auto_archive'.",
+                );
+            }
+
+            return $assetUrl;
+        }
+
+        return $this->buildAutoArchiveUrl($release['tag_name']);
+    }
+
+    /**
+     * Build the auto-generated GitLab source-archive URL for a tag.
+     *
+     * @since 2.0.0
+     *
+     * @param  string  $tagName  Release tag name (e.g. `v2.0.0`).
+     *
+     * @return string Auto-archive download URL.
+     */
+    protected function buildAutoArchiveUrl(string $tagName): string
+    {
+        return "https://gitlab.com/api/v4/projects/{$this->projectId}/repository/archive.zip?sha={$tagName}";
+    }
+
+    /**
+     * Locate a release-asset link whose name (or URL basename) matches a glob pattern.
+     *
+     * Matches case-insensitively using `fnmatch`. SHA-256 sidecar files
+     * (`*.sha256`) are always excluded so the checksum sidecar is not chosen
+     * as the download target when the pattern is broad.
+     *
+     * @since 2.0.0
+     *
+     * @param  array<string, mixed>  $release  Release payload from the GitLab API.
+     * @param  string  $pattern  Glob pattern compatible with `fnmatch`.
+     *
+     * @return string|null Matching asset URL, or null when no link matches.
+     */
+    protected function findReleaseAssetUrl(array $release, string $pattern): ?string
+    {
+        $links = $release['assets']['links'] ?? [];
+
+        if (! is_array($links)) {
+            return null;
+        }
+
+        $patternLower = strtolower($pattern);
+
+        foreach ($links as $link) {
+            if (! is_array($link)) {
+                continue;
+            }
+
+            $url = isset($link['url']) && is_string($link['url']) ? $link['url'] : '';
+
+            if ('' === $url) {
+                continue;
+            }
+
+            $name = isset($link['name']) && is_string($link['name']) && '' !== $link['name']
+                ? $link['name']
+                : basename(parse_url($url, PHP_URL_PATH) ?: $url);
+
+            $nameLower = strtolower($name);
+
+            // Never select a sidecar checksum as the download target.
+            if (str_ends_with($nameLower, '.sha256')) {
+                continue;
+            }
+
+            if (fnmatch($patternLower, $nameLower)) {
+                return $url;
+            }
+        }
+
+        return null;
     }
 
     /**

--- a/src/Modules/Core/Updates/config/updates.php
+++ b/src/Modules/Core/Updates/config/updates.php
@@ -142,9 +142,12 @@ return [
     |
     | - 'release_asset': resolve the download URL from `release.assets.links[]`
     |   by matching against `gitlab_release_asset_pattern`. This lets CI-built
-    |   tarballs (with curated contents and a sidecar checksum) be consumed
-    |   by the updater. If no link matches the pattern, the update fails
-    |   loudly rather than silently falling back to the auto-archive.
+    |   ZIP archives (with curated contents and a sidecar checksum) be consumed
+    |   by the updater. The matched asset must be a ZIP — the extractor in
+    |   `ApplicationUpdateManager::extractUpdate()` uses `ZipArchive`, so other
+    |   archive formats (e.g. tarballs) are not supported until that extractor
+    |   is extended. If no link matches the pattern, the update fails loudly
+    |   rather than silently falling back to the auto-archive.
     |
     */
     'gitlab_update_strategy' => env( 'GITLAB_UPDATE_STRATEGY', 'auto_archive' ),
@@ -160,9 +163,9 @@ return [
     | to the basename of its `url` when the name is missing.
     |
     | The default is `*.zip` because the update extractor uses `ZipArchive`.
-    | Other archive formats (e.g. `*.tar.gz`) can be selected via this glob,
-    | but the matched asset must still be a ZIP — supporting tarballs would
-    | require extending the extractor in `ApplicationUpdateManager`.
+    | Customizing this glob only changes which asset link is selected; the
+    | matched asset must still be a ZIP. Supporting other archive formats
+    | (tarballs, etc.) would require extending `ApplicationUpdateManager::extractUpdate()`.
     |
     */
     'gitlab_release_asset_pattern' => env( 'GITLAB_RELEASE_ASSET_PATTERN', '*.zip' ),

--- a/src/Modules/Core/Updates/config/updates.php
+++ b/src/Modules/Core/Updates/config/updates.php
@@ -127,4 +127,38 @@ return [
     |
     */
     'verify_checksum' => true,
+
+    /*
+    |--------------------------------------------------------------------------
+    | GitLab Update Strategy
+    |--------------------------------------------------------------------------
+    |
+    | Controls how `GitLabUpdateSource` resolves the download URL for a
+    | release. Two strategies are supported:
+    |
+    | - 'auto_archive' (default): use the auto-generated source archive at
+    |   `/api/v4/projects/{id}/repository/archive.zip?sha={tag}`. This works
+    |   for any repository regardless of whether CI uploaded release assets.
+    |
+    | - 'release_asset': resolve the download URL from `release.assets.links[]`
+    |   by matching against `gitlab_release_asset_pattern`. This lets CI-built
+    |   tarballs (with curated contents and a sidecar checksum) be consumed
+    |   by the updater. If no link matches the pattern, the update fails
+    |   loudly rather than silently falling back to the auto-archive.
+    |
+    */
+    'gitlab_update_strategy' => env( 'GITLAB_UPDATE_STRATEGY', 'auto_archive' ),
+
+    /*
+    |--------------------------------------------------------------------------
+    | GitLab Release Asset Pattern
+    |--------------------------------------------------------------------------
+    |
+    | Glob pattern (compatible with `fnmatch`) used to select the release
+    | asset link when `gitlab_update_strategy` is `'release_asset'`. Matched
+    | case-insensitively against the asset link's `name` field, falling back
+    | to the basename of its `url` when the name is missing.
+    |
+    */
+    'gitlab_release_asset_pattern' => env( 'GITLAB_RELEASE_ASSET_PATTERN', '*.tar.gz' ),
 ];

--- a/src/Modules/Core/Updates/config/updates.php
+++ b/src/Modules/Core/Updates/config/updates.php
@@ -159,6 +159,11 @@ return [
     | case-insensitively against the asset link's `name` field, falling back
     | to the basename of its `url` when the name is missing.
     |
+    | The default is `*.zip` because the update extractor uses `ZipArchive`.
+    | Other archive formats (e.g. `*.tar.gz`) can be selected via this glob,
+    | but the matched asset must still be a ZIP — supporting tarballs would
+    | require extending the extractor in `ApplicationUpdateManager`.
+    |
     */
-    'gitlab_release_asset_pattern' => env( 'GITLAB_RELEASE_ASSET_PATTERN', '*.tar.gz' ),
+    'gitlab_release_asset_pattern' => env( 'GITLAB_RELEASE_ASSET_PATTERN', '*.zip' ),
 ];

--- a/tests/Unit/Updates/GitLabUpdateSourceTest.php
+++ b/tests/Unit/Updates/GitLabUpdateSourceTest.php
@@ -514,12 +514,12 @@ class GitLabUpdateSourceTest extends TestCase
                     'assets'      => [
                         'links' => [
                             [
-                                'name' => 'app-2.0.0.tar.gz',
-                                'url'  => 'https://example.com/releases/app-2.0.0.tar.gz',
+                                'name' => 'app-2.0.0.zip',
+                                'url'  => 'https://example.com/releases/app-2.0.0.zip',
                             ],
                             [
-                                'name' => 'app-2.0.0.tar.gz.sha256',
-                                'url'  => 'https://example.com/releases/app-2.0.0.tar.gz.sha256',
+                                'name' => 'app-2.0.0.zip.sha256',
+                                'url'  => 'https://example.com/releases/app-2.0.0.zip.sha256',
                             ],
                         ],
                     ],
@@ -530,7 +530,7 @@ class GitLabUpdateSourceTest extends TestCase
         $source     = new GitLabUpdateSource('https://gitlab.com/user/repo', '1.0.0');
         $updateInfo = $source->checkForUpdate();
 
-        $this->assertSame('https://example.com/releases/app-2.0.0.tar.gz', $updateInfo->downloadUrl);
+        $this->assertSame('https://example.com/releases/app-2.0.0.zip', $updateInfo->downloadUrl);
     }
 
     /**
@@ -589,8 +589,8 @@ class GitLabUpdateSourceTest extends TestCase
                     'assets'      => [
                         'links' => [
                             [
-                                'name' => 'App-2.0.0.TAR.GZ',
-                                'url'  => 'https://example.com/App-2.0.0.TAR.GZ',
+                                'name' => 'App-2.0.0.ZIP',
+                                'url'  => 'https://example.com/App-2.0.0.ZIP',
                             ],
                         ],
                     ],
@@ -601,7 +601,7 @@ class GitLabUpdateSourceTest extends TestCase
         $source     = new GitLabUpdateSource('https://gitlab.com/user/repo', '1.0.0');
         $updateInfo = $source->checkForUpdate();
 
-        $this->assertSame('https://example.com/App-2.0.0.TAR.GZ', $updateInfo->downloadUrl);
+        $this->assertSame('https://example.com/App-2.0.0.ZIP', $updateInfo->downloadUrl);
     }
 
     /**
@@ -622,7 +622,7 @@ class GitLabUpdateSourceTest extends TestCase
                     'assets'      => [
                         'links' => [
                             [
-                                'url' => 'https://example.com/builds/app-2.0.0.tar.gz?token=abc',
+                                'url' => 'https://example.com/builds/app-2.0.0.zip?token=abc',
                             ],
                         ],
                     ],
@@ -633,7 +633,7 @@ class GitLabUpdateSourceTest extends TestCase
         $source     = new GitLabUpdateSource('https://gitlab.com/user/repo', '1.0.0');
         $updateInfo = $source->checkForUpdate();
 
-        $this->assertSame('https://example.com/builds/app-2.0.0.tar.gz?token=abc', $updateInfo->downloadUrl);
+        $this->assertSame('https://example.com/builds/app-2.0.0.zip?token=abc', $updateInfo->downloadUrl);
     }
 
     /**
@@ -656,12 +656,12 @@ class GitLabUpdateSourceTest extends TestCase
                     'assets'      => [
                         'links' => [
                             [
-                                'name' => 'app-2.0.0.tar.gz.sha256',
-                                'url'  => 'https://example.com/app-2.0.0.tar.gz.sha256',
+                                'name' => 'app-2.0.0.zip.sha256',
+                                'url'  => 'https://example.com/app-2.0.0.zip.sha256',
                             ],
                             [
-                                'name' => 'app-2.0.0.tar.gz',
-                                'url'  => 'https://example.com/app-2.0.0.tar.gz',
+                                'name' => 'app-2.0.0.zip',
+                                'url'  => 'https://example.com/app-2.0.0.zip',
                             ],
                         ],
                     ],
@@ -672,7 +672,7 @@ class GitLabUpdateSourceTest extends TestCase
         $source     = new GitLabUpdateSource('https://gitlab.com/user/repo', '1.0.0');
         $updateInfo = $source->checkForUpdate();
 
-        $this->assertSame('https://example.com/app-2.0.0.tar.gz', $updateInfo->downloadUrl);
+        $this->assertSame('https://example.com/app-2.0.0.zip', $updateInfo->downloadUrl);
     }
 
     /**
@@ -705,7 +705,7 @@ class GitLabUpdateSourceTest extends TestCase
         $source = new GitLabUpdateSource('https://gitlab.com/user/repo', '1.0.0');
 
         $this->expectException(UpdateException::class);
-        $this->expectExceptionMessage("No release asset link matched pattern '*.tar.gz'");
+        $this->expectExceptionMessage("No release asset link matched pattern '*.zip'");
 
         $source->checkForUpdate();
     }
@@ -737,6 +737,33 @@ class GitLabUpdateSourceTest extends TestCase
     }
 
     /**
+     * Test GitLab source throws for an unsupported `gitlab_update_strategy` value.
+     *
+     * @since 2.0.0
+     */
+    public function test_throws_for_unsupported_gitlab_update_strategy(): void
+    {
+        config()->set('cms.updates.gitlab_update_strategy', 'bogus_strategy');
+
+        Http::fake([
+            'gitlab.com/api/v4/projects/user%2Frepo/releases' => Http::response([
+                [
+                    'tag_name'    => 'v2.0.0',
+                    'description' => 'Release',
+                    'created_at'  => '2024-12-15T10:00:00.000Z',
+                ],
+            ], 200),
+        ]);
+
+        $source = new GitLabUpdateSource('https://gitlab.com/user/repo', '1.0.0');
+
+        $this->expectException(UpdateException::class);
+        $this->expectExceptionMessage("Unsupported `cms.updates.gitlab_update_strategy` value 'bogus_strategy'");
+
+        $source->checkForUpdate();
+    }
+
+    /**
      * Test GitLab source uses release_asset URL when downloading an explicit version.
      *
      * @since 2.0.0
@@ -753,20 +780,20 @@ class GitLabUpdateSourceTest extends TestCase
                 'assets'      => [
                     'links' => [
                         [
-                            'name' => 'app-2.0.0.tar.gz',
-                            'url'  => 'https://example.com/app-2.0.0.tar.gz',
+                            'name' => 'app-2.0.0.zip',
+                            'url'  => 'https://example.com/app-2.0.0.zip',
                         ],
                     ],
                 ],
             ], 200),
-            'example.com/app-2.0.0.tar.gz' => Http::response('tarball-bytes', 200),
+            'example.com/app-2.0.0.zip' => Http::response('zip-bytes', 200),
         ]);
 
         $source = new GitLabUpdateSource('https://gitlab.com/user/repo', '1.0.0');
         $source->downloadUpdate('v2.0.0');
 
         Http::assertSent(function ($request) {
-            return 'https://example.com/app-2.0.0.tar.gz' === $request->url();
+            return 'https://example.com/app-2.0.0.zip' === $request->url();
         });
     }
 

--- a/tests/Unit/Updates/GitLabUpdateSourceTest.php
+++ b/tests/Unit/Updates/GitLabUpdateSourceTest.php
@@ -464,6 +464,313 @@ class GitLabUpdateSourceTest extends TestCase
     }
 
     /**
+     * Test GitLab source defaults to auto-archive URL when strategy is unset.
+     *
+     * @since 2.0.0
+     */
+    public function test_uses_auto_archive_url_by_default(): void
+    {
+        // No `gitlab_update_strategy` set — should default to auto_archive.
+        Http::fake([
+            'gitlab.com/api/v4/projects/user%2Frepo/releases' => Http::response([
+                [
+                    'tag_name'    => 'v2.0.0',
+                    'description' => 'Release',
+                    'created_at'  => '2024-12-15T10:00:00.000Z',
+                    'assets'      => [
+                        'links' => [
+                            [
+                                'name' => 'app-2.0.0.tar.gz',
+                                'url'  => 'https://example.com/app-2.0.0.tar.gz',
+                            ],
+                        ],
+                    ],
+                ],
+            ], 200),
+        ]);
+
+        $source     = new GitLabUpdateSource('https://gitlab.com/user/repo', '1.0.0');
+        $updateInfo = $source->checkForUpdate();
+
+        $this->assertStringContainsString('/repository/archive.zip', $updateInfo->downloadUrl);
+        $this->assertStringContainsString('sha=v2.0.0', $updateInfo->downloadUrl);
+    }
+
+    /**
+     * Test GitLab source resolves download URL from release assets when strategy is release_asset.
+     *
+     * @since 2.0.0
+     */
+    public function test_uses_release_asset_url_when_strategy_is_release_asset(): void
+    {
+        config()->set('cms.updates.gitlab_update_strategy', 'release_asset');
+
+        Http::fake([
+            'gitlab.com/api/v4/projects/user%2Frepo/releases' => Http::response([
+                [
+                    'tag_name'    => 'v2.0.0',
+                    'description' => 'Release',
+                    'created_at'  => '2024-12-15T10:00:00.000Z',
+                    'assets'      => [
+                        'links' => [
+                            [
+                                'name' => 'app-2.0.0.tar.gz',
+                                'url'  => 'https://example.com/releases/app-2.0.0.tar.gz',
+                            ],
+                            [
+                                'name' => 'app-2.0.0.tar.gz.sha256',
+                                'url'  => 'https://example.com/releases/app-2.0.0.tar.gz.sha256',
+                            ],
+                        ],
+                    ],
+                ],
+            ], 200),
+        ]);
+
+        $source     = new GitLabUpdateSource('https://gitlab.com/user/repo', '1.0.0');
+        $updateInfo = $source->checkForUpdate();
+
+        $this->assertSame('https://example.com/releases/app-2.0.0.tar.gz', $updateInfo->downloadUrl);
+    }
+
+    /**
+     * Test GitLab source honors a configurable release asset glob pattern.
+     *
+     * @since 2.0.0
+     */
+    public function test_release_asset_pattern_is_configurable(): void
+    {
+        config()->set('cms.updates.gitlab_update_strategy', 'release_asset');
+        config()->set('cms.updates.gitlab_release_asset_pattern', '*-release.zip');
+
+        Http::fake([
+            'gitlab.com/api/v4/projects/user%2Frepo/releases' => Http::response([
+                [
+                    'tag_name'    => 'v2.0.0',
+                    'description' => 'Release',
+                    'created_at'  => '2024-12-15T10:00:00.000Z',
+                    'assets'      => [
+                        'links' => [
+                            [
+                                'name' => 'app-2.0.0.tar.gz',
+                                'url'  => 'https://example.com/app-2.0.0.tar.gz',
+                            ],
+                            [
+                                'name' => 'app-2.0.0-release.zip',
+                                'url'  => 'https://example.com/app-2.0.0-release.zip',
+                            ],
+                        ],
+                    ],
+                ],
+            ], 200),
+        ]);
+
+        $source     = new GitLabUpdateSource('https://gitlab.com/user/repo', '1.0.0');
+        $updateInfo = $source->checkForUpdate();
+
+        $this->assertSame('https://example.com/app-2.0.0-release.zip', $updateInfo->downloadUrl);
+    }
+
+    /**
+     * Test GitLab source matches the asset pattern case-insensitively.
+     *
+     * @since 2.0.0
+     */
+    public function test_release_asset_pattern_matches_case_insensitively(): void
+    {
+        config()->set('cms.updates.gitlab_update_strategy', 'release_asset');
+
+        Http::fake([
+            'gitlab.com/api/v4/projects/user%2Frepo/releases' => Http::response([
+                [
+                    'tag_name'    => 'v2.0.0',
+                    'description' => 'Release',
+                    'created_at'  => '2024-12-15T10:00:00.000Z',
+                    'assets'      => [
+                        'links' => [
+                            [
+                                'name' => 'App-2.0.0.TAR.GZ',
+                                'url'  => 'https://example.com/App-2.0.0.TAR.GZ',
+                            ],
+                        ],
+                    ],
+                ],
+            ], 200),
+        ]);
+
+        $source     = new GitLabUpdateSource('https://gitlab.com/user/repo', '1.0.0');
+        $updateInfo = $source->checkForUpdate();
+
+        $this->assertSame('https://example.com/App-2.0.0.TAR.GZ', $updateInfo->downloadUrl);
+    }
+
+    /**
+     * Test GitLab source falls back to URL basename when asset link has no name.
+     *
+     * @since 2.0.0
+     */
+    public function test_release_asset_matches_against_url_basename_when_name_missing(): void
+    {
+        config()->set('cms.updates.gitlab_update_strategy', 'release_asset');
+
+        Http::fake([
+            'gitlab.com/api/v4/projects/user%2Frepo/releases' => Http::response([
+                [
+                    'tag_name'    => 'v2.0.0',
+                    'description' => 'Release',
+                    'created_at'  => '2024-12-15T10:00:00.000Z',
+                    'assets'      => [
+                        'links' => [
+                            [
+                                'url' => 'https://example.com/builds/app-2.0.0.tar.gz?token=abc',
+                            ],
+                        ],
+                    ],
+                ],
+            ], 200),
+        ]);
+
+        $source     = new GitLabUpdateSource('https://gitlab.com/user/repo', '1.0.0');
+        $updateInfo = $source->checkForUpdate();
+
+        $this->assertSame('https://example.com/builds/app-2.0.0.tar.gz?token=abc', $updateInfo->downloadUrl);
+    }
+
+    /**
+     * Test GitLab source never selects a SHA-256 sidecar as the download target.
+     *
+     * @since 2.0.0
+     */
+    public function test_release_asset_strategy_skips_sha256_sidecars(): void
+    {
+        config()->set('cms.updates.gitlab_update_strategy', 'release_asset');
+        // Set a permissive pattern that would otherwise match the sidecar.
+        config()->set('cms.updates.gitlab_release_asset_pattern', '*');
+
+        Http::fake([
+            'gitlab.com/api/v4/projects/user%2Frepo/releases' => Http::response([
+                [
+                    'tag_name'    => 'v2.0.0',
+                    'description' => 'Release',
+                    'created_at'  => '2024-12-15T10:00:00.000Z',
+                    'assets'      => [
+                        'links' => [
+                            [
+                                'name' => 'app-2.0.0.tar.gz.sha256',
+                                'url'  => 'https://example.com/app-2.0.0.tar.gz.sha256',
+                            ],
+                            [
+                                'name' => 'app-2.0.0.tar.gz',
+                                'url'  => 'https://example.com/app-2.0.0.tar.gz',
+                            ],
+                        ],
+                    ],
+                ],
+            ], 200),
+        ]);
+
+        $source     = new GitLabUpdateSource('https://gitlab.com/user/repo', '1.0.0');
+        $updateInfo = $source->checkForUpdate();
+
+        $this->assertSame('https://example.com/app-2.0.0.tar.gz', $updateInfo->downloadUrl);
+    }
+
+    /**
+     * Test GitLab source throws when release_asset strategy is set but no asset matches.
+     *
+     * @since 2.0.0
+     */
+    public function test_throws_when_release_asset_strategy_and_no_matching_asset(): void
+    {
+        config()->set('cms.updates.gitlab_update_strategy', 'release_asset');
+
+        Http::fake([
+            'gitlab.com/api/v4/projects/user%2Frepo/releases' => Http::response([
+                [
+                    'tag_name'    => 'v2.0.0',
+                    'description' => 'Release',
+                    'created_at'  => '2024-12-15T10:00:00.000Z',
+                    'assets'      => [
+                        'links' => [
+                            [
+                                'name' => 'docs.pdf',
+                                'url'  => 'https://example.com/docs.pdf',
+                            ],
+                        ],
+                    ],
+                ],
+            ], 200),
+        ]);
+
+        $source = new GitLabUpdateSource('https://gitlab.com/user/repo', '1.0.0');
+
+        $this->expectException(UpdateException::class);
+        $this->expectExceptionMessage("No release asset link matched pattern '*.tar.gz'");
+
+        $source->checkForUpdate();
+    }
+
+    /**
+     * Test GitLab source throws when release_asset strategy is set but no asset links exist.
+     *
+     * @since 2.0.0
+     */
+    public function test_throws_when_release_asset_strategy_and_no_asset_links(): void
+    {
+        config()->set('cms.updates.gitlab_update_strategy', 'release_asset');
+
+        Http::fake([
+            'gitlab.com/api/v4/projects/user%2Frepo/releases' => Http::response([
+                [
+                    'tag_name'    => 'v2.0.0',
+                    'description' => 'Release without assets',
+                    'created_at'  => '2024-12-15T10:00:00.000Z',
+                ],
+            ], 200),
+        ]);
+
+        $source = new GitLabUpdateSource('https://gitlab.com/user/repo', '1.0.0');
+
+        $this->expectException(UpdateException::class);
+
+        $source->checkForUpdate();
+    }
+
+    /**
+     * Test GitLab source uses release_asset URL when downloading an explicit version.
+     *
+     * @since 2.0.0
+     */
+    public function test_release_asset_strategy_is_applied_for_explicit_version_downloads(): void
+    {
+        config()->set('cms.updates.gitlab_update_strategy', 'release_asset');
+
+        Http::fake([
+            'gitlab.com/api/v4/projects/user%2Frepo/releases/v2.0.0' => Http::response([
+                'tag_name'    => 'v2.0.0',
+                'description' => 'Release',
+                'created_at'  => '2024-12-15T10:00:00.000Z',
+                'assets'      => [
+                    'links' => [
+                        [
+                            'name' => 'app-2.0.0.tar.gz',
+                            'url'  => 'https://example.com/app-2.0.0.tar.gz',
+                        ],
+                    ],
+                ],
+            ], 200),
+            'example.com/app-2.0.0.tar.gz' => Http::response('tarball-bytes', 200),
+        ]);
+
+        $source = new GitLabUpdateSource('https://gitlab.com/user/repo', '1.0.0');
+        $source->downloadUpdate('v2.0.0');
+
+        Http::assertSent(function ($request) {
+            return 'https://example.com/app-2.0.0.tar.gz' === $request->url();
+        });
+    }
+
+    /**
      * Define environment setup.
      *
      * @since 1.0.0


### PR DESCRIPTION
## Description

Adds a `release_asset` strategy to `GitLabUpdateSource` so consumers can have the updater pull a curated, CI-built tarball from a release's asset links instead of GitLab's auto-generated repo source archive.

**Closes:** #118

## Type of Change

- [x] Enhancement (improves existing functionality)

## Related Issue

**Issue:** #118

## Motivation and Context

Until now, `GitLabUpdateSource::checkForUpdate()` always built a URL pointing at `/api/v4/projects/{id}/repository/archive.zip?sha={tag}`, which bypasses any release assets CI uploaded for the release. Consumers shipping a curated tarball (excluding dev files, test dirs, etc.) plus a sidecar checksum could not have those assets consumed by the updater. This change gates the new behavior behind a config flag so existing consumers are unaffected.

## Changes Made

- `src/Modules/Core/Updates/Sources/GitLabUpdateSource.php`
  - New `resolveDownloadUrl()` / `findReleaseAssetUrl()` / `buildAutoArchiveUrl()` helpers.
  - `checkForUpdate()` and `extractDownloadUrl()` now delegate URL resolution to `resolveDownloadUrl()`.
  - `release_asset` strategy matches `release.assets.links[]` against a configurable glob (case-insensitive, with URL-basename fallback when the link has no `name`). SHA-256 sidecars are skipped so they cannot be selected as the download target.
  - When the strategy is `release_asset` and no link matches, the source throws `UpdateException::downloadFailed()` with guidance — fail loud, do not silently fall back to the auto-archive.
- `src/Modules/Core/Updates/config/updates.php`
  - New `gitlab_update_strategy` (`auto_archive` default for back-compat, or `release_asset`), env-driven via `GITLAB_UPDATE_STRATEGY`.
  - New `gitlab_release_asset_pattern` (default `*.tar.gz`), env-driven via `GITLAB_RELEASE_ASSET_PATTERN`.
- `tests/Unit/Updates/GitLabUpdateSourceTest.php`
  - 9 new tests covering both strategies, configurable pattern, case-insensitive matching, basename fallback, sidecar exclusion, no-match fail-loud behavior, missing-assets fail-loud behavior, and the explicit-version download path.

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS
- PHP Version: 8.4.3
- Project Version: release/2.0

**Tests Performed:**
1. `./vendor/bin/pest tests/Unit/Updates/GitLabUpdateSourceTest.php` — 27 passed (47 assertions).
2. `./vendor/bin/pest tests/Unit/Updates tests/Feature/Updates` — 83 passed (181 assertions).
3. `php -d memory_limit=512M ./vendor/bin/pest` — 900 passed, 4 skipped (2330 assertions). Pre-existing skips, no regressions.

## Tests Added

- [x] Unit tests added/updated
- [x] All tests passing

**Test details:** 9 new Pest tests in `GitLabUpdateSourceTest.php` covering the new strategy + edge cases listed above.

## Documentation

- [x] Inline code documentation added

**Documentation details:** New config keys documented inline in `updates.php`. New methods carry PHPDoc with `@since 2.0.0`.

## Backwards Compatibility

Default `gitlab_update_strategy` is `auto_archive`, so existing consumers see no behavior change. Opting into `release_asset` is required to get the new behavior.

## Pre-Submission Checklist

- [x] Code passes all tests
- [x] Self-review completed
- [x] Comments added for complex code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * GitLab updates now support configurable download strategies: use the default archive URL or select a specific release asset via glob pattern. Asset selection ignores checksum sidecars and tolerates missing asset metadata; unsupported strategies or no matching asset yield clear errors.
  * New configuration options to control the GitLab update strategy and asset matching.

* **Tests**
  * Added tests covering strategy selection, pattern matching, edge cases, and error conditions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ArtisanPack-UI/cms-framework/pull/145?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->