### PR TITLE
enhancement: widen laravel/tinker constraint to allow v3 (Laravel 13 support)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
     "php": "^8.2",
     "illuminate/support": "^12.17.0|^13.0",
     "laravel/framework": "^12.0|^13.0",
-    "laravel/tinker": "^2.10.1",
+    "laravel/tinker": "^2.10.1|^3.0",
     "artisanpack-ui/accessibility": "^2.1.0",
     "artisanpack-ui/security": "^1.0.3|^2.0",
     "artisanpack-ui/core": "^1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "bf6c11328c8607edbdfa9f406cfaf036",
+    "content-hash": "495564de5c3857e1421b0c8ab71b28d0",
     "packages": [
         {
             "name": "artisanpack-ui/accessibility",
@@ -12233,5 +12233,5 @@
         "php": "^8.2"
     },
     "platform-dev": {},
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }


### PR DESCRIPTION
## Description

Widens the `laravel/tinker` constraint in `composer.json` from `^2.10.1` to `^2.10.1|^3.0` so consumer apps on Laravel 13 can install `cms-framework` without a composer resolution conflict.

`laravel/tinker` v2 caps at `illuminate/* ^12.0`. Laravel 13 consumer apps require `laravel/tinker ^3.0`, which the current pin blocked even though the framework constraint (`laravel/framework: ^12.0|^13.0`) already permits L13.

**Closes:** #167

## Type of Change

- [x] Enhancement (improves existing functionality)

## Related Issue

**Issue:** #167

## Motivation and Context

Surfaced while bumping Keystone CMS to Laravel 13. Composer resolution failed with:

```
artisanpack-ui/cms-framework 2.2.2 requires laravel/tinker ^2.10.1
  -> conflicts with root require laravel/tinker ^3.0
```

`laravel/tinker` is not referenced anywhere in `src/` or `tests/` — it is a top-level app concern, not a real package dependency on tinker internals. Widening the constraint unblocks Laravel 13 adoption with no runtime impact on cms-framework itself.

## Changes Made

- `composer.json`: widen `laravel/tinker` from `^2.10.1` to `^2.10.1|^3.0`
- `composer.lock`: regenerated (content-hash + plugin-api-version metadata only — no transitive dependency upgrades)

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS (Darwin 25.5.0)
- PHP Version: 8.4.3
- Project Version: 2.2.2 → release/2.2.3

**Tests Performed:**
1. `composer validate --strict --no-check-publish` — passes
2. `composer update laravel/tinker` — resolves cleanly, no unrelated upgrades in lockfile
3. `php -d memory_limit=512M vendor/bin/pest` — **995 passed, 7 skipped, 2569 assertions**
4. Manually verified `src/` and `tests/` contain no references to tinker internals

## Accessibility Tests Run

N/A — composer constraint change with no UI surface.

- [x] Keyboard navigation tested (N/A)
- [x] Screen reader tested (N/A)
- [x] Color contrast verified (N/A)
- [x] ARIA labels checked (N/A)

## Tests Added

No new tests — this is a composer constraint widening only, with no code paths to exercise. Existing 995 tests pass.

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] All tests passing

## Documentation

No documentation changes required — public API unchanged.

- [ ] Inline code documentation added
- [ ] README updated
- [ ] Wiki updated
- [ ] API documentation updated

## Pre-Submission Checklist

- [x] Followed contributing guidelines
- [x] Checked for other open PRs for same update
- [x] Code passes all tests
- [x] Code has been linted (no PHP code changed)
- [x] Accessibility tests completed (N/A)
- [x] Code follows project style guide
- [x] Self-review completed
- [x] No new warnings generated

## Notes on Acceptance Criteria

- [x] `composer.json` `require.laravel/tinker` accepts `^3.0`
- [ ] CI matrix (if present) includes a Laravel 13 + tinker 3 row — **N/A**: the existing CI matrix (`.github/workflows/ci.yml`) only varies PHP versions, with no Laravel-version matrix to extend.
- [ ] Tagged release published to Packagist — out of scope for this PR; handled by release process.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded Laravel Tinker compatibility to support versions 2.10.1 and 3.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->