### PR TITLE
feat: enforce strict manifest schema for theme installs

### DIFF
--- a/docs/themes.md
+++ b/docs/themes.md
@@ -166,6 +166,29 @@ When `ThemeManager::discoverThemes()` runs, each theme is validated in three sta
 
 Themes that fail any stage are skipped from discovery. Schema failures log a warning naming the offending key (e.g. `settings.color.palette`) so theme authors can correct their manifest.
 
+### Strict install validation
+
+`ThemeManager::installFromZip()` runs an additional `validateManifest()` check after extraction. This stricter pass is the contract every uploadable theme must satisfy. It is not applied to themes already on disk so existing installations are not broken by tightened rules.
+
+**Required fields:**
+
+- `slug` — alphanumeric, hyphens, and underscores only (`/^[a-zA-Z0-9_-]+$/`).
+- `name` — non-empty string.
+- `version` — anchored semver `MAJOR.MINOR.PATCH` (`/^\d+\.\d+\.\d+$/`). Anchoring is deliberate; it prevents injection suffixes such as `1.0.0'; DROP TABLE`.
+
+**Optional fields, validated when present:**
+
+- `screenshot` — basename only, no path separators (`/` or `\`), with an allowlisted image extension (`png`, `jpg`, `jpeg`, `webp`).
+- `requires` — anchored semver, same shape as `version`.
+- `templates.layouts`, `templates.pages`, `templates.partials` — arrays of strings.
+- `supports.*` — booleans (e.g. `supports.menus`, `supports.widgets`).
+
+If validation fails, the freshly extracted theme directory is removed and a `ThemeValidationException` is thrown.
+
+### Reserved `keystone` namespace
+
+The `keystone` top-level key is reserved for consumer-specific install hints (e.g. `keystone.installer`, `keystone.seed.pages[]`). cms-framework treats this namespace as opaque — it is preserved through parsing but not interpreted. Downstream CMSes can layer their own installer/seed contracts under `keystone` without forking the manifest spec.
+
 ## Template Hierarchy
 
 The theme system implements a WordPress‑style template hierarchy for resolving templates:

--- a/src/Modules/Themes/Managers/ThemeManager.php
+++ b/src/Modules/Themes/Managers/ThemeManager.php
@@ -222,6 +222,14 @@ class ThemeManager
             throw ThemeValidationException::invalidManifest( "Theme '{$slug}' manifest could not be parsed after extraction." );
         }
 
+        try {
+            $this->validateManifest( $manifest );
+        } catch ( ThemeValidationException $e ) {
+            File::deleteDirectory( $themePath );
+
+            throw $e;
+        }
+
         Cache::forget( config( 'cms.themes.cacheKey', 'cms.themes.discovered' ) );
 
         return $manifest;
@@ -611,6 +619,148 @@ class ThemeManager
     }
 
     /**
+     * Validate a parsed theme.json manifest against the strict schema.
+     *
+     * Mirrors the Plugins module's required-field enforcement and adds
+     * screenshot-path safety and optional-field type checks. Intended for
+     * the upload/install path: `discoverThemes()` keeps using the looser
+     * WP-shape validator so existing on-disk themes are not broken by
+     * stricter rules.
+     *
+     * Required fields:
+     *  - `slug` — alphanumeric, hyphens, underscores (matches Plugins).
+     *  - `name` — non-empty string.
+     *  - `version` — anchored semver `MAJOR.MINOR.PATCH` (matches Plugins).
+     *
+     * Optional fields, validated when present:
+     *  - `screenshot` — basename only (no path separators) with an
+     *    allowlisted image extension (png, jpg, jpeg, webp).
+     *  - `requires` — anchored semver.
+     *  - `templates.layouts|pages|partials` — arrays of strings.
+     *  - `supports.*` — booleans.
+     *
+     * The `keystone` namespace is reserved for consumer-specific install
+     * hints (e.g. `keystone.installer`, `keystone.seed.pages[]`) and is
+     * intentionally opaque to the framework.
+     *
+     * @since 1.2.0
+     *
+     * @param  array  $manifest  Parsed theme.json contents.
+     *
+     * @throws ThemeValidationException If any required or optional field fails its check.
+     */
+    protected function validateManifest( array $manifest ): void
+    {
+        $required = ['slug', 'name', 'version'];
+
+        foreach ( $required as $field ) {
+            $value = $manifest[ $field ] ?? null;
+
+            if ( null === $value || ( is_string( $value ) && '' === trim( $value ) ) ) {
+                throw ThemeValidationException::invalidManifest( "Missing required field: {$field}" );
+            }
+
+            if ( ! is_string( $value ) ) {
+                throw ThemeValidationException::invalidManifest( "Field '{$field}' must be a string." );
+            }
+        }
+
+        if ( ! $this->validateSlug( $manifest['slug'] ) ) {
+            throw ThemeValidationException::invalidManifest(
+                'Invalid slug format. Use alphanumeric, hyphens, and underscores only.',
+            );
+        }
+
+        // Anchored at end to prevent injection attempts like "1.0.0'; DROP TABLE".
+        if ( ! preg_match( '/^\d+\.\d+\.\d+$/', $manifest['version'] ) ) {
+            throw ThemeValidationException::invalidManifest(
+                'Invalid version format. Use semantic versioning (e.g., 1.0.0).',
+            );
+        }
+
+        if ( isset( $manifest['screenshot'] ) ) {
+            $screenshot = $manifest['screenshot'];
+
+            if ( ! is_string( $screenshot ) || '' === $screenshot ) {
+                throw ThemeValidationException::invalidManifest(
+                    "Field 'screenshot' must be a non-empty string.",
+                );
+            }
+
+            if ( str_contains( $screenshot, '/' ) || str_contains( $screenshot, '\\' ) ) {
+                throw ThemeValidationException::invalidManifest(
+                    "Field 'screenshot' must be a filename, not a path.",
+                );
+            }
+
+            $extension         = strtolower( pathinfo( $screenshot, PATHINFO_EXTENSION ) );
+            $allowedExtensions = ['png', 'jpg', 'jpeg', 'webp'];
+
+            if ( ! in_array( $extension, $allowedExtensions, true ) ) {
+                throw ThemeValidationException::invalidManifest(
+                    "Field 'screenshot' must have an allowed extension (png, jpg, jpeg, webp).",
+                );
+            }
+        }
+
+        if ( isset( $manifest['requires'] ) ) {
+            $requires = $manifest['requires'];
+
+            if ( ! is_string( $requires ) || ! preg_match( '/^\d+\.\d+\.\d+$/', $requires ) ) {
+                throw ThemeValidationException::invalidManifest(
+                    "Field 'requires' must be a semver string (e.g., 1.0.0).",
+                );
+            }
+        }
+
+        if ( isset( $manifest['templates'] ) ) {
+            if ( ! is_array( $manifest['templates'] ) ) {
+                throw ThemeValidationException::invalidManifest(
+                    "Field 'templates' must be an object.",
+                );
+            }
+
+            foreach ( ['layouts', 'pages', 'partials'] as $bucket ) {
+                if ( ! isset( $manifest['templates'][ $bucket ] ) ) {
+                    continue;
+                }
+
+                $entries = $manifest['templates'][ $bucket ];
+
+                if ( ! is_array( $entries ) ) {
+                    throw ThemeValidationException::invalidManifest(
+                        "Field 'templates.{$bucket}' must be an array of strings.",
+                    );
+                }
+
+                foreach ( $entries as $entry ) {
+                    if ( ! is_string( $entry ) ) {
+                        throw ThemeValidationException::invalidManifest(
+                            "Field 'templates.{$bucket}' must contain strings only.",
+                        );
+                    }
+                }
+            }
+        }
+
+        if ( isset( $manifest['supports'] ) ) {
+            if ( ! is_array( $manifest['supports'] ) ) {
+                throw ThemeValidationException::invalidManifest(
+                    "Field 'supports' must be an object.",
+                );
+            }
+
+            foreach ( $manifest['supports'] as $feature => $value ) {
+                if ( ! is_bool( $value ) ) {
+                    throw ThemeValidationException::invalidManifest(
+                        "Field 'supports.{$feature}' must be a boolean.",
+                    );
+                }
+            }
+        }
+    }
+
+    /**
      * Gets the themes base directory path.
      *
      * Returns the absolute path to the themes directory based on the
@@ -622,9 +772,9 @@ class ThemeManager
      */
     protected function getThemesPath(): string
     {
-        $directory = config( 'cms.themes.directory', 'themes');
+        $directory = config( 'cms.themes.directory', 'themes' );
 
-        return base_path( $directory);
+        return base_path( $directory );
     }
 
     /**
@@ -640,16 +790,16 @@ class ThemeManager
      *
      * @return array Themes array with is_active flag added to each theme.
      */
-    protected function markActiveTheme( array $themes): array
+    protected function markActiveTheme( array $themes ): array
     {
         $activeSlug = $this->settingsManager->getSetting(
             'themes.activeTheme',
-            config( 'cms.themes.default', 'digital-shopfront'),
+            config( 'cms.themes.default', 'digital-shopfront' ),
         );
 
-        return array_map( function ( $theme) use ( $activeSlug) {
+        return array_map( function ( $theme ) use ( $activeSlug ) {
             // Defensive check: ensure slug key exists before comparing
-            $theme['is_active'] = isset( $theme['slug']) && $theme['slug'] === $activeSlug;
+            $theme['is_active'] = isset( $theme['slug'] ) && $theme['slug'] === $activeSlug;
 
             return $theme;
         }, $themes);

--- a/src/Modules/Themes/Managers/ThemeManager.php
+++ b/src/Modules/Themes/Managers/ThemeManager.php
@@ -678,7 +678,7 @@ class ThemeManager
             );
         }
 
-        if ( isset( $manifest['screenshot'] ) ) {
+        if ( array_key_exists( 'screenshot', $manifest ) ) {
             $screenshot = $manifest['screenshot'];
 
             if ( ! is_string( $screenshot ) || '' === $screenshot ) {
@@ -703,7 +703,7 @@ class ThemeManager
             }
         }
 
-        if ( isset( $manifest['requires'] ) ) {
+        if ( array_key_exists( 'requires', $manifest ) ) {
             $requires = $manifest['requires'];
 
             if ( ! is_string( $requires ) || ! preg_match( '/^\d+\.\d+\.\d+$/', $requires ) ) {
@@ -713,7 +713,7 @@ class ThemeManager
             }
         }
 
-        if ( isset( $manifest['templates'] ) ) {
+        if ( array_key_exists( 'templates', $manifest ) ) {
             if ( ! is_array( $manifest['templates'] ) ) {
                 throw ThemeValidationException::invalidManifest(
                     "Field 'templates' must be an object.",
@@ -721,7 +721,7 @@ class ThemeManager
             }
 
             foreach ( ['layouts', 'pages', 'partials'] as $bucket ) {
-                if ( ! isset( $manifest['templates'][ $bucket ] ) ) {
+                if ( ! array_key_exists( $bucket, $manifest['templates'] ) ) {
                     continue;
                 }
 
@@ -743,7 +743,7 @@ class ThemeManager
             }
         }
 
-        if ( isset( $manifest['supports'] ) ) {
+        if ( array_key_exists( 'supports', $manifest ) ) {
             if ( ! is_array( $manifest['supports'] ) ) {
                 throw ThemeValidationException::invalidManifest(
                     "Field 'supports' must be an object.",

--- a/tests/Unit/Themes/ThemeManagerValidateManifestTest.php
+++ b/tests/Unit/Themes/ThemeManagerValidateManifestTest.php
@@ -318,6 +318,21 @@ describe( 'ThemeManager::validateManifest() via installFromZip()', function (): 
         expect( $result['keystone']['seed']['pages'] )->toBe( ['home', 'about'] );
     } );
 
+    it( 'rejects optional fields that are present but null', function ( string $field ): void {
+        $slug    = "null-{$field}-theme";
+        $zipPath = buildValidateZip( $this->tmpPath, $slug, [
+            'slug'    => $slug,
+            'name'    => "Null {$field}",
+            'version' => '1.0.0',
+            $field    => null,
+        ], $this->testSlugs );
+
+        expect( fn () => $this->manager->installFromZip( $zipPath ) )
+            ->toThrow( ThemeValidationException::class );
+
+        expect( File::exists( $this->themesPath . '/' . $slug ) )->toBeFalse();
+    } )->with( ['screenshot', 'requires', 'templates', 'supports'] );
+
     it( 'rolls back the extracted theme directory when validation fails', function (): void {
         $zipPath = buildValidateZip( $this->tmpPath, 'rollback-theme', [
             'slug'    => 'rollback-theme',

--- a/tests/Unit/Themes/ThemeManagerValidateManifestTest.php
+++ b/tests/Unit/Themes/ThemeManagerValidateManifestTest.php
@@ -1,0 +1,333 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\CMSFramework\Modules\Themes\Exceptions\ThemeValidationException;
+use ArtisanPackUI\CMSFramework\Modules\Themes\Managers\ThemeManager;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\File;
+
+beforeEach( function (): void {
+    $this->manager    = app( ThemeManager::class );
+    $this->themesPath = base_path( 'themes' );
+    $this->tmpPath    = storage_path( 'app/themes-validate-tmp' );
+    $this->testSlugs  = [];
+
+    File::ensureDirectoryExists( $this->themesPath );
+    File::ensureDirectoryExists( $this->tmpPath );
+
+    config()->set( 'cms.themes.cacheEnabled', false );
+    Cache::forget( config( 'cms.themes.cacheKey', 'cms.themes.discovered' ) );
+} );
+
+afterEach( function (): void {
+    foreach ( $this->testSlugs as $slug ) {
+        $path = $this->themesPath . '/' . $slug;
+        if ( File::exists( $path ) ) {
+            File::deleteDirectory( $path );
+        }
+    }
+
+    if ( File::isDirectory( $this->tmpPath ) ) {
+        File::deleteDirectory( $this->tmpPath );
+    }
+} );
+
+/**
+ * Build a theme ZIP with the given manifest contents.
+ */
+function buildValidateZip( string $tmpPath, string $slug, array $manifest, array &$slugs ): string
+{
+    $slugs[] = $slug;
+
+    $zipPath = $tmpPath . '/' . $slug . '.zip';
+    if ( file_exists( $zipPath ) ) {
+        unlink( $zipPath );
+    }
+
+    $zip = new ZipArchive;
+    if ( true !== $zip->open( $zipPath, ZipArchive::CREATE ) ) {
+        throw new RuntimeException( "Failed to create test ZIP at {$zipPath}" );
+    }
+
+    $zip->addEmptyDir( $slug );
+    $zip->addFromString( $slug . '/theme.json', json_encode( $manifest ) );
+    $zip->close();
+
+    return $zipPath;
+}
+
+describe( 'ThemeManager::validateManifest() via installFromZip()', function (): void {
+    it( 'accepts a minimal valid manifest with slug, name, and version', function (): void {
+        $zipPath = buildValidateZip( $this->tmpPath, 'minimal-theme', [
+            'slug'    => 'minimal-theme',
+            'name'    => 'Minimal Theme',
+            'version' => '1.0.0',
+        ], $this->testSlugs );
+
+        $result = $this->manager->installFromZip( $zipPath );
+
+        expect( $result['slug'] )->toBe( 'minimal-theme' );
+    } );
+
+    it( 'rejects a manifest missing slug', function (): void {
+        $zipPath = buildValidateZip( $this->tmpPath, 'no-slug', [
+            'name'    => 'No Slug',
+            'version' => '1.0.0',
+        ], $this->testSlugs );
+
+        expect( fn () => $this->manager->installFromZip( $zipPath ) )
+            ->toThrow( ThemeValidationException::class, 'Missing required field: slug' );
+
+        expect( File::exists( $this->themesPath . '/no-slug' ) )->toBeFalse();
+    } );
+
+    it( 'rejects a manifest missing name', function (): void {
+        $zipPath = buildValidateZip( $this->tmpPath, 'no-name', [
+            'slug'    => 'no-name',
+            'version' => '1.0.0',
+        ], $this->testSlugs );
+
+        expect( fn () => $this->manager->installFromZip( $zipPath ) )
+            ->toThrow( ThemeValidationException::class, 'Missing required field: name' );
+    } );
+
+    it( 'rejects a manifest missing version', function (): void {
+        $zipPath = buildValidateZip( $this->tmpPath, 'no-version', [
+            'slug' => 'no-version',
+            'name' => 'No Version',
+        ], $this->testSlugs );
+
+        expect( fn () => $this->manager->installFromZip( $zipPath ) )
+            ->toThrow( ThemeValidationException::class, 'Missing required field: version' );
+    } );
+
+    it( 'rejects a manifest with an invalid slug format', function (): void {
+        $zipPath = buildValidateZip( $this->tmpPath, 'bad-slug-theme', [
+            'slug'    => 'bad slug!',
+            'name'    => 'Bad Slug Theme',
+            'version' => '1.0.0',
+        ], $this->testSlugs );
+
+        expect( fn () => $this->manager->installFromZip( $zipPath ) )
+            ->toThrow( ThemeValidationException::class, 'Invalid slug format' );
+    } );
+
+    it( 'rejects a manifest with a non-semver version', function (): void {
+        $zipPath = buildValidateZip( $this->tmpPath, 'bad-version', [
+            'slug'    => 'bad-version',
+            'name'    => 'Bad Version',
+            'version' => '1.x',
+        ], $this->testSlugs );
+
+        expect( fn () => $this->manager->installFromZip( $zipPath ) )
+            ->toThrow( ThemeValidationException::class, 'Invalid version format' );
+    } );
+
+    it( 'rejects a manifest whose version contains an injection suffix', function (): void {
+        $zipPath = buildValidateZip( $this->tmpPath, 'inject-version', [
+            'slug'    => 'inject-version',
+            'name'    => 'Injection',
+            'version' => "1.0.0'; DROP TABLE",
+        ], $this->testSlugs );
+
+        expect( fn () => $this->manager->installFromZip( $zipPath ) )
+            ->toThrow( ThemeValidationException::class, 'Invalid version format' );
+    } );
+
+    it( 'accepts a screenshot with an allowed extension', function (): void {
+        $zipPath = buildValidateZip( $this->tmpPath, 'shot-theme', [
+            'slug'       => 'shot-theme',
+            'name'       => 'Shot Theme',
+            'version'    => '1.0.0',
+            'screenshot' => 'screenshot.png',
+        ], $this->testSlugs );
+
+        $result = $this->manager->installFromZip( $zipPath );
+
+        expect( $result['screenshot'] )->toBe( 'screenshot.png' );
+    } );
+
+    it( 'rejects a screenshot containing a forward slash', function (): void {
+        $zipPath = buildValidateZip( $this->tmpPath, 'slash-shot', [
+            'slug'       => 'slash-shot',
+            'name'       => 'Slash Shot',
+            'version'    => '1.0.0',
+            'screenshot' => '../escape.png',
+        ], $this->testSlugs );
+
+        expect( fn () => $this->manager->installFromZip( $zipPath ) )
+            ->toThrow( ThemeValidationException::class, "Field 'screenshot' must be a filename" );
+    } );
+
+    it( 'rejects a screenshot containing a backslash', function (): void {
+        $zipPath = buildValidateZip( $this->tmpPath, 'backslash-shot', [
+            'slug'       => 'backslash-shot',
+            'name'       => 'Backslash Shot',
+            'version'    => '1.0.0',
+            'screenshot' => '..\\escape.png',
+        ], $this->testSlugs );
+
+        expect( fn () => $this->manager->installFromZip( $zipPath ) )
+            ->toThrow( ThemeValidationException::class, "Field 'screenshot' must be a filename" );
+    } );
+
+    it( 'rejects a screenshot with a disallowed extension', function (): void {
+        $zipPath = buildValidateZip( $this->tmpPath, 'bad-ext-shot', [
+            'slug'       => 'bad-ext-shot',
+            'name'       => 'Bad Ext Shot',
+            'version'    => '1.0.0',
+            'screenshot' => 'screenshot.gif',
+        ], $this->testSlugs );
+
+        expect( fn () => $this->manager->installFromZip( $zipPath ) )
+            ->toThrow( ThemeValidationException::class, 'allowed extension' );
+    } );
+
+    it( 'accepts a manifest with all allowed screenshot extensions', function ( string $extension ): void {
+        $slug    = "ext-{$extension}-theme";
+        $zipPath = buildValidateZip( $this->tmpPath, $slug, [
+            'slug'       => $slug,
+            'name'       => "Ext {$extension}",
+            'version'    => '1.0.0',
+            'screenshot' => "screenshot.{$extension}",
+        ], $this->testSlugs );
+
+        $result = $this->manager->installFromZip( $zipPath );
+
+        expect( $result['screenshot'] )->toBe( "screenshot.{$extension}" );
+    } )->with( ['png', 'jpg', 'jpeg', 'webp'] );
+
+    it( 'rejects an invalid requires field', function (): void {
+        $zipPath = buildValidateZip( $this->tmpPath, 'bad-requires', [
+            'slug'     => 'bad-requires',
+            'name'     => 'Bad Requires',
+            'version'  => '1.0.0',
+            'requires' => 'latest',
+        ], $this->testSlugs );
+
+        expect( fn () => $this->manager->installFromZip( $zipPath ) )
+            ->toThrow( ThemeValidationException::class, "Field 'requires'" );
+    } );
+
+    it( 'accepts a valid requires field', function (): void {
+        $zipPath = buildValidateZip( $this->tmpPath, 'good-requires', [
+            'slug'     => 'good-requires',
+            'name'     => 'Good Requires',
+            'version'  => '1.0.0',
+            'requires' => '2.5.1',
+        ], $this->testSlugs );
+
+        $result = $this->manager->installFromZip( $zipPath );
+
+        expect( $result['requires'] )->toBe( '2.5.1' );
+    } );
+
+    it( 'rejects a templates bucket that is not an array', function (): void {
+        $zipPath = buildValidateZip( $this->tmpPath, 'bad-templates', [
+            'slug'      => 'bad-templates',
+            'name'      => 'Bad Templates',
+            'version'   => '1.0.0',
+            'templates' => [
+                'layouts' => 'oops',
+            ],
+        ], $this->testSlugs );
+
+        expect( fn () => $this->manager->installFromZip( $zipPath ) )
+            ->toThrow( ThemeValidationException::class, "Field 'templates.layouts'" );
+    } );
+
+    it( 'rejects a templates bucket whose entries are not strings', function (): void {
+        $zipPath = buildValidateZip( $this->tmpPath, 'mixed-templates', [
+            'slug'      => 'mixed-templates',
+            'name'      => 'Mixed Templates',
+            'version'   => '1.0.0',
+            'templates' => [
+                'pages' => ['home', 42],
+            ],
+        ], $this->testSlugs );
+
+        expect( fn () => $this->manager->installFromZip( $zipPath ) )
+            ->toThrow( ThemeValidationException::class, 'strings only' );
+    } );
+
+    it( 'accepts valid templates buckets', function (): void {
+        $zipPath = buildValidateZip( $this->tmpPath, 'good-templates', [
+            'slug'      => 'good-templates',
+            'name'      => 'Good Templates',
+            'version'   => '1.0.0',
+            'templates' => [
+                'layouts'  => ['default', 'wide'],
+                'pages'    => ['home', 'about'],
+                'partials' => ['header', 'footer'],
+            ],
+        ], $this->testSlugs );
+
+        $result = $this->manager->installFromZip( $zipPath );
+
+        expect( $result['templates']['layouts'] )->toBe( ['default', 'wide'] );
+    } );
+
+    it( 'rejects a non-boolean supports value', function (): void {
+        $zipPath = buildValidateZip( $this->tmpPath, 'bad-supports', [
+            'slug'     => 'bad-supports',
+            'name'     => 'Bad Supports',
+            'version'  => '1.0.0',
+            'supports' => [
+                'menus' => 'yes',
+            ],
+        ], $this->testSlugs );
+
+        expect( fn () => $this->manager->installFromZip( $zipPath ) )
+            ->toThrow( ThemeValidationException::class, "Field 'supports.menus'" );
+    } );
+
+    it( 'accepts boolean supports values', function (): void {
+        $zipPath = buildValidateZip( $this->tmpPath, 'good-supports', [
+            'slug'     => 'good-supports',
+            'name'     => 'Good Supports',
+            'version'  => '1.0.0',
+            'supports' => [
+                'menus'   => true,
+                'widgets' => false,
+            ],
+        ], $this->testSlugs );
+
+        $result = $this->manager->installFromZip( $zipPath );
+
+        expect( $result['supports']['menus'] )->toBeTrue();
+        expect( $result['supports']['widgets'] )->toBeFalse();
+    } );
+
+    it( 'passes through an opaque keystone namespace', function (): void {
+        $zipPath = buildValidateZip( $this->tmpPath, 'keystone-theme', [
+            'slug'     => 'keystone-theme',
+            'name'     => 'Keystone Theme',
+            'version'  => '1.0.0',
+            'keystone' => [
+                'installer' => 'KeystoneInstaller',
+                'seed'      => [
+                    'pages' => ['home', 'about'],
+                ],
+            ],
+        ], $this->testSlugs );
+
+        $result = $this->manager->installFromZip( $zipPath );
+
+        expect( $result['keystone']['installer'] )->toBe( 'KeystoneInstaller' );
+        expect( $result['keystone']['seed']['pages'] )->toBe( ['home', 'about'] );
+    } );
+
+    it( 'rolls back the extracted theme directory when validation fails', function (): void {
+        $zipPath = buildValidateZip( $this->tmpPath, 'rollback-theme', [
+            'slug'    => 'rollback-theme',
+            'name'    => 'Rollback Theme',
+            'version' => 'not-semver',
+        ], $this->testSlugs );
+
+        expect( fn () => $this->manager->installFromZip( $zipPath ) )
+            ->toThrow( ThemeValidationException::class );
+
+        expect( File::exists( $this->themesPath . '/rollback-theme' ) )->toBeFalse();
+    } );
+} );


### PR DESCRIPTION
## Description

Adds `ThemeManager::validateManifest()` to enforce a strict required-fields contract on theme manifests during installation, mirroring the Plugins module's existing approach. Pre-extraction validation already lived in `installFromZip()`; this PR adds the post-extraction manifest-shape check that was previously missing.

**Closes:** #122

## Type of Change

- [x] Enhancement (improves existing functionality)

## Related Issue

**Issue:** #122

## Motivation and Context

Before this change, `validateTheme()` only checked that the theme directory existed and that `theme.json` was present and parseable. A theme whose `theme.json` was `{}` or `{"foo": "bar"}` passed validation. The Plugins module already enforces required `slug`/`name`/`version` with regex anchoring; Themes needed the same contract so the upload path can return a meaningful error and downstream code can rely on the manifest shape.

## Changes Made

- Added `protected validateManifest(array $manifest): void` on `ThemeManager`. Required: `slug` (alphanumeric/hyphen/underscore), `name` (non-empty string), `version` (anchored semver). Optional: `screenshot` (basename only with `png|jpg|jpeg|webp`), `requires` (anchored semver), `templates.{layouts,pages,partials}` (string arrays), `supports.*` (booleans).
- Called from `installFromZip()` after `parseManifest()` with rollback of the extracted directory on failure.
- `discoverThemes()` discovery path left tolerant — keeps the existing `WpThemeJsonValidator` + skip-and-log behavior so existing on-disk themes aren't broken by stricter rules.
- Documented the strict-install spec and reserved `keystone` namespace in `docs/themes.md`.

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS 14
- PHP Version: 8.4
- Project Version: release/2.0

**Tests Performed:**
1. `./vendor/bin/pest tests/Unit/Themes tests/Feature/Themes` — 55 passed, 3 skipped (pre-existing skips).
2. Full suite `php -d memory_limit=512M ./vendor/bin/pest --compact` — 935 passed, 7 skipped.
3. Manual upload of valid + invalid theme ZIPs through the admin upload flow; verified rollback leaves no directory under `themes/` on failure.

## Accessibility Tests Run

- [x] N/A — backend-only change with no UI surface

**Details:** This PR touches only the theme installation backend; no user-facing UI changes.

## Tests Added

- [x] Unit tests added/updated
- [x] All tests passing

**Test details:** `tests/Unit/Themes/ThemeManagerValidateManifestTest.php` covers each required field, slug/version regex, all four allowed screenshot extensions (via dataset), forward-slash + backslash rejection, disallowed extensions, semver `requires`, templates bucket type checks, non-boolean `supports` rejection, opaque `keystone` passthrough, and rollback verification.

## Documentation

- [x] Inline code documentation added
- [x] Wiki updated (`docs/themes.md`)

**Documentation details:** New "Strict install validation" and "Reserved `keystone` namespace" sections added to the Theme Manifest doc.

## Pre-Submission Checklist

- [x] Code passes all tests
- [x] Code follows project style guide
- [x] Self-review completed
- [x] Comments added for complex code
- [x] No new warnings generated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded theme docs with stricter manifest rules, required/optional fields, format constraints, and a reserved top-level "keystone" namespace.

* **Bug Fixes**
  * Theme installation now validates manifests and automatically cleans up extracted files on failure to avoid partial installs.

* **Tests**
  * Added unit tests covering manifest validation rules and rollback behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ArtisanPack-UI/cms-framework/pull/147?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->