### PR TITLE
security: harden CI/release workflows (least-privilege permissions + fail on Packagist HTTP errors)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,9 @@ on:
     tags:
       - 'v*'
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -97,7 +100,7 @@ jobs:
       - name: Update Packagist
         if: success()
         run: |
-          curl -s -X POST \
+          curl --fail-with-body -sS -X POST \
             "https://packagist.org/api/update-package?username=${{ secrets.PACKAGIST_USERNAME }}&apiToken=${{ secrets.PACKAGIST_API_TOKEN }}" \
             -d "{\"repository\":{\"url\":\"https://github.com/${{ github.repository }}\"}}" \
             -H "Content-Type: application/json"


### PR DESCRIPTION
## Description

Hardens both GitHub Actions workflows with a least-privilege `permissions: contents: read` baseline, and makes the Packagist update step in `release.yml` actually fail the release on HTTP errors instead of swallowing them.

**Closes:** #140

## Type of Change

- [x] Security fix

## Related Issue

**Issue:** #140

## Motivation and Context

Without a workflow-level `permissions` block, jobs run with the runner's default `GITHUB_TOKEN` scopes — broader than they need. And in `release.yml`, the Packagist update step uses `curl -s` with no failure handling, so an HTTP 4xx/5xx from Packagist is silently swallowed: the release reports green even when the Packagist publish failed.

This PR applies the same hardening that was just landed on `artisanpack-ui/core` to keep the ecosystem's CI/CD consistent.

## Changes Made

- `.github/workflows/ci.yml` — added top-level `permissions: contents: read`.
- `.github/workflows/release.yml` — added top-level `permissions: contents: read`. The `release` job keeps its explicit `permissions: contents: write` override (needed by `softprops/action-gh-release` to publish the release).
- `.github/workflows/release.yml` — switched the Packagist update step from `curl -s` to `curl --fail-with-body -sS` so HTTP errors fail the step and the workflow.

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS (darwin 25.5.0)
- PHP Version: n/a (CI/tooling-only change)
- Project Version: 2.2.x

**Tests Performed:**
1. Verified both workflow files parse as valid YAML (`ruby -ryaml`).
2. Manual diff review against the `artisanpack-ui/core` reference workflows — the change matches the pattern the issue points at.
3. Real verification happens on the PR's own CI run; the `release.yml` change exercises on the next tag push.

## Accessibility Tests Run

- [ ] N/A — CI/tooling-only change, no user-facing UI.

## Tests Added

- [x] All tests passing

**Test details:** No new tests; this is a CI/tooling change with no runtime impact on the package or its API.

## Documentation

- [ ] N/A — no public API or documented behavior changed.

## Pre-Submission Checklist

- [x] Code passes all tests
- [x] Code follows project style guide
- [x] Self-review completed
- [x] No new warnings generated

## Notes / Deferred Work

Per the issue's "Additional Context", **SHA-pinning of third-party actions** (`@v4`/`@v2` → immutable commit SHAs) was intentionally deferred — that should land as a single org-wide pass across every ArtisanPack UI workflow (`ci.yml`, `release.yml`, `claude.yml`, `auto-milestone.yml`, `claude-code-review.yml`) rather than piecemeal here.

CodeRabbit CLI flagged one suggestion to add `actions: read` to the workflow-level `permissions` block for `actions/cache@v4`. This is a false positive — `actions/cache` uses the cache API, not the actions API, and the same `permissions: contents: read`-only config is already in production on `artisanpack-ui/core`. Skipped.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced security permissions in CI/CD workflows by restricting repository token access to read-only operations
  * Improved error handling in release deployment process to better detect and report failures

<!-- end of auto-generated comment: release notes by coderabbit.ai -->