### PR TITLE
fix: expose previous_post / next_post on Post for PostResolver navigation block

### DIFF
--- a/src/Modules/Blog/Models/Post.php
+++ b/src/Modules/Blog/Models/Post.php
@@ -342,15 +342,31 @@ class Post extends Model
 
         $operator       = 'previous' === $direction ? '<' : '>';
         $orderDirection = 'previous' === $direction ? 'desc' : 'asc';
+        $currentKey     = $this->getKey();
+        $currentDate    = $this->published_at;
 
-        // $operator is a literal '<' or '>' set above; $this->published_at
-        // is a Carbon cast, not user input. Same shape as Page::siblings().
+        // Ties on `published_at` are common (bulk imports, top-of-hour
+        // schedules). Break them with `id` in the same direction so the
+        // adjacency is deterministic and every post in a tied cluster has a
+        // defined previous / next.
+        //
+        // $operator / $idOperator are literals chosen above; $this->published_at
+        // and $this->getKey() are model-internal values. Same shape as
+        // Page::siblings().
         // phpcs:disable ArtisanPackUI.Security.ValidatedSanitizedInput.VariableNotSanitized
         $post = static::query()
             ->published()
             ->whereNotNull( 'published_at' )
-            ->where( 'published_at', $operator, $this->published_at )
+            ->where( function ( $q ) use ( $operator, $currentDate, $currentKey, $direction ): void {
+                $idOperator = 'previous' === $direction ? '<' : '>';
+                $q->where( 'published_at', $operator, $currentDate )
+                    ->orWhere( function ( $q ) use ( $currentDate, $currentKey, $idOperator ): void {
+                        $q->where( 'published_at', '=', $currentDate )
+                            ->where( 'id', $idOperator, $currentKey );
+                    } );
+            } )
             ->orderBy( 'published_at', $orderDirection )
+            ->orderBy( 'id', $orderDirection )
             ->first();
         // phpcs:enable ArtisanPackUI.Security.ValidatedSanitizedInput.VariableNotSanitized
 

--- a/src/Modules/Blog/Models/Post.php
+++ b/src/Modules/Blog/Models/Post.php
@@ -45,6 +45,8 @@ use Illuminate\Database\Eloquent\SoftDeletes;
  * @property \Illuminate\Support\Carbon $created_at
  * @property \Illuminate\Support\Carbon $updated_at
  * @property \Illuminate\Support\Carbon|null $deleted_at
+ * @property-read self|null $previous_post
+ * @property-read self|null $next_post
  *
  * @since 1.0.0
  */
@@ -64,6 +66,18 @@ class Post extends Model
      * @since 2.0.0
      */
     protected string $blockContentColumn = 'block_content';
+
+    /**
+     * Per-instance cache for `previous_post` / `next_post` adjacency
+     * lookups so the accessors fire a single query each direction
+     * regardless of how many times the visual-editor resolver (or any
+     * other consumer) reads them during a request.
+     *
+     * @since 2.2.0
+     *
+     * @var array<string, self|null>
+     */
+    protected array $adjacentPostCache = [];
 
     /**
      * The attributes that are mass assignable.
@@ -180,6 +194,41 @@ class Post extends Model
     }
 
     /**
+     * The previous published post ordered by `published_at`. Read by
+     * the visual-editor's `PostResolver::resolvePostNavigationLink()`
+     * when stamping `_resolvedPrevUrl` / `_resolvedPrevTitle` onto
+     * `post-navigation-link` blocks pointed at the previous post.
+     *
+     * Returns null when the current post has no `published_at` (an
+     * unpublished or draft post has no defined adjacency) or when no
+     * earlier published post exists. Result is memoised per-instance
+     * so paint-time block resolution only hits the database once.
+     *
+     * @since 2.2.0
+     */
+    public function getPreviousPostAttribute(): ?self
+    {
+        return $this->resolveAdjacentPost( 'previous' );
+    }
+
+    /**
+     * The next published post ordered by `published_at`. Read by the
+     * visual-editor's `PostResolver::resolvePostNavigationLink()`
+     * when stamping `_resolvedNextUrl` / `_resolvedNextTitle` onto
+     * `post-navigation-link` blocks pointed at the next post.
+     *
+     * Returns null when the current post has no `published_at` or
+     * when no later published post exists. Result is memoised
+     * per-instance.
+     *
+     * @since 2.2.0
+     */
+    public function getNextPostAttribute(): ?self
+    {
+        return $this->resolveAdjacentPost( 'next' );
+    }
+
+    /**
      * Scope a query to posts by a specific author.
      *
      * @since 1.0.0
@@ -264,6 +313,50 @@ class Post extends Model
     public function getPermalinkAttribute(): string
     {
         return url( "/blog/{$this->slug}" );
+    }
+
+    /**
+     * Resolve the adjacent published post in the requested direction
+     * (`'previous'` or `'next'`). Honors the same
+     * status-Published / `published_at <= now()` semantics as
+     * `scopePublished()` while additionally requiring `published_at`
+     * to be non-null so the strict `<` / `>` comparison on
+     * `published_at` produces a defined ordering.
+     *
+     * Memoised on `$adjacentPostCache` for the full lifetime of the
+     * model instance — Eloquent's `refresh()` reloads attributes but
+     * does not reset arbitrary instance state, so re-querying (or
+     * unsetting the property) is the way to invalidate.
+     *
+     * @since 2.2.0
+     */
+    protected function resolveAdjacentPost( string $direction ): ?self
+    {
+        if ( null === $this->published_at ) {
+            return null;
+        }
+
+        if ( array_key_exists( $direction, $this->adjacentPostCache ) ) {
+            return $this->adjacentPostCache[ $direction ];
+        }
+
+        $operator       = 'previous' === $direction ? '<' : '>';
+        $orderDirection = 'previous' === $direction ? 'desc' : 'asc';
+
+        // $operator is a literal '<' or '>' set above; $this->published_at
+        // is a Carbon cast, not user input. Same shape as Page::siblings().
+        // phpcs:disable ArtisanPackUI.Security.ValidatedSanitizedInput.VariableNotSanitized
+        $post = static::query()
+            ->published()
+            ->whereNotNull( 'published_at' )
+            ->where( 'published_at', $operator, $this->published_at )
+            ->orderBy( 'published_at', $orderDirection )
+            ->first();
+        // phpcs:enable ArtisanPackUI.Security.ValidatedSanitizedInput.VariableNotSanitized
+
+        $this->adjacentPostCache[ $direction ] = $post;
+
+        return $post;
     }
 
     /**

--- a/tests/Unit/Blog/PostModelTest.php
+++ b/tests/Unit/Blog/PostModelTest.php
@@ -660,6 +660,54 @@ test( 'previous_post and next_post return null when current post has no publishe
     expect( $draft->next_post )->toBeNull();
 } );
 
+test( 'previous_post and next_post break ties on published_at by id', function (): void {
+    $user = TestUser::create( [
+        'name'     => 'Test Author',
+        'email'    => 'author@example.com',
+        'password' => 'password',
+    ] );
+
+    $sharedDate = Carbon::create( 2026, 2, 1, 12 );
+
+    // Three posts sharing the same published_at — order is fully
+    // determined by id, which the factory assigns in creation order.
+    $first = Post::create( [
+        'title'        => 'Tied First',
+        'slug'         => 'tied-first',
+        'author_id'    => $user->id,
+        'status'       => 'published',
+        'published_at' => $sharedDate,
+    ] );
+
+    $middle = Post::create( [
+        'title'        => 'Tied Middle',
+        'slug'         => 'tied-middle',
+        'author_id'    => $user->id,
+        'status'       => 'published',
+        'published_at' => $sharedDate,
+    ] );
+
+    $last = Post::create( [
+        'title'        => 'Tied Last',
+        'slug'         => 'tied-last',
+        'author_id'    => $user->id,
+        'status'       => 'published',
+        'published_at' => $sharedDate,
+    ] );
+
+    expect( $middle->previous_post )->not->toBeNull();
+    expect( $middle->previous_post->is( $first ) )->toBeTrue();
+
+    expect( $middle->next_post )->not->toBeNull();
+    expect( $middle->next_post->is( $last ) )->toBeTrue();
+
+    // First post in the tied cluster has no earlier neighbour; last
+    // has no later one. Without the id tiebreak both would still see
+    // each other through the shared timestamp.
+    expect( $first->previous_post )->toBeNull();
+    expect( $last->next_post )->toBeNull();
+} );
+
 test( 'previous_post and next_post memoize results per instance', function (): void {
     $user = TestUser::create( [
         'name'     => 'Test Author',

--- a/tests/Unit/Blog/PostModelTest.php
+++ b/tests/Unit/Blog/PostModelTest.php
@@ -490,3 +490,207 @@ test( 'post uses soft deletes', function (): void {
     expect( Post::find( $postId ) )->toBeNull();
     expect( Post::withTrashed()->find( $postId ) )->not->toBeNull();
 } );
+
+test( 'previous_post returns the preceding published post by published_at', function (): void {
+    $user = TestUser::create( [
+        'name'     => 'Test Author',
+        'email'    => 'author@example.com',
+        'password' => 'password',
+    ] );
+
+    $older = Post::create( [
+        'title'        => 'Older Post',
+        'slug'         => 'older-post',
+        'author_id'    => $user->id,
+        'status'       => 'published',
+        'published_at' => Carbon::create( 2026, 1, 1, 12 ),
+    ] );
+
+    $current = Post::create( [
+        'title'        => 'Current Post',
+        'slug'         => 'current-post',
+        'author_id'    => $user->id,
+        'status'       => 'published',
+        'published_at' => Carbon::create( 2026, 2, 1, 12 ),
+    ] );
+
+    Post::create( [
+        'title'        => 'Newer Post',
+        'slug'         => 'newer-post',
+        'author_id'    => $user->id,
+        'status'       => 'published',
+        'published_at' => Carbon::create( 2026, 3, 1, 12 ),
+    ] );
+
+    expect( $current->previous_post )->toBeInstanceOf( Post::class );
+    expect( $current->previous_post->is( $older ) )->toBeTrue();
+} );
+
+test( 'next_post returns the following published post by published_at', function (): void {
+    $user = TestUser::create( [
+        'name'     => 'Test Author',
+        'email'    => 'author@example.com',
+        'password' => 'password',
+    ] );
+
+    Post::create( [
+        'title'        => 'Older Post',
+        'slug'         => 'older-post',
+        'author_id'    => $user->id,
+        'status'       => 'published',
+        'published_at' => Carbon::create( 2026, 1, 1, 12 ),
+    ] );
+
+    $current = Post::create( [
+        'title'        => 'Current Post',
+        'slug'         => 'current-post',
+        'author_id'    => $user->id,
+        'status'       => 'published',
+        'published_at' => Carbon::create( 2026, 2, 1, 12 ),
+    ] );
+
+    $newer = Post::create( [
+        'title'        => 'Newer Post',
+        'slug'         => 'newer-post',
+        'author_id'    => $user->id,
+        'status'       => 'published',
+        'published_at' => Carbon::create( 2026, 3, 1, 12 ),
+    ] );
+
+    expect( $current->next_post )->toBeInstanceOf( Post::class );
+    expect( $current->next_post->is( $newer ) )->toBeTrue();
+} );
+
+test( 'previous_post and next_post return null at the boundaries', function (): void {
+    $user = TestUser::create( [
+        'name'     => 'Test Author',
+        'email'    => 'author@example.com',
+        'password' => 'password',
+    ] );
+
+    $first = Post::create( [
+        'title'        => 'First Post',
+        'slug'         => 'first-post',
+        'author_id'    => $user->id,
+        'status'       => 'published',
+        'published_at' => Carbon::create( 2026, 1, 1, 12 ),
+    ] );
+
+    $last = Post::create( [
+        'title'        => 'Last Post',
+        'slug'         => 'last-post',
+        'author_id'    => $user->id,
+        'status'       => 'published',
+        'published_at' => Carbon::create( 2026, 2, 1, 12 ),
+    ] );
+
+    expect( $first->previous_post )->toBeNull();
+    expect( $last->next_post )->toBeNull();
+} );
+
+test( 'previous_post and next_post skip drafts and scheduled posts', function (): void {
+    $user = TestUser::create( [
+        'name'     => 'Test Author',
+        'email'    => 'author@example.com',
+        'password' => 'password',
+    ] );
+
+    $earlierPublished = Post::create( [
+        'title'        => 'Earlier Published',
+        'slug'         => 'earlier-published',
+        'author_id'    => $user->id,
+        'status'       => 'published',
+        'published_at' => Carbon::create( 2026, 1, 1, 12 ),
+    ] );
+
+    // Draft between the two published posts — should be skipped.
+    Post::create( [
+        'title'        => 'Draft Between',
+        'slug'         => 'draft-between',
+        'author_id'    => $user->id,
+        'status'       => 'draft',
+        'published_at' => Carbon::create( 2026, 2, 1, 12 ),
+    ] );
+
+    $current = Post::create( [
+        'title'        => 'Current Post',
+        'slug'         => 'current-post',
+        'author_id'    => $user->id,
+        'status'       => 'published',
+        'published_at' => Carbon::create( 2026, 3, 1, 12 ),
+    ] );
+
+    // Scheduled (future) post — should be skipped by next_post.
+    Post::create( [
+        'title'        => 'Scheduled Post',
+        'slug'         => 'scheduled-post',
+        'author_id'    => $user->id,
+        'status'       => 'published',
+        'published_at' => now()->addYear(),
+    ] );
+
+    expect( $current->previous_post )->not->toBeNull();
+    expect( $current->previous_post->is( $earlierPublished ) )->toBeTrue();
+    expect( $current->next_post )->toBeNull();
+} );
+
+test( 'previous_post and next_post return null when current post has no published_at', function (): void {
+    $user = TestUser::create( [
+        'name'     => 'Test Author',
+        'email'    => 'author@example.com',
+        'password' => 'password',
+    ] );
+
+    Post::create( [
+        'title'        => 'Older Post',
+        'slug'         => 'older-post',
+        'author_id'    => $user->id,
+        'status'       => 'published',
+        'published_at' => Carbon::create( 2026, 1, 1, 12 ),
+    ] );
+
+    $draft = Post::create( [
+        'title'     => 'Draft Without Date',
+        'slug'      => 'draft-without-date',
+        'author_id' => $user->id,
+        'status'    => 'draft',
+    ] );
+
+    expect( $draft->previous_post )->toBeNull();
+    expect( $draft->next_post )->toBeNull();
+} );
+
+test( 'previous_post and next_post memoize results per instance', function (): void {
+    $user = TestUser::create( [
+        'name'     => 'Test Author',
+        'email'    => 'author@example.com',
+        'password' => 'password',
+    ] );
+
+    Post::create( [
+        'title'        => 'Older Post',
+        'slug'         => 'older-post',
+        'author_id'    => $user->id,
+        'status'       => 'published',
+        'published_at' => Carbon::create( 2026, 1, 1, 12 ),
+    ] );
+
+    $current = Post::create( [
+        'title'        => 'Current Post',
+        'slug'         => 'current-post',
+        'author_id'    => $user->id,
+        'status'       => 'published',
+        'published_at' => Carbon::create( 2026, 2, 1, 12 ),
+    ] );
+
+    Illuminate\Support\Facades\DB::enableQueryLog();
+    Illuminate\Support\Facades\DB::flushQueryLog();
+
+    $current->previous_post;
+    $current->previous_post;
+    $current->previous_post;
+
+    expect( Illuminate\Support\Facades\DB::getQueryLog() )->toHaveCount( 1 );
+
+    Illuminate\Support\Facades\DB::disableQueryLog();
+} );


### PR DESCRIPTION
## Description

The visual-editor's `PostResolver::resolvePostNavigationLink()` reads `$post->previous_post` and `$post->next_post` to stamp `_resolvedPrevUrl` / `_resolvedPrevTitle` / `_resolvedNextUrl` / `_resolvedNextTitle` onto `artisanpack/post-navigation-link` (and `core/post-navigation-link`) blocks before the renderer fires. `Post` had no adjacency accessors, so the resolver fell through to empty strings and the front-end emitted an empty `<div class="wp-block-post-navigation-link"></div>` shell.

**Closes:** #154

## Type of Change

- [x] Bug fix (fixes an issue)
- [ ] New feature (adds new functionality)
- [x] Enhancement (improves existing functionality)
- [ ] Refactoring (code improvement, no behavior change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Security fix
- [ ] Breaking change (breaks backward compatibility)

## Related Issue

**Issue:** #154

Tracked upstream in [visual-editor#520](https://github.com/ArtisanPack-UI/visual-editor/issues/520).

## Motivation and Context

Without these accessors, the post-navigation-link block silently renders as an empty `<div>` shell on every single-post template, breaking the visual-editor's previous/next post navigation across any host on cms-framework 2.1 + visual-editor 1.0.

## Changes Made

- Added `getPreviousPostAttribute(): ?self` and `getNextPostAttribute(): ?self` to `Post`.
- Added a shared `resolveAdjacentPost(string $direction): ?self` helper that walks the `published()` scope ordered by `published_at`, with `whereNotNull('published_at')` to keep the strict `<` / `>` comparison well-defined.
- Added a per-instance `$adjacentPostCache` so each direction only fires a single query per request — the resolver can read both accessors without N+1 risk if the same post is rendered repeatedly.
- Updated the class-level `@property-read` PHPDoc.

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS 15
- PHP Version: 8.4 (package supports 8.2+)
- Project Version: cms-framework `release/2.2`

**Tests Performed:**
1. `./vendor/bin/pest tests/Unit/Blog/PostModelTest.php` — 25 passed (49 assertions).
2. Full suite via `php -d memory_limit=512M ./vendor/bin/pest --compact` — 991 passed, 7 skipped, 0 failed.
3. CodeRabbit CLI review against `release/2.2` — clean (0 findings) after addressing a docblock note about cache lifetime.

## Accessibility Tests Run

- [ ] Keyboard navigation tested
- [ ] Screen reader tested
- [ ] Color contrast verified
- [ ] ARIA labels checked

**Details:** Backend-only change to model accessors — no DOM or UI surface touched. The downstream block's accessible markup is owned by visual-editor's renderer.

## Tests Added

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] All tests passing

**Test details:** Six new unit tests in `tests/Unit/Blog/PostModelTest.php`:

1. `previous_post` returns the preceding published post by `published_at`.
2. `next_post` returns the following published post by `published_at`.
3. Both return `null` at the first/last boundary.
4. Both skip drafts and scheduled (future-dated) posts.
5. Both return `null` when the current post has no `published_at`.
6. Both memoize — repeated reads only fire a single query (verified via `DB::getQueryLog()`).

## Documentation

- [x] Inline code documentation added
- [ ] README updated
- [ ] Wiki updated
- [ ] API documentation updated

**Documentation details:** PHPDoc on the new accessors and `resolveAdjacentPost()` helper documents the published-scope semantics, the null-published-at boundary, and per-instance memoization. `@property-read` entries added to the class docblock.

## Screenshots

N/A — backend-only change.

## Pre-Submission Checklist

- [x] Followed contributing guidelines
- [x] Checked for other open PRs for same update
- [x] Code passes all tests
- [x] Code has been linted
- [x] Accessibility tests completed
- [x] Code follows project style guide
- [x] Self-review completed
- [x] Comments added for complex code
- [x] No new warnings generated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Blog posts now include previous/next navigation to published neighbors; drafts and scheduled items are ignored.
  * When posts share the same publish time, neighbors are chosen deterministically to ensure consistent navigation.
  * Navigation lookups are optimized to avoid repeated queries.

* **Tests**
  * Added comprehensive tests covering neighbor selection, scheduling/draft filtering, tie-breaks, and memoized lookup behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->