### PR TITLE
feat: fire lifecycle hooks from theme install/activate

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,12 +155,30 @@ The theme system allows customization of the CMS appearance.
 - Theme activation mechanism
 - JSON manifest validation
 - Basic theme structure
+- Lifecycle hooks for install/activate (see below)
 
 **Known Limitations:**
 - Asset compilation not implemented
 - No child theme support
 - Limited theme customization API
 - No theme preview functionality
+
+**Theme Lifecycle Hooks**
+
+The Themes module fires `doAction()` callbacks around `installFromZip()` and `activateTheme()` so host applications can subscribe listeners (seed content, register theme-supplied service providers, etc.) without forking the framework.
+
+| Hook | Fires | Payload | Throwing semantics |
+|------|-------|---------|--------------------|
+| `theme.installing` | After the ZIP is extracted and the manifest is validated, before the install is finalized. | `string $slug, array $manifest` | Throwing aborts the install; the extracted directory is rolled back. |
+| `theme.installed` | After the install completes and the discovery cache is cleared. | `string $slug, array $manifest` | Throwing propagates to the caller (install is already complete). |
+| `theme.activating` | After the target theme is resolved, before `themes.activeTheme` is updated. | `string $slug, array $manifest` | Throwing aborts activation; the active theme setting is not changed. |
+| `theme.activated` | After `themes.activeTheme` is updated and view caches are cleared. | `string $slug, array $manifest` | Throwing propagates to the caller (activation is already complete). |
+
+```php
+addAction('theme.activated', function (string $slug, array $manifest): void {
+    // Seed pages, register navigation entries, etc.
+});
+```
 
 **Recommendation:** Use for testing and development. Full theme support including asset compilation and child themes will be added in a future release.
 

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ The Themes module fires `doAction()` callbacks around `installFromZip()` and `ac
 | `theme.installing` | After the ZIP is extracted and the manifest is validated, before the install is finalized. | `string $slug, array $manifest` | Throwing aborts the install; the extracted directory is rolled back. |
 | `theme.installed` | After the install completes and the discovery cache is cleared. | `string $slug, array $manifest` | Throwing propagates to the caller (install is already complete). |
 | `theme.activating` | After the target theme is resolved, before `themes.activeTheme` is updated. | `string $slug, array $manifest` | Throwing aborts activation; the active theme setting is not changed. |
-| `theme.activated` | After `themes.activeTheme` is updated and view caches are cleared. | `string $slug, array $manifest` | Throwing propagates to the caller (activation is already complete). |
+| `theme.activated` | After `themes.activeTheme` is updated and cache invalidation is attempted (including `view:clear`, which is logged-and-continued on failure). | `string $slug, array $manifest` | Throwing propagates to the caller (activation is already complete). |
 
 ```php
 addAction('theme.activated', function (string $slug, array $manifest): void {

--- a/src/Modules/Themes/Managers/ThemeManager.php
+++ b/src/Modules/Themes/Managers/ThemeManager.php
@@ -153,6 +153,10 @@ class ThemeManager
             throw ThemeNotFoundException::forSlug( $slug );
         }
 
+        // Pre-activation hook: listeners may throw to short-circuit activation
+        // before any persistent state changes.
+        doAction( 'theme.activating', $slug, $theme );
+
         $this->settingsManager->updateSetting( 'themes.activeTheme', $slug );
 
         // Clear theme cache
@@ -170,6 +174,8 @@ class ThemeManager
                 ] );
             }
         }
+
+        doAction( 'theme.activated', $slug, $theme );
 
         return true;
     }
@@ -230,7 +236,20 @@ class ThemeManager
             throw $e;
         }
 
+        // Pre-install hook: listeners may throw to abort the install. The
+        // extracted directory is rolled back so we never leave a half-installed
+        // theme on disk after a vetoed install.
+        try {
+            doAction( 'theme.installing', $slug, $manifest );
+        } catch ( Exception $e ) {
+            File::deleteDirectory( $themePath );
+
+            throw $e;
+        }
+
         Cache::forget( config( 'cms.themes.cacheKey', 'cms.themes.discovered' ) );
+
+        doAction( 'theme.installed', $slug, $manifest );
 
         return $manifest;
     }

--- a/src/Modules/Themes/Managers/ThemeManager.php
+++ b/src/Modules/Themes/Managers/ThemeManager.php
@@ -24,6 +24,7 @@ use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\View;
+use Throwable;
 use ZipArchive;
 
 /**
@@ -238,10 +239,12 @@ class ThemeManager
 
         // Pre-install hook: listeners may throw to abort the install. The
         // extracted directory is rolled back so we never leave a half-installed
-        // theme on disk after a vetoed install.
+        // theme on disk after a vetoed install. We catch Throwable (not just
+        // Exception) so that Error/TypeError thrown from listener callbacks
+        // also trigger rollback before propagating.
         try {
             doAction( 'theme.installing', $slug, $manifest );
-        } catch ( Exception $e ) {
+        } catch ( Throwable $e ) {
             File::deleteDirectory( $themePath );
 
             throw $e;

--- a/tests/Feature/Themes/ThemeLifecycleHooksTest.php
+++ b/tests/Feature/Themes/ThemeLifecycleHooksTest.php
@@ -1,0 +1,216 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\CMSFramework\Modules\Settings\Managers\SettingsManager;
+use ArtisanPackUI\CMSFramework\Modules\Themes\Exceptions\ThemeNotFoundException;
+use ArtisanPackUI\CMSFramework\Modules\Themes\Managers\ThemeManager;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\File;
+
+beforeEach( function (): void {
+    $this->manager    = app( ThemeManager::class );
+    $this->themesPath = base_path( 'themes' );
+    $this->tmpPath    = storage_path( 'app/themes-hooks-tmp' );
+    $this->testSlugs  = [];
+
+    File::ensureDirectoryExists( $this->themesPath );
+    File::ensureDirectoryExists( $this->tmpPath );
+
+    config()->set( 'cms.themes.cacheEnabled', false );
+    Cache::forget( config( 'cms.themes.cacheKey', 'cms.themes.discovered' ) );
+
+    // Clear any lingering listeners from previous tests for our hook names.
+    foreach ( ['theme.installing', 'theme.installed', 'theme.activating', 'theme.activated'] as $hook ) {
+        removeAllActions( $hook );
+    }
+} );
+
+afterEach( function (): void {
+    foreach ( $this->testSlugs as $slug ) {
+        $path = $this->themesPath . '/' . $slug;
+        if ( File::exists( $path ) ) {
+            File::deleteDirectory( $path );
+        }
+    }
+
+    if ( File::isDirectory( $this->tmpPath ) ) {
+        File::deleteDirectory( $this->tmpPath );
+    }
+
+    foreach ( ['theme.installing', 'theme.installed', 'theme.activating', 'theme.activated'] as $hook ) {
+        removeAllActions( $hook );
+    }
+} );
+
+/**
+ * Build a ZIP with a single theme directory and given theme.json contents.
+ */
+function buildHookThemeZip( string $tmpPath, string $slug, array $manifest, array &$slugs ): string
+{
+    $slugs[] = $slug;
+
+    $zipPath = $tmpPath . '/' . $slug . '.zip';
+    if ( file_exists( $zipPath ) ) {
+        unlink( $zipPath );
+    }
+
+    $zip = new ZipArchive;
+    if ( true !== $zip->open( $zipPath, ZipArchive::CREATE ) ) {
+        throw new RuntimeException( "Failed to create test ZIP at {$zipPath}" );
+    }
+
+    $zip->addEmptyDir( $slug );
+    $zip->addFromString( $slug . '/theme.json', json_encode( $manifest ) );
+    $zip->close();
+
+    return $zipPath;
+}
+
+/**
+ * Write a theme.json file into a fresh test theme directory so activateTheme()
+ * can find it.
+ */
+function writeHookTheme( string $themesPath, string $slug, array $manifest, array &$slugs ): void
+{
+    $slugs[] = $slug;
+    $path    = $themesPath . '/' . $slug;
+    File::ensureDirectoryExists( $path );
+    File::put( $path . '/theme.json', json_encode( $manifest ) );
+}
+
+describe( 'theme install lifecycle hooks', function (): void {
+    it( 'fires theme.installing and theme.installed in order with slug + manifest payload', function (): void {
+        $manifest = [
+            'slug'    => 'hooks-install',
+            'name'    => 'Hooks Install',
+            'version' => '1.0.0',
+        ];
+
+        $events = [];
+
+        addAction( 'theme.installing', function ( string $slug, array $payload ) use ( &$events ): void {
+            $events[] = ['installing', $slug, $payload];
+        } );
+
+        addAction( 'theme.installed', function ( string $slug, array $payload ) use ( &$events ): void {
+            $events[] = ['installed', $slug, $payload];
+        } );
+
+        $zipPath = buildHookThemeZip( $this->tmpPath, 'hooks-install', $manifest, $this->testSlugs );
+
+        $this->manager->installFromZip( $zipPath );
+
+        expect( $events )->toHaveCount( 2 );
+        expect( $events[0][0] )->toBe( 'installing' );
+        expect( $events[0][1] )->toBe( 'hooks-install' );
+        expect( $events[0][2] )->toMatchArray( $manifest );
+        expect( $events[1][0] )->toBe( 'installed' );
+        expect( $events[1][1] )->toBe( 'hooks-install' );
+        expect( $events[1][2] )->toMatchArray( $manifest );
+    } );
+
+    it( 'aborts the install and rolls back the extracted directory when a theme.installing listener throws', function (): void {
+        $manifest = [
+            'slug'    => 'hooks-abort',
+            'name'    => 'Hooks Abort',
+            'version' => '1.0.0',
+        ];
+
+        $installedFired = false;
+
+        addAction( 'theme.installing', function (): void {
+            throw new RuntimeException( 'vetoed by listener' );
+        } );
+
+        addAction( 'theme.installed', function () use ( &$installedFired ): void {
+            $installedFired = true;
+        } );
+
+        $zipPath = buildHookThemeZip( $this->tmpPath, 'hooks-abort', $manifest, $this->testSlugs );
+
+        expect( fn () => $this->manager->installFromZip( $zipPath ) )
+            ->toThrow( RuntimeException::class, 'vetoed by listener' );
+
+        expect( $installedFired )->toBeFalse();
+        expect( File::exists( $this->themesPath . '/hooks-abort' ) )->toBeFalse();
+    } );
+} );
+
+describe( 'theme activate lifecycle hooks', function (): void {
+    it( 'fires theme.activating and theme.activated in order with slug + manifest payload', function (): void {
+        $manifest = [
+            'slug'    => 'hooks-activate',
+            'name'    => 'Hooks Activate',
+            'version' => '1.0.0',
+        ];
+
+        writeHookTheme( $this->themesPath, 'hooks-activate', $manifest, $this->testSlugs );
+
+        $events = [];
+
+        addAction( 'theme.activating', function ( string $slug, array $payload ) use ( &$events ): void {
+            $events[] = ['activating', $slug, $payload];
+        } );
+
+        addAction( 'theme.activated', function ( string $slug, array $payload ) use ( &$events ): void {
+            $events[] = ['activated', $slug, $payload];
+        } );
+
+        $this->manager->activateTheme( 'hooks-activate' );
+
+        expect( $events )->toHaveCount( 2 );
+        expect( $events[0][0] )->toBe( 'activating' );
+        expect( $events[0][1] )->toBe( 'hooks-activate' );
+        expect( $events[0][2] )->toMatchArray( $manifest );
+        expect( $events[1][0] )->toBe( 'activated' );
+        expect( $events[1][1] )->toBe( 'hooks-activate' );
+        expect( $events[1][2] )->toMatchArray( $manifest );
+    } );
+
+    it( 'aborts activation and does not persist the active theme setting when a theme.activating listener throws', function (): void {
+        writeHookTheme( $this->themesPath, 'hooks-veto-source', [
+            'slug'    => 'hooks-veto-source',
+            'name'    => 'Source',
+            'version' => '1.0.0',
+        ], $this->testSlugs );
+
+        writeHookTheme( $this->themesPath, 'hooks-veto-target', [
+            'slug'    => 'hooks-veto-target',
+            'name'    => 'Target',
+            'version' => '1.0.0',
+        ], $this->testSlugs );
+
+        // Establish a known starting state.
+        app( SettingsManager::class )->updateSetting( 'themes.activeTheme', 'hooks-veto-source' );
+
+        $activatedFired = false;
+
+        addAction( 'theme.activating', function (): void {
+            throw new RuntimeException( 'blocked' );
+        } );
+
+        addAction( 'theme.activated', function () use ( &$activatedFired ): void {
+            $activatedFired = true;
+        } );
+
+        expect( fn () => $this->manager->activateTheme( 'hooks-veto-target' ) )
+            ->toThrow( RuntimeException::class, 'blocked' );
+
+        expect( $activatedFired )->toBeFalse();
+        expect( app( SettingsManager::class )->getSetting( 'themes.activeTheme' ) )->toBe( 'hooks-veto-source' );
+    } );
+
+    it( 'does not fire any hooks when the theme does not exist', function (): void {
+        $fired = false;
+
+        addAction( 'theme.activating', function () use ( &$fired ): void {
+            $fired = true;
+        } );
+
+        expect( fn () => $this->manager->activateTheme( 'does-not-exist' ) )
+            ->toThrow( ThemeNotFoundException::class );
+
+        expect( $fired )->toBeFalse();
+    } );
+} );

--- a/tests/Feature/Themes/ThemeLifecycleHooksTest.php
+++ b/tests/Feature/Themes/ThemeLifecycleHooksTest.php
@@ -110,6 +110,26 @@ describe( 'theme install lifecycle hooks', function (): void {
         expect( $events[1][2] )->toMatchArray( $manifest );
     } );
 
+    it( 'rolls back the extracted directory when a theme.installing listener throws a non-Exception Throwable', function (): void {
+        $manifest = [
+            'slug'    => 'hooks-error',
+            'name'    => 'Hooks Error',
+            'version' => '1.0.0',
+        ];
+
+        addAction( 'theme.installing', function (): void {
+            // Error (parent of TypeError, etc.) is a Throwable but not an Exception.
+            throw new Error( 'fatal in listener' );
+        } );
+
+        $zipPath = buildHookThemeZip( $this->tmpPath, 'hooks-error', $manifest, $this->testSlugs );
+
+        expect( fn () => $this->manager->installFromZip( $zipPath ) )
+            ->toThrow( Error::class, 'fatal in listener' );
+
+        expect( File::exists( $this->themesPath . '/hooks-error' ) )->toBeFalse();
+    } );
+
     it( 'aborts the install and rolls back the extracted directory when a theme.installing listener throws', function (): void {
         $manifest = [
             'slug'    => 'hooks-abort',


### PR DESCRIPTION
## Description

Mirrors the Plugins module's `doAction()` lifecycle in the Themes module so host applications can subscribe listeners (seed content, register theme-supplied service providers, etc.) without forking the framework.

**Closes:** #123

## Type of Change

- [x] New feature (adds new functionality)

## Related Issue

**Issue:** #123

## Motivation and Context

`ThemeManager::activateTheme()` and `installFromZip()` had no hooks for downstream code to subscribe to, while Plugins fires the full install/activate arc via `doAction()`. This left Themes un-integratable for host CMS consumers that need to react to a theme being installed or activated.

## Changes Made

- Added `theme.installing` / `theme.installed` bookends around `installFromZip()`. A throwing `theme.installing` listener aborts the install and rolls back the extracted directory.
- Added `theme.activating` / `theme.activated` bookends around `activateTheme()`. A throwing `theme.activating` listener aborts before `themes.activeTheme` is updated.
- All four hooks fire with `(string $slug, array $manifest)`.
- Documented the hook contract (event name, payload, when fires, throwing semantics) in `README.md`.
- Added Pest coverage in `tests/Feature/Themes/ThemeLifecycleHooksTest.php` for firing order, payload shape, install rollback, activation veto, and the no-fire-on-missing-theme path.

## How Has This Been Tested?

**Testing Environment:**
- PHP Version: 8.4.3
- Project Version: release/2.0

**Tests Performed:**
1. New `ThemeLifecycleHooksTest` — 5 tests, 44 assertions, all passing.
2. Full Themes test suite (Feature + Unit) — 64 passed, 3 skipped, no regressions.
3. Full package suite — 944 passed, 7 skipped.
4. Manual verification in the host Keystone CMS app: subscribed `logger()->info()` listeners to each hook and confirmed `theme.activating` → `theme.activated` fire during admin activation. Instrumentation removed after verification.

## Accessibility Tests Run

- [ ] N/A — backend-only change; no UI surface affected.

## Tests Added

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] All tests passing

**Test details:** 5 new Pest feature tests in `tests/Feature/Themes/ThemeLifecycleHooksTest.php` covering happy-path firing order with payload, install veto with rollback, activation veto with no setting persistence, and that no hooks fire when the theme does not exist.

## Documentation

- [x] README updated

**Documentation details:** Added a "Theme Lifecycle Hooks" subsection under the Theme System section in `README.md` with a table of hook names, payloads, fire timing, and throwing semantics, plus a usage example.

## Pre-Submission Checklist

- [x] Code passes all tests
- [x] Code follows project style guide
- [x] Self-review completed
- [x] Comments added for complex code (rollback semantics)
- [x] No new warnings generated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Theme system now emits lifecycle action hooks (theme.installing, theme.installed, theme.activating, theme.activated) at key points during installation and activation to enable custom logic.

* **Documentation**
  * README expanded with detailed theme lifecycle hooks, payload specs, error/abort semantics, and usage examples.

* **Tests**
  * Added tests validating hook ordering, payloads, error handling, and rollback behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ArtisanPack-UI/cms-framework/pull/148?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->