### PR TITLE
Release v2.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+## [2.2.3] - 2026-06-14
+
+### Changed
+
+- **Widened `laravel/tinker` constraint to allow v3** ([#167](https://github.com/ArtisanPack-UI/cms-framework/issues/167), [#168](https://github.com/ArtisanPack-UI/cms-framework/pull/168)) — `composer.json` `require.laravel/tinker` is now `^2.10.1|^3.0`. `laravel/tinker` v2 caps at `illuminate/* ^12.0`, so Laravel 13 consumer apps require `laravel/tinker ^3.0`; the previous pin blocked the upgrade even though the framework constraint already permitted Laravel 13. No code changes — `tinker` is not referenced in `src/` or `tests/`. Existing Laravel 12 users on `laravel/tinker ^2.10.1` are unaffected.
+
 ## [2.2.2] - 2026-06-09
 
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "description": "Adds in the back end support for building a CMS with any front end framework.",
   "type": "library",
   "license": "MIT",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "autoload": {
     "psr-4": {
       "ArtisanPackUI\\CMSFramework\\": "src/",

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
     "php": "^8.2",
     "illuminate/support": "^12.17.0|^13.0",
     "laravel/framework": "^12.0|^13.0",
-    "laravel/tinker": "^2.10.1",
+    "laravel/tinker": "^2.10.1|^3.0",
     "artisanpack-ui/accessibility": "^2.1.0",
     "artisanpack-ui/security": "^1.0.3|^2.0",
     "artisanpack-ui/core": "^1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "bf6c11328c8607edbdfa9f406cfaf036",
+    "content-hash": "495564de5c3857e1421b0c8ab71b28d0",
     "packages": [
         {
             "name": "artisanpack-ui/accessibility",
@@ -12233,5 +12233,5 @@
         "php": "^8.2"
     },
     "platform-dev": {},
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "495564de5c3857e1421b0c8ab71b28d0",
+    "content-hash": "ab9f8b35abd79d21e96ed037564dd6c4",
     "packages": [
         {
             "name": "artisanpack-ui/accessibility",

--- a/config/cms-framework.php
+++ b/config/cms-framework.php
@@ -32,7 +32,7 @@ return [
 
         'info' => [
             'title'       => 'ArtisanPack CMS Framework API',
-            'version'     => '2.2.2',
+            'version'     => '2.2.3',
             'description' => 'RESTful API for the ArtisanPack CMS Framework. Provides endpoints for managing posts, pages, content types, users, roles, permissions, settings, notifications, plugins, and themes.',
         ],
 

--- a/src/Modules/OpenApi/Providers/OpenApiServiceProvider.php
+++ b/src/Modules/OpenApi/Providers/OpenApiServiceProvider.php
@@ -113,7 +113,7 @@ class OpenApiServiceProvider extends ServiceProvider
         $scrambleConfig['ui']       = ['title' => $info['title'] ?? 'ArtisanPack CMS Framework API'];
 
         $scrambleConfig['info'] = [
-            'version'     => $info['version'] ?? '2.2.2',
+            'version'     => $info['version'] ?? '2.2.3',
             'description' => $info['description'] ?? '',
         ];
 

--- a/tests/Unit/OpenApi/OpenApiServiceProviderTest.php
+++ b/tests/Unit/OpenApi/OpenApiServiceProviderTest.php
@@ -36,7 +36,7 @@ test( 'openapi config has default values', function (): void {
 
     expect( $config['enabled'] )->toBeTrue();
     expect( $config['info']['title'] )->toBe( 'ArtisanPack CMS Framework API' );
-    expect( $config['info']['version'] )->toBe( '2.2.2' );
+    expect( $config['info']['version'] )->toBe( '2.2.3' );
     expect( $config['ui_path'] )->toBe( '/docs/api/cms' );
     expect( $config['document_path'] )->toBe( '/docs/api/cms.json' );
 } );


### PR DESCRIPTION
## Release Information

- **Release Version:** v2.2.3
- **Release Date:** 2026-06-14
- **Release Type:** Patch
- **Release Branch:** `release/2.2.3`
- **Target Branch:** `main`

## Release Summary

Single-issue patch release that widens the `laravel/tinker` constraint to allow v3 so consumer apps on Laravel 13 can install `cms-framework` without a composer resolution conflict. No code changes — composer constraint widening only.

## Changelog

### Added
- None.

### Changed
- **Widened `laravel/tinker` constraint to allow v3** ([#167](https://github.com/ArtisanPack-UI/cms-framework/issues/167), [#168](https://github.com/ArtisanPack-UI/cms-framework/pull/168)) — `composer.json` `require.laravel/tinker` is now `^2.10.1|^3.0`. `laravel/tinker` v2 caps at `illuminate/* ^12.0`, so Laravel 13 consumer apps require `laravel/tinker ^3.0`; the previous pin blocked the upgrade even though the framework constraint already permitted Laravel 13. `tinker` is not referenced in `src/` or `tests/`. Existing Laravel 12 users on `laravel/tinker ^2.10.1` are unaffected.

### Deprecated
- None.

### Removed
- None.

### Fixed
- None.

### Security
- None.

## Issues and Pull Requests

**Issues Fixed:**
- Closes #167

**Related PRs:**
- #168 (merged — `enhancement: widen laravel/tinker constraint to allow v3`)

## Breaking Changes

- [x] No breaking changes
- [ ] Breaking changes documented below

Existing Laravel 12 consumer apps on `laravel/tinker ^2.10.1` continue to resolve identically. The widened constraint is strictly additive.

## Testing Checklist

- [x] All automated tests passing (995 passed, 7 skipped, 2569 assertions)
- [x] Manual testing completed (issue #167 manual verification confirmed unblock)
- [x] Accessibility tests passing (N/A — composer constraint change with no UI surface)
- [x] Performance tests passing (N/A)
- [x] Security scan completed (`composer audit`: 0 advisories)
- [ ] Tested in staging environment
- [x] Database migrations tested (N/A — no migrations in this release)

**Testing notes:**

- Full `pest` suite passes locally (PHP 8.4.22, `memory_limit=512M`).
- `composer audit` reports no known vulnerabilities.
- `composer validate` clean (warns only on the optional `version` field, which is required by the project's release workflow).

## Documentation Checklist

- [x] CHANGELOG updated (2.2.3 section added with date 2026-06-14)
- [x] README updated (N/A — no public API change)
- [x] API documentation updated (OpenAPI `info.version` fallback bumped to 2.2.3)
- [x] Migration guide written (N/A — no breaking changes)
- [x] Release notes written (this PR description)
- [x] Wiki updated (N/A — change does not affect documented surface)

## Pre-Release Checklist

- [x] Version number updated in all necessary files
  - `composer.json` → `2.2.3`
  - `config/cms-framework.php` (OpenAPI `info.version`) → `2.2.3`
  - `src/Modules/OpenApi/Providers/OpenApiServiceProvider.php` (fallback default) → `2.2.3`
  - `tests/Unit/OpenApi/OpenApiServiceProviderTest.php` (assertion) → `2.2.3`
  - `CHANGELOG.md` → `[2.2.3] - 2026-06-14`
- [x] Git tag prepared: `v2.2.3` (to be created on merge by release workflow)
- [x] Release branch created/updated: `release/2.2.3`
- [x] Dependencies updated and tested (`composer update --lock` clean)
- [x] Build artifacts generated (N/A — library package)
- [x] Deployment plan reviewed (Packagist auto-publish via `.github/workflows/release.yml`)
- [x] Rollback plan prepared (revert tag; consumers can pin to `2.2.2`)
- [x] Stakeholders notified

### Dependency audit

- **Lock file**: in sync with `composer.json`
- **Security**: `composer audit` → no vulnerabilities found
- **Outdated direct (patch/minor)**: `artisanpack-ui/security 2.0.1 → 2.0.2`, `dedoc/scramble 0.13.26 → 0.13.27`, `friendsofphp/php-cs-fixer 3.95.5 → 3.95.7` — not addressed in this patch release; safe to defer.
- **Outdated direct (major)**: `laravel/framework 12.62.0 → 13.15.0`, `laravel/tinker 2.11.1 → 3.0.2`, `orchestra/testbench 10.11.0 → 11.1.0`, `pestphp/pest 3.8.6 → 4.7.3`, `pestphp/pest-plugin-laravel 3.2.0 → 4.1.0`, `squizlabs/php_codesniffer 3.11.3 → 4.0.1` — Laravel 13 / tinker 3 are now installable in consumer apps because of this release, but the dev environment is held back deliberately to keep the Laravel 12 baseline green; out of scope for this patch.

## Deployment

**Deployment steps:**
1. Merge this PR to `main`.
2. `.github/workflows/release.yml` picks up the merge, tags `v2.2.3`, and publishes to Packagist.
3. Verify the release appears at https://packagist.org/packages/artisanpack-ui/cms-framework.

**Rollback plan:**
1. Delete the `v2.2.3` tag and the Packagist release.
2. Consumers can pin to `^2.2.2` to continue on the previous line; no schema or API changes to undo.

**Configuration changes:**
- None.

**Environment variables:**
- None.

## Post-Release Tasks

- [ ] Tag created: `v2.2.3`
- [ ] Release notes published
- [ ] Documentation deployed
- [ ] Announcement sent
- [ ] Monitoring verified
- [ ] Previous version support documented

## Notes

Pre-existing PHPCS noise (~2130 errors across 341 files) is identical on `main` and `release/2.2.3` — a known rule conflict between PHP-CS-Fixer's WordPress-style spacing and PHPCS's `NoSpaceBeforeOperator` sniff. CI already has `continue-on-error: true` on the PHPCS step. Not introduced by this release.

---

**Release Manager:** @jmartella

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Version bumped to 2.2.3
  * Expanded laravel/tinker dependency constraint from `^2.10.1` to `^2.10.1|^3.0`
  * Updated OpenAPI configuration version to reflect latest release

<!-- end of auto-generated comment: release notes by coderabbit.ai -->