### PR TITLE
docs: add 'Using with the visual editor' README section

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,90 @@ addAction('ap.cms.after_content_save', function($content) {
 });
 ```
 
+## Using with the visual editor
+
+cms-framework is fully usable standalone, but pairs with [`artisanpack-ui/visual-editor`](https://github.com/ArtisanPack-UI/visual-editor) to expose its `Post` and `Page` content to a Gutenberg-style block editor, back `core/site-*` blocks with real site settings, and seed `visual_editor.*` permissions into the RBAC tables. The full integration contract lives in visual-editor's [`docs/plans/12-cms-framework-integration.md`](https://github.com/ArtisanPack-UI/visual-editor/blob/release/1.0/docs/plans/12-cms-framework-integration.md); the reciprocal narrative is visual-editor's [Using with cms-framework](https://github.com/ArtisanPack-UI/visual-editor/blob/release/1.0/README.md#using-with-cms-framework) section.
+
+### Install both packages
+
+```bash
+composer require artisanpack-ui/cms-framework artisanpack-ui/visual-editor
+```
+
+Both packages are loosely coupled — every cms-framework hook into the editor is guarded by `class_exists(\ArtisanPackUI\VisualEditor\VisualEditor::class)`, so cms-framework continues to work standalone if visual-editor is not installed.
+
+### Run migrations
+
+```bash
+php artisan migrate
+```
+
+The cms-framework migration set adds a `block_content json nullable` column to the `posts` and `pages` tables (alongside the preserved legacy `content` longText column, which keeps powering search / excerpt / backwards-compatibility). Editing a legacy post in the visual editor populates `block_content` on first save; the legacy column is left untouched. See plan 12 [§4.2 Block content storage](https://github.com/ArtisanPack-UI/visual-editor/blob/release/1.0/docs/plans/12-cms-framework-integration.md#42-block-content-storage) for the dual-state guidance.
+
+### Resource map (`ap.visual-editor.resources`)
+
+When visual-editor is detected, cms-framework's service provider auto-registers `Post` and `Page` into the editor's `ap.visual-editor.resources` filter:
+
+```php
+// CMSFrameworkServiceProvider::boot()
+if ( class_exists( \ArtisanPackUI\VisualEditor\VisualEditor::class ) ) {
+    addFilter( 'ap.visual-editor.resources', function ( array $resources ): array {
+        return array_merge( [
+            'posts' => \ArtisanPackUI\CMSFramework\Modules\Blog\Models\Post::class,
+            'pages' => \ArtisanPackUI\CMSFramework\Modules\Pages\Models\Page::class,
+        ], $resources );
+    } );
+}
+```
+
+Host-app overrides in `config/artisanpack/visual-editor.php` always win on key collision, so swapping `posts` to a custom `App\Models\Post` is just a config edit. Full filter contract (input/output shape, collision behavior, validation guarantees, contributor timing): plan 12 [§4.1 Resource filter contract](https://github.com/ArtisanPack-UI/visual-editor/blob/release/1.0/docs/plans/12-cms-framework-integration.md#41-resource-filter-contract).
+
+### Site-meta bridge
+
+cms-framework registers the `site.*` setting family via `SettingsManager` and exposes a WordPress-shape envelope at `GET /api/settings/site` that the editor's `core/site-*` blocks consume:
+
+```php
+$settings->registerSetting( 'site.title',    config( 'app.name', '' ),  'sanitizeText',  SettingType::String );
+$settings->registerSetting( 'site.tagline',  '',                         'sanitizeText',  SettingType::String );
+$settings->registerSetting( 'site.url',      config( 'app.url', '' ),    'sanitizeUrl',   SettingType::String );
+$settings->registerSetting( 'site.logo_id',  null,                       'sanitizeInt',   SettingType::Integer );
+$settings->registerSetting( 'site.icon_id',  null,                       'sanitizeInt',   SettingType::Integer );
+```
+
+```json
+GET /api/settings/site
+{
+    "title": "ArtisanPack UI Demo",
+    "description": "A Laravel CMS",
+    "url": "https://example.test",
+    "site_logo": 42,
+    "site_icon": 17
+}
+```
+
+Mutating endpoints (`PUT /api/settings/site`) update the matching `Setting` rows through `SettingsManager`. See plan 12 [§4.3 Site-meta REST shape](https://github.com/ArtisanPack-UI/visual-editor/blob/release/1.0/docs/plans/12-cms-framework-integration.md#43-site-meta-rest-shape).
+
+### Permissions seed (`visual_editor.*`)
+
+When visual-editor is detected, cms-framework seeds the editor's permission family into its RBAC tables so host apps can grant them on roles immediately:
+
+```
+visual_editor.access
+visual_editor.posts.edit
+visual_editor.pages.edit
+visual_editor.templates.edit
+visual_editor.template-parts.edit
+visual_editor.patterns.edit
+visual_editor.global-styles.edit
+visual_editor.navigation.edit
+```
+
+Permissions are registered but not yet enforced by visual-editor's policies — that flips in a future release behind `artisanpack.visual-editor.authorization.delegate_to_cms_framework`. See plan 12 [§4.6 Permissions seed (G5)](https://github.com/ArtisanPack-UI/visual-editor/blob/release/1.0/docs/plans/12-cms-framework-integration.md#46-permissions-seed-g5).
+
+### Version pairing
+
+cms-framework and visual-editor ship as a version pair — the supported combinations are tracked in visual-editor's [Version compatibility](https://github.com/ArtisanPack-UI/visual-editor/blob/release/1.0/README.md#version-compatibility) matrix. Bumping the major on either package without bumping the partner is unsupported.
+
 ## Experimental Features
 
 The following features are **experimental** in the 1.0.0 release and should be used with caution in production environments:

--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ Mutating endpoints (`PUT /api/settings/site`) update the matching `Setting` rows
 
 When visual-editor is detected, cms-framework seeds the editor's permission family into its RBAC tables so host apps can grant them on roles immediately:
 
-```
+```text
 visual_editor.access
 visual_editor.posts.edit
 visual_editor.pages.edit


### PR DESCRIPTION
## Description

Adds a top-level **\"Using with the visual editor\"** section to the cms-framework README. This is the reciprocal of the [Using with cms-framework](https://github.com/ArtisanPack-UI/visual-editor/blob/release/1.0/README.md#using-with-cms-framework) section visual-editor added in G6 (visual-editor #403), so a release-pair user installing cms-framework v2.2 ↔ visual-editor v1.0 lands on a matching cross-reference from either side.

**Closes:** #150

## Type of Change

- [x] Documentation update

## Related Issue

**Issue:** #150

## Motivation and Context

visual-editor's v1.0 README already has a \"Using with cms-framework\" section (shipped via vE #403 / G6). Without the reciprocal section on this side, a release-pair user reading the cms-framework README at v2.2 gets no signal that visual-editor exists or how the two packages compose. The window to ship the matching section is the v2.2 ↔ vE 1.0 pair release — punting it leaves a one-sided cross-reference on the shelf.

## Changes Made

- `README.md` — new `## Using with the visual editor` section, inserted between Quick Start and Experimental Features. Covers:
  - **Install both packages** — the `composer require` pair plus the loose-coupling note (`class_exists` guard).
  - **Run migrations** — the dual-state `block_content json nullable` + preserved legacy `content` longText column, with a link to plan 12 [§4.2 Block content storage](https://github.com/ArtisanPack-UI/visual-editor/blob/release/1.0/docs/plans/12-cms-framework-integration.md#42-block-content-storage).
  - **Resource map (`ap.visual-editor.resources`)** — the auto-registration of `Post` and `Page` (guarded by `class_exists(\ArtisanPackUI\VisualEditor\VisualEditor::class)`), with a link to plan 12 [§4.1 Resource filter contract](https://github.com/ArtisanPack-UI/visual-editor/blob/release/1.0/docs/plans/12-cms-framework-integration.md#41-resource-filter-contract).
  - **Site-meta bridge** — the `site.*` `SettingsManager` registration and the `GET /api/settings/site` WP-shape envelope, with a link to plan 12 [§4.3 Site-meta REST shape](https://github.com/ArtisanPack-UI/visual-editor/blob/release/1.0/docs/plans/12-cms-framework-integration.md#43-site-meta-rest-shape).
  - **Permissions seed (`visual_editor.*`)** — the eight `visual_editor.*` permissions registered into the RBAC tables when visual-editor is detected, with a link to plan 12 [§4.6 Permissions seed (G5)](https://github.com/ArtisanPack-UI/visual-editor/blob/release/1.0/docs/plans/12-cms-framework-integration.md#46-permissions-seed-g5).
  - **Version pairing** — link back to visual-editor's [Version compatibility](https://github.com/ArtisanPack-UI/visual-editor/blob/release/1.0/README.md#version-compatibility) matrix.

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS (darwin 25.5.0)
- PHP Version: n/a (docs-only)
- Project Version: 2.2.x

**Tests Performed:**
1. Cross-checked every link against the visual-editor release/1.0 README and plan 12 anchors.
2. Visually compared the cms-framework section against vE's reciprocal section for shape and tone consistency.
3. Code samples / shapes pulled directly from plan 12 §4.1–§4.6 to keep the two docs from drifting.

## Accessibility Tests Run

- [ ] N/A — docs-only.

## Tests Added

- [x] All tests passing

**Test details:** No new tests; docs-only change with no runtime impact.

## Documentation

- [x] README updated

**Documentation details:** Only `README.md` is touched. The full integration contract still lives in visual-editor's plan 12 — the new section is a navigational entry point, not a duplicate.

## Pre-Submission Checklist

- [x] Code follows project style guide
- [x] Self-review completed
- [x] No new warnings generated

## Acceptance criteria coverage

- [x] cms-framework README has a \"Using with the visual editor\" section covering install, migrations, the `ap.visual-editor.resources` filter contribution, the site-meta bridge, and the permissions seed.
- [x] Section links back to visual-editor's \"Using with cms-framework\" section, to the version-pair matrix, and to plan 12.

Local `cr review --base release/2.2` returned **0 findings**.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a “Using with the visual editor” guide covering installation and setup.
  * Documents safe migration behavior that preserves legacy content while enabling the visual editor.
  * Describes automatic registration of content types and exposure of site settings via a JSON API for editor blocks, with updates persisted back to settings.
  * Notes permission seeding for the editor and version compatibility guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->