### PR TITLE
Release v2.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+## [2.2.1] - 2026-06-07
+
+### Fixed
+
+- **`update:perform` command `--version` flag collision** ([#162](https://github.com/ArtisanPack-UI/cms-framework/issues/162), [#163](https://github.com/ArtisanPack-UI/cms-framework/pull/163)) — Symfony Console reserves `--version`/`-V` as a global flag on every `Application`, so declaring `--version` on `PerformUpdateCommand` threw "An option named version already exists" at command-registration time, breaking every `php artisan ...` invocation in host apps as soon as the command was discoverable. Renamed the custom option to `--target-version` (and updated the corresponding `$this->option()` lookup). Added a regression test that verifies the command exposes `--target-version` and does not redeclare `--version` on its own definition.
+
 ## [2.2.0] - 2026-06-04
 
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "description": "Adds in the back end support for building a CMS with any front end framework.",
   "type": "library",
   "license": "MIT",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "autoload": {
     "psr-4": {
       "ArtisanPackUI\\CMSFramework\\": "src/",

--- a/config/cms-framework.php
+++ b/config/cms-framework.php
@@ -32,7 +32,7 @@ return [
 
         'info' => [
             'title'       => 'ArtisanPack CMS Framework API',
-            'version'     => '2.2.0',
+            'version'     => '2.2.1',
             'description' => 'RESTful API for the ArtisanPack CMS Framework. Provides endpoints for managing posts, pages, content types, users, roles, permissions, settings, notifications, plugins, and themes.',
         ],
 

--- a/src/Modules/Core/Updates/Console/PerformUpdateCommand.php
+++ b/src/Modules/Core/Updates/Console/PerformUpdateCommand.php
@@ -25,7 +25,7 @@ class PerformUpdateCommand extends Command
      * @var string
      */
     protected $signature = 'update:perform
-                            {--version= : Specific version to update to (default: latest)}
+                            {--target-version= : Specific version to update to (default: latest)}
                             {--force : Skip confirmation prompt}';
 
     /**
@@ -54,7 +54,7 @@ class PerformUpdateCommand extends Command
                 return self::SUCCESS;
             }
 
-            $version = $this->option( 'version' ) ?? $updateInfo->latestVersion;
+            $version = $this->option( 'target-version' ) ?? $updateInfo->latestVersion;
 
             // Show update information
             $this->newLine();

--- a/src/Modules/OpenApi/Providers/OpenApiServiceProvider.php
+++ b/src/Modules/OpenApi/Providers/OpenApiServiceProvider.php
@@ -113,7 +113,7 @@ class OpenApiServiceProvider extends ServiceProvider
         $scrambleConfig['ui']       = ['title' => $info['title'] ?? 'ArtisanPack CMS Framework API'];
 
         $scrambleConfig['info'] = [
-            'version'     => $info['version'] ?? '2.2.0',
+            'version'     => $info['version'] ?? '2.2.1',
             'description' => $info['description'] ?? '',
         ];
 

--- a/tests/Feature/Updates/UpdateFlowTest.php
+++ b/tests/Feature/Updates/UpdateFlowTest.php
@@ -113,6 +113,32 @@ class UpdateFlowTest extends TestCase
     }
 
     /**
+     * Test that update:perform does not collide with the global --version flag.
+     *
+     * Symfony Console reserves --version/-V on every Application, so the custom
+     * flag must be named differently (e.g. --target-version). Regression test
+     * for the option-already-exists exception thrown at command registration.
+     *
+     * @since 2.2.1
+     */
+    public function test_update_perform_uses_target_version_option(): void
+    {
+        $command    = Artisan::all()['update:perform'];
+        $definition = $command->getDefinition();
+
+        $this->assertTrue(
+            $definition->hasOption( 'target-version' ),
+            'update:perform must expose --target-version (renamed to avoid Symfony --version global collision).',
+        );
+        $this->assertTrue( $definition->getOption( 'target-version' )->acceptValue() );
+
+        $this->assertFalse(
+            $definition->hasOption( 'version' ),
+            'update:perform must not declare --version; it collides with the Symfony Application global flag.',
+        );
+    }
+
+    /**
      * Test cache clearing.
      *
      * @since 1.0.0

--- a/tests/Unit/OpenApi/OpenApiServiceProviderTest.php
+++ b/tests/Unit/OpenApi/OpenApiServiceProviderTest.php
@@ -36,7 +36,7 @@ test( 'openapi config has default values', function (): void {
 
     expect( $config['enabled'] )->toBeTrue();
     expect( $config['info']['title'] )->toBe( 'ArtisanPack CMS Framework API' );
-    expect( $config['info']['version'] )->toBe( '2.2.0' );
+    expect( $config['info']['version'] )->toBe( '2.2.1' );
     expect( $config['ui_path'] )->toBe( '/docs/api/cms' );
     expect( $config['document_path'] )->toBe( '/docs/api/cms.json' );
 } );


### PR DESCRIPTION
## Release Information

- **Release Version:** v2.2.1
- **Release Date:** 2026-06-07
- **Release Type:** Patch
- **Release Branch:** `release/2.2.1`
- **Target Branch:** `main`

## Release Summary

Patch release fixing a critical regression where the `update:perform` Artisan command's `--version` option collided with Symfony Console's reserved global `--version`/`-V` flag, causing every `php artisan ...` invocation in host apps to throw "An option named version already exists" as soon as the command was discoverable.

## Changelog

### Fixed

- **`update:perform` command `--version` flag collision** (#162, #163) — Renamed the custom option to `--target-version` (and updated the corresponding `$this->option()` lookup). Added a regression test that verifies the command exposes `--target-version` and does not redeclare `--version` on its own definition.

## Issues and Pull Requests

**Issues Fixed:**
- Closes #162

**Related PRs:**
- #163

## Breaking Changes

- [x] No breaking changes

Note: The `update:perform` command's `--version` flag has been renamed to `--target-version`. Since the command was previously unusable (it caused every Artisan invocation to crash), no real-world callers depend on the old flag.

## Testing Checklist

- [x] All automated tests passing (994 passed, 7 skipped)
- [x] Manual testing completed
- [ ] Accessibility tests passing
- [ ] Performance tests passing (if applicable)
- [x] Security scan completed
- [ ] Tested in staging environment
- [ ] Database migrations tested (if applicable)

**Testing notes:** Full Pest suite passes (994/994). Only fix in this release is the flag rename + regression test for #162.

## Documentation Checklist

- [x] CHANGELOG updated
- [ ] README updated (if needed) — not needed for this patch
- [ ] API documentation updated (if needed) — not needed for this patch
- [ ] Migration guide written (if breaking changes)
- [x] Release notes written

## Pre-Release Checklist

- [x] Version number updated in all necessary files (composer.json, config/cms-framework.php, OpenApiServiceProvider fallback)
- [ ] Git tag prepared: `v2.2.1`
- [x] Release branch created/updated: `release/2.2.1`
- [x] Dependencies updated and tested (lock file in sync)
- [ ] Build artifacts generated
- [ ] Deployment plan reviewed
- [ ] Rollback plan prepared

## Dependency Notes

**Security audit:** 2 advisories on transitive Symfony dependencies (not direct dependencies):
- `symfony/http-foundation` — CVE-2026-48736 (IPv6 transition forms in `IpUtils::PRIVATE_SUBNETS`)
- `symfony/routing` — CVE-2026-48784 (UrlGenerator dot-segment encoding)

These are inherited via Laravel and will resolve when Laravel pulls in patched Symfony versions. Not blocking for this patch release.

**Lock file:** Synced and validated.

## Notes

Pre-existing PHPCS issues (2,130 errors across 341 files) are not addressed in this release — they predate this branch and are out of scope for a one-fix patch.

---

**Release Manager:** @jacobmartella

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release 2.2.1

* **Bug Fixes**
  * Renamed the `update:perform` command option from `--version` to `--target-version` to prevent conflicts with Symfony Console's reserved global flag.

* **Tests**
  * Added regression test ensuring `--target-version` option is properly exposed in the update command.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->