### PR TITLE
Release v2.2.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,9 @@ on:
     tags:
       - 'v*'
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -97,7 +100,7 @@ jobs:
       - name: Update Packagist
         if: success()
         run: |
-          curl -s -X POST \
+          curl --fail-with-body -sS -X POST \
             "https://packagist.org/api/update-package?username=${{ secrets.PACKAGIST_USERNAME }}&apiToken=${{ secrets.PACKAGIST_API_TOKEN }}" \
             -d "{\"repository\":{\"url\":\"https://github.com/${{ github.repository }}\"}}" \
             -H "Content-Type: application/json"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+## [2.2.0] - 2026-06-04
+
+### Added
+
+- **`Post::previous_post` and `Post::next_post` accessors** ([#154](https://github.com/ArtisanPack-UI/cms-framework/issues/154), [#157](https://github.com/ArtisanPack-UI/cms-framework/pull/157)) — published-adjacent post lookups so the `artisanpack-ui/visual-editor` `PostResolver` can stamp navigation block payloads. Lookup is ordered by `published_at`, with `id` as a deterministic tie-breaker when timestamps collide.
+- **`HasRenderedBlockContent` concern on `Post` and `Page`** ([#155](https://github.com/ArtisanPack-UI/cms-framework/issues/155), [#156](https://github.com/ArtisanPack-UI/cms-framework/pull/156)) — exposes a `rendered_content` accessor so `PostResolver` in `artisanpack-ui/visual-editor` can stamp the `_resolvedContent` HTML payload directly from the model.
+- **"Using with the visual editor" README section** ([#150](https://github.com/ArtisanPack-UI/cms-framework/issues/150), [#159](https://github.com/ArtisanPack-UI/cms-framework/pull/159)) — documents the opt-in bridge to the `artisanpack-ui/visual-editor` package, including the `block_content` column, `HasBlockContent` polyfill, `_resolved*` attribute flow, and the new `previous_post` / `next_post` / `rendered_content` accessors.
+
+### Security
+
+- **Hardened CI and release GitHub Actions workflows** ([#140](https://github.com/ArtisanPack-UI/cms-framework/issues/140), [#158](https://github.com/ArtisanPack-UI/cms-framework/pull/158)) — added least-privilege `permissions:` blocks to `.github/workflows/ci.yml` and `.github/workflows/release.yml` so workflow tokens no longer inherit broad write scopes by default.
+
 ## [2.1.0] - 2026-06-02
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -128,6 +128,90 @@ addAction('ap.cms.after_content_save', function($content) {
 });
 ```
 
+## Using with the visual editor
+
+cms-framework is fully usable standalone, but pairs with [`artisanpack-ui/visual-editor`](https://github.com/ArtisanPack-UI/visual-editor) to expose its `Post` and `Page` content to a Gutenberg-style block editor, back `core/site-*` blocks with real site settings, and seed `visual_editor.*` permissions into the RBAC tables. The full integration contract lives in visual-editor's [`docs/plans/12-cms-framework-integration.md`](https://github.com/ArtisanPack-UI/visual-editor/blob/release/1.0/docs/plans/12-cms-framework-integration.md); the reciprocal narrative is visual-editor's [Using with cms-framework](https://github.com/ArtisanPack-UI/visual-editor/blob/release/1.0/README.md#using-with-cms-framework) section.
+
+### Install both packages
+
+```bash
+composer require artisanpack-ui/cms-framework artisanpack-ui/visual-editor
+```
+
+Both packages are loosely coupled — every cms-framework hook into the editor is guarded by `class_exists(\ArtisanPackUI\VisualEditor\VisualEditor::class)`, so cms-framework continues to work standalone if visual-editor is not installed.
+
+### Run migrations
+
+```bash
+php artisan migrate
+```
+
+The cms-framework migration set adds a `block_content json nullable` column to the `posts` and `pages` tables (alongside the preserved legacy `content` longText column, which keeps powering search / excerpt / backwards-compatibility). Editing a legacy post in the visual editor populates `block_content` on first save; the legacy column is left untouched. See plan 12 [§4.2 Block content storage](https://github.com/ArtisanPack-UI/visual-editor/blob/release/1.0/docs/plans/12-cms-framework-integration.md#42-block-content-storage) for the dual-state guidance.
+
+### Resource map (`ap.visual-editor.resources`)
+
+When visual-editor is detected, cms-framework's service provider auto-registers `Post` and `Page` into the editor's `ap.visual-editor.resources` filter:
+
+```php
+// CMSFrameworkServiceProvider::boot()
+if ( class_exists( \ArtisanPackUI\VisualEditor\VisualEditor::class ) ) {
+    addFilter( 'ap.visual-editor.resources', function ( array $resources ): array {
+        return array_merge( [
+            'posts' => \ArtisanPackUI\CMSFramework\Modules\Blog\Models\Post::class,
+            'pages' => \ArtisanPackUI\CMSFramework\Modules\Pages\Models\Page::class,
+        ], $resources );
+    } );
+}
+```
+
+Host-app overrides in `config/artisanpack/visual-editor.php` always win on key collision, so swapping `posts` to a custom `App\Models\Post` is just a config edit. Full filter contract (input/output shape, collision behavior, validation guarantees, contributor timing): plan 12 [§4.1 Resource filter contract](https://github.com/ArtisanPack-UI/visual-editor/blob/release/1.0/docs/plans/12-cms-framework-integration.md#41-resource-filter-contract).
+
+### Site-meta bridge
+
+cms-framework registers the `site.*` setting family via `SettingsManager` and exposes a WordPress-shape envelope at `GET /api/settings/site` that the editor's `core/site-*` blocks consume:
+
+```php
+$settings->registerSetting( 'site.title',    config( 'app.name', '' ),  'sanitizeText',  SettingType::String );
+$settings->registerSetting( 'site.tagline',  '',                         'sanitizeText',  SettingType::String );
+$settings->registerSetting( 'site.url',      config( 'app.url', '' ),    'sanitizeUrl',   SettingType::String );
+$settings->registerSetting( 'site.logo_id',  null,                       'sanitizeInt',   SettingType::Integer );
+$settings->registerSetting( 'site.icon_id',  null,                       'sanitizeInt',   SettingType::Integer );
+```
+
+```json
+GET /api/settings/site
+{
+    "title": "ArtisanPack UI Demo",
+    "description": "A Laravel CMS",
+    "url": "https://example.test",
+    "site_logo": 42,
+    "site_icon": 17
+}
+```
+
+Mutating endpoints (`PUT /api/settings/site`) update the matching `Setting` rows through `SettingsManager`. See plan 12 [§4.3 Site-meta REST shape](https://github.com/ArtisanPack-UI/visual-editor/blob/release/1.0/docs/plans/12-cms-framework-integration.md#43-site-meta-rest-shape).
+
+### Permissions seed (`visual_editor.*`)
+
+When visual-editor is detected, cms-framework seeds the editor's permission family into its RBAC tables so host apps can grant them on roles immediately:
+
+```
+visual_editor.access
+visual_editor.posts.edit
+visual_editor.pages.edit
+visual_editor.templates.edit
+visual_editor.template-parts.edit
+visual_editor.patterns.edit
+visual_editor.global-styles.edit
+visual_editor.navigation.edit
+```
+
+Permissions are registered but not yet enforced by visual-editor's policies — that flips in a future release behind `artisanpack.visual-editor.authorization.delegate_to_cms_framework`. See plan 12 [§4.6 Permissions seed (G5)](https://github.com/ArtisanPack-UI/visual-editor/blob/release/1.0/docs/plans/12-cms-framework-integration.md#46-permissions-seed-g5).
+
+### Version pairing
+
+cms-framework and visual-editor ship as a version pair — the supported combinations are tracked in visual-editor's [Version compatibility](https://github.com/ArtisanPack-UI/visual-editor/blob/release/1.0/README.md#version-compatibility) matrix. Bumping the major on either package without bumping the partner is unsupported.
+
 ## Experimental Features
 
 The following features are **experimental** in the 1.0.0 release and should be used with caution in production environments:

--- a/README.md
+++ b/README.md
@@ -166,6 +166,20 @@ if ( class_exists( \ArtisanPackUI\VisualEditor\VisualEditor::class ) ) {
 
 Host-app overrides in `config/artisanpack/visual-editor.php` always win on key collision, so swapping `posts` to a custom `App\Models\Post` is just a config edit. Full filter contract (input/output shape, collision behavior, validation guarantees, contributor timing): plan 12 [§4.1 Resource filter contract](https://github.com/ArtisanPack-UI/visual-editor/blob/release/1.0/docs/plans/12-cms-framework-integration.md#41-resource-filter-contract).
 
+### PostResolver accessors
+
+`Post` and `Page` expose a handful of accessors that visual-editor's `PostResolver` reads to stamp `_resolved*` attributes on `core/post-*` and `core/navigation` blocks:
+
+| Accessor | Type | Source | Used by |
+|---|---|---|---|
+| `rendered_content` | `string` | `HasRenderedBlockContent` concern — renders `block_content` through the visual editor's server-side renderer, falling back to the legacy `content` column when `block_content` is null | `_resolvedContent` on `core/post-content` |
+| `previous_post` | `?Post` | adjacent post ordered by `published_at` (ties broken by `id`) | `_resolvedPreviousPost` on `core/post-navigation-link` |
+| `next_post` | `?Post` | adjacent post ordered by `published_at` (ties broken by `id`) | `_resolvedNextPost` on `core/post-navigation-link` |
+| `comments_count` | `int` | approved comments only | `_resolvedCommentsCount` on `core/post-comments-count` |
+| `comments_url` | `string` | canonical `#comments` anchor on the post URL | `_resolvedCommentsUrl` on `core/post-comments-link` |
+
+All accessors are eager-load friendly and safe to call on detached models — the adjacency lookup short-circuits to `null` for unsaved or unpublished posts.
+
 ### Site-meta bridge
 
 cms-framework registers the `site.*` setting family via `SettingsManager` and exposes a WordPress-shape envelope at `GET /api/settings/site` that the editor's `core/site-*` blocks consume:

--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ Mutating endpoints (`PUT /api/settings/site`) update the matching `Setting` rows
 
 When visual-editor is detected, cms-framework seeds the editor's permission family into its RBAC tables so host apps can grant them on roles immediately:
 
-```
+```text
 visual_editor.access
 visual_editor.posts.edit
 visual_editor.pages.edit

--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ All accessors are eager-load friendly and safe to call on detached models — th
 
 ### Site-meta bridge
 
-cms-framework registers the `site.*` setting family via `SettingsManager` and exposes a WordPress-shape envelope at `GET /api/settings/site` that the editor's `core/site-*` blocks consume:
+cms-framework registers the `site.*` setting family via `SettingsManager` and exposes a WordPress-shape envelope at `GET /api/v1/settings/site` that the editor's `core/site-*` blocks consume:
 
 ```php
 $settings->registerSetting( 'site.title',    config( 'app.name', '' ),  'sanitizeText',  SettingType::String );
@@ -193,7 +193,7 @@ $settings->registerSetting( 'site.icon_id',  null,                       'saniti
 ```
 
 ```json
-GET /api/settings/site
+GET /api/v1/settings/site
 {
     "title": "ArtisanPack UI Demo",
     "description": "A Laravel CMS",
@@ -203,7 +203,7 @@ GET /api/settings/site
 }
 ```
 
-Mutating endpoints (`PUT /api/settings/site`) update the matching `Setting` rows through `SettingsManager`. See plan 12 [§4.3 Site-meta REST shape](https://github.com/ArtisanPack-UI/visual-editor/blob/release/1.0/docs/plans/12-cms-framework-integration.md#43-site-meta-rest-shape).
+Mutating endpoints (`PUT /api/v1/settings/site`) update the matching `Setting` rows through `SettingsManager`. See plan 12 [§4.3 Site-meta REST shape](https://github.com/ArtisanPack-UI/visual-editor/blob/release/1.0/docs/plans/12-cms-framework-integration.md#43-site-meta-rest-shape).
 
 ### Permissions seed (`visual_editor.*`)
 

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "description": "Adds in the back end support for building a CMS with any front end framework.",
   "type": "library",
   "license": "MIT",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "autoload": {
     "psr-4": {
       "ArtisanPackUI\\CMSFramework\\": "src/",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0b7fde38153e2f23fd6e7467c5915bcb",
+    "content-hash": "a157905f80a77dfecd878e11abdf8bf6",
     "packages": [
         {
             "name": "artisanpack-ui/accessibility",

--- a/config/cms-framework.php
+++ b/config/cms-framework.php
@@ -32,7 +32,7 @@ return [
 
         'info' => [
             'title'       => 'ArtisanPack CMS Framework API',
-            'version'     => '2.1.0',
+            'version'     => '2.2.0',
             'description' => 'RESTful API for the ArtisanPack CMS Framework. Provides endpoints for managing posts, pages, content types, users, roles, permissions, settings, notifications, plugins, and themes.',
         ],
 

--- a/src/Modules/Blog/Models/Post.php
+++ b/src/Modules/Blog/Models/Post.php
@@ -342,15 +342,31 @@ class Post extends Model
 
         $operator       = 'previous' === $direction ? '<' : '>';
         $orderDirection = 'previous' === $direction ? 'desc' : 'asc';
+        $currentKey     = $this->getKey();
+        $currentDate    = $this->published_at;
 
-        // $operator is a literal '<' or '>' set above; $this->published_at
-        // is a Carbon cast, not user input. Same shape as Page::siblings().
+        // Ties on `published_at` are common (bulk imports, top-of-hour
+        // schedules). Break them with `id` in the same direction so the
+        // adjacency is deterministic and every post in a tied cluster has a
+        // defined previous / next.
+        //
+        // $operator / $idOperator are literals chosen above; $this->published_at
+        // and $this->getKey() are model-internal values. Same shape as
+        // Page::siblings().
         // phpcs:disable ArtisanPackUI.Security.ValidatedSanitizedInput.VariableNotSanitized
         $post = static::query()
             ->published()
             ->whereNotNull( 'published_at' )
-            ->where( 'published_at', $operator, $this->published_at )
+            ->where( function ( $q ) use ( $operator, $currentDate, $currentKey, $direction ): void {
+                $idOperator = 'previous' === $direction ? '<' : '>';
+                $q->where( 'published_at', $operator, $currentDate )
+                    ->orWhere( function ( $q ) use ( $currentDate, $currentKey, $idOperator ): void {
+                        $q->where( 'published_at', '=', $currentDate )
+                            ->where( 'id', $idOperator, $currentKey );
+                    } );
+            } )
             ->orderBy( 'published_at', $orderDirection )
+            ->orderBy( 'id', $orderDirection )
             ->first();
         // phpcs:enable ArtisanPackUI.Security.ValidatedSanitizedInput.VariableNotSanitized
 

--- a/src/Modules/Blog/Models/Post.php
+++ b/src/Modules/Blog/Models/Post.php
@@ -321,7 +321,9 @@ class Post extends Model
      * status-Published / `published_at <= now()` semantics as
      * `scopePublished()` while additionally requiring `published_at`
      * to be non-null so the strict `<` / `>` comparison on
-     * `published_at` produces a defined ordering.
+     * `published_at` produces a defined ordering. Drafts and scheduled
+     * (future-dated) posts are short-circuited to `null` regardless of
+     * whether they have a `published_at` timestamp.
      *
      * Memoised on `$adjacentPostCache` for the full lifetime of the
      * model instance — Eloquent's `refresh()` reloads attributes but
@@ -332,7 +334,11 @@ class Post extends Model
      */
     protected function resolveAdjacentPost( string $direction ): ?self
     {
-        if ( null === $this->published_at ) {
+        // Drafts and scheduled posts (`status !== Published` or `published_at`
+        // in the future) must not resolve public neighbors. `isPublished()`
+        // gates both; the explicit non-null check then guarantees the strict
+        // `<` / `>` ordering below has a defined pivot.
+        if ( ! $this->isPublished() || null === $this->published_at ) {
             return null;
         }
 

--- a/src/Modules/Blog/Models/Post.php
+++ b/src/Modules/Blog/Models/Post.php
@@ -16,6 +16,7 @@ use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Enums\ContentStatus;
 use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Models\Concerns\HasContentStatus;
 use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Models\Concerns\HasCustomFields;
 use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Models\Concerns\HasFeaturedImage;
+use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Models\Concerns\HasRenderedBlockContent;
 use ArtisanPackUI\MediaLibrary\Models\Media;
 use ArtisanPackUI\VisualEditor\Concerns\HasBlockContent;
 use Carbon\Carbon;
@@ -35,6 +36,7 @@ use Illuminate\Database\Eloquent\SoftDeletes;
  * @property string $slug
  * @property string|null $content
  * @property array<int, array<string, mixed>>|null $block_content
+ * @property-read string $rendered_content
  * @property string|null $excerpt
  * @property int $author_id
  * @property ContentStatus $status
@@ -53,6 +55,7 @@ class Post extends Model
     use HasCustomFields;
     use HasFactory;
     use HasFeaturedImage;
+    use HasRenderedBlockContent;
     use SoftDeletes;
 
     /**

--- a/src/Modules/Blog/Models/Post.php
+++ b/src/Modules/Blog/Models/Post.php
@@ -45,6 +45,8 @@ use Illuminate\Database\Eloquent\SoftDeletes;
  * @property \Illuminate\Support\Carbon $created_at
  * @property \Illuminate\Support\Carbon $updated_at
  * @property \Illuminate\Support\Carbon|null $deleted_at
+ * @property-read self|null $previous_post
+ * @property-read self|null $next_post
  *
  * @since 1.0.0
  */
@@ -64,6 +66,18 @@ class Post extends Model
      * @since 2.0.0
      */
     protected string $blockContentColumn = 'block_content';
+
+    /**
+     * Per-instance cache for `previous_post` / `next_post` adjacency
+     * lookups so the accessors fire a single query each direction
+     * regardless of how many times the visual-editor resolver (or any
+     * other consumer) reads them during a request.
+     *
+     * @since 2.2.0
+     *
+     * @var array<string, self|null>
+     */
+    protected array $adjacentPostCache = [];
 
     /**
      * The attributes that are mass assignable.
@@ -180,6 +194,41 @@ class Post extends Model
     }
 
     /**
+     * The previous published post ordered by `published_at`. Read by
+     * the visual-editor's `PostResolver::resolvePostNavigationLink()`
+     * when stamping `_resolvedPrevUrl` / `_resolvedPrevTitle` onto
+     * `post-navigation-link` blocks pointed at the previous post.
+     *
+     * Returns null when the current post has no `published_at` (an
+     * unpublished or draft post has no defined adjacency) or when no
+     * earlier published post exists. Result is memoised per-instance
+     * so paint-time block resolution only hits the database once.
+     *
+     * @since 2.2.0
+     */
+    public function getPreviousPostAttribute(): ?self
+    {
+        return $this->resolveAdjacentPost( 'previous' );
+    }
+
+    /**
+     * The next published post ordered by `published_at`. Read by the
+     * visual-editor's `PostResolver::resolvePostNavigationLink()`
+     * when stamping `_resolvedNextUrl` / `_resolvedNextTitle` onto
+     * `post-navigation-link` blocks pointed at the next post.
+     *
+     * Returns null when the current post has no `published_at` or
+     * when no later published post exists. Result is memoised
+     * per-instance.
+     *
+     * @since 2.2.0
+     */
+    public function getNextPostAttribute(): ?self
+    {
+        return $this->resolveAdjacentPost( 'next' );
+    }
+
+    /**
      * Scope a query to posts by a specific author.
      *
      * @since 1.0.0
@@ -264,6 +313,50 @@ class Post extends Model
     public function getPermalinkAttribute(): string
     {
         return url( "/blog/{$this->slug}" );
+    }
+
+    /**
+     * Resolve the adjacent published post in the requested direction
+     * (`'previous'` or `'next'`). Honors the same
+     * status-Published / `published_at <= now()` semantics as
+     * `scopePublished()` while additionally requiring `published_at`
+     * to be non-null so the strict `<` / `>` comparison on
+     * `published_at` produces a defined ordering.
+     *
+     * Memoised on `$adjacentPostCache` for the full lifetime of the
+     * model instance — Eloquent's `refresh()` reloads attributes but
+     * does not reset arbitrary instance state, so re-querying (or
+     * unsetting the property) is the way to invalidate.
+     *
+     * @since 2.2.0
+     */
+    protected function resolveAdjacentPost( string $direction ): ?self
+    {
+        if ( null === $this->published_at ) {
+            return null;
+        }
+
+        if ( array_key_exists( $direction, $this->adjacentPostCache ) ) {
+            return $this->adjacentPostCache[ $direction ];
+        }
+
+        $operator       = 'previous' === $direction ? '<' : '>';
+        $orderDirection = 'previous' === $direction ? 'desc' : 'asc';
+
+        // $operator is a literal '<' or '>' set above; $this->published_at
+        // is a Carbon cast, not user input. Same shape as Page::siblings().
+        // phpcs:disable ArtisanPackUI.Security.ValidatedSanitizedInput.VariableNotSanitized
+        $post = static::query()
+            ->published()
+            ->whereNotNull( 'published_at' )
+            ->where( 'published_at', $operator, $this->published_at )
+            ->orderBy( 'published_at', $orderDirection )
+            ->first();
+        // phpcs:enable ArtisanPackUI.Security.ValidatedSanitizedInput.VariableNotSanitized
+
+        $this->adjacentPostCache[ $direction ] = $post;
+
+        return $post;
     }
 
     /**

--- a/src/Modules/ContentTypes/Models/Concerns/HasRenderedBlockContent.php
+++ b/src/Modules/ContentTypes/Models/Concerns/HasRenderedBlockContent.php
@@ -94,6 +94,29 @@ trait HasRenderedBlockContent
 
         $content = $this->getAttribute( 'content' );
 
+        // When `HasBlockContent` defaults to its own `content` column (i.e.
+        // the host model has NOT set `$blockContentColumn`), the trait
+        // registers an `array` cast on `content`. Legacy HTML records then
+        // surface as `null` / an array on `getAttribute()`, not a string,
+        // and the fallback below would silently drop them. Reach past the
+        // cast to recover the raw value — but only when the raw bytes are
+        // NOT JSON, otherwise we'd return the encoded block tree we just
+        // tried to render through the renderer.
+        if ( ! is_string( $content )
+            && method_exists( $this, 'getBlockContentColumn' )
+            && 'content' === $this->getBlockContentColumn()
+        ) {
+            $rawContent = $this->getRawOriginal( 'content' );
+
+            if ( is_string( $rawContent ) ) {
+                json_decode( $rawContent, true );
+
+                if ( JSON_ERROR_NONE !== json_last_error() ) {
+                    $content = $rawContent;
+                }
+            }
+        }
+
         return is_string( $content ) ? $content : '';
     }
 }

--- a/src/Modules/ContentTypes/Models/Concerns/HasRenderedBlockContent.php
+++ b/src/Modules/ContentTypes/Models/Concerns/HasRenderedBlockContent.php
@@ -1,0 +1,99 @@
+<?php
+
+declare( strict_types=1 );
+
+/**
+ * HasRenderedBlockContent Trait
+ *
+ * Exposes the rendered HTML for a model whose body is stored as a visual-editor
+ * block tree. Visual-editor's `PostResolver::resolveContent()` reads
+ * `$post->content` and only stamps `_resolvedContent` when it is a string;
+ * models that use `HasBlockContent` keep the body as a JSON-cast array, so
+ * the `core/post-content` block renders an empty `wp-block-post-content`
+ * div on the front end. This trait fills that gap.
+ *
+ * @since 2.2.0
+ */
+
+namespace ArtisanPackUI\CMSFramework\Modules\ContentTypes\Models\Concerns;
+
+use Throwable;
+
+/**
+ * Adds a `rendered_content` Eloquent accessor (and matching `renderContent()`
+ * method) that walks the model's block tree through the visual-editor
+ * renderer-blade package and returns the rendered HTML.
+ *
+ * The renderer is resolved lazily through the container so this stays a soft
+ * integration — cms-framework does not require `visual-editor-renderer-blade`
+ * as a composer dependency. When the renderer class is not installed, the
+ * accessor falls back to the model's existing `content` column (which may
+ * carry pre-rendered HTML for legacy records) and finally to an empty string.
+ *
+ * Intended to be combined with `ArtisanPackUI\VisualEditor\Concerns\HasBlockContent`,
+ * which supplies the `getBlockContent()` reader the trait calls.
+ *
+ * @since 2.2.0
+ *
+ * @mixin \Illuminate\Database\Eloquent\Model
+ */
+trait HasRenderedBlockContent
+{
+    /**
+     * Fully-qualified class name of the visual-editor block renderer.
+     *
+     * Kept as a string so cms-framework never autoloads the class when the
+     * renderer-blade package is not installed.
+     *
+     * @since 2.2.0
+     */
+    protected const BLOCK_RENDERER_CLASS = 'ArtisanPackUI\\VisualEditorRendererBlade\\BlockRenderer';
+
+    /**
+     * Eloquent accessor for `$model->rendered_content`.
+     *
+     * Visual-editor's `PostResolver::resolveContent()` prefers this attribute
+     * over the raw `content` column when present, so a `core/post-content`
+     * block stamps the actual rendered HTML rather than an empty string.
+     *
+     * @since 2.2.0
+     */
+    public function getRenderedContentAttribute(): string
+    {
+        return $this->renderContent();
+    }
+
+    /**
+     * Render the model's block tree to an HTML string.
+     *
+     * Resolves the visual-editor renderer-blade `BlockRenderer` through the
+     * container and walks the block tree returned by
+     * `HasBlockContent::getBlockContent()`. When the renderer class is not
+     * installed (or resolving / rendering throws), falls back to the
+     * model's `content` column if it is a string, otherwise returns an
+     * empty string.
+     *
+     * @since 2.2.0
+     */
+    public function renderContent(): string
+    {
+        if ( method_exists( $this, 'getBlockContent' ) && class_exists( self::BLOCK_RENDERER_CLASS ) ) {
+            $blocks = $this->getBlockContent();
+
+            if ( [] !== $blocks ) {
+                try {
+                    $renderer = app( self::BLOCK_RENDERER_CLASS );
+
+                    return $renderer->render( $blocks );
+                } catch ( Throwable ) {
+                    // Renderer installed but failed to resolve or render —
+                    // fall through to the pre-rendered string fallback below.
+                }
+            }
+        }
+
+        $content = $this->getAttribute( 'content' );
+
+        return is_string( $content ) ? $content : '';
+    }
+}

--- a/src/Modules/OpenApi/Providers/OpenApiServiceProvider.php
+++ b/src/Modules/OpenApi/Providers/OpenApiServiceProvider.php
@@ -113,7 +113,7 @@ class OpenApiServiceProvider extends ServiceProvider
         $scrambleConfig['ui']       = ['title' => $info['title'] ?? 'ArtisanPack CMS Framework API'];
 
         $scrambleConfig['info'] = [
-            'version'     => $info['version'] ?? '2.1.0',
+            'version'     => $info['version'] ?? '2.2.0',
             'description' => $info['description'] ?? '',
         ];
 

--- a/src/Modules/Pages/Models/Page.php
+++ b/src/Modules/Pages/Models/Page.php
@@ -16,6 +16,7 @@ use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Enums\ContentStatus;
 use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Models\Concerns\HasContentStatus;
 use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Models\Concerns\HasCustomFields;
 use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Models\Concerns\HasFeaturedImage;
+use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Models\Concerns\HasRenderedBlockContent;
 use ArtisanPackUI\MediaLibrary\Models\Media;
 use ArtisanPackUI\VisualEditor\Concerns\HasBlockContent;
 use Carbon\Carbon;
@@ -36,6 +37,7 @@ use Illuminate\Support\Collection;
  * @property string $slug
  * @property string|null $content
  * @property array<int, array<string, mixed>>|null $block_content
+ * @property-read string $rendered_content
  * @property string|null $excerpt
  * @property int $author_id
  * @property int|null $parent_id
@@ -57,6 +59,7 @@ class Page extends Model
     use HasCustomFields;
     use HasFactory;
     use HasFeaturedImage;
+    use HasRenderedBlockContent;
     use SoftDeletes;
 
     /**

--- a/tests/Unit/Blog/PostModelTest.php
+++ b/tests/Unit/Blog/PostModelTest.php
@@ -660,6 +660,54 @@ test( 'previous_post and next_post return null when current post has no publishe
     expect( $draft->next_post )->toBeNull();
 } );
 
+test( 'previous_post and next_post break ties on published_at by id', function (): void {
+    $user = TestUser::create( [
+        'name'     => 'Test Author',
+        'email'    => 'author@example.com',
+        'password' => 'password',
+    ] );
+
+    $sharedDate = Carbon::create( 2026, 2, 1, 12 );
+
+    // Three posts sharing the same published_at — order is fully
+    // determined by id, which the factory assigns in creation order.
+    $first = Post::create( [
+        'title'        => 'Tied First',
+        'slug'         => 'tied-first',
+        'author_id'    => $user->id,
+        'status'       => 'published',
+        'published_at' => $sharedDate,
+    ] );
+
+    $middle = Post::create( [
+        'title'        => 'Tied Middle',
+        'slug'         => 'tied-middle',
+        'author_id'    => $user->id,
+        'status'       => 'published',
+        'published_at' => $sharedDate,
+    ] );
+
+    $last = Post::create( [
+        'title'        => 'Tied Last',
+        'slug'         => 'tied-last',
+        'author_id'    => $user->id,
+        'status'       => 'published',
+        'published_at' => $sharedDate,
+    ] );
+
+    expect( $middle->previous_post )->not->toBeNull();
+    expect( $middle->previous_post->is( $first ) )->toBeTrue();
+
+    expect( $middle->next_post )->not->toBeNull();
+    expect( $middle->next_post->is( $last ) )->toBeTrue();
+
+    // First post in the tied cluster has no earlier neighbour; last
+    // has no later one. Without the id tiebreak both would still see
+    // each other through the shared timestamp.
+    expect( $first->previous_post )->toBeNull();
+    expect( $last->next_post )->toBeNull();
+} );
+
 test( 'previous_post and next_post memoize results per instance', function (): void {
     $user = TestUser::create( [
         'name'     => 'Test Author',

--- a/tests/Unit/Blog/PostModelTest.php
+++ b/tests/Unit/Blog/PostModelTest.php
@@ -490,3 +490,207 @@ test( 'post uses soft deletes', function (): void {
     expect( Post::find( $postId ) )->toBeNull();
     expect( Post::withTrashed()->find( $postId ) )->not->toBeNull();
 } );
+
+test( 'previous_post returns the preceding published post by published_at', function (): void {
+    $user = TestUser::create( [
+        'name'     => 'Test Author',
+        'email'    => 'author@example.com',
+        'password' => 'password',
+    ] );
+
+    $older = Post::create( [
+        'title'        => 'Older Post',
+        'slug'         => 'older-post',
+        'author_id'    => $user->id,
+        'status'       => 'published',
+        'published_at' => Carbon::create( 2026, 1, 1, 12 ),
+    ] );
+
+    $current = Post::create( [
+        'title'        => 'Current Post',
+        'slug'         => 'current-post',
+        'author_id'    => $user->id,
+        'status'       => 'published',
+        'published_at' => Carbon::create( 2026, 2, 1, 12 ),
+    ] );
+
+    Post::create( [
+        'title'        => 'Newer Post',
+        'slug'         => 'newer-post',
+        'author_id'    => $user->id,
+        'status'       => 'published',
+        'published_at' => Carbon::create( 2026, 3, 1, 12 ),
+    ] );
+
+    expect( $current->previous_post )->toBeInstanceOf( Post::class );
+    expect( $current->previous_post->is( $older ) )->toBeTrue();
+} );
+
+test( 'next_post returns the following published post by published_at', function (): void {
+    $user = TestUser::create( [
+        'name'     => 'Test Author',
+        'email'    => 'author@example.com',
+        'password' => 'password',
+    ] );
+
+    Post::create( [
+        'title'        => 'Older Post',
+        'slug'         => 'older-post',
+        'author_id'    => $user->id,
+        'status'       => 'published',
+        'published_at' => Carbon::create( 2026, 1, 1, 12 ),
+    ] );
+
+    $current = Post::create( [
+        'title'        => 'Current Post',
+        'slug'         => 'current-post',
+        'author_id'    => $user->id,
+        'status'       => 'published',
+        'published_at' => Carbon::create( 2026, 2, 1, 12 ),
+    ] );
+
+    $newer = Post::create( [
+        'title'        => 'Newer Post',
+        'slug'         => 'newer-post',
+        'author_id'    => $user->id,
+        'status'       => 'published',
+        'published_at' => Carbon::create( 2026, 3, 1, 12 ),
+    ] );
+
+    expect( $current->next_post )->toBeInstanceOf( Post::class );
+    expect( $current->next_post->is( $newer ) )->toBeTrue();
+} );
+
+test( 'previous_post and next_post return null at the boundaries', function (): void {
+    $user = TestUser::create( [
+        'name'     => 'Test Author',
+        'email'    => 'author@example.com',
+        'password' => 'password',
+    ] );
+
+    $first = Post::create( [
+        'title'        => 'First Post',
+        'slug'         => 'first-post',
+        'author_id'    => $user->id,
+        'status'       => 'published',
+        'published_at' => Carbon::create( 2026, 1, 1, 12 ),
+    ] );
+
+    $last = Post::create( [
+        'title'        => 'Last Post',
+        'slug'         => 'last-post',
+        'author_id'    => $user->id,
+        'status'       => 'published',
+        'published_at' => Carbon::create( 2026, 2, 1, 12 ),
+    ] );
+
+    expect( $first->previous_post )->toBeNull();
+    expect( $last->next_post )->toBeNull();
+} );
+
+test( 'previous_post and next_post skip drafts and scheduled posts', function (): void {
+    $user = TestUser::create( [
+        'name'     => 'Test Author',
+        'email'    => 'author@example.com',
+        'password' => 'password',
+    ] );
+
+    $earlierPublished = Post::create( [
+        'title'        => 'Earlier Published',
+        'slug'         => 'earlier-published',
+        'author_id'    => $user->id,
+        'status'       => 'published',
+        'published_at' => Carbon::create( 2026, 1, 1, 12 ),
+    ] );
+
+    // Draft between the two published posts — should be skipped.
+    Post::create( [
+        'title'        => 'Draft Between',
+        'slug'         => 'draft-between',
+        'author_id'    => $user->id,
+        'status'       => 'draft',
+        'published_at' => Carbon::create( 2026, 2, 1, 12 ),
+    ] );
+
+    $current = Post::create( [
+        'title'        => 'Current Post',
+        'slug'         => 'current-post',
+        'author_id'    => $user->id,
+        'status'       => 'published',
+        'published_at' => Carbon::create( 2026, 3, 1, 12 ),
+    ] );
+
+    // Scheduled (future) post — should be skipped by next_post.
+    Post::create( [
+        'title'        => 'Scheduled Post',
+        'slug'         => 'scheduled-post',
+        'author_id'    => $user->id,
+        'status'       => 'published',
+        'published_at' => now()->addYear(),
+    ] );
+
+    expect( $current->previous_post )->not->toBeNull();
+    expect( $current->previous_post->is( $earlierPublished ) )->toBeTrue();
+    expect( $current->next_post )->toBeNull();
+} );
+
+test( 'previous_post and next_post return null when current post has no published_at', function (): void {
+    $user = TestUser::create( [
+        'name'     => 'Test Author',
+        'email'    => 'author@example.com',
+        'password' => 'password',
+    ] );
+
+    Post::create( [
+        'title'        => 'Older Post',
+        'slug'         => 'older-post',
+        'author_id'    => $user->id,
+        'status'       => 'published',
+        'published_at' => Carbon::create( 2026, 1, 1, 12 ),
+    ] );
+
+    $draft = Post::create( [
+        'title'     => 'Draft Without Date',
+        'slug'      => 'draft-without-date',
+        'author_id' => $user->id,
+        'status'    => 'draft',
+    ] );
+
+    expect( $draft->previous_post )->toBeNull();
+    expect( $draft->next_post )->toBeNull();
+} );
+
+test( 'previous_post and next_post memoize results per instance', function (): void {
+    $user = TestUser::create( [
+        'name'     => 'Test Author',
+        'email'    => 'author@example.com',
+        'password' => 'password',
+    ] );
+
+    Post::create( [
+        'title'        => 'Older Post',
+        'slug'         => 'older-post',
+        'author_id'    => $user->id,
+        'status'       => 'published',
+        'published_at' => Carbon::create( 2026, 1, 1, 12 ),
+    ] );
+
+    $current = Post::create( [
+        'title'        => 'Current Post',
+        'slug'         => 'current-post',
+        'author_id'    => $user->id,
+        'status'       => 'published',
+        'published_at' => Carbon::create( 2026, 2, 1, 12 ),
+    ] );
+
+    Illuminate\Support\Facades\DB::enableQueryLog();
+    Illuminate\Support\Facades\DB::flushQueryLog();
+
+    $current->previous_post;
+    $current->previous_post;
+    $current->previous_post;
+
+    expect( Illuminate\Support\Facades\DB::getQueryLog() )->toHaveCount( 1 );
+
+    Illuminate\Support\Facades\DB::disableQueryLog();
+} );

--- a/tests/Unit/Blog/PostModelTest.php
+++ b/tests/Unit/Blog/PostModelTest.php
@@ -660,6 +660,65 @@ test( 'previous_post and next_post return null when current post has no publishe
     expect( $draft->next_post )->toBeNull();
 } );
 
+test( 'previous_post and next_post return null when current post is a draft with a published_at', function (): void {
+    $user = TestUser::create( [
+        'name'     => 'Test Author',
+        'email'    => 'author@example.com',
+        'password' => 'password',
+    ] );
+
+    Post::create( [
+        'title'        => 'Public Neighbor',
+        'slug'         => 'public-neighbor',
+        'author_id'    => $user->id,
+        'status'       => 'published',
+        'published_at' => Carbon::create( 2026, 1, 1, 12 ),
+    ] );
+
+    // A draft can carry a `published_at` (e.g. user set a date then
+    // reverted to draft). Adjacency must not leak public neighbors
+    // for it.
+    $draftWithDate = Post::create( [
+        'title'        => 'Draft With Date',
+        'slug'         => 'draft-with-date',
+        'author_id'    => $user->id,
+        'status'       => 'draft',
+        'published_at' => Carbon::create( 2026, 2, 1, 12 ),
+    ] );
+
+    expect( $draftWithDate->previous_post )->toBeNull();
+    expect( $draftWithDate->next_post )->toBeNull();
+} );
+
+test( 'previous_post and next_post return null when current post is scheduled', function (): void {
+    $user = TestUser::create( [
+        'name'     => 'Test Author',
+        'email'    => 'author@example.com',
+        'password' => 'password',
+    ] );
+
+    Post::create( [
+        'title'        => 'Public Neighbor',
+        'slug'         => 'public-neighbor',
+        'author_id'    => $user->id,
+        'status'       => 'published',
+        'published_at' => Carbon::create( 2026, 1, 1, 12 ),
+    ] );
+
+    // Status = Published but `published_at` is in the future — the
+    // post is not yet public, so adjacency must short-circuit.
+    $scheduled = Post::create( [
+        'title'        => 'Scheduled Post',
+        'slug'         => 'scheduled-post',
+        'author_id'    => $user->id,
+        'status'       => 'published',
+        'published_at' => now()->addYear(),
+    ] );
+
+    expect( $scheduled->previous_post )->toBeNull();
+    expect( $scheduled->next_post )->toBeNull();
+} );
+
 test( 'previous_post and next_post break ties on published_at by id', function (): void {
     $user = TestUser::create( [
         'name'     => 'Test Author',

--- a/tests/Unit/ContentTypes/HasRenderedBlockContentTest.php
+++ b/tests/Unit/ContentTypes/HasRenderedBlockContentTest.php
@@ -44,9 +44,12 @@ namespace ArtisanPackUI\VisualEditorRendererBlade {
 namespace {
 
     use ArtisanPackUI\CMSFramework\Modules\Blog\Models\Post;
+    use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Models\Concerns\HasRenderedBlockContent;
     use ArtisanPackUI\CMSFramework\Modules\Pages\Models\Page;
     use ArtisanPackUI\CMSFramework\Tests\Support\TestUser;
+    use ArtisanPackUI\VisualEditor\Concerns\HasBlockContent;
     use ArtisanPackUI\VisualEditorRendererBlade\BlockRenderer;
+    use Illuminate\Database\Eloquent\Model;
 
     beforeEach( function (): void {
         $this->artisan( 'migrate', ['--database' => 'testing'] );
@@ -144,6 +147,45 @@ namespace {
         ] );
 
         expect( $post->rendered_content )->toBe( '' );
+    } );
+
+    test( 'renderContent() recovers legacy HTML when the block content column defaults to content (array cast)', function (): void {
+        // Anonymous model that uses HasBlockContent WITHOUT overriding
+        // $blockContentColumn — so the trait registers an `array` cast on
+        // the `content` column. Legacy HTML stored there surfaces as a
+        // non-string via the cast, but the raw original is the HTML bytes.
+        $model = new class extends Model {
+            use HasBlockContent;
+            use HasRenderedBlockContent;
+        };
+
+        $model->setRawAttributes( [ 'content' => '<p>legacy HTML</p>' ], true );
+
+        // Sanity-check: the cast layer hands back something that is NOT a
+        // string (Laravel decodes invalid JSON to null), so the naive
+        // `is_string` fallback would drop the legacy HTML.
+        expect( is_string( $model->getAttribute( 'content' ) ) )->toBeFalse();
+
+        expect( $model->renderContent() )->toBe( '<p>legacy HTML</p>' );
+    } );
+
+    test( 'renderContent() does NOT return raw JSON when the block content column defaults to content', function (): void {
+        // Mirror of the prior test but with the raw column holding a JSON
+        // block tree (i.e. the typical post-2.x record). The fallback must
+        // NOT echo the encoded JSON back as "legacy HTML" — it should drop
+        // to an empty string when the renderer is unavailable or returns
+        // empty for an unknown reason.
+        $model = new class extends Model {
+            use HasBlockContent;
+            use HasRenderedBlockContent;
+        };
+
+        $rawJson = '[{"name":"core/paragraph","attributes":{"content":"hi"},"innerBlocks":[]}]';
+        $model->setRawAttributes( [ 'content' => $rawJson ], true );
+
+        BlockRenderer::$throwOnRender = true;
+
+        expect( $model->renderContent() )->toBe( '' );
     } );
 
     test( 'rendered_content swallows renderer failures and falls back to the content column', function (): void {

--- a/tests/Unit/ContentTypes/HasRenderedBlockContentTest.php
+++ b/tests/Unit/ContentTypes/HasRenderedBlockContentTest.php
@@ -1,0 +1,173 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditorRendererBlade {
+
+    if ( ! class_exists( BlockRenderer::class, false ) ) {
+        /**
+         * Test-only stand-in for the visual-editor renderer-blade BlockRenderer.
+         *
+         * cms-framework does not depend on `visual-editor-renderer-blade`,
+         * so the real class is not autoloadable in this suite. Declaring a
+         * sibling class under the same FQCN lets the trait's `class_exists`
+         * gate succeed in the "renderer installed" scenarios; tests that
+         * exercise the renderer-missing path use a separate FQCN override
+         * on the trait constant.
+         */
+        class BlockRenderer
+        {
+            /** @var array<int, array<string, mixed>>|null */
+            public static ?array $lastTree = null;
+
+            public static string $stubOutput = '<p>stubbed render</p>';
+
+            public static bool $throwOnRender = false;
+
+            /**
+             * @param  array<int, array<string, mixed>>  $tree
+             */
+            public function render( array $tree ): string
+            {
+                self::$lastTree = $tree;
+
+                if ( self::$throwOnRender ) {
+                    throw new \RuntimeException( 'stub renderer failure' );
+                }
+
+                return self::$stubOutput;
+            }
+        }
+    }
+}
+
+namespace {
+
+    use ArtisanPackUI\CMSFramework\Modules\Blog\Models\Post;
+    use ArtisanPackUI\CMSFramework\Modules\Pages\Models\Page;
+    use ArtisanPackUI\CMSFramework\Tests\Support\TestUser;
+    use ArtisanPackUI\VisualEditorRendererBlade\BlockRenderer;
+
+    beforeEach( function (): void {
+        $this->artisan( 'migrate', ['--database' => 'testing'] );
+
+        BlockRenderer::$lastTree      = null;
+        BlockRenderer::$stubOutput    = '<p>stubbed render</p>';
+        BlockRenderer::$throwOnRender = false;
+    } );
+
+    test( 'rendered_content accessor walks block tree through the renderer', function (): void {
+        $user = TestUser::create( [
+            'name'     => 'Author',
+            'email'    => 'author@example.com',
+            'password' => 'password',
+        ] );
+
+        $blocks = [
+            ['blockName' => 'core/paragraph', 'attrs' => [], 'innerHTML' => '<p>Hi</p>'],
+        ];
+
+        $post = Post::create( [
+            'title'     => 'Rendered Post',
+            'slug'      => 'rendered-post',
+            'author_id' => $user->id,
+            'status'    => 'draft',
+        ] );
+
+        $post->setBlockContent( $blocks );
+        $post->save();
+
+        expect( $post->fresh()->rendered_content )->toBe( '<p>stubbed render</p>' );
+        expect( BlockRenderer::$lastTree )->toBe( $blocks );
+    } );
+
+    test( 'renderContent() method returns the same value as the accessor', function (): void {
+        $user = TestUser::create( [
+            'name'     => 'Author',
+            'email'    => 'author@example.com',
+            'password' => 'password',
+        ] );
+
+        $page = Page::create( [
+            'title'     => 'Rendered Page',
+            'slug'      => 'rendered-page',
+            'author_id' => $user->id,
+            'status'    => 'draft',
+        ] );
+
+        $page->setBlockContent( [
+            ['blockName' => 'core/heading', 'attrs' => ['level' => 2], 'innerHTML' => '<h2>Hello</h2>'],
+        ] );
+        $page->save();
+
+        BlockRenderer::$stubOutput = '<h2>Hello</h2>';
+
+        $fresh = Page::find( $page->id );
+
+        expect( $fresh->renderContent() )->toBe( '<h2>Hello</h2>' );
+        expect( $fresh->rendered_content )->toBe( '<h2>Hello</h2>' );
+    } );
+
+    test( 'rendered_content falls back to the content column when block tree is empty', function (): void {
+        $user = TestUser::create( [
+            'name'     => 'Author',
+            'email'    => 'author@example.com',
+            'password' => 'password',
+        ] );
+
+        $post = Post::create( [
+            'title'     => 'Legacy Post',
+            'slug'      => 'legacy-post',
+            'author_id' => $user->id,
+            'status'    => 'draft',
+            'content'   => '<p>pre-rendered legacy HTML</p>',
+        ] );
+
+        expect( $post->rendered_content )->toBe( '<p>pre-rendered legacy HTML</p>' );
+        // Renderer should NOT have been invoked — the block tree was empty,
+        // so the trait short-circuits to the legacy content column.
+        expect( BlockRenderer::$lastTree )->toBeNull();
+    } );
+
+    test( 'rendered_content returns an empty string when block tree and content are both empty', function (): void {
+        $user = TestUser::create( [
+            'name'     => 'Author',
+            'email'    => 'author@example.com',
+            'password' => 'password',
+        ] );
+
+        $post = Post::create( [
+            'title'     => 'Empty Post',
+            'slug'      => 'empty-post',
+            'author_id' => $user->id,
+            'status'    => 'draft',
+        ] );
+
+        expect( $post->rendered_content )->toBe( '' );
+    } );
+
+    test( 'rendered_content swallows renderer failures and falls back to the content column', function (): void {
+        $user = TestUser::create( [
+            'name'     => 'Author',
+            'email'    => 'author@example.com',
+            'password' => 'password',
+        ] );
+
+        $post = Post::create( [
+            'title'     => 'Failing Render',
+            'slug'      => 'failing-render',
+            'author_id' => $user->id,
+            'status'    => 'draft',
+            'content'   => '<p>fallback HTML</p>',
+        ] );
+
+        $post->setBlockContent( [
+            ['blockName' => 'core/paragraph', 'attrs' => [], 'innerHTML' => '<p>Hi</p>'],
+        ] );
+        $post->save();
+
+        BlockRenderer::$throwOnRender = true;
+
+        expect( $post->fresh()->rendered_content )->toBe( '<p>fallback HTML</p>' );
+    } );
+}

--- a/tests/Unit/OpenApi/OpenApiServiceProviderTest.php
+++ b/tests/Unit/OpenApi/OpenApiServiceProviderTest.php
@@ -36,7 +36,7 @@ test( 'openapi config has default values', function (): void {
 
     expect( $config['enabled'] )->toBeTrue();
     expect( $config['info']['title'] )->toBe( 'ArtisanPack CMS Framework API' );
-    expect( $config['info']['version'] )->toBe( '2.1.0' );
+    expect( $config['info']['version'] )->toBe( '2.2.0' );
     expect( $config['ui_path'] )->toBe( '/docs/api/cms' );
     expect( $config['document_path'] )->toBe( '/docs/api/cms.json' );
 } );


### PR DESCRIPTION
## Release Information

- **Release Version:** v2.2.0
- **Release Date:** 2026-06-04
- **Release Type:** Minor
- **Release Branch:** `release/2.2`
- **Target Branch:** `main`

## Release Summary

A minor maintenance release that completes the `artisanpack-ui/visual-editor` integration story started in v2.0.0: `Post` and `Page` now expose the accessors visual-editor's `PostResolver` needs to stamp `core/post-content` and `core/navigation` blocks (`rendered_content`, `previous_post`, `next_post`), the bridge is now formally documented in the README, and the GitHub Actions workflows have been hardened with least-privilege token scopes.

## Changelog

### Added

- **`Post::previous_post` and `Post::next_post` accessors** (#157, closes #154) — published-adjacent post lookups for visual-editor's `PostResolver` to stamp navigation block payloads. Ordered by `published_at` with `id` as a deterministic tie-breaker.
- **`HasRenderedBlockContent` concern on `Post` and `Page`** (#156, closes #155) — exposes a `rendered_content` accessor so `PostResolver` can stamp the `_resolvedContent` HTML payload directly from the model.
- **"Using with the visual editor" README section** (#159, closes #150) — documents the opt-in bridge to `artisanpack-ui/visual-editor`, including the `block_content` column, `HasBlockContent` polyfill, `_resolved*` attribute flow, and the new `previous_post` / `next_post` / `rendered_content` accessors.

### Security

- **Hardened CI and release GitHub Actions workflows** (#158, closes #140) — added least-privilege `permissions:` blocks to `.github/workflows/ci.yml` and `.github/workflows/release.yml` so workflow tokens no longer inherit broad write scopes by default.

## Issues and Pull Requests

**Issues Fixed:**
- Closes #140
- Closes #150
- Closes #154
- Closes #155

**Related PRs:**
- #156
- #157
- #158
- #159

## Breaking Changes

- [x] No breaking changes
- [ ] Breaking changes documented below

## Testing Checklist

- [x] All automated tests passing (992 passed, 7 skipped, 2562 assertions)
- [x] Code lint clean (`php-cs-fixer fix` no changes)
- [x] Security scan completed (see Dependency Notes)
- [ ] Manual testing completed
- [ ] Tested in staging environment

**Testing notes:**

`./vendor/bin/pest` → 992 passed, 7 skipped, 0 failures. OpenAPI version assertion updated to `2.2.0`.

## Documentation Checklist

- [x] CHANGELOG updated — `[Unreleased]` rolled to `[2.2.0] - 2026-06-04`, new empty `[Unreleased]` section added
- [x] README updated — added `PostResolver accessors` subsection to "Using with the visual editor" documenting `rendered_content`, `previous_post`, `next_post`, `comments_count`, `comments_url`
- [x] API documentation updated — OpenAPI `info.version` bumped to `2.2.0` in `config/cms-framework.php` and the `OpenApiServiceProvider` default
- [ ] Migration guide written (not needed — no breaking changes)
- [x] Release notes written (this PR)

## Pre-Release Checklist

- [x] Version number updated in all necessary files (composer.json, config/cms-framework.php, src/Modules/OpenApi/Providers/OpenApiServiceProvider.php default, tests)
- [ ] Git tag prepared: `v2.2.0` (post-merge)
- [x] Release branch created/updated: `release/2.2`
- [x] Dependencies updated and tested (`composer.lock` re-synced)
- [ ] Stakeholders notified

## Dependency Notes

`composer audit` reports **2 upstream advisories** in transitive Symfony dependencies. Neither is in cms-framework code and both await upstream patched versions in the Laravel 12 dependency tree:

- `symfony/http-foundation` — CVE-2026-48736 (`IpUtils::PRIVATE_SUBNETS` omits IPv6 transition forms)
- `symfony/routing` — CVE-2026-48784 (`UrlGenerator` dot-segment encoding skips every other chained `../`)

These are tracked for the next Laravel framework bump and do not block this release.

## Post-Release Tasks

- [ ] Tag created: `v2.2.0`
- [ ] Release notes published
- [ ] Bump `artisanpack-ui/cms-framework` constraint in `artisanpack-ui/visual-editor` to `^2.2`

## Notes

This release is the cms-framework half of the visual-editor `PostResolver` contract. The visual-editor side (which reads the new `previous_post` / `next_post` / `rendered_content` accessors) ships alongside as part of `release/1.0`. Both packages remain loosely coupled — every cms-framework hook into the editor is still guarded by `class_exists(\ArtisanPackUI\VisualEditor\VisualEditor::class)`.

---

**Release Manager:** @jacobmartella

**For Reviewers:**
- Verify all checklist items completed
- Review changelog accuracy against `git log main..release/2.2`
- Confirm version numbers consistent (composer.json, config, OpenApi default, test assertions)
- Confirm no breaking changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added previous/next post navigation and a rendered_content attribute for posts and pages

* **Documentation**
  * New visual editor integration guide in README and CHANGELOG entry for v2.2.0

* **Security**
  * CI and release workflows restricted to least-privilege permissions

* **Tests**
  * Added unit tests covering post adjacency, rendered content behavior, and OpenAPI version default

* **Chores**
  * Package and OpenAPI version bumped to 2.2.0
<!-- end of auto-generated comment: release notes by coderabbit.ai -->