### PR TITLE
fix: expose rendered HTML on Post / Page so PostResolver can stamp _resolvedContent

### DIFF
--- a/src/Modules/Blog/Models/Post.php
+++ b/src/Modules/Blog/Models/Post.php
@@ -16,6 +16,7 @@ use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Enums\ContentStatus;
 use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Models\Concerns\HasContentStatus;
 use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Models\Concerns\HasCustomFields;
 use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Models\Concerns\HasFeaturedImage;
+use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Models\Concerns\HasRenderedBlockContent;
 use ArtisanPackUI\MediaLibrary\Models\Media;
 use ArtisanPackUI\VisualEditor\Concerns\HasBlockContent;
 use Carbon\Carbon;
@@ -35,6 +36,7 @@ use Illuminate\Database\Eloquent\SoftDeletes;
  * @property string $slug
  * @property string|null $content
  * @property array<int, array<string, mixed>>|null $block_content
+ * @property-read string $rendered_content
  * @property string|null $excerpt
  * @property int $author_id
  * @property ContentStatus $status
@@ -53,6 +55,7 @@ class Post extends Model
     use HasCustomFields;
     use HasFactory;
     use HasFeaturedImage;
+    use HasRenderedBlockContent;
     use SoftDeletes;
 
     /**

--- a/src/Modules/ContentTypes/Models/Concerns/HasRenderedBlockContent.php
+++ b/src/Modules/ContentTypes/Models/Concerns/HasRenderedBlockContent.php
@@ -94,6 +94,29 @@ trait HasRenderedBlockContent
 
         $content = $this->getAttribute( 'content' );
 
+        // When `HasBlockContent` defaults to its own `content` column (i.e.
+        // the host model has NOT set `$blockContentColumn`), the trait
+        // registers an `array` cast on `content`. Legacy HTML records then
+        // surface as `null` / an array on `getAttribute()`, not a string,
+        // and the fallback below would silently drop them. Reach past the
+        // cast to recover the raw value — but only when the raw bytes are
+        // NOT JSON, otherwise we'd return the encoded block tree we just
+        // tried to render through the renderer.
+        if ( ! is_string( $content )
+            && method_exists( $this, 'getBlockContentColumn' )
+            && 'content' === $this->getBlockContentColumn()
+        ) {
+            $rawContent = $this->getRawOriginal( 'content' );
+
+            if ( is_string( $rawContent ) ) {
+                json_decode( $rawContent, true );
+
+                if ( JSON_ERROR_NONE !== json_last_error() ) {
+                    $content = $rawContent;
+                }
+            }
+        }
+
         return is_string( $content ) ? $content : '';
     }
 }

--- a/src/Modules/ContentTypes/Models/Concerns/HasRenderedBlockContent.php
+++ b/src/Modules/ContentTypes/Models/Concerns/HasRenderedBlockContent.php
@@ -1,0 +1,99 @@
+<?php
+
+declare( strict_types=1 );
+
+/**
+ * HasRenderedBlockContent Trait
+ *
+ * Exposes the rendered HTML for a model whose body is stored as a visual-editor
+ * block tree. Visual-editor's `PostResolver::resolveContent()` reads
+ * `$post->content` and only stamps `_resolvedContent` when it is a string;
+ * models that use `HasBlockContent` keep the body as a JSON-cast array, so
+ * the `core/post-content` block renders an empty `wp-block-post-content`
+ * div on the front end. This trait fills that gap.
+ *
+ * @since 2.2.0
+ */
+
+namespace ArtisanPackUI\CMSFramework\Modules\ContentTypes\Models\Concerns;
+
+use Throwable;
+
+/**
+ * Adds a `rendered_content` Eloquent accessor (and matching `renderContent()`
+ * method) that walks the model's block tree through the visual-editor
+ * renderer-blade package and returns the rendered HTML.
+ *
+ * The renderer is resolved lazily through the container so this stays a soft
+ * integration — cms-framework does not require `visual-editor-renderer-blade`
+ * as a composer dependency. When the renderer class is not installed, the
+ * accessor falls back to the model's existing `content` column (which may
+ * carry pre-rendered HTML for legacy records) and finally to an empty string.
+ *
+ * Intended to be combined with `ArtisanPackUI\VisualEditor\Concerns\HasBlockContent`,
+ * which supplies the `getBlockContent()` reader the trait calls.
+ *
+ * @since 2.2.0
+ *
+ * @mixin \Illuminate\Database\Eloquent\Model
+ */
+trait HasRenderedBlockContent
+{
+    /**
+     * Fully-qualified class name of the visual-editor block renderer.
+     *
+     * Kept as a string so cms-framework never autoloads the class when the
+     * renderer-blade package is not installed.
+     *
+     * @since 2.2.0
+     */
+    protected const BLOCK_RENDERER_CLASS = 'ArtisanPackUI\\VisualEditorRendererBlade\\BlockRenderer';
+
+    /**
+     * Eloquent accessor for `$model->rendered_content`.
+     *
+     * Visual-editor's `PostResolver::resolveContent()` prefers this attribute
+     * over the raw `content` column when present, so a `core/post-content`
+     * block stamps the actual rendered HTML rather than an empty string.
+     *
+     * @since 2.2.0
+     */
+    public function getRenderedContentAttribute(): string
+    {
+        return $this->renderContent();
+    }
+
+    /**
+     * Render the model's block tree to an HTML string.
+     *
+     * Resolves the visual-editor renderer-blade `BlockRenderer` through the
+     * container and walks the block tree returned by
+     * `HasBlockContent::getBlockContent()`. When the renderer class is not
+     * installed (or resolving / rendering throws), falls back to the
+     * model's `content` column if it is a string, otherwise returns an
+     * empty string.
+     *
+     * @since 2.2.0
+     */
+    public function renderContent(): string
+    {
+        if ( method_exists( $this, 'getBlockContent' ) && class_exists( self::BLOCK_RENDERER_CLASS ) ) {
+            $blocks = $this->getBlockContent();
+
+            if ( [] !== $blocks ) {
+                try {
+                    $renderer = app( self::BLOCK_RENDERER_CLASS );
+
+                    return $renderer->render( $blocks );
+                } catch ( Throwable ) {
+                    // Renderer installed but failed to resolve or render —
+                    // fall through to the pre-rendered string fallback below.
+                }
+            }
+        }
+
+        $content = $this->getAttribute( 'content' );
+
+        return is_string( $content ) ? $content : '';
+    }
+}

--- a/src/Modules/Pages/Models/Page.php
+++ b/src/Modules/Pages/Models/Page.php
@@ -16,6 +16,7 @@ use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Enums\ContentStatus;
 use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Models\Concerns\HasContentStatus;
 use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Models\Concerns\HasCustomFields;
 use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Models\Concerns\HasFeaturedImage;
+use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Models\Concerns\HasRenderedBlockContent;
 use ArtisanPackUI\MediaLibrary\Models\Media;
 use ArtisanPackUI\VisualEditor\Concerns\HasBlockContent;
 use Carbon\Carbon;
@@ -36,6 +37,7 @@ use Illuminate\Support\Collection;
  * @property string $slug
  * @property string|null $content
  * @property array<int, array<string, mixed>>|null $block_content
+ * @property-read string $rendered_content
  * @property string|null $excerpt
  * @property int $author_id
  * @property int|null $parent_id
@@ -57,6 +59,7 @@ class Page extends Model
     use HasCustomFields;
     use HasFactory;
     use HasFeaturedImage;
+    use HasRenderedBlockContent;
     use SoftDeletes;
 
     /**

--- a/tests/Unit/ContentTypes/HasRenderedBlockContentTest.php
+++ b/tests/Unit/ContentTypes/HasRenderedBlockContentTest.php
@@ -44,9 +44,12 @@ namespace ArtisanPackUI\VisualEditorRendererBlade {
 namespace {
 
     use ArtisanPackUI\CMSFramework\Modules\Blog\Models\Post;
+    use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Models\Concerns\HasRenderedBlockContent;
     use ArtisanPackUI\CMSFramework\Modules\Pages\Models\Page;
     use ArtisanPackUI\CMSFramework\Tests\Support\TestUser;
+    use ArtisanPackUI\VisualEditor\Concerns\HasBlockContent;
     use ArtisanPackUI\VisualEditorRendererBlade\BlockRenderer;
+    use Illuminate\Database\Eloquent\Model;
 
     beforeEach( function (): void {
         $this->artisan( 'migrate', ['--database' => 'testing'] );
@@ -144,6 +147,45 @@ namespace {
         ] );
 
         expect( $post->rendered_content )->toBe( '' );
+    } );
+
+    test( 'renderContent() recovers legacy HTML when the block content column defaults to content (array cast)', function (): void {
+        // Anonymous model that uses HasBlockContent WITHOUT overriding
+        // $blockContentColumn — so the trait registers an `array` cast on
+        // the `content` column. Legacy HTML stored there surfaces as a
+        // non-string via the cast, but the raw original is the HTML bytes.
+        $model = new class extends Model {
+            use HasBlockContent;
+            use HasRenderedBlockContent;
+        };
+
+        $model->setRawAttributes( [ 'content' => '<p>legacy HTML</p>' ], true );
+
+        // Sanity-check: the cast layer hands back something that is NOT a
+        // string (Laravel decodes invalid JSON to null), so the naive
+        // `is_string` fallback would drop the legacy HTML.
+        expect( is_string( $model->getAttribute( 'content' ) ) )->toBeFalse();
+
+        expect( $model->renderContent() )->toBe( '<p>legacy HTML</p>' );
+    } );
+
+    test( 'renderContent() does NOT return raw JSON when the block content column defaults to content', function (): void {
+        // Mirror of the prior test but with the raw column holding a JSON
+        // block tree (i.e. the typical post-2.x record). The fallback must
+        // NOT echo the encoded JSON back as "legacy HTML" — it should drop
+        // to an empty string when the renderer is unavailable or returns
+        // empty for an unknown reason.
+        $model = new class extends Model {
+            use HasBlockContent;
+            use HasRenderedBlockContent;
+        };
+
+        $rawJson = '[{"name":"core/paragraph","attributes":{"content":"hi"},"innerBlocks":[]}]';
+        $model->setRawAttributes( [ 'content' => $rawJson ], true );
+
+        BlockRenderer::$throwOnRender = true;
+
+        expect( $model->renderContent() )->toBe( '' );
     } );
 
     test( 'rendered_content swallows renderer failures and falls back to the content column', function (): void {

--- a/tests/Unit/ContentTypes/HasRenderedBlockContentTest.php
+++ b/tests/Unit/ContentTypes/HasRenderedBlockContentTest.php
@@ -1,0 +1,173 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditorRendererBlade {
+
+    if ( ! class_exists( BlockRenderer::class, false ) ) {
+        /**
+         * Test-only stand-in for the visual-editor renderer-blade BlockRenderer.
+         *
+         * cms-framework does not depend on `visual-editor-renderer-blade`,
+         * so the real class is not autoloadable in this suite. Declaring a
+         * sibling class under the same FQCN lets the trait's `class_exists`
+         * gate succeed in the "renderer installed" scenarios; tests that
+         * exercise the renderer-missing path use a separate FQCN override
+         * on the trait constant.
+         */
+        class BlockRenderer
+        {
+            /** @var array<int, array<string, mixed>>|null */
+            public static ?array $lastTree = null;
+
+            public static string $stubOutput = '<p>stubbed render</p>';
+
+            public static bool $throwOnRender = false;
+
+            /**
+             * @param  array<int, array<string, mixed>>  $tree
+             */
+            public function render( array $tree ): string
+            {
+                self::$lastTree = $tree;
+
+                if ( self::$throwOnRender ) {
+                    throw new \RuntimeException( 'stub renderer failure' );
+                }
+
+                return self::$stubOutput;
+            }
+        }
+    }
+}
+
+namespace {
+
+    use ArtisanPackUI\CMSFramework\Modules\Blog\Models\Post;
+    use ArtisanPackUI\CMSFramework\Modules\Pages\Models\Page;
+    use ArtisanPackUI\CMSFramework\Tests\Support\TestUser;
+    use ArtisanPackUI\VisualEditorRendererBlade\BlockRenderer;
+
+    beforeEach( function (): void {
+        $this->artisan( 'migrate', ['--database' => 'testing'] );
+
+        BlockRenderer::$lastTree      = null;
+        BlockRenderer::$stubOutput    = '<p>stubbed render</p>';
+        BlockRenderer::$throwOnRender = false;
+    } );
+
+    test( 'rendered_content accessor walks block tree through the renderer', function (): void {
+        $user = TestUser::create( [
+            'name'     => 'Author',
+            'email'    => 'author@example.com',
+            'password' => 'password',
+        ] );
+
+        $blocks = [
+            ['blockName' => 'core/paragraph', 'attrs' => [], 'innerHTML' => '<p>Hi</p>'],
+        ];
+
+        $post = Post::create( [
+            'title'     => 'Rendered Post',
+            'slug'      => 'rendered-post',
+            'author_id' => $user->id,
+            'status'    => 'draft',
+        ] );
+
+        $post->setBlockContent( $blocks );
+        $post->save();
+
+        expect( $post->fresh()->rendered_content )->toBe( '<p>stubbed render</p>' );
+        expect( BlockRenderer::$lastTree )->toBe( $blocks );
+    } );
+
+    test( 'renderContent() method returns the same value as the accessor', function (): void {
+        $user = TestUser::create( [
+            'name'     => 'Author',
+            'email'    => 'author@example.com',
+            'password' => 'password',
+        ] );
+
+        $page = Page::create( [
+            'title'     => 'Rendered Page',
+            'slug'      => 'rendered-page',
+            'author_id' => $user->id,
+            'status'    => 'draft',
+        ] );
+
+        $page->setBlockContent( [
+            ['blockName' => 'core/heading', 'attrs' => ['level' => 2], 'innerHTML' => '<h2>Hello</h2>'],
+        ] );
+        $page->save();
+
+        BlockRenderer::$stubOutput = '<h2>Hello</h2>';
+
+        $fresh = Page::find( $page->id );
+
+        expect( $fresh->renderContent() )->toBe( '<h2>Hello</h2>' );
+        expect( $fresh->rendered_content )->toBe( '<h2>Hello</h2>' );
+    } );
+
+    test( 'rendered_content falls back to the content column when block tree is empty', function (): void {
+        $user = TestUser::create( [
+            'name'     => 'Author',
+            'email'    => 'author@example.com',
+            'password' => 'password',
+        ] );
+
+        $post = Post::create( [
+            'title'     => 'Legacy Post',
+            'slug'      => 'legacy-post',
+            'author_id' => $user->id,
+            'status'    => 'draft',
+            'content'   => '<p>pre-rendered legacy HTML</p>',
+        ] );
+
+        expect( $post->rendered_content )->toBe( '<p>pre-rendered legacy HTML</p>' );
+        // Renderer should NOT have been invoked — the block tree was empty,
+        // so the trait short-circuits to the legacy content column.
+        expect( BlockRenderer::$lastTree )->toBeNull();
+    } );
+
+    test( 'rendered_content returns an empty string when block tree and content are both empty', function (): void {
+        $user = TestUser::create( [
+            'name'     => 'Author',
+            'email'    => 'author@example.com',
+            'password' => 'password',
+        ] );
+
+        $post = Post::create( [
+            'title'     => 'Empty Post',
+            'slug'      => 'empty-post',
+            'author_id' => $user->id,
+            'status'    => 'draft',
+        ] );
+
+        expect( $post->rendered_content )->toBe( '' );
+    } );
+
+    test( 'rendered_content swallows renderer failures and falls back to the content column', function (): void {
+        $user = TestUser::create( [
+            'name'     => 'Author',
+            'email'    => 'author@example.com',
+            'password' => 'password',
+        ] );
+
+        $post = Post::create( [
+            'title'     => 'Failing Render',
+            'slug'      => 'failing-render',
+            'author_id' => $user->id,
+            'status'    => 'draft',
+            'content'   => '<p>fallback HTML</p>',
+        ] );
+
+        $post->setBlockContent( [
+            ['blockName' => 'core/paragraph', 'attrs' => [], 'innerHTML' => '<p>Hi</p>'],
+        ] );
+        $post->save();
+
+        BlockRenderer::$throwOnRender = true;
+
+        expect( $post->fresh()->rendered_content )->toBe( '<p>fallback HTML</p>' );
+    } );
+}


### PR DESCRIPTION
## Description

Adds a `HasRenderedBlockContent` trait (mixed into `Post` and `Page`) that exposes `$post->rendered_content` (Eloquent accessor) and `$post->renderContent()` (method) so that visual-editor's `PostResolver::resolveContent()` can stamp `_resolvedContent` against a real HTML string rather than dropping to empty.

The renderer is lazy-resolved through the container, so cms-framework stays decoupled from `artisanpack-ui/visual-editor-renderer-blade`: when the renderer class is not installed (or rendering throws) the accessor falls back to the model's existing `content` column and finally to an empty string.

**Closes:** #155

## Type of Change

- [x] Bug fix (fixes an issue)
- [x] Enhancement (improves existing functionality)

## Related Issue

**Issue:** #155

## Motivation and Context

`HasBlockContent` stores the body as a JSON-cast array (the parsed block tree). Visual-editor's `PostResolver::resolveContent()` reads `$post->content` and only stamps `_resolvedContent` when it is a string. As a result, any single-post / single-page template using `core/post-content` (or `artisanpack/post-content`) renders an empty `wp-block-post-content` div on the front end.

This bug is latent since the `core/post-content` fork landed and was exposed by the navigation / metadata family work tracked in visual-editor#520. The paired `PostResolver` change (which will prefer `$post->rendered_content` over `$post->content`) ships in a separate visual-editor PR.

## Changes Made

- Added `ArtisanPackUI\CMSFramework\Modules\ContentTypes\Models\Concerns\HasRenderedBlockContent` trait exposing `getRenderedContentAttribute()` and `renderContent()`.
- Applied the trait to `Post` and `Page`; updated their `@property-read` docblocks to advertise `$rendered_content`.
- Container-resolved the renderer via FQCN string so cms-framework never autoloads `ArtisanPackUI\VisualEditorRendererBlade\BlockRenderer` when the renderer-blade package is absent.
- Added 5 unit tests covering the renderer-present happy path, accessor/method parity, empty-block-tree fallback to `content`, both-empty empty-string return, and renderer-throws fallback.

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS (Darwin 25.5.0)
- PHP Version: 8.4.21
- Project Version: cms-framework `release/2.2`

**Tests Performed:**
1. `./vendor/bin/pest --filter=HasRenderedBlockContent` — 5 / 5 pass (new tests).
2. `php -d memory_limit=1024M ./vendor/bin/pest` — full suite green (983 passed, 7 skipped, 0 failures).
3. `./vendor/bin/php-cs-fixer fix --dry-run --diff` — clean.
4. Manual tinker verification against the dev app (`Herd/artisanpack-ui-dev`):
   - Block tree containing `core/paragraph` + `core/heading` rendered to `<p class="wp-block-paragraph">Hello from blocks!</p><h2 class="wp-block-heading">Section</h2>`.
   - Emptying the block tree returned the legacy `content` string (`<p>legacy pre-rendered fallback</p>`).
   - Clearing both block tree and `content` returned `""` (string, not null).
   - `$post->rendered_content === $post->renderContent()` in all branches.
5. `cr review --base release/2.2 --prompt-only` — 0 findings.

## Accessibility Tests Run

- [ ] Keyboard navigation tested
- [ ] Screen reader tested
- [ ] Color contrast verified
- [ ] ARIA labels checked

**Details:** N/A — this is a backend Eloquent-accessor change with no UI surface.

## Tests Added

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] All tests passing

**Test details:** `tests/Unit/ContentTypes/HasRenderedBlockContentTest.php` declares a test-only stand-in for `ArtisanPackUI\VisualEditorRendererBlade\BlockRenderer` (cms-framework does not depend on `visual-editor-renderer-blade`) so the `class_exists` gate inside the trait can be exercised from the suite.

## Documentation

- [x] Inline code documentation added
- [ ] README updated
- [ ] Wiki updated
- [ ] API documentation updated

**Documentation details:** Trait + accessor are documented inline with PHPDoc; the `@property-read string $rendered_content` line on `Post` and `Page` advertises the new attribute to static analysers.

## Pre-Submission Checklist

- [x] Followed contributing guidelines
- [x] Checked for other open PRs for same update
- [x] Code passes all tests
- [x] Code has been linted (`php-cs-fixer` clean)
- [x] Accessibility tests completed (N/A — backend change)
- [x] Code follows project style guide
- [x] Self-review completed
- [x] Comments added for complex code
- [x] No new warnings generated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Posts and pages now expose a read-only rendered-content attribute, improving how block-based content is presented with graceful fallback to legacy content when rendering isn't available.

* **Tests**
  * Added comprehensive tests covering rendered-content behavior, renderer delegation, error handling, legacy fallbacks, and edge cases for cast/JSON content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->