### PR TITLE
fix: rename update:perform --version flag to --target-version

### DIFF
--- a/src/Modules/Core/Updates/Console/PerformUpdateCommand.php
+++ b/src/Modules/Core/Updates/Console/PerformUpdateCommand.php
@@ -25,7 +25,7 @@ class PerformUpdateCommand extends Command
      * @var string
      */
     protected $signature = 'update:perform
-                            {--version= : Specific version to update to (default: latest)}
+                            {--target-version= : Specific version to update to (default: latest)}
                             {--force : Skip confirmation prompt}';
 
     /**
@@ -54,7 +54,7 @@ class PerformUpdateCommand extends Command
                 return self::SUCCESS;
             }
 
-            $version = $this->option( 'version' ) ?? $updateInfo->latestVersion;
+            $version = $this->option( 'target-version' ) ?? $updateInfo->latestVersion;
 
             // Show update information
             $this->newLine();

--- a/tests/Feature/Updates/UpdateFlowTest.php
+++ b/tests/Feature/Updates/UpdateFlowTest.php
@@ -113,6 +113,32 @@ class UpdateFlowTest extends TestCase
     }
 
     /**
+     * Test that update:perform does not collide with the global --version flag.
+     *
+     * Symfony Console reserves --version/-V on every Application, so the custom
+     * flag must be named differently (e.g. --target-version). Regression test
+     * for the option-already-exists exception thrown at command registration.
+     *
+     * @since 2.2.1
+     */
+    public function test_update_perform_uses_target_version_option(): void
+    {
+        $command    = Artisan::all()['update:perform'];
+        $definition = $command->getDefinition();
+
+        $this->assertTrue(
+            $definition->hasOption( 'target-version' ),
+            'update:perform must expose --target-version (renamed to avoid Symfony --version global collision).',
+        );
+        $this->assertTrue( $definition->getOption( 'target-version' )->acceptValue() );
+
+        $this->assertFalse(
+            $definition->hasOption( 'version' ),
+            'update:perform must not declare --version; it collides with the Symfony Application global flag.',
+        );
+    }
+
+    /**
      * Test cache clearing.
      *
      * @since 1.0.0


### PR DESCRIPTION
## Description

`PerformUpdateCommand` declared `--version` as a custom Artisan option, but Symfony Console reserves `--version`/`-V` as a global flag on every `Application`. As soon as the command was discoverable, `php artisan ...` threw `An option named "version" already exists.` at command-registration time — breaking every Artisan invocation in host apps, not just `update:perform`.

This PR renames the option to `--target-version` (and updates the corresponding `$this->option()` lookup). The Symfony global `-V, --version` still works as expected.

**Closes:** #162

## Type of Change

- [x] Bug fix (fixes an issue)

## Related Issue

**Issue:** #162

## Motivation and Context

Without this fix, the `Updates` module is unusable from the CLI — and worse, it poisons the entire `php artisan` namespace whenever the command is registered. The in-app "Update now" button is unaffected because it calls `ApplicationUpdateManager::performUpdate()` directly, but ops/CLI usage is fully blocked.

`--version` was unreachable in practice, so renaming it is not a breaking change for any working caller. `--target-version` is more explicit about intent and avoids the collision.

## Changes Made

- Renamed `--version` to `--target-version` in `PerformUpdateCommand::$signature`.
- Updated `$this->option( 'version' )` to `$this->option( 'target-version' )`.
- Added regression test `test_update_perform_uses_target_version_option` to `tests/Feature/Updates/UpdateFlowTest.php` confirming the renamed option is present and the colliding name is not redeclared on the command definition.

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS (Darwin 25.5.0)
- Browser (if applicable): n/a (CLI-only)
- PHP Version: 8.4.3
- Project Version: `artisanpack-ui/cms-framework` `release/2.2.1`

**Tests Performed:**
1. `./vendor/bin/pest tests/Feature/Updates/UpdateFlowTest.php` — all 8 tests passing (20 assertions), including the new regression test.
2. Linked the branch into `~/Herd/jmwd-keystone-cms` via path repository; ran `php artisan list` — no longer throws `An option named "version" already exists`.
3. `php artisan update:perform --help` — now shows `--target-version[=TARGET-VERSION]` alongside the standard Symfony `-V, --version`.
4. `php artisan update:perform --target-version=99.99.99 --force` — flag parses correctly; command runs through its handler (fails only at the unrelated `UPDATE_SOURCE_URL` check, which is expected in the test host).

## Accessibility Tests Run

- [ ] Keyboard navigation tested
- [ ] Screen reader tested
- [ ] Color contrast verified
- [ ] ARIA labels checked

**Details:** N/A — CLI-only change with no UI surface.

## Tests Added

- [ ] Unit tests added/updated
- [x] Integration tests added/updated
- [x] All tests passing

**Test details:** Added `test_update_perform_uses_target_version_option` to `UpdateFlowTest` asserting the command exposes `--target-version` and does not redeclare `--version` on its own input definition.

## Documentation

- [x] Inline code documentation added
- [ ] README updated
- [ ] Wiki updated
- [ ] API documentation updated

**Documentation details:** New test method carries a PHPDoc block explaining the Symfony collision and pointing future readers at the root cause.

## Screenshots

N/A.

## Pre-Submission Checklist

- [x] Followed contributing guidelines
- [x] Checked for other open PRs for same update
- [x] Code passes all tests
- [x] Code has been linted
- [x] Accessibility tests completed
- [x] Code follows project style guide
- [x] Self-review completed
- [x] Comments added for complex code
- [x] No new warnings generated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the `update:perform` console command to use `--target-version` option instead of `--version`, resolving conflicts with the global version flag.

* **Tests**
  * Added integration test to verify the `--target-version` option is properly exposed in the update command.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->