### PR TITLE
feat: Blog Comments submodule (model + REST + policy) — #151

### DIFF
--- a/src/Modules/Blog/Http/Controllers/CommentController.php
+++ b/src/Modules/Blog/Http/Controllers/CommentController.php
@@ -1,0 +1,170 @@
+<?php
+
+declare( strict_types=1 );
+
+/**
+ * Comment Controller for the CMS Framework Blog Module.
+ *
+ * Provides RESTful API endpoints for comment management. Read endpoints
+ * default to the approved set (public-facing); moderation surfaces can
+ * request other statuses with the `?status=...` filter and the right
+ * capability.
+ *
+ * @since 2.1.0
+ */
+
+namespace ArtisanPackUI\CMSFramework\Modules\Blog\Http\Controllers;
+
+use ArtisanPackUI\CMSFramework\Modules\Blog\Http\Requests\CommentRequest;
+use ArtisanPackUI\CMSFramework\Modules\Blog\Http\Resources\CommentResource;
+use ArtisanPackUI\CMSFramework\Modules\Blog\Models\Comment;
+use Dedoc\Scramble\Attributes\Group;
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
+use Illuminate\Http\Response;
+use Illuminate\Routing\Controller;
+
+/**
+ * @since 2.1.0
+ */
+#[Group( 'Comments', weight: 2 )]
+class CommentController extends Controller
+{
+    use AuthorizesRequests;
+
+    /**
+     * List comments. Defaults to approved + top-level set; pass
+     * `post_id`, `parent_id`, `status` to filter. Replies are
+     * eager-loaded one level deep so the visual-editor renderer can
+     * draw the immediate thread without a follow-up request.
+     *
+     * @since 2.1.0
+     */
+    public function index( Request $request ): AnonymousResourceCollection
+    {
+        $this->authorize( 'viewAny', Comment::class );
+
+        // `replies` defaults to the approved set on the relation,
+        // so eager-loading is safe for public callers.
+        $query = Comment::query()->with( 'replies' );
+
+        if ( $request->filled( 'post_id' ) ) {
+            $query->where( 'post_id', ( int ) $request->input( 'post_id' ) );
+        }
+
+        if ( $request->has( 'parent_id' ) ) {
+            $parent = $request->input( 'parent_id' );
+            $query->where( 'parent_id', '' === $parent || null === $parent ? null : ( int ) $parent );
+        } else {
+            // Default to top-level comments when no parent filter is
+            // supplied; consumers iterating manually can pass
+            // `?parent_id=` (empty) or `?parent_id=null` explicitly.
+            $query->whereNull( 'parent_id' );
+        }
+
+        // Status filter is moderation-gated: only callers with the
+        // `comments.moderate` capability can request non-approved
+        // sets. Public callers always see the approved view,
+        // regardless of what they pass on the query string.
+        $requestedStatus = $request->input( 'status' );
+        $user            = $request->user();
+        $canModerate     = null !== $user && $user->can( applyFilters( 'comments.moderate', 'comments.moderate' ) );
+        $status          = ( $canModerate && null !== $requestedStatus && '' !== $requestedStatus )
+            ? $requestedStatus
+            : Comment::STATUS_APPROVED;
+
+        $query->where( 'status', $status );
+
+        $perPage = ( int ) $request->input( 'per_page', 15 );
+        $perPage = max( 1, min( 100, $perPage ) );
+
+        return CommentResource::collection(
+            $query->latest()->paginate( $perPage )
+        );
+    }
+
+    /**
+     * @since 2.1.0
+     */
+    public function show( Comment $comment ): CommentResource
+    {
+        $this->authorize( 'view', $comment );
+
+        return new CommentResource( $comment->load( 'replies' ) );
+    }
+
+    /**
+     * @since 2.1.0
+     */
+    public function store( CommentRequest $request ): JsonResponse
+    {
+        $this->authorize( 'create', Comment::class );
+
+        $data = $request->validated();
+        $user = $request->user();
+
+        // `user_id` is server-controlled — stripped from the request
+        // body in `CommentRequest::prepareForValidation()` to prevent
+        // impersonation. Wire it in from the authenticated session
+        // here.
+        if ( null !== $user ) {
+            $data['user_id'] = $user->getAuthIdentifier();
+        }
+
+        // Default status: approved when the requester is an
+        // authenticated user with moderation capability; pending
+        // otherwise. `CommentRequest::prepareForValidation()` strips
+        // a client-supplied `status` unless the caller can moderate,
+        // so this branch fires for everyone else.
+        if ( ! isset( $data['status'] ) ) {
+            $autoApprove     = null !== $user && $user->can( applyFilters( 'comments.moderate', 'comments.moderate' ) );
+            $defaultStatus   = $autoApprove ? Comment::STATUS_APPROVED : Comment::STATUS_PENDING;
+            $data['status']  = applyFilters( 'comments.store.defaultStatus', $defaultStatus, $request );
+        }
+
+        if ( Comment::STATUS_APPROVED === $data['status'] && empty( $data['approved_at'] ) ) {
+            $data['approved_at'] = now();
+        }
+
+        $comment = Comment::create( $data );
+
+        return ( new CommentResource( $comment ) )
+            ->response()
+            ->setStatusCode( Response::HTTP_CREATED );
+    }
+
+    /**
+     * @since 2.1.0
+     */
+    public function update( CommentRequest $request, Comment $comment ): CommentResource
+    {
+        $this->authorize( 'update', $comment );
+
+        $data = $request->validated();
+
+        // Re-stamp approved_at when moving into the approved status.
+        if ( isset( $data['status'] )
+            && Comment::STATUS_APPROVED === $data['status']
+            && Comment::STATUS_APPROVED !== $comment->status ) {
+            $data['approved_at'] = now();
+        }
+
+        $comment->update( $data );
+
+        return new CommentResource( $comment->fresh() );
+    }
+
+    /**
+     * @since 2.1.0
+     */
+    public function destroy( Comment $comment ): Response
+    {
+        $this->authorize( 'delete', $comment );
+
+        $comment->delete();
+
+        return response()->noContent();
+    }
+}

--- a/src/Modules/Blog/Http/Requests/CommentRequest.php
+++ b/src/Modules/Blog/Http/Requests/CommentRequest.php
@@ -1,0 +1,130 @@
+<?php
+
+declare( strict_types=1 );
+
+/**
+ * Comment Request for the CMS Framework Blog Module.
+ *
+ * Validates incoming comment data on create and update. The shape is
+ * deliberately small — content + (post_id|parent_id) + (user-bound
+ * OR guest author fields). Authorization is delegated to
+ * `CommentPolicy`; the controller calls `$this->authorize()` before
+ * dispatching to the model.
+ *
+ * @since 2.1.0
+ */
+
+namespace ArtisanPackUI\CMSFramework\Modules\Blog\Http\Requests;
+
+use ArtisanPackUI\CMSFramework\Modules\Blog\Models\Comment;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+/**
+ * @since 2.1.0
+ */
+class CommentRequest extends FormRequest
+{
+    /**
+     * @since 2.1.0
+     */
+    public function authorize(): bool
+    {
+        // Per-operation gating happens in the controller via the
+        // CommentPolicy. The form request only handles validation.
+        return true;
+    }
+
+    /**
+     * @since 2.1.0
+     *
+     * @return array<string, array<int, mixed>>
+     */
+    public function rules(): array
+    {
+        $isUpdate = in_array( $this->method(), [ 'PUT', 'PATCH' ], true );
+
+        // `parent_id` must belong to the same post — otherwise a
+        // client could reply to comment X on post A but file the
+        // reply against post B, corrupting the thread tree. Build
+        // the constraint as a per-post `exists` rule.
+        $postId        = $this->input( 'post_id' );
+        $parentIdRule  = Rule::exists( 'post_comments', 'id' );
+        if ( null !== $postId && '' !== $postId ) {
+            $parentIdRule = $parentIdRule->where( 'post_id', ( int ) $postId );
+        }
+
+        $rules = [
+            'post_id'      => $isUpdate
+                ? [ 'sometimes', 'integer', 'exists:posts,id' ]
+                : [ 'required', 'integer', 'exists:posts,id' ],
+            'parent_id'    => [ 'nullable', 'integer', $parentIdRule ],
+            'author_name'  => [ 'nullable', 'string', 'max:255' ],
+            'author_email' => [ 'nullable', 'email', 'max:255' ],
+            'author_url'   => [ 'nullable', 'url', 'max:2048' ],
+            'content'      => [ $isUpdate ? 'sometimes' : 'required', 'string', 'min:1', 'max:65535' ],
+        ];
+
+        // `status` is moderation-controlled: only viewers with the
+        // `comments.moderate` capability are allowed to submit it.
+        // For anyone else we strip the field out before validation
+        // runs (see `prepareForValidation()` below) so a client-side
+        // `status=approved` payload can't self-approve.
+        if ( $this->callerCanModerate() ) {
+            $rules['status'] = [
+                'sometimes',
+                Rule::in( [
+                    Comment::STATUS_APPROVED,
+                    Comment::STATUS_PENDING,
+                    Comment::STATUS_SPAM,
+                    Comment::STATUS_TRASH,
+                ] ),
+            ];
+        }
+
+        return $rules;
+    }
+
+    /**
+     * Strip any client-supplied `user_id` and (for non-moderators)
+     * `status` before validation runs. `user_id` is always taken
+     * from `auth()->id()` in the controller — accepting it from the
+     * client would allow impersonation; `status` defaults to
+     * `approved` (auto-approve for moderators) or `pending`
+     * otherwise.
+     *
+     * @since 2.1.0
+     */
+    protected function prepareForValidation(): void
+    {
+        $input = $this->input();
+
+        unset( $input['user_id'] );
+
+        if ( ! $this->callerCanModerate() ) {
+            unset( $input['status'], $input['approved_at'] );
+        }
+
+        // Replace($input) drops untouched fields, so re-merge
+        // everything back at once.
+        $this->replace( $input );
+    }
+
+    /**
+     * Determine whether the caller can submit moderation-level
+     * fields. Gated by the same `comments.moderate` capability the
+     * `CommentPolicy::moderate` ability checks.
+     *
+     * @since 2.1.0
+     */
+    protected function callerCanModerate(): bool
+    {
+        $user = $this->user();
+
+        if ( null === $user ) {
+            return false;
+        }
+
+        return $user->can( applyFilters( 'comments.moderate', 'comments.moderate' ) );
+    }
+}

--- a/src/Modules/Blog/Http/Resources/CommentResource.php
+++ b/src/Modules/Blog/Http/Resources/CommentResource.php
@@ -1,0 +1,63 @@
+<?php
+
+declare( strict_types=1 );
+
+/**
+ * Comment Resource for the CMS Framework Blog Module.
+ *
+ * Transforms `Comment` model instances into JSON API responses. The
+ * envelope is shaped so the visual-editor's comment renderer can
+ * consume it without further massaging — `author` is normalized to
+ * `{ name, url, avatar_url }` whether the comment was left by a
+ * registered user or a guest.
+ *
+ * @since 2.1.0
+ */
+
+namespace ArtisanPackUI\CMSFramework\Modules\Blog\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * @since 2.1.0
+ */
+class CommentResource extends JsonResource
+{
+    /**
+     * @since 2.1.0
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray( Request $request ): array
+    {
+        $user        = $request->user();
+        $canModerate = null !== $user && $user->can( applyFilters( 'comments.moderate', 'comments.moderate' ) );
+
+        return [
+            'id'             => $this->id,
+            'post_id'        => $this->post_id,
+            'parent_id'      => $this->parent_id,
+            'user_id'        => $this->user_id,
+            'content'        => $this->content,
+            'status'         => $this->status,
+            'approved_at'    => $this->approved_at,
+            'created_at'     => $this->created_at,
+            'updated_at'     => $this->updated_at,
+            'author'         => [
+                'name'       => $this->author->name ?? '',
+                'url'        => $this->author->url ?? '',
+                'avatar_url' => $this->avatar_url,
+                'is_guest'   => null === $this->user_id,
+            ],
+            'permalink'      => $this->permalink,
+            // `edit_link` exposes an admin URL — only surface it to
+            // viewers that can actually moderate the comment.
+            'edit_link'      => $this->when( $canModerate, fn () => $this->edit_link ),
+            'reply_link'     => $this->reply_link,
+            'replies'        => CommentResource::collection(
+                $this->whenLoaded( 'replies' )
+            ),
+        ];
+    }
+}

--- a/src/Modules/Blog/Models/Comment.php
+++ b/src/Modules/Blog/Models/Comment.php
@@ -1,0 +1,321 @@
+<?php
+
+declare( strict_types=1 );
+
+/**
+ * Comment Model
+ *
+ * Represents a comment on a blog post. Comments belong to a post and
+ * optionally to an authenticated user; threaded replies hang off
+ * `parent_id`. The accessor surface mirrors the shape the visual-editor
+ * package's `CommentResolver` reads when stamping `_resolved*`
+ * attributes on `artisanpack/comment-*` blocks.
+ *
+ * @since 2.1.0
+ */
+
+namespace ArtisanPackUI\CMSFramework\Modules\Blog\Models;
+
+use ArtisanPackUI\CMSFramework\Modules\Blog\Database\Factories\CommentFactory;
+use Carbon\Carbon;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+/**
+ * Comment Model
+ *
+ * @property int $id
+ * @property int $post_id
+ * @property int|null $parent_id
+ * @property int|null $user_id
+ * @property string|null $author_name
+ * @property string|null $author_email
+ * @property string|null $author_url
+ * @property string $content
+ * @property string $status
+ * @property Carbon|null $approved_at
+ * @property Carbon $created_at
+ * @property Carbon $updated_at
+ * @property Carbon|null $deleted_at
+ *
+ * @since 2.1.0
+ */
+class Comment extends Model
+{
+    use HasFactory;
+    use SoftDeletes;
+
+    /**
+     * Status constants. Mirrors WordPress' comment_approved values
+     * conceptually but kept as strings so host apps can extend the
+     * status vocabulary via the hooks system.
+     *
+     * @since 2.1.0
+     */
+    public const STATUS_APPROVED = 'approved';
+    public const STATUS_PENDING  = 'pending';
+    public const STATUS_SPAM     = 'spam';
+    public const STATUS_TRASH    = 'trash';
+
+    /**
+     * Explicit table name — the package convention prefixes Blog tables
+     * with `post_*` (see `post_categories`, `post_tag_pivots`).
+     *
+     * @since 2.1.0
+     *
+     * @var string
+     */
+    protected $table = 'post_comments';
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @since 2.1.0
+     *
+     * @var array<int, string>
+     */
+    protected $fillable = [
+        'post_id',
+        'parent_id',
+        'user_id',
+        'author_name',
+        'author_email',
+        'author_url',
+        'content',
+        'status',
+        'approved_at',
+    ];
+
+    /**
+     * Get the post this comment belongs to.
+     *
+     * @since 2.1.0
+     */
+    public function post(): BelongsTo
+    {
+        return $this->belongsTo( Post::class );
+    }
+
+    /**
+     * Get the authenticated user who left the comment (nullable for
+     * guest comments).
+     *
+     * @since 2.1.0
+     */
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo( config( 'auth.providers.users.model' ), 'user_id' );
+    }
+
+    /**
+     * Get the parent comment when this comment is a reply.
+     *
+     * @since 2.1.0
+     */
+    public function parent(): BelongsTo
+    {
+        return $this->belongsTo( self::class, 'parent_id' );
+    }
+
+    /**
+     * Get the approved replies hanging off this comment. Mirrors the
+     * default scoping on `Post::comments()` so consumers iterating
+     * public threads don't leak pending / spam / trash replies. Use
+     * `$comment->repliesIncludingUnapproved()` (or query
+     * `$comment->hasMany(self::class, 'parent_id')` directly) for
+     * moderation surfaces that need the full set.
+     *
+     * @since 2.1.0
+     */
+    public function replies(): HasMany
+    {
+        return $this->hasMany( self::class, 'parent_id' )->approved()->oldest();
+    }
+
+    /**
+     * Get every reply (regardless of moderation status) — used by
+     * the admin / moderation surfaces. Public consumers should use
+     * the default `replies()` relation above.
+     *
+     * @since 2.1.0
+     */
+    public function repliesIncludingUnapproved(): HasMany
+    {
+        return $this->hasMany( self::class, 'parent_id' );
+    }
+
+    /**
+     * Scope a query to approved comments only.
+     *
+     * @since 2.1.0
+     */
+    public function scopeApproved( Builder $query ): Builder
+    {
+        return $query->where( 'status', self::STATUS_APPROVED );
+    }
+
+    /**
+     * Scope a query to pending comments.
+     *
+     * @since 2.1.0
+     */
+    public function scopePending( Builder $query ): Builder
+    {
+        return $query->where( 'status', self::STATUS_PENDING );
+    }
+
+    /**
+     * Scope a query to spam comments.
+     *
+     * @since 2.1.0
+     */
+    public function scopeSpam( Builder $query ): Builder
+    {
+        return $query->where( 'status', self::STATUS_SPAM );
+    }
+
+    /**
+     * Scope a query to top-level comments (no parent).
+     *
+     * @since 2.1.0
+     */
+    public function scopeTopLevel( Builder $query ): Builder
+    {
+        return $query->whereNull( 'parent_id' );
+    }
+
+    /**
+     * Get the resolved author for the comment. Returns the related
+     * `User` when the comment was left by an authenticated user,
+     * otherwise a guest-shaped `stdClass` populated from the
+     * `author_*` columns. Always returns an object with at least
+     * `name` / `url` / `avatar_url` keys so consumers (e.g. the
+     * visual-editor `CommentResolver`) can read them uniformly.
+     *
+     * @since 2.1.0
+     */
+    public function getAuthorAttribute(): object
+    {
+        if ( null !== $this->user_id && null !== $this->user ) {
+            return $this->user;
+        }
+
+        return ( object ) [
+            'name'        => $this->author_name ?? '',
+            'url'         => $this->author_url ?? '',
+            'avatar_url'  => $this->avatar_url,
+            'is_guest'    => true,
+        ];
+    }
+
+    /**
+     * Get the avatar URL for the comment author. Prefers the related
+     * user's avatar (when the User model exposes one), otherwise
+     * falls back to a Gravatar derived from `author_email`.
+     *
+     * @since 2.1.0
+     */
+    public function getAvatarUrlAttribute(): string
+    {
+        if ( null !== $this->user_id && null !== $this->user ) {
+            $userAvatar = $this->user->avatar_url ?? $this->user->avatar ?? null;
+            if ( is_string( $userAvatar ) && '' !== $userAvatar ) {
+                return $userAvatar;
+            }
+        }
+
+        $email = $this->user?->email ?? $this->author_email ?? '';
+
+        if ( '' === $email ) {
+            return '';
+        }
+
+        $hash = md5( strtolower( trim( $email ) ) );
+
+        return "https://www.gravatar.com/avatar/{$hash}?d=mp&s=96";
+    }
+
+    /**
+     * Get the public permalink for the comment.
+     *
+     * @since 2.1.0
+     */
+    public function getPermalinkAttribute(): string
+    {
+        $postPermalink = $this->post?->permalink ?? '';
+
+        if ( '' === $postPermalink ) {
+            return '';
+        }
+
+        return $postPermalink . '#comment-' . $this->id;
+    }
+
+    /**
+     * Get the admin edit link for the comment. Routes through a
+     * filter so host apps can supply their own moderation URL.
+     *
+     * @since 2.1.0
+     */
+    public function getEditLinkAttribute(): string
+    {
+        $default = url( "/admin/comments/{$this->id}/edit" );
+
+        if ( function_exists( 'applyFilters' ) ) {
+            return ( string ) applyFilters( 'comment.editLink', $default, $this );
+        }
+
+        return $default;
+    }
+
+    /**
+     * Get the public reply URL for the comment.
+     *
+     * @since 2.1.0
+     */
+    public function getReplyLinkAttribute(): string
+    {
+        $postPermalink = $this->post?->permalink ?? '';
+
+        if ( '' === $postPermalink ) {
+            return '';
+        }
+
+        $separator = str_contains( $postPermalink, '?' ) ? '&' : '?';
+
+        return $postPermalink . $separator . 'replytocom=' . $this->id;
+    }
+
+    /**
+     * Get the attributes that should be cast.
+     *
+     * @since 2.1.0
+     *
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'approved_at' => 'datetime',
+        ];
+    }
+
+    /**
+     * Resolve the factory for this model. The default Laravel
+     * factory guesser produces `Database\Factories\{FQCN}Factory`,
+     * which doesn't match the package's
+     * `Modules\Blog\Database\Factories\CommentFactory` location.
+     * Other modules (Notifications, Users) use the same override.
+     *
+     * @since 2.1.0
+     */
+    protected static function newFactory(): Factory
+    {
+        return CommentFactory::new();
+    }
+}

--- a/src/Modules/Blog/Models/Post.php
+++ b/src/Modules/Blog/Models/Post.php
@@ -24,6 +24,7 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
 
 /**
@@ -118,6 +119,61 @@ class Post extends Model
     public function tags(): BelongsToMany
     {
         return $this->belongsToMany( PostTag::class, 'post_tag_pivots', 'post_id', 'post_tag_id' );
+    }
+
+    /**
+     * Get the comments for the post. Returns approved comments by
+     * default so consumers (e.g. the visual-editor `CommentResolver`)
+     * iterate over the public set out of the box. Use
+     * `$post->commentsIncludingUnapproved()` (or query
+     * `$post->hasMany(Comment::class)` directly with another status
+     * scope) for moderation surfaces.
+     *
+     * @since 2.1.0
+     */
+    public function comments(): HasMany
+    {
+        return $this->hasMany( Comment::class )->approved()->latest();
+    }
+
+    /**
+     * Get every comment on the post (regardless of moderation
+     * status). Used by admin / moderation surfaces; public consumers
+     * should use `comments()` above.
+     *
+     * @since 2.1.0
+     */
+    public function commentsIncludingUnapproved(): HasMany
+    {
+        return $this->hasMany( Comment::class );
+    }
+
+    /**
+     * Convenience integer count of approved comments. Read by the
+     * visual-editor's `PostResolver` when stamping
+     * `_resolvedCommentCount` onto post-comments-* display blocks.
+     *
+     * @since 2.1.0
+     */
+    public function getCommentsCountAttribute(): int
+    {
+        if ( $this->relationLoaded( 'comments' ) ) {
+            return $this->comments->count();
+        }
+
+        return $this->comments()->count();
+    }
+
+    /**
+     * Public URL to the comments section on the post permalink. The
+     * visual-editor's `PostResolver` reads this when stamping
+     * `_resolvedCommentsUrl` onto the `post-comments-link` block.
+     *
+     * @since 2.1.0
+     */
+    public function getCommentsUrlAttribute(): string
+    {
+        return $this->permalink . '#comments';
     }
 
     /**

--- a/src/Modules/Blog/Policies/CommentPolicy.php
+++ b/src/Modules/Blog/Policies/CommentPolicy.php
@@ -1,0 +1,125 @@
+<?php
+
+declare( strict_types=1 );
+
+/**
+ * Comment Policy for the CMS Framework Blog Module.
+ *
+ * Mirrors `PostPolicy` — gates Comment CRUD + moderation through
+ * the artisanpack-ui/hooks filter system so host apps can override
+ * the capability slugs per operation.
+ *
+ * @since 2.1.0
+ */
+
+namespace ArtisanPackUI\CMSFramework\Modules\Blog\Policies;
+
+use ArtisanPackUI\CMSFramework\Modules\Blog\Models\Comment;
+use Illuminate\Contracts\Auth\Authenticatable;
+
+/**
+ * @since 2.1.0
+ */
+class CommentPolicy
+{
+    /**
+     * @since 2.1.0
+     */
+    public function viewAny( ?Authenticatable $user ): bool
+    {
+        /**
+         * Filters the capability used to determine whether a user can list comments.
+         * @hook  comments.viewAny
+         */
+        $capability = applyFilters( 'comments.viewAny', 'comments.view' );
+
+        // Allow anonymous reads of the approved set so guest visitors
+        // can see comments on the front-end. Host apps that want to
+        // gate even the approved view can return `false` from a
+        // hooks filter on `comments.viewAny.public`.
+        if ( applyFilters( 'comments.viewAny.public', true ) ) {
+            return true;
+        }
+
+        return null !== $user && $user->can( $capability );
+    }
+
+    /**
+     * @since 2.1.0
+     */
+    public function view( ?Authenticatable $user, Comment $comment ): bool
+    {
+        if ( Comment::STATUS_APPROVED === $comment->status
+            && applyFilters( 'comments.view.public', true, $comment ) ) {
+            return true;
+        }
+
+        if ( null === $user ) {
+            return false;
+        }
+
+        return $user->can( applyFilters( 'comments.view', 'comments.view', $comment ) );
+    }
+
+    /**
+     * @since 2.1.0
+     */
+    public function create( ?Authenticatable $user ): bool
+    {
+        // Guest commenting is allowed by default; host apps can opt
+        // out by returning `false` from `comments.create.public`.
+        if ( null === $user ) {
+            return ( bool ) applyFilters( 'comments.create.public', true );
+        }
+
+        return $user->can( applyFilters( 'comments.create', 'comments.create' ) );
+    }
+
+    /**
+     * @since 2.1.0
+     */
+    public function update( Authenticatable $user, Comment $comment ): bool
+    {
+        $canEditAny = $user->can( applyFilters( 'comments.update', 'comments.edit', $comment ) );
+
+        if ( $canEditAny ) {
+            return true;
+        }
+
+        $canEditOwn = $user->can( applyFilters( 'comments.updateOwn', 'comments.editOwn', $comment ) );
+
+        if ( $canEditOwn && null !== $comment->user_id && $comment->user_id === $user->getAuthIdentifier() ) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * @since 2.1.0
+     */
+    public function delete( Authenticatable $user, Comment $comment ): bool
+    {
+        $canDeleteAny = $user->can( applyFilters( 'comments.delete', 'comments.delete', $comment ) );
+
+        if ( $canDeleteAny ) {
+            return true;
+        }
+
+        $canDeleteOwn = $user->can( applyFilters( 'comments.deleteOwn', 'comments.deleteOwn', $comment ) );
+
+        if ( $canDeleteOwn && null !== $comment->user_id && $comment->user_id === $user->getAuthIdentifier() ) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * @since 2.1.0
+     */
+    public function moderate( Authenticatable $user, Comment $comment ): bool
+    {
+        return $user->can( applyFilters( 'comments.moderate', 'comments.moderate', $comment ) );
+    }
+}

--- a/src/Modules/Blog/Providers/BlogServiceProvider.php
+++ b/src/Modules/Blog/Providers/BlogServiceProvider.php
@@ -24,8 +24,11 @@ use ArtisanPackUI\CMSFramework\Modules\Blog\Policies\PostTagPolicy;
 use ArtisanPackUI\CMSFramework\Modules\Blog\Services\QueryRuntime;
 use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Managers\ContentTypeManager;
 use ArtisanPackUI\CMSFramework\Modules\Pages\Managers\PageManager;
+use Illuminate\Cache\RateLimiting\Limit;
+use Illuminate\Http\Request;
 use Illuminate\Routing\Router;
 use Illuminate\Support\Facades\Gate;
+use Illuminate\Support\Facades\RateLimiter;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\ServiceProvider;
 
@@ -73,6 +76,11 @@ class BlogServiceProvider extends ServiceProvider
         // Load migrations
         $this->loadMigrationsFrom( __DIR__ . '/../database/migrations' );
 
+        // Register the `comments` rate limiter BEFORE the routes load
+        // so the `throttle:comments` middleware attached to the
+        // public `POST /api/v1/comments` route resolves.
+        $this->registerCommentsRateLimiter();
+
         // Load API routes
         Route::prefix( 'api/v1' )
             ->middleware( 'api' )
@@ -113,6 +121,44 @@ class BlogServiceProvider extends ServiceProvider
             'icon'          => 'fas-newspaper',
             'menu_position' => 20,
         ] );
+    }
+
+    /**
+     * Register the `comments` rate limiter used by the public
+     * `POST /api/v1/comments` route. Authenticated callers get a
+     * generous bucket keyed by user id; unauthenticated guests get
+     * a tighter bucket keyed by IP so a single host can't bulk-spam
+     * the table. Host apps can override either bucket via the
+     * `comments.rate-limit.authenticated` / `comments.rate-limit.guest`
+     * hooks filters, or replace the limiter entirely by re-calling
+     * `RateLimiter::for( 'comments', ... )` from their own provider
+     * after this package boots.
+     *
+     * @since 2.1.0
+     */
+    protected function registerCommentsRateLimiter(): void
+    {
+        RateLimiter::for( 'comments', function ( Request $request ): Limit {
+            $user = $request->user();
+
+            if ( null !== $user ) {
+                $authenticatedLimit = ( int ) applyFilters(
+                    'comments.rate-limit.authenticated',
+                    60
+                );
+
+                return Limit::perMinute( $authenticatedLimit )
+                    ->by( 'comments:user:' . $user->getAuthIdentifier() );
+            }
+
+            $guestLimit = ( int ) applyFilters(
+                'comments.rate-limit.guest',
+                10
+            );
+
+            return Limit::perMinute( $guestLimit )
+                ->by( 'comments:ip:' . ( $request->ip() ?? 'unknown' ) );
+        } );
     }
 
     /**

--- a/src/Modules/Blog/Providers/BlogServiceProvider.php
+++ b/src/Modules/Blog/Providers/BlogServiceProvider.php
@@ -13,9 +13,11 @@ declare( strict_types=1 );
 namespace ArtisanPackUI\CMSFramework\Modules\Blog\Providers;
 
 use ArtisanPackUI\CMSFramework\Modules\Blog\Managers\BlogManager;
+use ArtisanPackUI\CMSFramework\Modules\Blog\Models\Comment;
 use ArtisanPackUI\CMSFramework\Modules\Blog\Models\Post;
 use ArtisanPackUI\CMSFramework\Modules\Blog\Models\PostCategory;
 use ArtisanPackUI\CMSFramework\Modules\Blog\Models\PostTag;
+use ArtisanPackUI\CMSFramework\Modules\Blog\Policies\CommentPolicy;
 use ArtisanPackUI\CMSFramework\Modules\Blog\Policies\PostCategoryPolicy;
 use ArtisanPackUI\CMSFramework\Modules\Blog\Policies\PostPolicy;
 use ArtisanPackUI\CMSFramework\Modules\Blog\Policies\PostTagPolicy;
@@ -80,6 +82,7 @@ class BlogServiceProvider extends ServiceProvider
         Gate::policy( Post::class, PostPolicy::class );
         Gate::policy( PostCategory::class, PostCategoryPolicy::class );
         Gate::policy( PostTag::class, PostTagPolicy::class );
+        Gate::policy( Comment::class, CommentPolicy::class );
 
         // Register blog content type
         $this->registerBlogContentType();

--- a/src/Modules/Blog/database/factories/CommentFactory.php
+++ b/src/Modules/Blog/database/factories/CommentFactory.php
@@ -14,9 +14,10 @@ declare( strict_types=1 );
 
 namespace ArtisanPackUI\CMSFramework\Modules\Blog\Database\Factories;
 
-use App\Models\User;
 use ArtisanPackUI\CMSFramework\Modules\Blog\Models\Comment;
 use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
 
 /**
  * @extends Factory<Comment>
@@ -62,11 +63,44 @@ class CommentFactory extends Factory
     public function byUser( ?int $userId = null ): static
     {
         return $this->state( fn ( array $attributes ) => [
-            'user_id'      => $userId ?? User::factory(),
+            'user_id'      => $userId ?? $this->resolveUserFactory(),
             'author_name'  => null,
             'author_email' => null,
             'author_url'   => null,
         ] );
+    }
+
+    /**
+     * Resolve the configured user model's factory so host apps whose
+     * `auth.providers.users.model` is not `App\Models\User` still
+     * create the right user when `byUser()` is called without an id.
+     * Mirrors `Post::author()`'s use of the same config key.
+     *
+     * @since 2.1.0
+     */
+    protected function resolveUserFactory(): Factory|int|null
+    {
+        $userModel = config( 'auth.providers.users.model' );
+
+        if ( ! is_string( $userModel ) || ! class_exists( $userModel ) ) {
+            return null;
+        }
+
+        if ( ! is_subclass_of( $userModel, Model::class ) ) {
+            return null;
+        }
+
+        // `HasFactory` is the conventional gate; if the host's User
+        // model doesn't expose a factory, fall back to leaving
+        // `user_id` null so the caller must supply it explicitly.
+        if ( ! in_array( HasFactory::class, class_uses_recursive( $userModel ), true ) ) {
+            return null;
+        }
+
+        /** @var Factory $factory */
+        $factory = $userModel::factory();
+
+        return $factory;
     }
 
     /**

--- a/src/Modules/Blog/database/factories/CommentFactory.php
+++ b/src/Modules/Blog/database/factories/CommentFactory.php
@@ -1,0 +1,126 @@
+<?php
+
+declare( strict_types=1 );
+
+/**
+ * Comment Factory for the CMS Framework Blog Module.
+ *
+ * Generates fake comment data for testing and seeding. States cover
+ * the approval lifecycle (approved / pending / spam / trash) and the
+ * threading shape (replies hung off a parent comment).
+ *
+ * @since 2.1.0
+ */
+
+namespace ArtisanPackUI\CMSFramework\Modules\Blog\Database\Factories;
+
+use App\Models\User;
+use ArtisanPackUI\CMSFramework\Modules\Blog\Models\Comment;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<Comment>
+ */
+class CommentFactory extends Factory
+{
+    /**
+     * @var class-string<Comment>
+     */
+    protected $model = Comment::class;
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        // `post_id` is intentionally omitted from the default state.
+        // Callers must supply a post via `->for( $post )` or by
+        // setting `post_id` explicitly — Comments cannot exist
+        // without a parent post, and the Post model's `newFactory()`
+        // override is not in place (consistent with the rest of
+        // the Blog tests, which `Post::create()` directly rather
+        // than going through a factory).
+        return [
+            'parent_id'    => null,
+            'user_id'      => null,
+            'author_name'  => fake()->name(),
+            'author_email' => fake()->safeEmail(),
+            'author_url'   => fake()->optional( 0.3 )->url(),
+            'content'      => fake()->paragraph(),
+            'status'       => Comment::STATUS_APPROVED,
+            'approved_at'  => now(),
+        ];
+    }
+
+    /**
+     * Indicate the comment was left by an authenticated user. Clears
+     * the guest `author_*` fields so the model's accessor falls back
+     * to the related User.
+     *
+     * @since 2.1.0
+     */
+    public function byUser( ?int $userId = null ): static
+    {
+        return $this->state( fn ( array $attributes ) => [
+            'user_id'      => $userId ?? User::factory(),
+            'author_name'  => null,
+            'author_email' => null,
+            'author_url'   => null,
+        ] );
+    }
+
+    /**
+     * Indicate the comment is a reply to another comment.
+     *
+     * @since 2.1.0
+     */
+    public function replyTo( Comment|int $parent ): static
+    {
+        $parentId = $parent instanceof Comment ? $parent->id : $parent;
+        $postId   = $parent instanceof Comment ? $parent->post_id : null;
+
+        return $this->state( fn ( array $attributes ) => array_filter( [
+            'parent_id' => $parentId,
+            'post_id'   => $postId,
+        ], static fn ( $value ) => null !== $value ) );
+    }
+
+    /**
+     * Indicate the comment is pending moderation.
+     *
+     * @since 2.1.0
+     */
+    public function pending(): static
+    {
+        return $this->state( fn ( array $attributes ) => [
+            'status'      => Comment::STATUS_PENDING,
+            'approved_at' => null,
+        ] );
+    }
+
+    /**
+     * Indicate the comment has been flagged as spam.
+     *
+     * @since 2.1.0
+     */
+    public function spam(): static
+    {
+        return $this->state( fn ( array $attributes ) => [
+            'status'      => Comment::STATUS_SPAM,
+            'approved_at' => null,
+        ] );
+    }
+
+    /**
+     * Indicate the comment is in the trash.
+     *
+     * @since 2.1.0
+     */
+    public function trash(): static
+    {
+        return $this->state( fn ( array $attributes ) => [
+            'status'      => Comment::STATUS_TRASH,
+            'approved_at' => null,
+        ] );
+    }
+}

--- a/src/Modules/Blog/database/migrations/2026_06_02_000001_create_post_comments_table.php
+++ b/src/Modules/Blog/database/migrations/2026_06_02_000001_create_post_comments_table.php
@@ -26,7 +26,9 @@ return new class extends Migration {
             $table->timestamps();
             $table->softDeletes();
 
-            $table->index( 'post_id' );
+            // The composite (post_id, status) index covers post_id-only
+            // lookups via its leftmost prefix, so a standalone post_id
+            // index would just be write/storage overhead.
             $table->index( 'parent_id' );
             $table->index( 'status' );
             $table->index( [ 'post_id', 'status' ] );

--- a/src/Modules/Blog/database/migrations/2026_06_02_000001_create_post_comments_table.php
+++ b/src/Modules/Blog/database/migrations/2026_06_02_000001_create_post_comments_table.php
@@ -1,0 +1,44 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create( 'post_comments', function ( Blueprint $table ): void {
+            $table->id();
+            $table->foreignId( 'post_id' )->constrained( 'posts' )->onDelete( 'cascade' );
+            $table->foreignId( 'parent_id' )->nullable()
+                ->constrained( 'post_comments' )->onDelete( 'cascade' );
+            $table->foreignId( 'user_id' )->nullable()
+                ->constrained( 'users' )->onDelete( 'set null' );
+            $table->string( 'author_name' )->nullable();
+            $table->string( 'author_email' )->nullable();
+            $table->string( 'author_url' )->nullable();
+            $table->text( 'content' );
+            $table->string( 'status' )->default( 'pending' );
+            $table->timestamp( 'approved_at' )->nullable();
+            $table->timestamps();
+            $table->softDeletes();
+
+            $table->index( 'post_id' );
+            $table->index( 'parent_id' );
+            $table->index( 'status' );
+            $table->index( [ 'post_id', 'status' ] );
+            $table->index( 'created_at' );
+        } );
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists( 'post_comments' );
+    }
+};

--- a/src/Modules/Blog/routes/api.php
+++ b/src/Modules/Blog/routes/api.php
@@ -8,6 +8,7 @@ declare( strict_types=1 );
  * @since 1.0.0
  */
 
+use ArtisanPackUI\CMSFramework\Modules\Blog\Http\Controllers\CommentController;
 use ArtisanPackUI\CMSFramework\Modules\Blog\Http\Controllers\PostCategoryController;
 use ArtisanPackUI\CMSFramework\Modules\Blog\Http\Controllers\PostController;
 use ArtisanPackUI\CMSFramework\Modules\Blog\Http\Controllers\PostTagController;
@@ -67,4 +68,28 @@ Route::prefix( 'post-tags' )->middleware( 'auth' )->group( function (): void {
     Route::get( '/{id}', [PostTagController::class, 'show'] );
     Route::put( '/{id}', [PostTagController::class, 'update'] );
     Route::delete( '/{id}', [PostTagController::class, 'destroy'] );
+} );
+
+/*
+|--------------------------------------------------------------------------
+| Comments API Routes
+|--------------------------------------------------------------------------
+|
+| Read endpoints (`index`, `show`) are public — `CommentPolicy` filters
+| the approved set so guest visitors can fetch comments without an auth
+| token. Create / update / delete go through the policy's authenticated
+| capability checks (`comments.create`, `comments.update`, etc.).
+|
+*/
+
+Route::prefix( 'comments' )->group( function (): void {
+    Route::get( '/', [CommentController::class, 'index'] );
+    Route::get( '/{comment}', [CommentController::class, 'show'] );
+
+    Route::middleware( 'auth' )->group( function (): void {
+        Route::post( '/', [CommentController::class, 'store'] );
+        Route::put( '/{comment}', [CommentController::class, 'update'] );
+        Route::patch( '/{comment}', [CommentController::class, 'update'] );
+        Route::delete( '/{comment}', [CommentController::class, 'destroy'] );
+    } );
 } );

--- a/src/Modules/Blog/routes/api.php
+++ b/src/Modules/Blog/routes/api.php
@@ -77,17 +77,20 @@ Route::prefix( 'post-tags' )->middleware( 'auth' )->group( function (): void {
 |
 | Read endpoints (`index`, `show`) are public — `CommentPolicy` filters
 | the approved set so guest visitors can fetch comments without an auth
-| token. Create / update / delete go through the policy's authenticated
-| capability checks (`comments.create`, `comments.update`, etc.).
+| token. `store` is also publicly reachable (the policy's
+| `comments.create.public` filter defaults to allow); guest commenters
+| supply `author_name` / `author_email` / `author_url` and the
+| controller defaults the resulting comment to `pending` so a
+| moderator can approve it. Update / delete are auth-gated.
 |
 */
 
 Route::prefix( 'comments' )->group( function (): void {
     Route::get( '/', [CommentController::class, 'index'] );
     Route::get( '/{comment}', [CommentController::class, 'show'] );
+    Route::post( '/', [CommentController::class, 'store'] );
 
     Route::middleware( 'auth' )->group( function (): void {
-        Route::post( '/', [CommentController::class, 'store'] );
         Route::put( '/{comment}', [CommentController::class, 'update'] );
         Route::patch( '/{comment}', [CommentController::class, 'update'] );
         Route::delete( '/{comment}', [CommentController::class, 'destroy'] );

--- a/src/Modules/Blog/routes/api.php
+++ b/src/Modules/Blog/routes/api.php
@@ -83,12 +83,22 @@ Route::prefix( 'post-tags' )->middleware( 'auth' )->group( function (): void {
 | controller defaults the resulting comment to `pending` so a
 | moderator can approve it. Update / delete are auth-gated.
 |
+| The public `POST /comments` route is throttled via the
+| `throttle:comments` named limiter (defined in
+| `BlogServiceProvider::registerCommentsRateLimiter()`) to keep
+| unauthenticated callers from bulk-inserting against `post_comments`.
+| Default buckets: 10/min for guests (keyed by IP), 60/min for
+| authenticated users (keyed by user id) — overridable via the
+| `comments.rate-limit.guest` / `comments.rate-limit.authenticated`
+| hooks filters.
+|
 */
 
 Route::prefix( 'comments' )->group( function (): void {
     Route::get( '/', [CommentController::class, 'index'] );
     Route::get( '/{comment}', [CommentController::class, 'show'] );
-    Route::post( '/', [CommentController::class, 'store'] );
+    Route::post( '/', [CommentController::class, 'store'] )
+        ->middleware( 'throttle:comments' );
 
     Route::middleware( 'auth' )->group( function (): void {
         Route::put( '/{comment}', [CommentController::class, 'update'] );

--- a/tests/Feature/Blog/CommentControllerTest.php
+++ b/tests/Feature/Blog/CommentControllerTest.php
@@ -1,0 +1,274 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\CMSFramework\Modules\Blog\Models\Comment;
+use ArtisanPackUI\CMSFramework\Modules\Blog\Models\Post;
+use ArtisanPackUI\CMSFramework\Tests\Support\TestUser;
+use Illuminate\Support\Facades\Gate;
+use Illuminate\Support\Str;
+
+function grantAllCommentPermissions(): void
+{
+    Gate::define( 'comments.view', fn () => true );
+    Gate::define( 'comments.create', fn () => true );
+    Gate::define( 'comments.edit', fn () => true );
+    Gate::define( 'comments.editOwn', fn () => true );
+    Gate::define( 'comments.delete', fn () => true );
+    Gate::define( 'comments.deleteOwn', fn () => true );
+    Gate::define( 'comments.moderate', fn () => true );
+}
+
+function createCommentTestPost( ?TestUser $author = null ): Post
+{
+    $author ??= TestUser::factory()->create();
+    $title    = fake()->sentence( 6, true );
+
+    return Post::create( [
+        'title'        => $title,
+        'slug'         => Str::slug( $title ) . '-' . Str::random( 5 ),
+        'content'      => fake()->paragraphs( 2, true ),
+        'author_id'    => $author->id,
+        'status'       => 'published',
+        'published_at' => now(),
+    ] );
+}
+
+test( 'index returns approved top-level comments for a post, paginated', function (): void {
+    $post = createCommentTestPost();
+
+    Comment::factory()->for( $post )->count( 3 )->create();
+    Comment::factory()->for( $post )->pending()->create();
+    Comment::factory()->for( $post )->spam()->create();
+
+    $response = $this->getJson( "/api/v1/comments?post_id={$post->id}" );
+
+    $response->assertSuccessful();
+    expect( $response->json( 'data' ) )->toHaveCount( 3 );
+    foreach ( $response->json( 'data' ) as $row ) {
+        expect( $row['status'] )->toBe( Comment::STATUS_APPROVED );
+        expect( $row['post_id'] )->toBe( $post->id );
+    }
+} );
+
+test( 'index excludes replies by default but includes them via parent_id filter', function (): void {
+    $post   = createCommentTestPost();
+    $parent = Comment::factory()->for( $post )->create();
+    Comment::factory()->for( $post )->replyTo( $parent )->count( 2 )->create();
+
+    $top = $this->getJson( "/api/v1/comments?post_id={$post->id}" );
+    expect( $top->json( 'data' ) )->toHaveCount( 1 );
+
+    $replies = $this->getJson( "/api/v1/comments?post_id={$post->id}&parent_id={$parent->id}" );
+    expect( $replies->json( 'data' ) )->toHaveCount( 2 );
+} );
+
+test( 'show returns a single approved comment to anonymous viewers', function (): void {
+    $post    = createCommentTestPost();
+    $comment = Comment::factory()->for( $post )->create();
+
+    $response = $this->getJson( "/api/v1/comments/{$comment->id}" );
+
+    $response->assertSuccessful();
+    expect( $response->json( 'data.id' ) )->toBe( $comment->id )
+        ->and( $response->json( 'data.author.is_guest' ) )->toBeTrue()
+        ->and( $response->json( 'data.permalink' ) )->toContain( '#comment-' . $comment->id );
+} );
+
+test( 'show rejects anonymous access to a non-approved comment', function (): void {
+    $post    = createCommentTestPost();
+    $comment = Comment::factory()->for( $post )->pending()->create();
+
+    $response = $this->getJson( "/api/v1/comments/{$comment->id}" );
+
+    $response->assertForbidden();
+} );
+
+test( 'store creates a new comment for an authenticated user', function (): void {
+    grantAllCommentPermissions();
+    $author     = TestUser::factory()->create();
+    $post       = createCommentTestPost( $author );
+    $commenter  = TestUser::factory()->create();
+
+    $response = $this->actingAs( $commenter )->postJson( '/api/v1/comments', [
+        'post_id' => $post->id,
+        'content' => 'A new comment from an authenticated user.',
+    ] );
+
+    $response->assertCreated();
+    expect( Comment::count() )->toBe( 1 );
+    expect( $response->json( 'data.content' ) )->toBe( 'A new comment from an authenticated user.' );
+    expect( $response->json( 'data.status' ) )->toBe( Comment::STATUS_APPROVED );
+} );
+
+test( 'store defaults to pending status for non-moderator users', function (): void {
+    // Only grant create, not moderate — the controller should set
+    // status=pending rather than auto-approving.
+    Gate::define( 'comments.create', fn () => true );
+    $post      = createCommentTestPost();
+    $commenter = TestUser::factory()->create();
+
+    $response = $this->actingAs( $commenter )->postJson( '/api/v1/comments', [
+        'post_id'      => $post->id,
+        'author_name'  => 'Jane',
+        'author_email' => 'jane@example.com',
+        'content'      => 'Pending guest comment',
+    ] );
+
+    $response->assertCreated();
+    expect( $response->json( 'data.status' ) )->toBe( Comment::STATUS_PENDING );
+} );
+
+test( 'update changes the status to approved and stamps approved_at', function (): void {
+    grantAllCommentPermissions();
+    $user    = TestUser::factory()->create();
+    $post    = createCommentTestPost();
+    $comment = Comment::factory()->for( $post )->pending()->create();
+
+    $response = $this->actingAs( $user )->putJson( "/api/v1/comments/{$comment->id}", [
+        'status' => Comment::STATUS_APPROVED,
+    ] );
+
+    $response->assertSuccessful();
+    expect( $response->json( 'data.status' ) )->toBe( Comment::STATUS_APPROVED );
+    expect( $comment->fresh()->approved_at )->not->toBeNull();
+} );
+
+test( 'destroy soft-deletes the comment for authorized users', function (): void {
+    grantAllCommentPermissions();
+    $user    = TestUser::factory()->create();
+    $post    = createCommentTestPost();
+    $comment = Comment::factory()->for( $post )->create();
+
+    $response = $this->actingAs( $user )->deleteJson( "/api/v1/comments/{$comment->id}" );
+
+    $response->assertNoContent();
+    expect( Comment::query()->withTrashed()->find( $comment->id )->trashed() )->toBeTrue();
+} );
+
+test( 'unauthenticated update is rejected', function (): void {
+    $post    = createCommentTestPost();
+    $comment = Comment::factory()->for( $post )->create();
+
+    $response = $this->putJson( "/api/v1/comments/{$comment->id}", [
+        'content' => 'attempted update',
+    ] );
+
+    $response->assertUnauthorized();
+} );
+
+test( 'non-moderator cannot self-approve via the status field on store', function (): void {
+    Gate::define( 'comments.create', fn () => true );
+    // Deliberately NOT granting comments.moderate.
+    $post      = createCommentTestPost();
+    $commenter = TestUser::factory()->create();
+
+    $response = $this->actingAs( $commenter )->postJson( '/api/v1/comments', [
+        'post_id' => $post->id,
+        'content' => 'Trying to self-approve',
+        'status'  => Comment::STATUS_APPROVED,
+    ] );
+
+    $response->assertCreated();
+    // Server should have ignored the client-supplied status and
+    // fallen through to the pending default.
+    expect( $response->json( 'data.status' ) )->toBe( Comment::STATUS_PENDING );
+} );
+
+test( 'client-supplied user_id is ignored on store', function (): void {
+    grantAllCommentPermissions();
+    $post              = createCommentTestPost();
+    $commenter         = TestUser::factory()->create();
+    $impersonationTarget = TestUser::factory()->create();
+
+    $response = $this->actingAs( $commenter )->postJson( '/api/v1/comments', [
+        'post_id' => $post->id,
+        'content' => 'Trying to impersonate',
+        'user_id' => $impersonationTarget->id,
+    ] );
+
+    $response->assertCreated();
+    expect( $response->json( 'data.user_id' ) )->toBe( $commenter->id );
+} );
+
+test( 'public callers cannot request non-approved comments via the status query string', function (): void {
+    $post = createCommentTestPost();
+    Comment::factory()->for( $post )->count( 2 )->create();
+    Comment::factory()->for( $post )->pending()->count( 3 )->create();
+
+    $response = $this->getJson(
+        "/api/v1/comments?post_id={$post->id}&status=" . Comment::STATUS_PENDING
+    );
+
+    $response->assertSuccessful();
+    // Public should still only see the approved set, regardless of
+    // the `status=pending` query string.
+    expect( $response->json( 'data' ) )->toHaveCount( 2 );
+    foreach ( $response->json( 'data' ) as $row ) {
+        expect( $row['status'] )->toBe( Comment::STATUS_APPROVED );
+    }
+} );
+
+test( 'edit_link is hidden from non-moderator viewers', function (): void {
+    $post    = createCommentTestPost();
+    $comment = Comment::factory()->for( $post )->create();
+
+    $response = $this->getJson( "/api/v1/comments/{$comment->id}" );
+
+    $response->assertSuccessful();
+    expect( $response->json( 'data' ) )->not->toHaveKey( 'edit_link' );
+} );
+
+test( 'edit_link is included for moderators', function (): void {
+    grantAllCommentPermissions();
+    $moderator = TestUser::factory()->create();
+    $post      = createCommentTestPost();
+    $comment   = Comment::factory()->for( $post )->create();
+
+    $response = $this->actingAs( $moderator )->getJson( "/api/v1/comments/{$comment->id}" );
+
+    $response->assertSuccessful();
+    expect( $response->json( 'data.edit_link' ) )->toBeString()
+        ->and( $response->json( 'data.edit_link' ) )->toContain( 'comments/' . $comment->id );
+} );
+
+test( 'per_page values outside the 1..100 window are clamped', function (): void {
+    $post = createCommentTestPost();
+    Comment::factory()->for( $post )->count( 5 )->create();
+
+    $tooSmall = $this->getJson( "/api/v1/comments?post_id={$post->id}&per_page=0" );
+    expect( $tooSmall->json( 'meta.per_page' ) )->toBe( 1 );
+
+    $tooLarge = $this->getJson( "/api/v1/comments?post_id={$post->id}&per_page=9999" );
+    expect( $tooLarge->json( 'meta.per_page' ) )->toBe( 100 );
+} );
+
+test( 'parent_id must belong to the same post', function (): void {
+    grantAllCommentPermissions();
+    $user        = TestUser::factory()->create();
+    $postA       = createCommentTestPost();
+    $postB       = createCommentTestPost();
+    $parentOnA   = Comment::factory()->for( $postA )->create();
+
+    // Reply targeted at postB but referencing a parent on postA.
+    $response = $this->actingAs( $user )->postJson( '/api/v1/comments', [
+        'post_id'   => $postB->id,
+        'parent_id' => $parentOnA->id,
+        'content'   => 'cross-post reply',
+    ] );
+
+    $response->assertStatus( 422 );
+    $response->assertJsonValidationErrors( [ 'parent_id' ] );
+} );
+
+test( 'validation fails when required fields are missing on store', function (): void {
+    grantAllCommentPermissions();
+    $user = TestUser::factory()->create();
+
+    $response = $this->actingAs( $user )->postJson( '/api/v1/comments', [
+        // missing post_id and content
+    ] );
+
+    $response->assertStatus( 422 );
+    $response->assertJsonValidationErrors( [ 'post_id', 'content' ] );
+} );

--- a/tests/Feature/Blog/CommentControllerTest.php
+++ b/tests/Feature/Blog/CommentControllerTest.php
@@ -243,6 +243,27 @@ test( 'per_page values outside the 1..100 window are clamped', function (): void
     expect( $tooLarge->json( 'meta.per_page' ) )->toBe( 100 );
 } );
 
+test( 'unauthenticated guest can post a comment with author fields, defaulting to pending', function (): void {
+    $post = createCommentTestPost();
+
+    // No `actingAs()` — the guest path runs through
+    // CommentPolicy::create's `comments.create.public` filter which
+    // defaults to allow.
+    $response = $this->postJson( '/api/v1/comments', [
+        'post_id'      => $post->id,
+        'author_name'  => 'Jane Guest',
+        'author_email' => 'jane@example.com',
+        'author_url'   => 'https://example.test/jane',
+        'content'      => 'A guest comment',
+    ] );
+
+    $response->assertCreated();
+    expect( $response->json( 'data.author.name' ) )->toBe( 'Jane Guest' )
+        ->and( $response->json( 'data.author.is_guest' ) )->toBeTrue()
+        ->and( $response->json( 'data.status' ) )->toBe( Comment::STATUS_PENDING )
+        ->and( $response->json( 'data.user_id' ) )->toBeNull();
+} );
+
 test( 'parent_id must belong to the same post', function (): void {
     grantAllCommentPermissions();
     $user        = TestUser::factory()->create();

--- a/tests/Feature/Blog/CommentControllerTest.php
+++ b/tests/Feature/Blog/CommentControllerTest.php
@@ -243,6 +243,32 @@ test( 'per_page values outside the 1..100 window are clamped', function (): void
     expect( $tooLarge->json( 'meta.per_page' ) )->toBe( 100 );
 } );
 
+test( 'public POST /comments is throttled after the guest bucket is exhausted', function (): void {
+    // Tighten the guest limit for the duration of this test so we
+    // don't have to fire ten requests to prove the limiter is wired.
+    addFilter( 'comments.rate-limit.guest', fn () => 2 );
+
+    $post = createCommentTestPost();
+
+    $payload = [
+        'post_id'      => $post->id,
+        'author_name'  => 'Spammy',
+        'author_email' => 'spam@example.com',
+        'content'      => 'Comment under throttle',
+    ];
+
+    $this->postJson( '/api/v1/comments', $payload )->assertCreated();
+    $this->postJson( '/api/v1/comments', $payload )->assertCreated();
+
+    // Third request from the same IP within the minute should trip
+    // the throttle and short-circuit before the controller runs.
+    $this->postJson( '/api/v1/comments', $payload )->assertStatus( 429 );
+
+    // Clean up the filter so neighbouring tests get the default
+    // guest bucket.
+    removeAllFilters( 'comments.rate-limit.guest' );
+} );
+
 test( 'unauthenticated guest can post a comment with author fields, defaulting to pending', function (): void {
     $post = createCommentTestPost();
 

--- a/tests/Unit/Blog/CommentModelTest.php
+++ b/tests/Unit/Blog/CommentModelTest.php
@@ -1,0 +1,180 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\CMSFramework\Modules\Blog\Models\Comment;
+use ArtisanPackUI\CMSFramework\Modules\Blog\Models\Post;
+use ArtisanPackUI\CMSFramework\Tests\Support\TestUser;
+
+beforeEach( function (): void {
+    $this->artisan( 'migrate', [ '--database' => 'testing' ] );
+} );
+
+function makeCommentTestAuthor(): TestUser
+{
+    return TestUser::create( [
+        'name'     => 'Test Author',
+        'email'    => 'author-' . uniqid() . '@example.com',
+        'password' => 'password',
+    ] );
+}
+
+function makeCommentTestPost( TestUser $author ): Post
+{
+    return Post::create( [
+        'title'     => 'A post with comments',
+        'slug'      => 'a-post-with-comments-' . uniqid(),
+        'content'   => 'Body',
+        'author_id' => $author->id,
+        'status'    => 'published',
+    ] );
+}
+
+test( 'a comment can be created against a post', function (): void {
+    $post = makeCommentTestPost( makeCommentTestAuthor() );
+
+    $comment = Comment::create( [
+        'post_id'      => $post->id,
+        'author_name'  => 'Jane Doe',
+        'author_email' => 'jane@example.com',
+        'content'      => 'Great post!',
+        'status'       => Comment::STATUS_APPROVED,
+        'approved_at'  => now(),
+    ] );
+
+    expect( $comment->id )->toBeInt()
+        ->and( $comment->post_id )->toBe( $post->id )
+        ->and( $comment->content )->toBe( 'Great post!' )
+        ->and( $comment->status )->toBe( Comment::STATUS_APPROVED );
+} );
+
+test( 'guest author accessor returns a normalized shape from author_* columns', function (): void {
+    $post = makeCommentTestPost( makeCommentTestAuthor() );
+
+    $comment = Comment::create( [
+        'post_id'      => $post->id,
+        'author_name'  => 'Jane Doe',
+        'author_email' => 'jane@example.com',
+        'author_url'   => 'https://example.test/jane',
+        'content'      => 'Hello',
+        'status'       => Comment::STATUS_APPROVED,
+    ] );
+
+    expect( $comment->author->name )->toBe( 'Jane Doe' )
+        ->and( $comment->author->url )->toBe( 'https://example.test/jane' )
+        ->and( $comment->author->is_guest )->toBeTrue();
+} );
+
+test( 'authenticated author accessor returns the related user', function (): void {
+    $author      = makeCommentTestAuthor();
+    $post        = makeCommentTestPost( $author );
+    $commenter   = TestUser::create( [
+        'name'     => 'Alice Commenter',
+        'email'    => 'alice@example.com',
+        'password' => 'password',
+    ] );
+
+    $comment = Comment::create( [
+        'post_id' => $post->id,
+        'user_id' => $commenter->id,
+        'content' => 'A registered-user comment',
+        'status'  => Comment::STATUS_APPROVED,
+    ] );
+
+    expect( $comment->author->id )->toBe( $commenter->id )
+        ->and( $comment->author->name )->toBe( 'Alice Commenter' );
+} );
+
+test( 'avatar_url falls back to a gravatar derived from author_email', function (): void {
+    $post = makeCommentTestPost( makeCommentTestAuthor() );
+
+    $comment = Comment::create( [
+        'post_id'      => $post->id,
+        'author_name'  => 'Jane Doe',
+        'author_email' => 'JANE@example.com  ',
+        'content'      => 'Hello',
+        'status'       => Comment::STATUS_APPROVED,
+    ] );
+
+    $expectedHash = md5( 'jane@example.com' );
+    expect( $comment->avatar_url )->toContain( $expectedHash )
+        ->and( $comment->avatar_url )->toStartWith( 'https://www.gravatar.com/avatar/' );
+} );
+
+test( 'permalink builds against the post permalink', function (): void {
+    $post    = makeCommentTestPost( makeCommentTestAuthor() );
+    $comment = Comment::create( [
+        'post_id'     => $post->id,
+        'author_name' => 'X',
+        'content'     => 'C',
+        'status'      => Comment::STATUS_APPROVED,
+    ] );
+
+    expect( $comment->permalink )->toBe( $post->permalink . '#comment-' . $comment->id );
+} );
+
+test( 'reply_link adds the replytocom query string', function (): void {
+    $post    = makeCommentTestPost( makeCommentTestAuthor() );
+    $comment = Comment::create( [
+        'post_id'     => $post->id,
+        'author_name' => 'X',
+        'content'     => 'C',
+        'status'      => Comment::STATUS_APPROVED,
+    ] );
+
+    expect( $comment->reply_link )->toContain( 'replytocom=' . $comment->id );
+} );
+
+test( 'approved scope filters to approved status', function (): void {
+    $post = makeCommentTestPost( makeCommentTestAuthor() );
+
+    Comment::factory()->for( $post )->create();
+    Comment::factory()->for( $post )->pending()->create();
+    Comment::factory()->for( $post )->spam()->create();
+
+    $approved = Comment::approved()->get();
+
+    expect( $approved )->toHaveCount( 1 )
+        ->and( $approved->first()->status )->toBe( Comment::STATUS_APPROVED );
+} );
+
+test( 'topLevel scope filters out replies', function (): void {
+    $post   = makeCommentTestPost( makeCommentTestAuthor() );
+    $parent = Comment::factory()->for( $post )->create();
+    Comment::factory()->for( $post )->replyTo( $parent )->create();
+
+    expect( Comment::topLevel()->count() )->toBe( 1 )
+        ->and( Comment::query()->count() )->toBe( 2 );
+} );
+
+test( 'replies relation returns child comments', function (): void {
+    $post   = makeCommentTestPost( makeCommentTestAuthor() );
+    $parent = Comment::factory()->for( $post )->create();
+    Comment::factory()->for( $post )->replyTo( $parent )->count( 3 )->create();
+
+    expect( $parent->replies()->count() )->toBe( 3 );
+} );
+
+test( 'post comments relation returns only approved by default', function (): void {
+    $post = makeCommentTestPost( makeCommentTestAuthor() );
+
+    Comment::factory()->for( $post )->count( 2 )->create();
+    Comment::factory()->for( $post )->pending()->create();
+    Comment::factory()->for( $post )->spam()->create();
+
+    expect( $post->comments()->count() )->toBe( 2 );
+} );
+
+test( 'post comments_count accessor returns the approved total', function (): void {
+    $post = makeCommentTestPost( makeCommentTestAuthor() );
+
+    Comment::factory()->for( $post )->count( 4 )->create();
+    Comment::factory()->for( $post )->pending()->create();
+
+    expect( $post->comments_count )->toBe( 4 );
+} );
+
+test( 'post comments_url returns permalink with #comments anchor', function (): void {
+    $post = makeCommentTestPost( makeCommentTestAuthor() );
+    expect( $post->comments_url )->toBe( $post->permalink . '#comments' );
+} );


### PR DESCRIPTION
## Description

Adds the missing `Comments` submodule to the Blog module so the visual-editor package's comments-family forks ([visual-editor #519](https://github.com/ArtisanPack-UI/visual-editor/issues/519)) have a real data layer to render against. Mirrors the existing `Post` / `PostCategory` / `PostTag` conventions under `src/Modules/Blog/`.

**Closes:** #151

## Type of Change

- [x] New feature (adds new functionality)

## Related Issue

**Issue:** #151

## Motivation and Context

The visual-editor's `CommentResolver` and `PostResolver` post-comments-* branches expect a `Post::comments` relation plus `$comment->author->name`, `$comment->content`, `$comment->edit_link`, `$comment->reply_link`, `$post->comments_count`, `$post->comments_url`, etc. None of that data shape existed anywhere in cms-framework — the editor's comment blocks rendered as placeholders with no data source. This PR lands the schema, model, accessors, REST surface, and policy that those resolvers consume.

## Changes Made

### Schema (`post_comments`)
- `post_id` FK (cascade), `parent_id` FK self (cascade), `user_id` FK users (nullable, set null on delete)
- Guest author columns (`author_name`, `author_email`, `author_url`) for unauthenticated comments
- `content` (text), `status` (enum: approved/pending/spam/trash), `approved_at`, timestamps, soft deletes
- Indexes on `post_id`, `parent_id`, `status`, composite `(post_id, status)`, `created_at`

### `Comment` model
- `belongsTo` Post, User (nullable), parent Comment + `hasMany` replies (`replies()` is scope-filtered to approved; `repliesIncludingUnapproved()` for admin surfaces)
- `author` accessor normalizes registered User and guest comments to one shape (`name` / `url` / `avatar_url` / `is_guest`)
- `avatar_url` falls back to Gravatar derived from `author_email`
- `permalink`, `edit_link`, `reply_link` accessors emit the WP-shape the visual-editor consumes
- Status scopes: `approved()`, `pending()`, `spam()`, `topLevel()`

### `Post` extensions
- `comments()` relation (approved by default; `commentsIncludingUnapproved()` for admin)
- `comments_count` and `comments_url` accessors

### REST surface (`/api/v1/comments`)
- GET `index` (public; the `?status=...` filter is **moderation-gated** so public callers always see the approved set)
- GET `show` (public for approved comments, gated otherwise)
- POST `store`, PUT/PATCH `update`, DELETE `destroy` (`auth` middleware + policy)

### Security hardening (all addressed in this PR)
- `CommentRequest::prepareForValidation()` strips client-supplied `user_id` (server-set from `auth()` in the controller) and, for non-moderators, `status` + `approved_at`. Prevents impersonation + self-approval.
- `parent_id` is validated to belong to the same `post_id` so a reply can't be filed against a different post's thread.
- Public `?status=...` is honored only when the caller has the `comments.moderate` capability; otherwise the controller forces `status=approved`.
- `CommentResource::edit_link` only renders when the viewer has `comments.moderate` (otherwise omitted via `whenLoaded`).
- `per_page` clamped to `[1, 100]`.
- Eager-loaded `replies` use the approved-only relation on `Comment`.

### `CommentPolicy`
Mirrors `PostPolicy`'s hook-gated pattern: `viewAny` / `view` / `create` / `update` / `delete` / `moderate`. Defaults to public read for approved comments + guest commenting allowed; host apps can opt out via the `comments.*.public` filters.

### Factory + seeding
`CommentFactory` with `byUser($id)`, `replyTo($parent)`, `pending()`, `spam()`, `trash()` states. Mirrors PostFactory conventions.

## How Has This Been Tested?

**Testing Environment:**
- macOS Darwin 25.5.0
- PHP 8.4.3 (with `-d memory_limit=1G` to clear the pre-existing PluginManager OOM in the full suite)
- Project version: `release/2.1`

**Tests Performed:**
- Pre-PR `cr review --base release/2.1 --prompt-only`: 3 passes. Initial review returned 8 findings (3 critical/major security: self-approval / impersonation / public status leak, plus 5 minor). All addressed. Second pass returned 2 minor findings (cross-test helper-name collision + cross-post `parent_id` validation). Both addressed. **Third pass: 0 findings**.
- **Blog tests**: `73 passed (158 assertions)` — 44 pre-existing Post/Tag/Category + 12 new `CommentModelTest` + 17 new `CommentControllerTest` (10 baseline + 6 security regressions + 1 cross-post `parent_id` test).
- **Full suite**: `969 passed, 7 skipped (2507 assertions)` after raising memory limit. No regressions.

## Tests Added

- [x] Unit tests added (`CommentModelTest`: 12 tests, 21 assertions).
- [x] Feature tests added (`CommentControllerTest`: 17 tests, including the security regressions for self-approval, impersonation, public status-filter gating, edit_link gating, per_page clamping, cross-post `parent_id` rejection).
- [x] All tests passing.

## Documentation

- [x] Inline PHPDoc on every new class / method, including the rationale for security-sensitive decisions (`prepareForValidation()`, the moderation-gated status filter, the approved-only `replies()` relation).

## Pre-Submission Checklist

- [x] Followed contributing guidelines (Blog module conventions).
- [x] No other open PRs for #151.
- [x] Code passes all tests (969 + 7 skipped, 0 regressions).
- [x] CodeRabbit CLI pre-PR pass run against `release/2.1`; final pass returned 0 findings.
- [x] Code follows project style guide.
- [x] Self-review completed.
- [x] Comments added for non-obvious decisions.
- [x] No new warnings generated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a full comment system: nested replies, guest/authored comments, moderation states, permalinks, reply links, and API resources exposing author, avatar and links
  * Public API endpoints for listing, viewing, creating, updating and deleting comments with pagination, filtering and per-page clamping

* **Security & Validation**
  * Server-side validation prevents client-supplied user/status, scopes parent_id to same post, and enforces moderation controls

* **Database**
  * New comments table with soft deletes and indexes

* **Tests**
  * Feature and unit tests for API, model accessors, validation, permissions and rate limiting
<!-- end of auto-generated comment: release notes by coderabbit.ai -->