### PR TITLE
feat(ai): CMS content-authoring AI agents (post title, excerpt, tags, category, slug)

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,50 @@ Permissions are registered but not yet enforced by visual-editor's policies — 
 
 cms-framework and visual-editor ship as a version pair — the supported combinations are tracked in visual-editor's [Version compatibility](https://github.com/ArtisanPack-UI/visual-editor/blob/release/1.0/README.md#version-compatibility) matrix. Bumping the major on either package without bumping the partner is unsupported.
 
+## AI features
+
+The framework ships five AI-powered content-authoring agents (added in 2.3.0). Each maps to a feature key in the `artisanpack-ui/ai` foundation and is registered automatically via the service provider's `aiFeatures()` hook — no wiring required in host apps.
+
+| Feature key            | Agent                          | What it does                                                            |
+|------------------------|--------------------------------|-------------------------------------------------------------------------|
+| `cms.post_title`       | `PostTitleSuggestionAgent`     | Generate 3–5 title variants from a draft body.                          |
+| `cms.excerpt`          | `ExcerptGenerationAgent`       | Generate a natural excerpt (default ≤200 chars) from full content.      |
+| `cms.suggest_tags`     | `TagSuggestionAgent`           | Select tags from an existing taxonomy (optionally propose new ones).    |
+| `cms.suggest_category` | `CategorySuggestionAgent`      | Pick a single category (as a slash-delimited path) from a tree.         |
+| `cms.suggest_slug`     | `SlugSuggestionAgent`          | Produce an SEO-friendly slug (short, keyword-forward, no stop words).   |
+
+Every agent honors the feature toggle configured in `artisanpack.ai.features.<key>.enabled` — when the toggle is off, the agent throws `FeatureDisabledException` and no model call is made.
+
+### Trigger surfaces
+
+The same five agents are exposed to every front-end framework:
+
+- **Livewire**: dispatch `ap-cms-ai:{action}` browser events at the `ap-cms-ai-tools` component (`ArtisanPackUI\CMSFramework\Livewire\Ai\AiTools`). Results come back on `ap-cms-ai:{featureKey}:{success|invalid-input|disabled|missing-credentials|error}`.
+- **React / Vue / anything else**: `POST` to the REST endpoints mounted under `/api/v1/cms/ai` (`AiController`). This keeps `@artisanpack-ui/react` and `@artisanpack-ui/vue` framework-agnostic — those packages do NOT need to know anything about CMS AI features.
+
+Available endpoints (all `auth` middleware, JSON body):
+
+| Method | Path                                | Body                                                   |
+|--------|-------------------------------------|--------------------------------------------------------|
+| GET    | `/api/v1/cms/ai/features`           | —                                                      |
+| POST   | `/api/v1/cms/ai/post-title`         | `{ content, tone?, count? }`                           |
+| POST   | `/api/v1/cms/ai/excerpt`            | `{ content, max_chars? }`                              |
+| POST   | `/api/v1/cms/ai/suggest-tags`       | `{ content, available_tags, allow_new?, max_selected? }` |
+| POST   | `/api/v1/cms/ai/suggest-category`   | `{ content, category_tree }`                           |
+| POST   | `/api/v1/cms/ai/suggest-slug`       | `{ title, excerpt?, max_chars? }`                      |
+
+Error responses use consistent status codes: `403 feature_disabled`, `422 invalid_input`, `503 missing_credentials`, `500 internal_error`.
+
+### Requirements
+
+The AI features require `artisanpack-ui/ai ^1.0`. It's declared as a `suggest` in `composer.json` — install it explicitly to opt in:
+
+```bash
+composer require artisanpack-ui/ai:^1.0
+```
+
+Without it, the agents, the Livewire component, and the REST endpoints stay unregistered — the framework boots normally.
+
 ## Experimental Features
 
 The following features are **experimental** in the 1.0.0 release and should be used with caution in production environments:

--- a/composer.json
+++ b/composer.json
@@ -57,7 +57,12 @@
     "orchestra/testbench": "^10.2",
     "artisanpack-ui/code-style": "^1.1",
     "artisanpack-ui/code-style-pint": "^1.1",
-    "dealerdirect/phpcodesniffer-composer-installer": "^1.0"
+    "artisanpack-ui/ai": "^1.0",
+    "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
+    "livewire/livewire": "^3.6"
+  },
+  "suggest": {
+    "artisanpack-ui/ai": "Recommended ^1.0 — enables the AI content-authoring agents (post-title suggestions, excerpt generation, tag/category suggestion, SEO slug suggestion). Without it the `aiFeatures()` service-provider hook is a no-op and the AI trigger surfaces (Livewire component + REST endpoints) stay hidden."
   },
   "config": {
     "allow-plugins": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ab9f8b35abd79d21e96ed037564dd6c4",
+    "content-hash": "c71262b357fb68a3161113c27bec3d58",
     "packages": [
         {
             "name": "artisanpack-ui/accessibility",
@@ -6991,6 +6991,78 @@
     ],
     "packages-dev": [
         {
+            "name": "artisanpack-ui/ai",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ArtisanPack-UI/ai.git",
+                "reference": "082f1cd337742d34b8035d116c6c5ad8e5453fca"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ArtisanPack-UI/ai/zipball/082f1cd337742d34b8035d116c6c5ad8e5453fca",
+                "reference": "082f1cd337742d34b8035d116c6c5ad8e5453fca",
+                "shasum": ""
+            },
+            "require": {
+                "artisanpack-ui/core": "^1.0",
+                "illuminate/support": "^12.0|^13.0",
+                "laravel/ai": "^0.8",
+                "php": "^8.3"
+            },
+            "require-dev": {
+                "artisanpack-ui/code-style": "^1.1",
+                "artisanpack-ui/code-style-pint": "^1.1",
+                "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
+                "friendsofphp/php-cs-fixer": "^3.75",
+                "laravel/pint": "^1.26",
+                "livewire/livewire": "^3.6",
+                "orchestra/testbench": "^10.2|^11.0",
+                "pestphp/pest": "^3.8|^4.0",
+                "pestphp/pest-plugin-laravel": "^3.2|^4.1"
+            },
+            "suggest": {
+                "artisanpack-ui/cms-framework": "Automatically registers AI credentials, features, budget and cache setting groups under the CMS admin surface.",
+                "artisanpack-ui/livewire-ui-components": "Renders the AI Settings and Usage admin surfaces using x-artisanpack-* components.",
+                "livewire/livewire": "Required to mount the AI Settings and Usage dashboard Livewire components under cms-framework's admin nav."
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "aliases": {
+                        "Ai": "ArtisanPackUI\\Ai\\Facades\\Ai"
+                    },
+                    "providers": [
+                        "ArtisanPackUI\\Ai\\AiServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/helpers.php"
+                ],
+                "psr-4": {
+                    "ArtisanPackUI\\Ai\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jacob Martella",
+                    "email": "me@jacobmartella.com"
+                }
+            ],
+            "description": "Shared AI foundation for the ArtisanPack UI ecosystem, built on top of laravel/ai.",
+            "support": {
+                "issues": "https://github.com/ArtisanPack-UI/ai/issues",
+                "source": "https://github.com/ArtisanPack-UI/ai/tree/v1.0.0"
+            },
+            "time": "2026-07-06T21:25:38+00:00"
+        },
+        {
             "name": "artisanpack-ui/code-style",
             "version": "1.1.1",
             "source": {
@@ -7105,6 +7177,157 @@
                 "source": "https://github.com/ArtisanPack-UI/code-style-pint/tree/v1.1.1"
             },
             "time": "2026-06-09T00:58:49+00:00"
+        },
+        {
+            "name": "aws/aws-crt-php",
+            "version": "v1.2.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/awslabs/aws-crt-php.git",
+                "reference": "d71d9906c7bb63a28295447ba12e74723bd3730e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/awslabs/aws-crt-php/zipball/d71d9906c7bb63a28295447ba12e74723bd3730e",
+                "reference": "d71d9906c7bb63a28295447ba12e74723bd3730e",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.8.35||^5.6.3||^9.5",
+                "yoast/phpunit-polyfills": "^1.0"
+            },
+            "suggest": {
+                "ext-awscrt": "Make sure you install awscrt native extension to use any of the functionality."
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "AWS SDK Common Runtime Team",
+                    "email": "aws-sdk-common-runtime@amazon.com"
+                }
+            ],
+            "description": "AWS Common Runtime for PHP",
+            "homepage": "https://github.com/awslabs/aws-crt-php",
+            "keywords": [
+                "amazon",
+                "aws",
+                "crt",
+                "sdk"
+            ],
+            "support": {
+                "issues": "https://github.com/awslabs/aws-crt-php/issues",
+                "source": "https://github.com/awslabs/aws-crt-php/tree/v1.2.7"
+            },
+            "time": "2024-10-18T22:15:13+00:00"
+        },
+        {
+            "name": "aws/aws-sdk-php",
+            "version": "3.388.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/aws/aws-sdk-php.git",
+                "reference": "d48fe5eabeda0cf58025636f78ac8dcd8e60a724"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/d48fe5eabeda0cf58025636f78ac8dcd8e60a724",
+                "reference": "d48fe5eabeda0cf58025636f78ac8dcd8e60a724",
+                "shasum": ""
+            },
+            "require": {
+                "aws/aws-crt-php": "^1.2.3",
+                "ext-json": "*",
+                "ext-pcre": "*",
+                "ext-simplexml": "*",
+                "guzzlehttp/guzzle": "^7.4.5",
+                "guzzlehttp/promises": "^2.0",
+                "guzzlehttp/psr7": "^2.4.5",
+                "mtdowling/jmespath.php": "^2.9.1",
+                "php": ">=8.1",
+                "psr/http-message": "^1.0 || ^2.0",
+                "symfony/filesystem": "^v5.4.45 || ^v6.4.3 || ^v7.1.0 || ^v8.0.0"
+            },
+            "require-dev": {
+                "andrewsville/php-token-reflection": "^1.4",
+                "aws/aws-php-sns-message-validator": "~1.0",
+                "behat/behat": "~3.0",
+                "composer/composer": "^2.7.8",
+                "dms/phpunit-arraysubset-asserts": "^v0.5.0",
+                "doctrine/cache": "~1.4",
+                "ext-dom": "*",
+                "ext-openssl": "*",
+                "ext-sockets": "*",
+                "phpunit/phpunit": "^10.0",
+                "psr/cache": "^2.0 || ^3.0",
+                "psr/simple-cache": "^2.0 || ^3.0",
+                "sebastian/comparator": "^1.2.3 || ^4.0 || ^5.0",
+                "yoast/phpunit-polyfills": "^2.0"
+            },
+            "suggest": {
+                "aws/aws-php-sns-message-validator": "To validate incoming SNS notifications",
+                "doctrine/cache": "To use the DoctrineCacheAdapter",
+                "ext-curl": "To send requests using cURL",
+                "ext-openssl": "Allows working with CloudFront private distributions and verifying received SNS messages",
+                "ext-pcntl": "To use client-side monitoring",
+                "ext-sockets": "To use client-side monitoring"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/functions.php"
+                ],
+                "psr-4": {
+                    "Aws\\": "src/"
+                },
+                "exclude-from-classmap": [
+                    "src/data/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Amazon Web Services",
+                    "homepage": "https://aws.amazon.com"
+                }
+            ],
+            "description": "AWS SDK for PHP - Use Amazon Web Services in your PHP project",
+            "homepage": "https://aws.amazon.com/sdk-for-php",
+            "keywords": [
+                "amazon",
+                "aws",
+                "cloud",
+                "dynamodb",
+                "ec2",
+                "glacier",
+                "s3",
+                "sdk"
+            ],
+            "support": {
+                "forum": "https://github.com/aws/aws-sdk-php/discussions",
+                "issues": "https://github.com/aws/aws-sdk-php/issues",
+                "source": "https://github.com/aws/aws-sdk-php/tree/3.388.2"
+            },
+            "time": "2026-07-08T23:12:50+00:00"
         },
         {
             "name": "brianium/paratest",
@@ -8080,6 +8303,80 @@
             "time": "2025-03-19T14:43:43+00:00"
         },
         {
+            "name": "laravel/ai",
+            "version": "v0.8.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laravel/ai.git",
+                "reference": "b23bc857576d7c4b3bb52ffd8be936ae74005d23"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laravel/ai/zipball/b23bc857576d7c4b3bb52ffd8be936ae74005d23",
+                "reference": "b23bc857576d7c4b3bb52ffd8be936ae74005d23",
+                "shasum": ""
+            },
+            "require": {
+                "aws/aws-sdk-php": "^3.339",
+                "illuminate/console": "^12.0|^13.0",
+                "illuminate/container": "^12.0|^13.0",
+                "illuminate/contracts": "^12.0|^13.0",
+                "illuminate/database": "^12.0|^13.0",
+                "illuminate/filesystem": "^12.0|^13.0",
+                "illuminate/json-schema": "^12.62|^13.15",
+                "illuminate/support": "^12.0|^13.0",
+                "laravel/prompts": "^0.3.6",
+                "laravel/serializable-closure": "^2.0",
+                "php": "^8.3"
+            },
+            "require-dev": {
+                "laravel/mcp": "^0.8",
+                "laravel/pint": "^1.26",
+                "mockery/mockery": "^1.6.12",
+                "orchestra/testbench": "^10.6|^11.0",
+                "pestphp/pest": "^3.0|^4.0",
+                "pestphp/pest-plugin-laravel": "^3.0|^4.0",
+                "phpstan/phpstan": "^2.1"
+            },
+            "suggest": {
+                "laravel/mcp": "Required to use MCP client tools or MCP server tools with Laravel AI agents."
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Laravel\\Ai\\AiServiceProvider"
+                    ]
+                },
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "functions.php"
+                ],
+                "psr-4": {
+                    "Laravel\\Ai\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "The official AI SDK for Laravel.",
+            "homepage": "https://github.com/laravel/ai",
+            "keywords": [
+                "ai",
+                "laravel"
+            ],
+            "support": {
+                "issues": "https://github.com/laravel/ai/issues",
+                "source": "https://github.com/laravel/ai"
+            },
+            "time": "2026-06-10T11:23:35+00:00"
+        },
+        {
             "name": "laravel/pail",
             "version": "v1.2.7",
             "source": {
@@ -8291,6 +8588,82 @@
             "time": "2026-05-27T04:02:01+00:00"
         },
         {
+            "name": "livewire/livewire",
+            "version": "v3.8.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/livewire/livewire.git",
+                "reference": "e77fce60d0615d68dc6b8fafe98a6739d9752a24"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/livewire/livewire/zipball/e77fce60d0615d68dc6b8fafe98a6739d9752a24",
+                "reference": "e77fce60d0615d68dc6b8fafe98a6739d9752a24",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/database": "^10.0|^11.0|^12.0|^13.0",
+                "illuminate/routing": "^10.0|^11.0|^12.0|^13.0",
+                "illuminate/support": "^10.0|^11.0|^12.0|^13.0",
+                "illuminate/validation": "^10.0|^11.0|^12.0|^13.0",
+                "laravel/prompts": "^0.1.24|^0.2|^0.3",
+                "league/mime-type-detection": "^1.9",
+                "php": "^8.1",
+                "symfony/console": "^6.0|^7.0|^8.0",
+                "symfony/http-kernel": "^6.2|^7.0|^8.0"
+            },
+            "require-dev": {
+                "calebporzio/sushi": "^2.1",
+                "laravel/framework": "^10.15.0|^11.0|^12.0|^13.0",
+                "mockery/mockery": "^1.3.1",
+                "orchestra/testbench": "^8.21.0|^9.0|^10.0|^11.0",
+                "orchestra/testbench-dusk": "^8.24|^9.1|^10.0|^11.0",
+                "phpunit/phpunit": "^10.4|^11.5|^12.5",
+                "psy/psysh": "^0.11.22|^0.12"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "aliases": {
+                        "Livewire": "Livewire\\Livewire"
+                    },
+                    "providers": [
+                        "Livewire\\LivewireServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/helpers.php"
+                ],
+                "psr-4": {
+                    "Livewire\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Caleb Porzio",
+                    "email": "calebporzio@gmail.com"
+                }
+            ],
+            "description": "A front-end framework for Laravel.",
+            "support": {
+                "issues": "https://github.com/livewire/livewire/issues",
+                "source": "https://github.com/livewire/livewire/tree/v3.8.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/livewire",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-06-27T03:14:20+00:00"
+        },
+        {
             "name": "mockery/mockery",
             "version": "1.6.12",
             "source": {
@@ -8372,6 +8745,72 @@
                 "source": "https://github.com/mockery/mockery"
             },
             "time": "2024-05-16T03:13:13+00:00"
+        },
+        {
+            "name": "mtdowling/jmespath.php",
+            "version": "2.9.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/jmespath/jmespath.php.git",
+                "reference": "2157c5e50e813ec6a96c1eed3be7f64a20fb32a8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/jmespath/jmespath.php/zipball/2157c5e50e813ec6a96c1eed3be7f64a20fb32a8",
+                "reference": "2157c5e50e813ec6a96c1eed3be7f64a20fb32a8",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2.5 || ^8.0",
+                "symfony/polyfill-mbstring": "^1.17"
+            },
+            "require-dev": {
+                "composer/xdebug-handler": "^3.0.3",
+                "phpunit/phpunit": "^8.5.52"
+            },
+            "bin": [
+                "bin/jp.php"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.9-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/JmesPath.php"
+                ],
+                "psr-4": {
+                    "JmesPath\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Graham Campbell",
+                    "email": "hello@gjcampbell.co.uk",
+                    "homepage": "https://github.com/GrahamCampbell"
+                },
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                }
+            ],
+            "description": "Declaratively specify how to extract elements from a JSON document",
+            "keywords": [
+                "json",
+                "jsonpath"
+            ],
+            "support": {
+                "issues": "https://github.com/jmespath/jmespath.php/issues",
+                "source": "https://github.com/jmespath/jmespath.php/tree/2.9.2"
+            },
+            "time": "2026-07-06T18:56:19+00:00"
         },
         {
             "name": "nunomaduro/collision",

--- a/src/Ai/Agents/CategorySuggestionAgent.php
+++ b/src/Ai/Agents/CategorySuggestionAgent.php
@@ -1,0 +1,272 @@
+<?php
+
+/**
+ * Category suggestion agent.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage CMSFramework
+ *
+ * @since      2.3.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Ai\Agents;
+
+use ArtisanPackUI\Ai\Agents\ArtisanPackAgent;
+use ArtisanPackUI\Ai\Contracts\AgentPrompter;
+use ArtisanPackUI\Ai\Credentials\Credentials;
+use ArtisanPackUI\Ai\Exceptions\FeatureError;
+use JsonException;
+
+/**
+ * Suggest a single category for a post from a hierarchical taxonomy.
+ * Unlike tags, category assignment is usually single-select and picks
+ * the most specific matching node — the returned string is the full
+ * slash-delimited path (e.g. `News/Product Updates`) so parent
+ * disambiguation is unambiguous.
+ *
+ * ## Input
+ *
+ * ```
+ * [
+ *   'content'       => string,   // required
+ *   'category_tree' => array,    // required, nested list of {name, children?}
+ * ]
+ * ```
+ *
+ * ## Output schema
+ *
+ * ```
+ * {
+ *   selected:   string,      // slash-delimited path into category_tree, or "" if none fit
+ *   confidence: float,       // 0.0 - 1.0
+ *   rationale:  string       // single sentence
+ * }
+ * ```
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage CMSFramework
+ *
+ * @since      2.3.0
+ */
+class CategorySuggestionAgent extends ArtisanPackAgent
+{
+    /**
+     * {@inheritDoc}
+     */
+    public string $featureKey = 'cms.suggest_category';
+
+    /**
+     * {@inheritDoc}
+     */
+    public string $package = 'artisanpack-ui/cms-framework';
+
+    /**
+     * {@inheritDoc}
+     */
+    public string $defaultModel = 'claude-haiku-4-5';
+
+    /**
+     * {@inheritDoc}
+     */
+    public function instructions(): string
+    {
+        return <<<'PROMPT'
+You pick a single category for a piece of content from a hierarchical taxonomy.
+
+Requirements:
+- `selected` MUST be a slash-delimited path whose segments each match a `name` from `category_tree`, walked from a root down through any children. Case must match exactly.
+- Prefer the most specific matching leaf. Only pick an ancestor when no descendant fits.
+- If no category fits with reasonable confidence, return `selected` as an empty string, `confidence` as 0, and explain why in `rationale`. Never guess.
+- `confidence` is 0.0 (weak signal) to 1.0 (strong signal).
+- `rationale` is a single sentence tying the choice back to specific evidence in the content.
+
+Return a JSON object with keys: `selected` (string), `confidence` (float 0..1), `rationale` (string).
+PROMPT;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function outputSchema(): array
+    {
+        return [
+            'type'                 => 'object',
+            'additionalProperties' => false,
+            'required'             => [ 'selected', 'confidence', 'rationale' ],
+            'properties'           => [
+                'selected'   => [ 'type' => 'string' ],
+                'confidence' => [
+                    'type'    => 'number',
+                    'minimum' => 0,
+                    'maximum' => 1,
+                ],
+                'rationale'  => [ 'type' => 'string' ],
+            ],
+        ];
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function execute( Credentials $credentials, string $model, string $instructions ): array
+    {
+        $normalized = $this->normalizeInput( $this->input() );
+
+        $prompter = app( AgentPrompter::class );
+
+        $result = $prompter->prompt(
+            credentials: $credentials,
+            model: $model,
+            instructions: $instructions,
+            message: $this->buildMessage( $normalized ),
+            outputSchema: $this->outputSchema(),
+        );
+
+        return [
+            'output'        => $this->validateOutput( $result['output'], $normalized['valid_paths'] ),
+            'input_tokens'  => (int) ( $result['input_tokens'] ?? 0 ),
+            'output_tokens' => (int) ( $result['output_tokens'] ?? 0 ),
+        ];
+    }
+
+    /**
+     * Validate and shape-check the raw agent input.
+     *
+     * @since 2.3.0
+     *
+     * @param  mixed  $input  Raw agent input.
+     *
+     * @return array{ content: string, category_tree: array<int, mixed>, valid_paths: array<string, true> }
+     */
+    protected function normalizeInput( mixed $input ): array
+    {
+        if ( ! is_array( $input ) ) {
+            throw FeatureError::forFeature(
+                $this->featureKey,
+                'input must be an array with `content` and `category_tree` keys.',
+            );
+        }
+
+        $content = isset( $input['content'] ) && is_string( $input['content'] ) ? trim( $input['content'] ) : '';
+
+        if ( '' === $content ) {
+            throw FeatureError::forFeature( $this->featureKey, '`content` must be a non-empty string.' );
+        }
+
+        if ( ! isset( $input['category_tree'] ) || ! is_array( $input['category_tree'] ) ) {
+            throw FeatureError::forFeature( $this->featureKey, '`category_tree` must be an array.' );
+        }
+
+        $tree        = array_values( $input['category_tree'] );
+        $validPaths  = [];
+        $this->collectPaths( $tree, '', $validPaths );
+
+        return [
+            'content'       => $content,
+            'category_tree' => $tree,
+            'valid_paths'   => $validPaths,
+        ];
+    }
+
+    /**
+     * Walk the category tree, building a flat lookup of every valid
+     * slash-delimited path. Entries without a `name` are silently
+     * skipped so a malformed leaf can't reject the whole tree.
+     *
+     * @since 2.3.0
+     *
+     * @param  array<int, mixed>    $nodes    Sibling nodes at this depth.
+     * @param  string               $prefix   Accumulated path prefix.
+     * @param  array<string, true>  $paths    Accumulator (by reference).
+     *
+     * @return void
+     */
+    protected function collectPaths( array $nodes, string $prefix, array &$paths ): void
+    {
+        foreach ( $nodes as $node ) {
+            if ( ! is_array( $node ) ) {
+                continue;
+            }
+
+            $name = isset( $node['name'] ) && is_string( $node['name'] ) ? trim( $node['name'] ) : '';
+            if ( '' === $name ) {
+                continue;
+            }
+
+            $path            = '' === $prefix ? $name : $prefix . '/' . $name;
+            $paths[ $path ]  = true;
+
+            if ( isset( $node['children'] ) && is_array( $node['children'] ) ) {
+                $this->collectPaths( $node['children'], $path, $paths );
+            }
+        }
+    }
+
+    /**
+     * Assemble the structured message body for the prompter.
+     *
+     * @since 2.3.0
+     *
+     * @param  array{ content: string, category_tree: array<int, mixed>, valid_paths: array<string, true> }  $input  Normalized input.
+     *
+     * @return array<int, array<string, string>>
+     */
+    protected function buildMessage( array $input ): array
+    {
+        try {
+            $encoded = json_encode(
+                $input['category_tree'],
+                JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR,
+            );
+        } catch ( JsonException $exception ) {
+            throw FeatureError::forFeature(
+                $this->featureKey,
+                sprintf( 'category_tree could not be serialized: %s', $exception->getMessage() ),
+                $exception,
+            );
+        }
+
+        return [
+            [ 'type' => 'text', 'text' => 'category_tree: ' . $encoded ],
+            [ 'type' => 'text', 'text' => "Content:\n" . $input['content'] ],
+        ];
+    }
+
+    /**
+     * Enforce output invariants — drop hallucinated paths, clamp
+     * confidence, and coerce an empty selection to zero confidence so
+     * downstream callers can trust the pair.
+     *
+     * @since 2.3.0
+     *
+     * @param  array<string, mixed>  $output       Decoded model output.
+     * @param  array<string, true>   $validPaths   Set of legal slash-paths.
+     *
+     * @return array{ selected: string, confidence: float, rationale: string }
+     */
+    protected function validateOutput( array $output, array $validPaths ): array
+    {
+        $selected = isset( $output['selected'] ) ? trim( (string) $output['selected'] ) : '';
+
+        if ( '' !== $selected && ! isset( $validPaths[ $selected ] ) ) {
+            $selected = '';
+        }
+
+        $confidence = isset( $output['confidence'] ) ? (float) $output['confidence'] : 0.0;
+        $confidence = max( 0.0, min( 1.0, $confidence ) );
+
+        if ( '' === $selected ) {
+            $confidence = 0.0;
+        }
+
+        $rationale = isset( $output['rationale'] ) ? trim( (string) $output['rationale'] ) : '';
+
+        return [
+            'selected'   => $selected,
+            'confidence' => $confidence,
+            'rationale'  => $rationale,
+        ];
+    }
+}

--- a/src/Ai/Agents/CategorySuggestionAgent.php
+++ b/src/Ai/Agents/CategorySuggestionAgent.php
@@ -195,8 +195,18 @@ PROMPT;
                 continue;
             }
 
-            $path            = '' === $prefix ? $name : $prefix . '/' . $name;
-            $paths[ $path ]  = true;
+            // Reject names containing the path separator. If we accepted them
+            // we would produce paths indistinguishable from real parent/child
+            // paths — e.g. `{name: 'News/Updates'}` and `{name: 'News',
+            // children: [{name: 'Updates'}]}` both serialize to `News/Updates`
+            // and the validator would be unable to disambiguate a hallucinated
+            // model pick from a real one.
+            if ( str_contains( $name, '/' ) ) {
+                continue;
+            }
+
+            $path           = '' === $prefix ? $name : $prefix . '/' . $name;
+            $paths[ $path ] = true;
 
             if ( isset( $node['children'] ) && is_array( $node['children'] ) ) {
                 $this->collectPaths( $node['children'], $path, $paths );

--- a/src/Ai/Agents/ExcerptGenerationAgent.php
+++ b/src/Ai/Agents/ExcerptGenerationAgent.php
@@ -1,0 +1,212 @@
+<?php
+
+/**
+ * Excerpt generation agent.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage CMSFramework
+ *
+ * @since      2.3.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Ai\Agents;
+
+use ArtisanPackUI\Ai\Agents\ArtisanPackAgent;
+use ArtisanPackUI\Ai\Contracts\AgentPrompter;
+use ArtisanPackUI\Ai\Credentials\Credentials;
+use ArtisanPackUI\Ai\Exceptions\FeatureError;
+
+/**
+ * Generate a natural-sounding excerpt (default `<= 200 chars`) from a
+ * post's full content. Callers may raise the length cap up to 400 chars
+ * for longer meta descriptions.
+ *
+ * ## Input
+ *
+ * ```
+ * [
+ *   'content'    => string,       // required, full post body
+ *   'max_chars'  => int|null,     // optional, 80-400 (default 200)
+ * ]
+ * ```
+ *
+ * ## Output schema
+ *
+ * ```
+ * {
+ *   excerpt: string,   // <= max_chars
+ *   char_count: int    // actual excerpt length
+ * }
+ * ```
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage CMSFramework
+ *
+ * @since      2.3.0
+ */
+class ExcerptGenerationAgent extends ArtisanPackAgent
+{
+    /**
+     * {@inheritDoc}
+     */
+    public string $featureKey = 'cms.excerpt';
+
+    /**
+     * {@inheritDoc}
+     */
+    public string $package = 'artisanpack-ui/cms-framework';
+
+    /**
+     * {@inheritDoc}
+     */
+    public string $defaultModel = 'claude-haiku-4-5';
+
+    /**
+     * {@inheritDoc}
+     */
+    public function instructions(): string
+    {
+        return <<<'PROMPT'
+You summarize a post's body into a single-paragraph excerpt suitable for a listing page or a meta description.
+
+Requirements:
+- Return one paragraph, at most `max_chars` characters (see the accompanying instruction). Prefer to end on a sentence boundary.
+- Base the excerpt strictly on the supplied content. Do NOT invent facts.
+- Do NOT start with "This post" / "In this article" / "The author" — write the excerpt as if it were the standalone description of the content.
+- Preserve neutral, factual tone; do not editorialize or add calls to action unless the source content itself does.
+- If the content is too short to summarize (e.g. a one-sentence post), return the content verbatim (or truncated at max_chars) rather than padding it out.
+
+Return a JSON object with keys `excerpt` (string) and `char_count` (integer, the length of `excerpt`).
+PROMPT;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function outputSchema(): array
+    {
+        return [
+            'type'                 => 'object',
+            'additionalProperties' => false,
+            'required'             => [ 'excerpt', 'char_count' ],
+            'properties'           => [
+                'excerpt'    => [ 'type' => 'string' ],
+                'char_count' => [
+                    'type'    => 'integer',
+                    'minimum' => 0,
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function execute( Credentials $credentials, string $model, string $instructions ): array
+    {
+        $normalized = $this->normalizeInput( $this->input() );
+
+        $prompter = app( AgentPrompter::class );
+
+        $result = $prompter->prompt(
+            credentials: $credentials,
+            model: $model,
+            instructions: $instructions,
+            message: $this->buildMessage( $normalized ),
+            outputSchema: $this->outputSchema(),
+        );
+
+        return [
+            'output'        => $this->validateOutput( $result['output'], $normalized['max_chars'] ),
+            'input_tokens'  => (int) ( $result['input_tokens'] ?? 0 ),
+            'output_tokens' => (int) ( $result['output_tokens'] ?? 0 ),
+        ];
+    }
+
+    /**
+     * Validate and shape-check the raw agent input.
+     *
+     * @since 2.3.0
+     *
+     * @param  mixed  $input  Raw agent input.
+     *
+     * @return array{ content: string, max_chars: int }
+     */
+    protected function normalizeInput( mixed $input ): array
+    {
+        if ( ! is_array( $input ) ) {
+            throw FeatureError::forFeature(
+                $this->featureKey,
+                'input must be an array with a `content` key.',
+            );
+        }
+
+        $content = isset( $input['content'] ) && is_string( $input['content'] ) ? trim( $input['content'] ) : '';
+
+        if ( '' === $content ) {
+            throw FeatureError::forFeature( $this->featureKey, '`content` must be a non-empty string.' );
+        }
+
+        $maxChars = 200;
+        if ( isset( $input['max_chars'] ) ) {
+            $parsed = filter_var(
+                $input['max_chars'],
+                FILTER_VALIDATE_INT,
+                [ 'options' => [ 'min_range' => 80, 'max_range' => 400 ] ],
+            );
+
+            if ( false !== $parsed ) {
+                $maxChars = $parsed;
+            }
+        }
+
+        return [
+            'content'   => $content,
+            'max_chars' => $maxChars,
+        ];
+    }
+
+    /**
+     * Assemble the structured message body for the prompter.
+     *
+     * @since 2.3.0
+     *
+     * @param  array{ content: string, max_chars: int }  $input  Normalized input.
+     *
+     * @return array<int, array<string, string>>
+     */
+    protected function buildMessage( array $input ): array
+    {
+        return [
+            [ 'type' => 'text', 'text' => sprintf( 'max_chars: %d', $input['max_chars'] ) ],
+            [ 'type' => 'text', 'text' => "Content:\n" . $input['content'] ],
+        ];
+    }
+
+    /**
+     * Enforce output invariants — clamp excerpt length and recompute
+     * `char_count` from the returned excerpt so callers can trust it.
+     *
+     * @since 2.3.0
+     *
+     * @param  array<string, mixed>  $output    Decoded model output.
+     * @param  int                   $maxChars  Requested cap.
+     *
+     * @return array{ excerpt: string, char_count: int }
+     */
+    protected function validateOutput( array $output, int $maxChars ): array
+    {
+        $excerpt = isset( $output['excerpt'] ) ? trim( (string) $output['excerpt'] ) : '';
+
+        if ( mb_strlen( $excerpt ) > $maxChars ) {
+            $excerpt = mb_substr( $excerpt, 0, $maxChars );
+        }
+
+        return [
+            'excerpt'    => $excerpt,
+            'char_count' => mb_strlen( $excerpt ),
+        ];
+    }
+}

--- a/src/Ai/Agents/PostTitleSuggestionAgent.php
+++ b/src/Ai/Agents/PostTitleSuggestionAgent.php
@@ -1,0 +1,257 @@
+<?php
+
+/**
+ * Post title suggestion agent.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage CMSFramework
+ *
+ * @since      2.3.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Ai\Agents;
+
+use ArtisanPackUI\Ai\Agents\ArtisanPackAgent;
+use ArtisanPackUI\Ai\Contracts\AgentPrompter;
+use ArtisanPackUI\Ai\Credentials\Credentials;
+use ArtisanPackUI\Ai\Exceptions\FeatureError;
+
+/**
+ * Content-authoring helper. Generate 3–5 title variants from the draft
+ * body of a post. Consumable by any package that authors long-form
+ * content (visual-editor, custom CMS surfaces, etc.).
+ *
+ * ## Input
+ *
+ * ```
+ * [
+ *   'content' => string,        // required, draft body
+ *   'tone'    => string|null,   // optional, e.g. "playful", "authoritative"
+ *   'count'   => int|null,      // optional, 3–5 (default 5)
+ * ]
+ * ```
+ *
+ * ## Output schema
+ *
+ * ```
+ * {
+ *   titles: [ { title: string, rationale: string } ]
+ * }
+ * ```
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage CMSFramework
+ *
+ * @since      2.3.0
+ */
+class PostTitleSuggestionAgent extends ArtisanPackAgent
+{
+    /**
+     * {@inheritDoc}
+     */
+    public string $featureKey = 'cms.post_title';
+
+    /**
+     * {@inheritDoc}
+     */
+    public string $package = 'artisanpack-ui/cms-framework';
+
+    /**
+     * {@inheritDoc}
+     */
+    public string $defaultModel = 'claude-haiku-4-5';
+
+    /**
+     * {@inheritDoc}
+     */
+    public function instructions(): string
+    {
+        return <<<'PROMPT'
+You generate title variants for a piece of long-form content.
+
+Requirements:
+- Return between 3 and 5 titles, ordered strongest-first.
+- Every title must be <= 80 characters and free of trailing punctuation (except a question mark when the title is a question).
+- Base every title strictly on the supplied content. Do NOT invent facts, statistics, names, or quotes.
+- Vary the shape across the set — one direct/descriptive, one benefit-led, one curiosity/question if appropriate. Avoid clickbait.
+- If a `tone` is supplied, bias all variants toward it without abandoning accuracy.
+- `rationale` is a single sentence explaining why the title fits.
+
+Return a JSON object with key `titles` (array of {title, rationale}).
+PROMPT;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function outputSchema(): array
+    {
+        return [
+            'type'                 => 'object',
+            'additionalProperties' => false,
+            'required'             => [ 'titles' ],
+            'properties'           => [
+                'titles' => [
+                    'type'     => 'array',
+                    'minItems' => 1,
+                    'maxItems' => 5,
+                    'items'    => [
+                        'type'                 => 'object',
+                        'additionalProperties' => false,
+                        'required'             => [ 'title', 'rationale' ],
+                        'properties'           => [
+                            'title'     => [
+                                'type'      => 'string',
+                                'maxLength' => 80,
+                            ],
+                            'rationale' => [ 'type' => 'string' ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function execute( Credentials $credentials, string $model, string $instructions ): array
+    {
+        $normalized = $this->normalizeInput( $this->input() );
+
+        $prompter = app( AgentPrompter::class );
+
+        $result = $prompter->prompt(
+            credentials: $credentials,
+            model: $model,
+            instructions: $instructions,
+            message: $this->buildMessage( $normalized ),
+            outputSchema: $this->outputSchema(),
+        );
+
+        return [
+            'output'        => $this->validateOutput( $result['output'], $normalized['count'] ),
+            'input_tokens'  => (int) ( $result['input_tokens'] ?? 0 ),
+            'output_tokens' => (int) ( $result['output_tokens'] ?? 0 ),
+        ];
+    }
+
+    /**
+     * Validate and shape-check the raw agent input.
+     *
+     * @since 2.3.0
+     *
+     * @param  mixed  $input  Raw agent input.
+     *
+     * @return array{ content: string, tone: string|null, count: int }
+     */
+    protected function normalizeInput( mixed $input ): array
+    {
+        if ( ! is_array( $input ) ) {
+            throw FeatureError::forFeature(
+                $this->featureKey,
+                'input must be an array with a `content` key.',
+            );
+        }
+
+        $content = isset( $input['content'] ) && is_string( $input['content'] ) ? trim( $input['content'] ) : '';
+
+        if ( '' === $content ) {
+            throw FeatureError::forFeature( $this->featureKey, '`content` must be a non-empty string.' );
+        }
+
+        $tone = null;
+        if ( isset( $input['tone'] ) && is_string( $input['tone'] ) && '' !== trim( $input['tone'] ) ) {
+            $tone = trim( $input['tone'] );
+        }
+
+        $count = 5;
+        if ( isset( $input['count'] ) ) {
+            $parsed = filter_var(
+                $input['count'],
+                FILTER_VALIDATE_INT,
+                [ 'options' => [ 'min_range' => 3, 'max_range' => 5 ] ],
+            );
+
+            if ( false !== $parsed ) {
+                $count = $parsed;
+            }
+        }
+
+        return [
+            'content' => $content,
+            'tone'    => $tone,
+            'count'   => $count,
+        ];
+    }
+
+    /**
+     * Assemble the structured message body for the prompter.
+     *
+     * @since 2.3.0
+     *
+     * @param  array{ content: string, tone: string|null, count: int }  $input  Normalized input.
+     *
+     * @return array<int, array<string, string>>
+     */
+    protected function buildMessage( array $input ): array
+    {
+        $parts = [
+            [ 'type' => 'text', 'text' => sprintf( 'Requested count: %d', $input['count'] ) ],
+        ];
+
+        if ( null !== $input['tone'] ) {
+            $parts[] = [ 'type' => 'text', 'text' => sprintf( 'Tone: %s', $input['tone'] ) ];
+        }
+
+        $parts[] = [ 'type' => 'text', 'text' => "Content:\n" . $input['content'] ];
+
+        return $parts;
+    }
+
+    /**
+     * Enforce output invariants and clamp to the requested count.
+     *
+     * @since 2.3.0
+     *
+     * @param  array<string, mixed>  $output  Decoded model output.
+     * @param  int                   $count   Requested title count.
+     *
+     * @return array{ titles: array<int, array{ title: string, rationale: string }> }
+     */
+    protected function validateOutput( array $output, int $count ): array
+    {
+        $raw = isset( $output['titles'] ) && is_array( $output['titles'] ) ? $output['titles'] : [];
+
+        $clean = [];
+        foreach ( $raw as $entry ) {
+            if ( ! is_array( $entry ) ) {
+                continue;
+            }
+
+            $title     = isset( $entry['title'] ) ? trim( (string) $entry['title'] ) : '';
+            $rationale = isset( $entry['rationale'] ) ? trim( (string) $entry['rationale'] ) : '';
+
+            if ( '' === $title || '' === $rationale ) {
+                continue;
+            }
+
+            if ( mb_strlen( $title ) > 80 ) {
+                $title = mb_substr( $title, 0, 80 );
+            }
+
+            $clean[] = [
+                'title'     => $title,
+                'rationale' => $rationale,
+            ];
+
+            if ( count( $clean ) === $count ) {
+                break;
+            }
+        }
+
+        return [ 'titles' => $clean ];
+    }
+}

--- a/src/Ai/Agents/SlugSuggestionAgent.php
+++ b/src/Ai/Agents/SlugSuggestionAgent.php
@@ -17,6 +17,7 @@ use ArtisanPackUI\Ai\Agents\ArtisanPackAgent;
 use ArtisanPackUI\Ai\Contracts\AgentPrompter;
 use ArtisanPackUI\Ai\Credentials\Credentials;
 use ArtisanPackUI\Ai\Exceptions\FeatureError;
+use Illuminate\Support\Str;
 
 /**
  * Suggest a URL slug for a post from its title (and optional excerpt).
@@ -251,6 +252,13 @@ PROMPT;
      * clamp it to `max_chars`, cutting on a hyphen boundary when
      * possible so we don't truncate mid-word.
      *
+     * Delegates the ASCII-folding + kebab-case pipeline to `Str::slug()`.
+     * The previous byte-oriented `preg_replace( '/[^a-z0-9-]+/', '-', … )`
+     * collapsed every non-ASCII byte to a hyphen, so a model return like
+     * `cafe-culture` (with an acute-e) became `caf-culture`. `Str::slug`
+     * transliterates instead, matching the agent's documented
+     * "transliterate non-ASCII" contract.
+     *
      * @since 2.3.0
      *
      * @param  string  $raw       Raw candidate slug.
@@ -260,10 +268,7 @@ PROMPT;
      */
     protected function sanitizeSlug( string $raw, int $maxChars ): string
     {
-        $slug = strtolower( trim( $raw ) );
-        $slug = preg_replace( '/[^a-z0-9-]+/', '-', $slug ) ?? '';
-        $slug = preg_replace( '/-+/', '-', $slug ) ?? '';
-        $slug = trim( $slug, '-' );
+        $slug = Str::slug( $raw, '-' );
 
         if ( strlen( $slug ) <= $maxChars ) {
             return $slug;

--- a/src/Ai/Agents/SlugSuggestionAgent.php
+++ b/src/Ai/Agents/SlugSuggestionAgent.php
@@ -1,0 +1,285 @@
+<?php
+
+/**
+ * Slug suggestion agent.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage CMSFramework
+ *
+ * @since      2.3.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Ai\Agents;
+
+use ArtisanPackUI\Ai\Agents\ArtisanPackAgent;
+use ArtisanPackUI\Ai\Contracts\AgentPrompter;
+use ArtisanPackUI\Ai\Credentials\Credentials;
+use ArtisanPackUI\Ai\Exceptions\FeatureError;
+
+/**
+ * Suggest a URL slug for a post from its title (and optional excerpt).
+ * Unlike a straight kebab-case of the title, this agent optimizes for
+ * SEO: it drops stop words, keeps the keyword-forward tokens, and stays
+ * short (default 60 char cap).
+ *
+ * Uniqueness against existing slugs is intentionally NOT part of the
+ * agent's contract — the caller enforces uniqueness (Eloquent lookup,
+ * database constraint, ...) with the returned slug.
+ *
+ * ## Input
+ *
+ * ```
+ * [
+ *   'title'     => string,       // required
+ *   'excerpt'   => string|null,  // optional, helps disambiguate short titles
+ *   'max_chars' => int|null,     // optional, 20-100 (default 60)
+ * ]
+ * ```
+ *
+ * ## Output schema
+ *
+ * ```
+ * {
+ *   slug:       string,      // sanitized kebab-case slug, <= max_chars
+ *   alternates: string[]     // 0-2 backup slugs for uniqueness collisions
+ * }
+ * ```
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage CMSFramework
+ *
+ * @since      2.3.0
+ */
+class SlugSuggestionAgent extends ArtisanPackAgent
+{
+    /**
+     * {@inheritDoc}
+     */
+    public string $featureKey = 'cms.suggest_slug';
+
+    /**
+     * {@inheritDoc}
+     */
+    public string $package = 'artisanpack-ui/cms-framework';
+
+    /**
+     * {@inheritDoc}
+     */
+    public string $defaultModel = 'claude-haiku-4-5';
+
+    /**
+     * {@inheritDoc}
+     */
+    public function instructions(): string
+    {
+        return <<<'PROMPT'
+You generate a URL slug from a post title.
+
+Requirements:
+- The slug MUST be lowercase kebab-case (ASCII letters, digits, and hyphens only). No leading, trailing, or consecutive hyphens.
+- Drop stop words (the, a, an, and, or, but, for, on, of, to, with, in, at, by, from, is, are, was, were, be, been, being) unless removing them would obscure meaning.
+- Prefer the noun/keyword-carrying tokens of the title over filler.
+- Do NOT translate. Transliterate non-ASCII characters into their closest ASCII equivalent.
+- Stay within `max_chars` characters. Cut a whole trailing word rather than truncating mid-word.
+- Return up to 2 `alternates` — each also compliant with the rules above — as fallback options a caller can try on a uniqueness collision. Zero alternates is fine when only one obvious slug fits.
+
+Return a JSON object with keys `slug` (string) and `alternates` (array of strings).
+PROMPT;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function outputSchema(): array
+    {
+        return [
+            'type'                 => 'object',
+            'additionalProperties' => false,
+            'required'             => [ 'slug', 'alternates' ],
+            'properties'           => [
+                'slug'       => [ 'type' => 'string' ],
+                'alternates' => [
+                    'type'     => 'array',
+                    'maxItems' => 2,
+                    'items'    => [ 'type' => 'string' ],
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function execute( Credentials $credentials, string $model, string $instructions ): array
+    {
+        $normalized = $this->normalizeInput( $this->input() );
+
+        $prompter = app( AgentPrompter::class );
+
+        $result = $prompter->prompt(
+            credentials: $credentials,
+            model: $model,
+            instructions: $instructions,
+            message: $this->buildMessage( $normalized ),
+            outputSchema: $this->outputSchema(),
+        );
+
+        return [
+            'output'        => $this->validateOutput( $result['output'], $normalized['max_chars'] ),
+            'input_tokens'  => (int) ( $result['input_tokens'] ?? 0 ),
+            'output_tokens' => (int) ( $result['output_tokens'] ?? 0 ),
+        ];
+    }
+
+    /**
+     * Validate and shape-check the raw agent input.
+     *
+     * @since 2.3.0
+     *
+     * @param  mixed  $input  Raw agent input.
+     *
+     * @return array{ title: string, excerpt: string|null, max_chars: int }
+     */
+    protected function normalizeInput( mixed $input ): array
+    {
+        if ( ! is_array( $input ) ) {
+            throw FeatureError::forFeature(
+                $this->featureKey,
+                'input must be an array with a `title` key.',
+            );
+        }
+
+        $title = isset( $input['title'] ) && is_string( $input['title'] ) ? trim( $input['title'] ) : '';
+
+        if ( '' === $title ) {
+            throw FeatureError::forFeature( $this->featureKey, '`title` must be a non-empty string.' );
+        }
+
+        $excerpt = null;
+        if ( isset( $input['excerpt'] ) && is_string( $input['excerpt'] ) && '' !== trim( $input['excerpt'] ) ) {
+            $excerpt = trim( $input['excerpt'] );
+        }
+
+        $maxChars = 60;
+        if ( isset( $input['max_chars'] ) ) {
+            $parsed = filter_var(
+                $input['max_chars'],
+                FILTER_VALIDATE_INT,
+                [ 'options' => [ 'min_range' => 20, 'max_range' => 100 ] ],
+            );
+
+            if ( false !== $parsed ) {
+                $maxChars = $parsed;
+            }
+        }
+
+        return [
+            'title'     => $title,
+            'excerpt'   => $excerpt,
+            'max_chars' => $maxChars,
+        ];
+    }
+
+    /**
+     * Assemble the structured message body for the prompter.
+     *
+     * @since 2.3.0
+     *
+     * @param  array{ title: string, excerpt: string|null, max_chars: int }  $input  Normalized input.
+     *
+     * @return array<int, array<string, string>>
+     */
+    protected function buildMessage( array $input ): array
+    {
+        $parts = [
+            [ 'type' => 'text', 'text' => sprintf( 'max_chars: %d', $input['max_chars'] ) ],
+            [ 'type' => 'text', 'text' => 'Title: ' . $input['title'] ],
+        ];
+
+        if ( null !== $input['excerpt'] ) {
+            $parts[] = [ 'type' => 'text', 'text' => "Excerpt:\n" . $input['excerpt'] ];
+        }
+
+        return $parts;
+    }
+
+    /**
+     * Enforce output invariants — sanitize each slug so a hallucinated
+     * uppercase-with-underscores string can't leak through.
+     *
+     * @since 2.3.0
+     *
+     * @param  array<string, mixed>  $output    Decoded model output.
+     * @param  int                   $maxChars  Requested cap.
+     *
+     * @return array{ slug: string, alternates: array<int, string> }
+     */
+    protected function validateOutput( array $output, int $maxChars ): array
+    {
+        $slug = $this->sanitizeSlug( isset( $output['slug'] ) ? (string) $output['slug'] : '', $maxChars );
+
+        $alternates = [];
+        $rawAlts    = isset( $output['alternates'] ) && is_array( $output['alternates'] ) ? $output['alternates'] : [];
+
+        foreach ( $rawAlts as $candidate ) {
+            if ( ! is_string( $candidate ) ) {
+                continue;
+            }
+
+            $clean = $this->sanitizeSlug( $candidate, $maxChars );
+            if ( '' === $clean || $clean === $slug || in_array( $clean, $alternates, true ) ) {
+                continue;
+            }
+
+            $alternates[] = $clean;
+
+            if ( 2 === count( $alternates ) ) {
+                break;
+            }
+        }
+
+        return [
+            'slug'       => $slug,
+            'alternates' => $alternates,
+        ];
+    }
+
+    /**
+     * Coerce a raw string into a compliant lowercase kebab-case slug and
+     * clamp it to `max_chars`, cutting on a hyphen boundary when
+     * possible so we don't truncate mid-word.
+     *
+     * @since 2.3.0
+     *
+     * @param  string  $raw       Raw candidate slug.
+     * @param  int     $maxChars  Length cap.
+     *
+     * @return string
+     */
+    protected function sanitizeSlug( string $raw, int $maxChars ): string
+    {
+        $slug = strtolower( trim( $raw ) );
+        $slug = preg_replace( '/[^a-z0-9-]+/', '-', $slug ) ?? '';
+        $slug = preg_replace( '/-+/', '-', $slug ) ?? '';
+        $slug = trim( $slug, '-' );
+
+        if ( strlen( $slug ) <= $maxChars ) {
+            return $slug;
+        }
+
+        $truncated  = substr( $slug, 0, $maxChars );
+        $lastHyphen = strrpos( $truncated, '-' );
+
+        // Prefer cutting on a hyphen so we don't leave a partial word
+        // hanging at the end of the slug — but only when doing so keeps
+        // a meaningful portion of the string (guard against a single
+        // leading word blowing past the cap).
+        if ( false !== $lastHyphen && $lastHyphen > 0 ) {
+            $truncated = substr( $truncated, 0, $lastHyphen );
+        }
+
+        return trim( $truncated, '-' );
+    }
+}

--- a/src/Ai/Agents/TagSuggestionAgent.php
+++ b/src/Ai/Agents/TagSuggestionAgent.php
@@ -1,0 +1,301 @@
+<?php
+
+/**
+ * Tag suggestion agent.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage CMSFramework
+ *
+ * @since      2.3.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Ai\Agents;
+
+use ArtisanPackUI\Ai\Agents\ArtisanPackAgent;
+use ArtisanPackUI\Ai\Contracts\AgentPrompter;
+use ArtisanPackUI\Ai\Credentials\Credentials;
+use ArtisanPackUI\Ai\Exceptions\FeatureError;
+
+/**
+ * Suggest tags for a post from an existing taxonomy. By default the
+ * agent MUST pick from `available_tags` and never invents new tags. Set
+ * `allow_new: true` to unlock a `suggested_new` array of candidate tag
+ * names — hosts remain responsible for creating them.
+ *
+ * ## Input
+ *
+ * ```
+ * [
+ *   'content'        => string,          // required
+ *   'available_tags' => string[],        // required, existing tag names
+ *   'allow_new'      => bool|null,       // optional, default false
+ *   'max_selected'   => int|null,        // optional, 1-10 (default 5)
+ * ]
+ * ```
+ *
+ * ## Output schema
+ *
+ * ```
+ * {
+ *   selected:      [ { tag: string, confidence: float } ],
+ *   suggested_new: string[]              // only when allow_new is true
+ * }
+ * ```
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage CMSFramework
+ *
+ * @since      2.3.0
+ */
+class TagSuggestionAgent extends ArtisanPackAgent
+{
+    /**
+     * {@inheritDoc}
+     */
+    public string $featureKey = 'cms.suggest_tags';
+
+    /**
+     * {@inheritDoc}
+     */
+    public string $package = 'artisanpack-ui/cms-framework';
+
+    /**
+     * {@inheritDoc}
+     */
+    public string $defaultModel = 'claude-haiku-4-5';
+
+    /**
+     * {@inheritDoc}
+     */
+    public function instructions(): string
+    {
+        return <<<'PROMPT'
+You select tags for a piece of content from a fixed taxonomy.
+
+Requirements:
+- Every entry in `selected.tag` MUST come from the supplied `available_tags` list, matched by exact string. Case must match.
+- `confidence` is 0.0 (weak signal) to 1.0 (strong signal). Prefer omitting a tag over guessing — an empty `selected` array is a valid answer.
+- Return at most `max_selected` entries, ordered by confidence descending.
+- Base every selection on evidence in the supplied content. Do NOT project topics that are not present.
+- If `allow_new` is true, you MAY additionally return `suggested_new` — a short list of tag names that would meaningfully cover a topic present in the content but missing from `available_tags`. Do not repeat names that are already in `available_tags` (case-insensitive). Each new name must be a short, lowercase, kebab-case slug (2–4 words at most). Omit `suggested_new` entirely (or return an empty array) when nothing is missing.
+- If `allow_new` is false or absent, do NOT include `suggested_new` at all — the taxonomy is closed.
+
+Return a JSON object with keys: `selected` (array of {tag, confidence}) and optionally `suggested_new` (array of strings).
+PROMPT;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function outputSchema(): array
+    {
+        return [
+            'type'                 => 'object',
+            'additionalProperties' => false,
+            'required'             => [ 'selected' ],
+            'properties'           => [
+                'selected'      => [
+                    'type'  => 'array',
+                    'items' => [
+                        'type'                 => 'object',
+                        'additionalProperties' => false,
+                        'required'             => [ 'tag', 'confidence' ],
+                        'properties'           => [
+                            'tag'        => [ 'type' => 'string' ],
+                            'confidence' => [
+                                'type'    => 'number',
+                                'minimum' => 0,
+                                'maximum' => 1,
+                            ],
+                        ],
+                    ],
+                ],
+                'suggested_new' => [
+                    'type'  => 'array',
+                    'items' => [ 'type' => 'string' ],
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function execute( Credentials $credentials, string $model, string $instructions ): array
+    {
+        $normalized = $this->normalizeInput( $this->input() );
+
+        $prompter = app( AgentPrompter::class );
+
+        $result = $prompter->prompt(
+            credentials: $credentials,
+            model: $model,
+            instructions: $instructions,
+            message: $this->buildMessage( $normalized ),
+            outputSchema: $this->outputSchema(),
+        );
+
+        return [
+            'output'        => $this->validateOutput( $result['output'], $normalized ),
+            'input_tokens'  => (int) ( $result['input_tokens'] ?? 0 ),
+            'output_tokens' => (int) ( $result['output_tokens'] ?? 0 ),
+        ];
+    }
+
+    /**
+     * Validate and shape-check the raw agent input.
+     *
+     * @since 2.3.0
+     *
+     * @param  mixed  $input  Raw agent input.
+     *
+     * @return array{ content: string, available_tags: array<int, string>, allow_new: bool, max_selected: int }
+     */
+    protected function normalizeInput( mixed $input ): array
+    {
+        if ( ! is_array( $input ) ) {
+            throw FeatureError::forFeature(
+                $this->featureKey,
+                'input must be an array with `content` and `available_tags` keys.',
+            );
+        }
+
+        $content = isset( $input['content'] ) && is_string( $input['content'] ) ? trim( $input['content'] ) : '';
+
+        if ( '' === $content ) {
+            throw FeatureError::forFeature( $this->featureKey, '`content` must be a non-empty string.' );
+        }
+
+        if ( ! isset( $input['available_tags'] ) || ! is_array( $input['available_tags'] ) ) {
+            throw FeatureError::forFeature( $this->featureKey, '`available_tags` must be an array of strings.' );
+        }
+
+        $tags = [];
+        foreach ( $input['available_tags'] as $tag ) {
+            if ( is_string( $tag ) && '' !== trim( $tag ) ) {
+                $tags[] = trim( $tag );
+            }
+        }
+
+        $allowNew = isset( $input['allow_new'] ) && filter_var( $input['allow_new'], FILTER_VALIDATE_BOOLEAN );
+
+        $maxSelected = 5;
+        if ( isset( $input['max_selected'] ) ) {
+            $parsed = filter_var(
+                $input['max_selected'],
+                FILTER_VALIDATE_INT,
+                [ 'options' => [ 'min_range' => 1, 'max_range' => 10 ] ],
+            );
+
+            if ( false !== $parsed ) {
+                $maxSelected = $parsed;
+            }
+        }
+
+        return [
+            'content'        => $content,
+            'available_tags' => $tags,
+            'allow_new'      => $allowNew,
+            'max_selected'   => $maxSelected,
+        ];
+    }
+
+    /**
+     * Assemble the structured message body for the prompter.
+     *
+     * @since 2.3.0
+     *
+     * @param  array{ content: string, available_tags: array<int, string>, allow_new: bool, max_selected: int }  $input  Normalized input.
+     *
+     * @return array<int, array<string, string>>
+     */
+    protected function buildMessage( array $input ): array
+    {
+        return [
+            [ 'type' => 'text', 'text' => sprintf( 'allow_new: %s', $input['allow_new'] ? 'true' : 'false' ) ],
+            [ 'type' => 'text', 'text' => sprintf( 'max_selected: %d', $input['max_selected'] ) ],
+            [ 'type' => 'text', 'text' => 'available_tags: ' . implode( ', ', $input['available_tags'] ) ],
+            [ 'type' => 'text', 'text' => "Content:\n" . $input['content'] ],
+        ];
+    }
+
+    /**
+     * Enforce output invariants — drop hallucinated tags, clamp size,
+     * and only include `suggested_new` when the caller allowed it.
+     *
+     * @since 2.3.0
+     *
+     * @param  array<string, mixed>                                                                              $output      Decoded model output.
+     * @param  array{ content: string, available_tags: array<int, string>, allow_new: bool, max_selected: int }  $normalized  Normalized input.
+     *
+     * @return array{ selected: array<int, array{ tag: string, confidence: float }>, suggested_new?: array<int, string> }
+     */
+    protected function validateOutput( array $output, array $normalized ): array
+    {
+        $allowed = array_flip( $normalized['available_tags'] );
+
+        $selected    = [];
+        $rawSelected = isset( $output['selected'] ) && is_array( $output['selected'] ) ? $output['selected'] : [];
+
+        foreach ( $rawSelected as $entry ) {
+            if ( ! is_array( $entry ) ) {
+                continue;
+            }
+
+            $tag = isset( $entry['tag'] ) ? (string) $entry['tag'] : '';
+
+            if ( '' === $tag || ! isset( $allowed[ $tag ] ) ) {
+                continue;
+            }
+
+            $confidence = isset( $entry['confidence'] ) ? (float) $entry['confidence'] : 0.0;
+            $confidence = max( 0.0, min( 1.0, $confidence ) );
+
+            $selected[] = [
+                'tag'        => $tag,
+                'confidence' => $confidence,
+            ];
+
+            if ( count( $selected ) === $normalized['max_selected'] ) {
+                break;
+            }
+        }
+
+        $result = [ 'selected' => $selected ];
+
+        if ( $normalized['allow_new'] ) {
+            $existingLower = array_flip( array_map( 'strtolower', $normalized['available_tags'] ) );
+            $seen          = [];
+            $new           = [];
+
+            $rawNew = isset( $output['suggested_new'] ) && is_array( $output['suggested_new'] )
+                ? $output['suggested_new']
+                : [];
+
+            foreach ( $rawNew as $candidate ) {
+                if ( ! is_string( $candidate ) ) {
+                    continue;
+                }
+
+                $trimmed = trim( $candidate );
+                if ( '' === $trimmed ) {
+                    continue;
+                }
+
+                $lower = strtolower( $trimmed );
+                if ( isset( $existingLower[ $lower ] ) || isset( $seen[ $lower ] ) ) {
+                    continue;
+                }
+
+                $seen[ $lower ] = true;
+                $new[]          = $trimmed;
+            }
+
+            $result['suggested_new'] = $new;
+        }
+
+        return $result;
+    }
+}

--- a/src/Ai/Agents/TagSuggestionAgent.php
+++ b/src/Ai/Agents/TagSuggestionAgent.php
@@ -244,7 +244,11 @@ PROMPT;
                 continue;
             }
 
-            $tag = isset( $entry['tag'] ) ? (string) $entry['tag'] : '';
+            // Trim BEFORE the allow-list lookup — `normalizeInput` trimmed
+            // every `available_tags` entry, so a model return of `"laravel "`
+            // (with incidental whitespace) would silently fail the isset
+            // check and drop an otherwise-valid selection.
+            $tag = isset( $entry['tag'] ) ? trim( (string) $entry['tag'] ) : '';
 
             if ( '' === $tag || ! isset( $allowed[ $tag ] ) ) {
                 continue;

--- a/src/CMSFrameworkServiceProvider.php
+++ b/src/CMSFrameworkServiceProvider.php
@@ -14,6 +14,13 @@ declare( strict_types=1 );
 
 namespace ArtisanPackUI\CMSFramework;
 
+use ArtisanPackUI\Ai\Contracts\FeatureRegistry;
+use ArtisanPackUI\CMSFramework\Ai\Agents\CategorySuggestionAgent;
+use ArtisanPackUI\CMSFramework\Ai\Agents\ExcerptGenerationAgent;
+use ArtisanPackUI\CMSFramework\Ai\Agents\PostTitleSuggestionAgent;
+use ArtisanPackUI\CMSFramework\Ai\Agents\SlugSuggestionAgent;
+use ArtisanPackUI\CMSFramework\Ai\Agents\TagSuggestionAgent;
+use ArtisanPackUI\CMSFramework\Livewire\Ai\AiTools;
 use ArtisanPackUI\CMSFramework\Modules\Admin\Providers\AdminServiceProvider;
 use ArtisanPackUI\CMSFramework\Modules\AdminWidgets\Providers\AdminWidgetServiceProvider;
 use ArtisanPackUI\CMSFramework\Modules\Blog\Models\Post;
@@ -34,9 +41,11 @@ use ArtisanPackUI\CMSFramework\Modules\Users\Providers\UserServiceProvider;
 use ArtisanPackUI\VisualEditor\Concerns\HasBlockContent;
 use ArtisanPackUI\VisualEditor\VisualEditor;
 use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\ServiceProvider;
 use InvalidArgumentException;
+use Livewire\Livewire;
 
 /**
  * Registers and bootstraps the CMS Framework within the application.
@@ -49,6 +58,26 @@ use InvalidArgumentException;
  */
 class CMSFrameworkServiceProvider extends ServiceProvider
 {
+
+    /**
+     * The full set of AI feature keys the cms-framework exposes.
+     *
+     * Single source of truth: {@see AiController::features()},
+     * {@see AiTools::enabledFeatures()}, and any host bundle wiring
+     * (React/Vue apps that hit `/api/v1/cms/ai/features`) all read from
+     * here so a future CMS AI feature only lands in one place.
+     *
+     * @since 2.3.0
+     *
+     * @var array<int, string>
+     */
+    public const AI_FEATURE_KEYS = [
+        'cms.post_title',
+        'cms.excerpt',
+        'cms.suggest_tags',
+        'cms.suggest_category',
+        'cms.suggest_slug',
+    ];
     /**
      * Permission slugs and human-readable names registered into
      * cms-framework's RBAC tables when visual-editor is detected.
@@ -72,6 +101,45 @@ class CMSFrameworkServiceProvider extends ServiceProvider
         'visual_editor.global-styles.edit'  => 'Edit Global Styles in Visual Editor',
         'visual_editor.navigation.edit'     => 'Edit Navigation in Visual Editor',
     ];
+
+    /**
+     * Declare the AI features this package owns.
+     *
+     * Auto-discovered by `artisanpack-ui/ai`'s `FeatureRegistry` (see
+     * AI RFC — GitHub discussion #8). When the AI package is absent
+     * this method is simply never called and has no effect — the
+     * cms-framework still boots without AI wiring, and the AI Livewire
+     * component + REST endpoints stay unregistered.
+     *
+     * @since 2.3.0
+     *
+     * @return array<string, array{ agent: class-string, package: string }>
+     */
+    public function aiFeatures(): array
+    {
+        return [
+            'cms.post_title'       => [
+                'agent'   => PostTitleSuggestionAgent::class,
+                'package' => 'artisanpack-ui/cms-framework',
+            ],
+            'cms.excerpt'          => [
+                'agent'   => ExcerptGenerationAgent::class,
+                'package' => 'artisanpack-ui/cms-framework',
+            ],
+            'cms.suggest_tags'     => [
+                'agent'   => TagSuggestionAgent::class,
+                'package' => 'artisanpack-ui/cms-framework',
+            ],
+            'cms.suggest_category' => [
+                'agent'   => CategorySuggestionAgent::class,
+                'package' => 'artisanpack-ui/cms-framework',
+            ],
+            'cms.suggest_slug'     => [
+                'agent'   => SlugSuggestionAgent::class,
+                'package' => 'artisanpack-ui/cms-framework',
+            ],
+        ];
+    }
 
     /**
      * Boots the CMS framework and loads database migration files.
@@ -101,6 +169,8 @@ class CMSFrameworkServiceProvider extends ServiceProvider
         $this->loadMigrationsFrom( __DIR__ . '/../database/migrations' );
 
         $this->registerVisualEditorBridge();
+
+        $this->registerAiSurfaces();
     }
 
     /**
@@ -172,6 +242,36 @@ class CMSFrameworkServiceProvider extends ServiceProvider
         $this->app->register( SiteEditorServiceProvider::class );
         $this->app->register( PluginsServiceProvider::class );
         $this->app->register( OpenApiServiceProvider::class );
+    }
+
+    /**
+     * Registers the CMS AI trigger surfaces (Livewire component +
+     * `/api/v1/cms/ai/*` REST endpoints).
+     *
+     * Both are guarded on the {@see FeatureRegistry} contract from
+     * `artisanpack-ui/ai`: when the AI package isn't installed the
+     * registrations are skipped so the cms-framework still boots.
+     *
+     * The REST endpoints are the framework-agnostic path — React and
+     * Vue apps hit them directly without either shared package
+     * (`@artisanpack-ui/react`, `@artisanpack-ui/vue`) needing to know
+     * anything about CMS AI features.
+     *
+     * @since 2.3.0
+     */
+    protected function registerAiSurfaces(): void
+    {
+        if ( ! interface_exists( FeatureRegistry::class ) ) {
+            return;
+        }
+
+        if ( class_exists( Livewire::class ) ) {
+            Livewire::component( 'ap-cms-ai-tools', AiTools::class );
+        }
+
+        Route::prefix( 'api/v1/cms/ai' )
+            ->middleware( 'api' )
+            ->group( __DIR__ . '/Http/routes/ai.php' );
     }
 
     /**

--- a/src/Http/Controllers/Ai/AiController.php
+++ b/src/Http/Controllers/Ai/AiController.php
@@ -1,0 +1,208 @@
+<?php
+
+/**
+ * JSON API controller for the cms-framework AI trigger surface.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage CMSFramework
+ *
+ * @since      2.3.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Http\Controllers\Ai;
+
+use ArtisanPackUI\Ai\Contracts\FeatureRegistry;
+use ArtisanPackUI\Ai\Exceptions\FeatureDisabledException;
+use ArtisanPackUI\Ai\Exceptions\FeatureError;
+use ArtisanPackUI\Ai\Exceptions\MissingCredentialsException;
+use ArtisanPackUI\CMSFramework\Ai\Agents\CategorySuggestionAgent;
+use ArtisanPackUI\CMSFramework\Ai\Agents\ExcerptGenerationAgent;
+use ArtisanPackUI\CMSFramework\Ai\Agents\PostTitleSuggestionAgent;
+use ArtisanPackUI\CMSFramework\Ai\Agents\SlugSuggestionAgent;
+use ArtisanPackUI\CMSFramework\Ai\Agents\TagSuggestionAgent;
+use ArtisanPackUI\CMSFramework\CMSFrameworkServiceProvider;
+use ArtisanPackUI\CMSFramework\Http\Requests\Ai\ExcerptRequest;
+use ArtisanPackUI\CMSFramework\Http\Requests\Ai\PostTitleRequest;
+use ArtisanPackUI\CMSFramework\Http\Requests\Ai\SuggestCategoryRequest;
+use ArtisanPackUI\CMSFramework\Http\Requests\Ai\SuggestSlugRequest;
+use ArtisanPackUI\CMSFramework\Http\Requests\Ai\SuggestTagsRequest;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\Log;
+use Throwable;
+
+/**
+ * REST surface used by non-Livewire front-ends. Each endpoint runs one
+ * agent against a validated body and returns the shaped output.
+ *
+ * Kept intentionally framework-agnostic — React and Vue apps consume
+ * these endpoints directly via `fetch`, so adding a CMS AI feature does
+ * not require any changes to the `@artisanpack-ui/react` or
+ * `@artisanpack-ui/vue` packages. Feature-toggle enforcement lives
+ * inside the agents themselves; this controller only wraps errors in a
+ * consistent JSON envelope.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage CMSFramework
+ *
+ * @since      2.3.0
+ */
+class AiController
+{
+    /**
+     * Return the enabled state of the five cms.* features so a
+     * front-end can decide which affordances to render.
+     *
+     * @since 2.3.0
+     *
+     * @return JsonResponse
+     */
+    public function features(): JsonResponse
+    {
+        /** @var FeatureRegistry $registry */
+        $registry = app( FeatureRegistry::class );
+
+        $state = [];
+        foreach ( CMSFrameworkServiceProvider::AI_FEATURE_KEYS as $key ) {
+            $state[ $key ] = null !== $registry->get( $key ) && $registry->isToggleOn( $key );
+        }
+
+        return new JsonResponse( [ 'features' => $state ] );
+    }
+
+    /**
+     * POST /post-title.
+     *
+     * @since 2.3.0
+     *
+     * @param  PostTitleRequest  $request  Validated request.
+     *
+     * @return JsonResponse
+     */
+    public function postTitle( PostTitleRequest $request ): JsonResponse
+    {
+        return $this->runAgent(
+            'cms.post_title',
+            fn () => PostTitleSuggestionAgent::for( $request->validated() )->run(),
+        );
+    }
+
+    /**
+     * POST /excerpt.
+     *
+     * @since 2.3.0
+     *
+     * @param  ExcerptRequest  $request  Validated request.
+     *
+     * @return JsonResponse
+     */
+    public function excerpt( ExcerptRequest $request ): JsonResponse
+    {
+        return $this->runAgent(
+            'cms.excerpt',
+            fn () => ExcerptGenerationAgent::for( $request->validated() )->run(),
+        );
+    }
+
+    /**
+     * POST /suggest-tags.
+     *
+     * @since 2.3.0
+     *
+     * @param  SuggestTagsRequest  $request  Validated request.
+     *
+     * @return JsonResponse
+     */
+    public function suggestTags( SuggestTagsRequest $request ): JsonResponse
+    {
+        return $this->runAgent(
+            'cms.suggest_tags',
+            fn () => TagSuggestionAgent::for( $request->validated() )->run(),
+        );
+    }
+
+    /**
+     * POST /suggest-category.
+     *
+     * @since 2.3.0
+     *
+     * @param  SuggestCategoryRequest  $request  Validated request.
+     *
+     * @return JsonResponse
+     */
+    public function suggestCategory( SuggestCategoryRequest $request ): JsonResponse
+    {
+        return $this->runAgent(
+            'cms.suggest_category',
+            fn () => CategorySuggestionAgent::for( $request->validated() )->run(),
+        );
+    }
+
+    /**
+     * POST /suggest-slug.
+     *
+     * @since 2.3.0
+     *
+     * @param  SuggestSlugRequest  $request  Validated request.
+     *
+     * @return JsonResponse
+     */
+    public function suggestSlug( SuggestSlugRequest $request ): JsonResponse
+    {
+        return $this->runAgent(
+            'cms.suggest_slug',
+            fn () => SlugSuggestionAgent::for( $request->validated() )->run(),
+        );
+    }
+
+    /**
+     * Shared wrapper — normalizes the four agent-exception categories
+     * into consistent status codes + JSON envelopes.
+     *
+     * @since 2.3.0
+     *
+     * @param  string    $featureKey  Feature key (for logging + envelope).
+     * @param  callable  $callback    Callable returning the agent output.
+     *
+     * @return JsonResponse
+     */
+    private function runAgent( string $featureKey, callable $callback ): JsonResponse
+    {
+        try {
+            $output = $callback();
+            return new JsonResponse( [
+                'feature' => $featureKey,
+                'output'  => $output,
+            ] );
+        } catch ( FeatureDisabledException $e ) {
+            return new JsonResponse( [
+                'feature' => $featureKey,
+                'error'   => 'feature_disabled',
+                'message' => $e->getMessage(),
+            ], 403 );
+        } catch ( MissingCredentialsException $e ) {
+            return new JsonResponse( [
+                'feature' => $featureKey,
+                'error'   => 'missing_credentials',
+                'message' => $e->getMessage(),
+            ], 503 );
+        } catch ( FeatureError $e ) {
+            return new JsonResponse( [
+                'feature' => $featureKey,
+                'error'   => 'invalid_input',
+                'message' => $e->getMessage(),
+            ], 422 );
+        } catch ( Throwable $e ) {
+            Log::error( 'cms-framework AI API call failed', [
+                'feature' => $featureKey,
+                'error'   => $e->getMessage(),
+            ] );
+            return new JsonResponse( [
+                'feature' => $featureKey,
+                'error'   => 'internal_error',
+                'message' => 'Unexpected error running AI feature.',
+            ], 500 );
+        }
+    }
+}

--- a/src/Http/Requests/Ai/ExcerptRequest.php
+++ b/src/Http/Requests/Ai/ExcerptRequest.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * Form request for the excerpt AI endpoint.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage CMSFramework
+ *
+ * @since      2.3.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Http\Requests\Ai;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class ExcerptRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'content'   => [ 'required', 'string' ],
+            'max_chars' => [ 'nullable', 'integer', 'between:80,400' ],
+        ];
+    }
+}

--- a/src/Http/Requests/Ai/PostTitleRequest.php
+++ b/src/Http/Requests/Ai/PostTitleRequest.php
@@ -1,0 +1,36 @@
+<?php
+
+/**
+ * Form request for the post-title AI endpoint.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage CMSFramework
+ *
+ * @since      2.3.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Http\Requests\Ai;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class PostTitleRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'content' => [ 'required', 'string' ],
+            'tone'    => [ 'nullable', 'string', 'max:120' ],
+            'count'   => [ 'nullable', 'integer', 'between:3,5' ],
+        ];
+    }
+}

--- a/src/Http/Requests/Ai/SuggestCategoryRequest.php
+++ b/src/Http/Requests/Ai/SuggestCategoryRequest.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * Form request for the category suggestion AI endpoint.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage CMSFramework
+ *
+ * @since      2.3.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Http\Requests\Ai;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class SuggestCategoryRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'content'       => [ 'required', 'string' ],
+            'category_tree' => [ 'required', 'array' ],
+        ];
+    }
+}

--- a/src/Http/Requests/Ai/SuggestSlugRequest.php
+++ b/src/Http/Requests/Ai/SuggestSlugRequest.php
@@ -1,0 +1,36 @@
+<?php
+
+/**
+ * Form request for the slug suggestion AI endpoint.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage CMSFramework
+ *
+ * @since      2.3.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Http\Requests\Ai;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class SuggestSlugRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'title'     => [ 'required', 'string' ],
+            'excerpt'   => [ 'nullable', 'string' ],
+            'max_chars' => [ 'nullable', 'integer', 'between:20,100' ],
+        ];
+    }
+}

--- a/src/Http/Requests/Ai/SuggestTagsRequest.php
+++ b/src/Http/Requests/Ai/SuggestTagsRequest.php
@@ -1,0 +1,38 @@
+<?php
+
+/**
+ * Form request for the tag suggestion AI endpoint.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage CMSFramework
+ *
+ * @since      2.3.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Http\Requests\Ai;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class SuggestTagsRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'content'          => [ 'required', 'string' ],
+            'available_tags'   => [ 'required', 'array' ],
+            'available_tags.*' => [ 'string' ],
+            'allow_new'        => [ 'nullable', 'boolean' ],
+            'max_selected'     => [ 'nullable', 'integer', 'between:1,10' ],
+        ];
+    }
+}

--- a/src/Http/routes/ai.php
+++ b/src/Http/routes/ai.php
@@ -1,0 +1,25 @@
+<?php
+
+declare( strict_types=1 );
+
+/**
+ * CMS Framework AI API Routes.
+ *
+ * Mounted at `/api/v1/cms/ai` by CMSFrameworkServiceProvider so that
+ * React and Vue front-ends can trigger the five cms.* AI agents
+ * (post title, excerpt, tags, category, slug) via plain HTTP.
+ *
+ * @since 2.3.0
+ */
+
+use ArtisanPackUI\CMSFramework\Http\Controllers\Ai\AiController;
+use Illuminate\Support\Facades\Route;
+
+Route::middleware( 'auth' )->group( function (): void {
+    Route::get( '/features', [ AiController::class, 'features' ] );
+    Route::post( '/post-title', [ AiController::class, 'postTitle' ] );
+    Route::post( '/excerpt', [ AiController::class, 'excerpt' ] );
+    Route::post( '/suggest-tags', [ AiController::class, 'suggestTags' ] );
+    Route::post( '/suggest-category', [ AiController::class, 'suggestCategory' ] );
+    Route::post( '/suggest-slug', [ AiController::class, 'suggestSlug' ] );
+} );

--- a/src/Http/routes/ai.php
+++ b/src/Http/routes/ai.php
@@ -15,7 +15,11 @@ declare( strict_types=1 );
 use ArtisanPackUI\CMSFramework\Http\Controllers\Ai\AiController;
 use Illuminate\Support\Facades\Route;
 
-Route::middleware( 'auth' )->group( function (): void {
+// `auth:sanctum` (not plain `auth`) — the parent group is mounted under
+// the `api` middleware stack which strips session state, so the default
+// web-guard would reject Sanctum bearer tokens from React/Vue SPAs and
+// silently 401 exactly the callers this surface is designed for.
+Route::middleware( 'auth:sanctum' )->group( function (): void {
     Route::get( '/features', [ AiController::class, 'features' ] );
     Route::post( '/post-title', [ AiController::class, 'postTitle' ] );
     Route::post( '/excerpt', [ AiController::class, 'excerpt' ] );

--- a/src/Livewire/Ai/AiTools.php
+++ b/src/Livewire/Ai/AiTools.php
@@ -1,0 +1,268 @@
+<?php
+
+/**
+ * Livewire trigger surface for the cms-framework AI features.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage CMSFramework
+ *
+ * @since      2.3.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Livewire\Ai;
+
+use ArtisanPackUI\Ai\Contracts\FeatureRegistry;
+use ArtisanPackUI\Ai\Exceptions\FeatureDisabledException;
+use ArtisanPackUI\Ai\Exceptions\FeatureError;
+use ArtisanPackUI\Ai\Exceptions\MissingCredentialsException;
+use ArtisanPackUI\CMSFramework\Ai\Agents\CategorySuggestionAgent;
+use ArtisanPackUI\CMSFramework\Ai\Agents\ExcerptGenerationAgent;
+use ArtisanPackUI\CMSFramework\Ai\Agents\PostTitleSuggestionAgent;
+use ArtisanPackUI\CMSFramework\Ai\Agents\SlugSuggestionAgent;
+use ArtisanPackUI\CMSFramework\Ai\Agents\TagSuggestionAgent;
+use ArtisanPackUI\CMSFramework\CMSFrameworkServiceProvider;
+use Illuminate\Support\Facades\Log;
+use Livewire\Attributes\On;
+use Livewire\Component;
+use Throwable;
+
+/**
+ * Thin Livewire wrapper that runs any of the five cms-framework AI
+ * agents and dispatches the shaped result via a browser event. Admin
+ * Blade surfaces (and any host embedding the CMS) listen for
+ * `ap-cms-ai:{featureKey}:{status}` and fold the payload into the UI.
+ *
+ * React and Vue front-ends do NOT need this component — they call the
+ * REST endpoints registered under `/api/v1/cms/ai/*` directly (see
+ * `AiController`). This keeps `@artisanpack-ui/react` and
+ * `@artisanpack-ui/vue` framework-agnostic: adding a new AI trigger
+ * only touches the backend package.
+ *
+ * The component intentionally holds no persistent state — a Livewire
+ * class was picked so CSRF, auth, and rate limiting come "for free"
+ * via the standard Livewire endpoint, and feature-toggle checks live
+ * in one place.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage CMSFramework
+ *
+ * @since      2.3.0
+ */
+class AiTools extends Component
+{
+    /**
+     * Generate 3–5 title variants from a draft body.
+     *
+     * @since 2.3.0
+     *
+     * @param  string       $content  Draft body.
+     * @param  string|null  $tone     Optional tone hint.
+     * @param  int|null     $count    Optional variant count (3-5).
+     *
+     * @return void
+     */
+    #[On( 'ap-cms-ai:suggest-post-titles' )]
+    public function suggestPostTitles( string $content, ?string $tone = null, ?int $count = null ): void
+    {
+        $this->run(
+            'cms.post_title',
+            fn () => PostTitleSuggestionAgent::for( [
+                'content' => $content,
+                'tone'    => $tone,
+                'count'   => $count,
+            ] )->run(),
+        );
+    }
+
+    /**
+     * Generate an excerpt from full post content.
+     *
+     * @since 2.3.0
+     *
+     * @param  string    $content   Full post body.
+     * @param  int|null  $maxChars  Optional length cap (80-400).
+     *
+     * @return void
+     */
+    #[On( 'ap-cms-ai:generate-excerpt' )]
+    public function generateExcerpt( string $content, ?int $maxChars = null ): void
+    {
+        $this->run(
+            'cms.excerpt',
+            fn () => ExcerptGenerationAgent::for( [
+                'content'   => $content,
+                'max_chars' => $maxChars,
+            ] )->run(),
+        );
+    }
+
+    /**
+     * Suggest tags from an existing taxonomy.
+     *
+     * @since 2.3.0
+     *
+     * @param  string             $content        Content to tag.
+     * @param  array<int, string> $availableTags  Existing tag names.
+     * @param  bool               $allowNew       Whether to include suggested_new.
+     * @param  int|null           $maxSelected    Optional cap on selected tags (1-10).
+     *
+     * @return void
+     */
+    #[On( 'ap-cms-ai:suggest-tags' )]
+    public function suggestTags(
+        string $content,
+        array $availableTags,
+        bool $allowNew = false,
+        ?int $maxSelected = null,
+    ): void {
+        $this->run(
+            'cms.suggest_tags',
+            fn () => TagSuggestionAgent::for( [
+                'content'        => $content,
+                'available_tags' => $availableTags,
+                'allow_new'      => $allowNew,
+                'max_selected'   => $maxSelected,
+            ] )->run(),
+        );
+    }
+
+    /**
+     * Suggest a single category from a hierarchical taxonomy.
+     *
+     * @since 2.3.0
+     *
+     * @param  string             $content       Content to categorize.
+     * @param  array<int, mixed>  $categoryTree  Nested list of {name, children?} nodes.
+     *
+     * @return void
+     */
+    #[On( 'ap-cms-ai:suggest-category' )]
+    public function suggestCategory( string $content, array $categoryTree ): void
+    {
+        $this->run(
+            'cms.suggest_category',
+            fn () => CategorySuggestionAgent::for( [
+                'content'       => $content,
+                'category_tree' => $categoryTree,
+            ] )->run(),
+        );
+    }
+
+    /**
+     * Suggest an SEO-friendly slug from a title.
+     *
+     * @since 2.3.0
+     *
+     * @param  string       $title     Post title.
+     * @param  string|null  $excerpt   Optional excerpt for disambiguation.
+     * @param  int|null     $maxChars  Optional length cap (20-100).
+     *
+     * @return void
+     */
+    #[On( 'ap-cms-ai:suggest-slug' )]
+    public function suggestSlug( string $title, ?string $excerpt = null, ?int $maxChars = null ): void
+    {
+        $this->run(
+            'cms.suggest_slug',
+            fn () => SlugSuggestionAgent::for( [
+                'title'     => $title,
+                'excerpt'   => $excerpt,
+                'max_chars' => $maxChars,
+            ] )->run(),
+        );
+    }
+
+    /**
+     * Return the currently-enabled feature toggle map so the front-end
+     * knows which affordances to render.
+     *
+     * @since 2.3.0
+     *
+     * @return array<string, bool>
+     */
+    public function enabledFeatures(): array
+    {
+        /** @var FeatureRegistry $registry */
+        $registry = app( FeatureRegistry::class );
+
+        $state = [];
+        foreach ( CMSFrameworkServiceProvider::AI_FEATURE_KEYS as $key ) {
+            $state[ $key ] = null !== $registry->get( $key ) && $registry->isToggleOn( $key );
+        }
+        return $state;
+    }
+
+    /**
+     * Blade shell — hosts can override the view or inline the component
+     * without body. The default view is intentionally empty; this is a
+     * transport component, not a UI.
+     *
+     * @since 2.3.0
+     *
+     * @return string
+     */
+    public function render(): string
+    {
+        return '<div class="ap-cms-ai-tools" data-testid="ap-cms-ai-tools"></div>';
+    }
+
+    /**
+     * Shared run-and-emit path. Kept private so callers can only reach
+     * agents through the five public entry points, each of which
+     * pre-shapes its input.
+     *
+     * @since 2.3.0
+     *
+     * @param  string   $featureKey  Feature key (for status events).
+     * @param  callable $callback    Callable that runs the agent and returns its output.
+     *
+     * @return void
+     */
+    private function run( string $featureKey, callable $callback ): void
+    {
+        try {
+            $output = $callback();
+
+            $this->dispatch(
+                sprintf( 'ap-cms-ai:%s:success', $featureKey ),
+                feature: $featureKey,
+                output: $output,
+            );
+        } catch ( FeatureDisabledException $e ) {
+            $this->dispatch(
+                sprintf( 'ap-cms-ai:%s:disabled', $featureKey ),
+                feature: $featureKey,
+                message: $e->getMessage(),
+            );
+        } catch ( MissingCredentialsException $e ) {
+            $this->dispatch(
+                sprintf( 'ap-cms-ai:%s:missing-credentials', $featureKey ),
+                feature: $featureKey,
+                message: $e->getMessage(),
+            );
+        } catch ( FeatureError $e ) {
+            // Validation-style failure (missing required field, hallucinated
+            // tag, etc.). Emit under a distinct event so front-ends can
+            // route it to a form-level warning instead of a generic
+            // error toast — mirrors the HTTP surface's 422 status.
+            $this->dispatch(
+                sprintf( 'ap-cms-ai:%s:invalid-input', $featureKey ),
+                feature: $featureKey,
+                message: $e->getMessage(),
+            );
+        } catch ( Throwable $e ) {
+            Log::error( 'cms-framework AI trigger failed', [
+                'feature' => $featureKey,
+                'error'   => $e->getMessage(),
+            ] );
+
+            $this->dispatch(
+                sprintf( 'ap-cms-ai:%s:error', $featureKey ),
+                feature: $featureKey,
+                message: 'Unexpected error running AI feature.',
+            );
+        }
+    }
+}

--- a/tests/Feature/Ai/AiAgentTestSetup.php
+++ b/tests/Feature/Ai/AiAgentTestSetup.php
@@ -1,0 +1,59 @@
+<?php
+
+/**
+ * Shared bootstrap for cms-framework AI agent tests.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage CMSFramework
+ *
+ * @since      2.3.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Tests\Feature\Ai;
+
+use ArtisanPackUI\Ai\Contracts\AgentPrompter;
+use ArtisanPackUI\Ai\Contracts\CredentialResolver;
+use ArtisanPackUI\Ai\Credentials\ChainedCredentialResolver;
+use ArtisanPackUI\Ai\Credentials\Credentials;
+use ArtisanPackUI\CMSFramework\CMSFrameworkServiceProvider;
+use ArtisanPackUI\CMSFramework\Tests\Support\FakeAgentPrompter;
+
+/**
+ * Registers a fake prompter, stub credentials, and enables the five
+ * feature toggles the CMS AI surface cares about.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage CMSFramework
+ *
+ * @since      2.3.0
+ */
+final class AiAgentTestSetup
+{
+    /**
+     * @since 2.3.0
+     *
+     * @param  \Illuminate\Foundation\Application  $app  Application instance.
+     *
+     * @return FakeAgentPrompter The bound fake prompter.
+     */
+    public static function bootstrap( $app ): FakeAgentPrompter
+    {
+        /** @var ChainedCredentialResolver $resolver */
+        $resolver = $app->make( CredentialResolver::class );
+        $resolver->setOverride(
+            new Credentials( provider: 'anthropic', apiKey: 'sk-test', defaultModel: 'claude-haiku-4-5' ),
+        );
+        $resolver->useStore( fn () => null );
+
+        $prompter = new FakeAgentPrompter();
+        $app->instance( AgentPrompter::class, $prompter );
+
+        foreach ( CMSFrameworkServiceProvider::AI_FEATURE_KEYS as $key ) {
+            $app['config']->set( "artisanpack.ai.features.{$key}.enabled", true );
+        }
+
+        return $prompter;
+    }
+}

--- a/tests/Feature/Ai/CategorySuggestionAgentTest.php
+++ b/tests/Feature/Ai/CategorySuggestionAgentTest.php
@@ -84,6 +84,33 @@ it( 'clamps confidence to [0, 1]', function (): void {
     expect( $result['confidence'] )->toBe( 1.0 );
 } );
 
+it( 'ignores category nodes whose name contains the path separator', function (): void {
+    $ambiguousTree = [
+        [ 'name' => 'News/Updates' ], // rejected — would collide with the nested form
+        [
+            'name'     => 'News',
+            'children' => [
+                [ 'name' => 'Updates' ],
+            ],
+        ],
+    ];
+
+    $this->prompter->queue( [
+        'selected'   => 'News/Updates',
+        'confidence' => 0.9,
+        'rationale'  => 'nested form',
+    ] );
+
+    $result = CategorySuggestionAgent::for( [
+        'content'       => 'body',
+        'category_tree' => $ambiguousTree,
+    ] )->run();
+
+    // The path resolves unambiguously via the nested form; the ambiguous root
+    // never entered valid_paths, so a hallucination there could not survive.
+    expect( $result['selected'] )->toBe( 'News/Updates' );
+} );
+
 it( 'raises FeatureError on invalid input', function (): void {
     expect( fn () => CategorySuggestionAgent::for( 'nope' )->run() )->toThrow( FeatureError::class );
 

--- a/tests/Feature/Ai/CategorySuggestionAgentTest.php
+++ b/tests/Feature/Ai/CategorySuggestionAgentTest.php
@@ -1,0 +1,95 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Tests\Feature\Ai;
+
+use ArtisanPackUI\Ai\Exceptions\FeatureError;
+use ArtisanPackUI\CMSFramework\Ai\Agents\CategorySuggestionAgent;
+
+beforeEach( function (): void {
+    $this->prompter = AiAgentTestSetup::bootstrap( $this->app );
+
+    $this->tree = [
+        [
+            'name'     => 'News',
+            'children' => [
+                [ 'name' => 'Product Updates' ],
+                [ 'name' => 'Company' ],
+            ],
+        ],
+        [ 'name' => 'Tutorials' ],
+    ];
+} );
+
+it( 'accepts a valid slash-delimited path', function (): void {
+    $this->prompter->queue( [
+        'selected'   => 'News/Product Updates',
+        'confidence' => 0.9,
+        'rationale'  => 'body announces a new feature',
+    ] );
+
+    $result = CategorySuggestionAgent::for( [
+        'content'       => 'We just shipped X.',
+        'category_tree' => $this->tree,
+    ] )->run();
+
+    expect( $result['selected'] )->toBe( 'News/Product Updates' );
+    expect( $result['confidence'] )->toBe( 0.9 );
+} );
+
+it( 'drops hallucinated paths and zeros confidence when no fit is chosen', function (): void {
+    $this->prompter->queue( [
+        'selected'   => 'News/Not A Real Child',
+        'confidence' => 0.8,
+        'rationale'  => 'guessed',
+    ] );
+
+    $result = CategorySuggestionAgent::for( [
+        'content'       => 'body',
+        'category_tree' => $this->tree,
+    ] )->run();
+
+    expect( $result['selected'] )->toBe( '' );
+    expect( $result['confidence'] )->toBe( 0.0 );
+} );
+
+it( 'accepts a root-level path', function (): void {
+    $this->prompter->queue( [
+        'selected'   => 'Tutorials',
+        'confidence' => 0.7,
+        'rationale'  => 'looks like a tutorial',
+    ] );
+
+    $result = CategorySuggestionAgent::for( [
+        'content'       => 'body',
+        'category_tree' => $this->tree,
+    ] )->run();
+
+    expect( $result['selected'] )->toBe( 'Tutorials' );
+} );
+
+it( 'clamps confidence to [0, 1]', function (): void {
+    $this->prompter->queue( [
+        'selected'   => 'Tutorials',
+        'confidence' => 2.5,
+        'rationale'  => 'r',
+    ] );
+
+    $result = CategorySuggestionAgent::for( [
+        'content'       => 'body',
+        'category_tree' => $this->tree,
+    ] )->run();
+
+    expect( $result['confidence'] )->toBe( 1.0 );
+} );
+
+it( 'raises FeatureError on invalid input', function (): void {
+    expect( fn () => CategorySuggestionAgent::for( 'nope' )->run() )->toThrow( FeatureError::class );
+
+    expect( fn () => CategorySuggestionAgent::for( [ 'content' => 'ok' ] )->run() )
+        ->toThrow( FeatureError::class );
+
+    expect( fn () => CategorySuggestionAgent::for( [ 'category_tree' => [] ] )->run() )
+        ->toThrow( FeatureError::class );
+} );

--- a/tests/Feature/Ai/ExcerptGenerationAgentTest.php
+++ b/tests/Feature/Ai/ExcerptGenerationAgentTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Tests\Feature\Ai;
+
+use ArtisanPackUI\Ai\Exceptions\FeatureError;
+use ArtisanPackUI\CMSFramework\Ai\Agents\ExcerptGenerationAgent;
+
+beforeEach( function (): void {
+    $this->prompter = AiAgentTestSetup::bootstrap( $this->app );
+} );
+
+it( 'returns the excerpt and computes char_count from the returned string', function (): void {
+    $this->prompter->queue( [
+        'excerpt'    => 'A short excerpt.',
+        'char_count' => 999, // model lying — validator must recompute
+    ] );
+
+    $result = ExcerptGenerationAgent::for( [ 'content' => 'A long post about many things.' ] )->run();
+
+    expect( $result['excerpt'] )->toBe( 'A short excerpt.' );
+    expect( $result['char_count'] )->toBe( mb_strlen( 'A short excerpt.' ) );
+} );
+
+it( 'truncates excerpts longer than max_chars', function (): void {
+    $long = str_repeat( 'x', 300 );
+    $this->prompter->queue( [ 'excerpt' => $long, 'char_count' => 300 ] );
+
+    $result = ExcerptGenerationAgent::for( [
+        'content'   => 'body',
+        'max_chars' => 150,
+    ] )->run();
+
+    expect( mb_strlen( $result['excerpt'] ) )->toBe( 150 );
+    expect( $result['char_count'] )->toBe( 150 );
+} );
+
+it( 'forwards max_chars into the prompter message', function (): void {
+    $this->prompter->queue( [ 'excerpt' => 'ok', 'char_count' => 2 ] );
+
+    ExcerptGenerationAgent::for( [
+        'content'   => 'body',
+        'max_chars' => 250,
+    ] )->run();
+
+    $parts = collect( $this->prompter->calls[0]['message'] )->pluck( 'text' );
+    expect( $parts->contains( fn ( string $t ): bool => str_contains( $t, 'max_chars: 250' ) ) )->toBeTrue();
+} );
+
+it( 'raises FeatureError on invalid input', function (): void {
+    expect( fn () => ExcerptGenerationAgent::for( 'not-an-array' )->run() )
+        ->toThrow( FeatureError::class );
+
+    expect( fn () => ExcerptGenerationAgent::for( [ 'content' => '' ] )->run() )
+        ->toThrow( FeatureError::class );
+} );

--- a/tests/Feature/Ai/FeatureRegistrationTest.php
+++ b/tests/Feature/Ai/FeatureRegistrationTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Tests\Feature\Ai;
+
+use ArtisanPackUI\Ai\Contracts\FeatureRegistry;
+use ArtisanPackUI\CMSFramework\Ai\Agents\CategorySuggestionAgent;
+use ArtisanPackUI\CMSFramework\Ai\Agents\ExcerptGenerationAgent;
+use ArtisanPackUI\CMSFramework\Ai\Agents\PostTitleSuggestionAgent;
+use ArtisanPackUI\CMSFramework\Ai\Agents\SlugSuggestionAgent;
+use ArtisanPackUI\CMSFramework\Ai\Agents\TagSuggestionAgent;
+use ArtisanPackUI\CMSFramework\CMSFrameworkServiceProvider;
+
+it( 'declares five cms.* features from the service provider', function (): void {
+    $provider = new CMSFrameworkServiceProvider( $this->app );
+    $features = $provider->aiFeatures();
+
+    expect( $features )->toHaveKeys( [
+        'cms.post_title',
+        'cms.excerpt',
+        'cms.suggest_tags',
+        'cms.suggest_category',
+        'cms.suggest_slug',
+    ] );
+
+    expect( $features['cms.post_title']['agent'] )->toBe( PostTitleSuggestionAgent::class );
+    expect( $features['cms.excerpt']['agent'] )->toBe( ExcerptGenerationAgent::class );
+    expect( $features['cms.suggest_tags']['agent'] )->toBe( TagSuggestionAgent::class );
+    expect( $features['cms.suggest_category']['agent'] )->toBe( CategorySuggestionAgent::class );
+    expect( $features['cms.suggest_slug']['agent'] )->toBe( SlugSuggestionAgent::class );
+
+    foreach ( $features as $definition ) {
+        expect( $definition['package'] )->toBe( 'artisanpack-ui/cms-framework' );
+    }
+} );
+
+it( 'registers the five features with the FeatureRegistry at boot', function (): void {
+    /** @var FeatureRegistry $registry */
+    $registry = $this->app->make( FeatureRegistry::class );
+
+    foreach ( CMSFrameworkServiceProvider::AI_FEATURE_KEYS as $key ) {
+        expect( $registry->get( $key ) )->not->toBeNull();
+    }
+} );

--- a/tests/Feature/Ai/PostTitleSuggestionAgentTest.php
+++ b/tests/Feature/Ai/PostTitleSuggestionAgentTest.php
@@ -1,0 +1,90 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Tests\Feature\Ai;
+
+use ArtisanPackUI\Ai\Exceptions\FeatureError;
+use ArtisanPackUI\CMSFramework\Ai\Agents\PostTitleSuggestionAgent;
+
+beforeEach( function (): void {
+    $this->prompter = AiAgentTestSetup::bootstrap( $this->app );
+} );
+
+it( 'returns shaped titles when the prompter responds', function (): void {
+    $this->prompter->queue( [
+        'titles' => [
+            [ 'title' => 'How to Ship Faster', 'rationale' => 'benefit-led' ],
+            [ 'title' => 'What Makes a Great CMS?', 'rationale' => 'curiosity question' ],
+            [ 'title' => 'Ship Faster with the CMS Framework', 'rationale' => 'direct/descriptive' ],
+        ],
+    ] );
+
+    $result = PostTitleSuggestionAgent::for( [
+        'content' => 'A long draft about shipping faster with the CMS framework.',
+    ] )->run();
+
+    expect( $result['titles'] )->toHaveCount( 3 );
+    expect( $result['titles'][0]['title'] )->toBe( 'How to Ship Faster' );
+} );
+
+it( 'drops titles missing required fields', function (): void {
+    $this->prompter->queue( [
+        'titles' => [
+            [ 'title' => 'Ok', 'rationale' => 'direct' ],
+            [ 'title'     => '', 'rationale' => 'empty title' ],
+            [ 'rationale' => 'no title at all' ],
+        ],
+    ] );
+
+    $result = PostTitleSuggestionAgent::for( [ 'content' => 'body' ] )->run();
+
+    expect( $result['titles'] )->toHaveCount( 1 );
+    expect( $result['titles'][0]['title'] )->toBe( 'Ok' );
+} );
+
+it( 'clamps titles longer than 80 chars', function (): void {
+    $long = str_repeat( 'a', 120 );
+    $this->prompter->queue( [
+        'titles' => [ [ 'title' => $long, 'rationale' => 'too long' ] ],
+    ] );
+
+    $result = PostTitleSuggestionAgent::for( [ 'content' => 'body' ] )->run();
+
+    expect( mb_strlen( $result['titles'][0]['title'] ) )->toBe( 80 );
+} );
+
+it( 'honors the requested count', function (): void {
+    $queued = [ 'titles' => [] ];
+    for ( $i = 0; $i < 5; $i++ ) {
+        $queued['titles'][] = [ 'title' => "Title {$i}", 'rationale' => 'ok' ];
+    }
+    $this->prompter->queue( $queued );
+
+    $result = PostTitleSuggestionAgent::for( [
+        'content' => 'body',
+        'count'   => 3,
+    ] )->run();
+
+    expect( $result['titles'] )->toHaveCount( 3 );
+} );
+
+it( 'forwards tone into the prompter message when set', function (): void {
+    $this->prompter->queue( [ 'titles' => [ [ 'title' => 't', 'rationale' => 'r' ] ] ] );
+
+    PostTitleSuggestionAgent::for( [
+        'content' => 'body',
+        'tone'    => 'playful',
+    ] )->run();
+
+    $parts = collect( $this->prompter->calls[0]['message'] )->pluck( 'text' );
+    expect( $parts->contains( fn ( string $t ): bool => str_contains( $t, 'Tone: playful' ) ) )->toBeTrue();
+} );
+
+it( 'raises FeatureError on invalid input', function (): void {
+    expect( fn () => PostTitleSuggestionAgent::for( 'not-an-array' )->run() )
+        ->toThrow( FeatureError::class );
+
+    expect( fn () => PostTitleSuggestionAgent::for( [ 'content' => '' ] )->run() )
+        ->toThrow( FeatureError::class );
+} );

--- a/tests/Feature/Ai/SlugSuggestionAgentTest.php
+++ b/tests/Feature/Ai/SlugSuggestionAgentTest.php
@@ -34,6 +34,19 @@ it( 'sanitizes non-kebab output from the model', function (): void {
     expect( $result['slug'] )->toBe( 'how-to-ship-faster' );
 } );
 
+it( 'transliterates non-ASCII characters instead of collapsing them to hyphens', function (): void {
+    $this->prompter->queue( [
+        'slug'       => 'café-culture-año',
+        'alternates' => [],
+    ] );
+
+    $result = SlugSuggestionAgent::for( [ 'title' => 'Café Culture — Año Nuevo' ] )->run();
+
+    // A byte-oriented regex would produce 'caf-culture-a-o' or similar.
+    // Str::slug() transliterates é→e and ñ→n instead.
+    expect( $result['slug'] )->toBe( 'cafe-culture-ano' );
+} );
+
 it( 'clamps the slug to max_chars on a hyphen boundary when possible', function (): void {
     $this->prompter->queue( [
         'slug'       => 'a-b-c-d-e-f-g-h-i-j-k-l-m-n-o-p-q-r-s-t-u-v-w-x-y-z',

--- a/tests/Feature/Ai/SlugSuggestionAgentTest.php
+++ b/tests/Feature/Ai/SlugSuggestionAgentTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Tests\Feature\Ai;
+
+use ArtisanPackUI\Ai\Exceptions\FeatureError;
+use ArtisanPackUI\CMSFramework\Ai\Agents\SlugSuggestionAgent;
+
+beforeEach( function (): void {
+    $this->prompter = AiAgentTestSetup::bootstrap( $this->app );
+} );
+
+it( 'returns the model slug and any alternates', function (): void {
+    $this->prompter->queue( [
+        'slug'       => 'ship-faster-cms',
+        'alternates' => [ 'faster-cms', 'cms-shipping' ],
+    ] );
+
+    $result = SlugSuggestionAgent::for( [ 'title' => 'How to Ship Faster with the CMS' ] )->run();
+
+    expect( $result['slug'] )->toBe( 'ship-faster-cms' );
+    expect( $result['alternates'] )->toBe( [ 'faster-cms', 'cms-shipping' ] );
+} );
+
+it( 'sanitizes non-kebab output from the model', function (): void {
+    $this->prompter->queue( [
+        'slug'       => 'How To_Ship__Faster!!',
+        'alternates' => [],
+    ] );
+
+    $result = SlugSuggestionAgent::for( [ 'title' => 'Anything' ] )->run();
+
+    expect( $result['slug'] )->toBe( 'how-to-ship-faster' );
+} );
+
+it( 'clamps the slug to max_chars on a hyphen boundary when possible', function (): void {
+    $this->prompter->queue( [
+        'slug'       => 'a-b-c-d-e-f-g-h-i-j-k-l-m-n-o-p-q-r-s-t-u-v-w-x-y-z',
+        'alternates' => [],
+    ] );
+
+    $result = SlugSuggestionAgent::for( [
+        'title'     => 'title',
+        'max_chars' => 20,
+    ] )->run();
+
+    expect( strlen( $result['slug'] ) )->toBeLessThanOrEqual( 20 );
+    expect( str_ends_with( $result['slug'], '-' ) )->toBeFalse();
+} );
+
+it( 'drops alternates that duplicate the primary slug or each other', function (): void {
+    $this->prompter->queue( [
+        'slug'       => 'ship-faster',
+        'alternates' => [ 'ship-faster', 'faster-shipping', 'faster-shipping' ],
+    ] );
+
+    $result = SlugSuggestionAgent::for( [ 'title' => 't' ] )->run();
+
+    expect( $result['alternates'] )->toBe( [ 'faster-shipping' ] );
+} );
+
+it( 'raises FeatureError on invalid input', function (): void {
+    expect( fn () => SlugSuggestionAgent::for( 'nope' )->run() )->toThrow( FeatureError::class );
+
+    expect( fn () => SlugSuggestionAgent::for( [ 'title' => '' ] )->run() )
+        ->toThrow( FeatureError::class );
+} );

--- a/tests/Feature/Ai/TagSuggestionAgentTest.php
+++ b/tests/Feature/Ai/TagSuggestionAgentTest.php
@@ -1,0 +1,109 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Tests\Feature\Ai;
+
+use ArtisanPackUI\Ai\Exceptions\FeatureError;
+use ArtisanPackUI\CMSFramework\Ai\Agents\TagSuggestionAgent;
+
+beforeEach( function (): void {
+    $this->prompter = AiAgentTestSetup::bootstrap( $this->app );
+} );
+
+it( 'returns only tags that appear in available_tags', function (): void {
+    $this->prompter->queue( [
+        'selected' => [
+            [ 'tag' => 'laravel', 'confidence' => 0.9 ],
+            [ 'tag' => 'not-a-real-tag', 'confidence' => 0.7 ], // must be dropped
+            [ 'tag' => 'cms', 'confidence' => 0.6 ],
+        ],
+    ] );
+
+    $result = TagSuggestionAgent::for( [
+        'content'        => 'post body',
+        'available_tags' => [ 'laravel', 'cms', 'php' ],
+    ] )->run();
+
+    expect( $result['selected'] )->toHaveCount( 2 );
+    expect( collect( $result['selected'] )->pluck( 'tag' )->all() )->toBe( [ 'laravel', 'cms' ] );
+} );
+
+it( 'omits suggested_new when allow_new is false', function (): void {
+    $this->prompter->queue( [
+        'selected'      => [],
+        'suggested_new' => [ 'brand-new-tag' ],
+    ] );
+
+    $result = TagSuggestionAgent::for( [
+        'content'        => 'body',
+        'available_tags' => [ 'a' ],
+    ] )->run();
+
+    expect( $result )->not->toHaveKey( 'suggested_new' );
+} );
+
+it( 'returns suggested_new when allow_new is true, dropping duplicates', function (): void {
+    $this->prompter->queue( [
+        'selected'      => [],
+        'suggested_new' => [
+            'brand-new-tag',
+            'Laravel', // already exists case-insensitively
+            'brand-new-tag', // duplicate within response
+            'another-new',
+        ],
+    ] );
+
+    $result = TagSuggestionAgent::for( [
+        'content'        => 'body',
+        'available_tags' => [ 'laravel' ],
+        'allow_new'      => true,
+    ] )->run();
+
+    expect( $result['suggested_new'] )->toBe( [ 'brand-new-tag', 'another-new' ] );
+} );
+
+it( 'clamps confidences to [0, 1]', function (): void {
+    $this->prompter->queue( [
+        'selected' => [
+            [ 'tag' => 'a', 'confidence' => 1.7 ],
+            [ 'tag' => 'b', 'confidence' => -0.3 ],
+        ],
+    ] );
+
+    $result = TagSuggestionAgent::for( [
+        'content'        => 'body',
+        'available_tags' => [ 'a', 'b' ],
+    ] )->run();
+
+    expect( $result['selected'][0]['confidence'] )->toBe( 1.0 );
+    expect( $result['selected'][1]['confidence'] )->toBe( 0.0 );
+} );
+
+it( 'honors max_selected', function (): void {
+    $this->prompter->queue( [
+        'selected' => [
+            [ 'tag' => 'a', 'confidence' => 1.0 ],
+            [ 'tag' => 'b', 'confidence' => 0.9 ],
+            [ 'tag' => 'c', 'confidence' => 0.8 ],
+        ],
+    ] );
+
+    $result = TagSuggestionAgent::for( [
+        'content'        => 'body',
+        'available_tags' => [ 'a', 'b', 'c' ],
+        'max_selected'   => 2,
+    ] )->run();
+
+    expect( $result['selected'] )->toHaveCount( 2 );
+} );
+
+it( 'raises FeatureError on invalid input', function (): void {
+    expect( fn () => TagSuggestionAgent::for( 'nope' )->run() )->toThrow( FeatureError::class );
+
+    expect( fn () => TagSuggestionAgent::for( [ 'available_tags' => [] ] )->run() )
+        ->toThrow( FeatureError::class );
+
+    expect( fn () => TagSuggestionAgent::for( [ 'content' => 'ok' ] )->run() )
+        ->toThrow( FeatureError::class );
+} );

--- a/tests/Feature/Ai/TagSuggestionAgentTest.php
+++ b/tests/Feature/Ai/TagSuggestionAgentTest.php
@@ -29,6 +29,22 @@ it( 'returns only tags that appear in available_tags', function (): void {
     expect( collect( $result['selected'] )->pluck( 'tag' )->all() )->toBe( [ 'laravel', 'cms' ] );
 } );
 
+it( 'trims incidental whitespace from model-returned tags before allow-list lookup', function (): void {
+    $this->prompter->queue( [
+        'selected' => [
+            [ 'tag' => 'laravel ', 'confidence' => 0.9 ],
+            [ 'tag' => "\tcms\n", 'confidence' => 0.8 ],
+        ],
+    ] );
+
+    $result = TagSuggestionAgent::for( [
+        'content'        => 'body',
+        'available_tags' => [ 'laravel', 'cms' ],
+    ] )->run();
+
+    expect( collect( $result['selected'] )->pluck( 'tag' )->all() )->toBe( [ 'laravel', 'cms' ] );
+} );
+
 it( 'omits suggested_new when allow_new is false', function (): void {
     $this->prompter->queue( [
         'selected'      => [],

--- a/tests/Support/FakeAgentPrompter.php
+++ b/tests/Support/FakeAgentPrompter.php
@@ -1,0 +1,93 @@
+<?php
+
+/**
+ * Test fake for the AgentPrompter contract.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage CMSFramework
+ *
+ * @since      2.3.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Tests\Support;
+
+use ArtisanPackUI\Ai\Contracts\AgentPrompter;
+use ArtisanPackUI\Ai\Credentials\Credentials;
+
+/**
+ * Records every prompter call and returns queued responses in FIFO
+ * order. Mirrors the fakes shipped by the ai package's own suite and
+ * by visual-editor.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage CMSFramework
+ *
+ * @since      2.3.0
+ */
+final class FakeAgentPrompter implements AgentPrompter
+{
+    /**
+     * Recorded calls, in invocation order.
+     *
+     * @var array<int, array<string, mixed>>
+     */
+    public array $calls = [];
+
+    /**
+     * Queued responses (FIFO).
+     *
+     * @var array<int, array<string, mixed>>
+     */
+    private array $queue = [];
+
+    /**
+     * Push a canned response onto the queue.
+     *
+     * @since 2.3.0
+     *
+     * @param  array<string, mixed>  $output        Structured output body.
+     * @param  int                   $inputTokens   Reported input tokens.
+     * @param  int                   $outputTokens  Reported output tokens.
+     *
+     * @return void
+     */
+    public function queue( array $output, int $inputTokens = 100, int $outputTokens = 50 ): void
+    {
+        $this->queue[] = [
+            'output'        => $output,
+            'input_tokens'  => $inputTokens,
+            'output_tokens' => $outputTokens,
+        ];
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function prompt(
+        Credentials $credentials,
+        string $model,
+        string $instructions,
+        string|array $message,
+        array $outputSchema,
+    ): array {
+        $this->calls[] = [
+            'credentials'   => $credentials,
+            'model'         => $model,
+            'instructions'  => $instructions,
+            'message'       => $message,
+            'output_schema' => $outputSchema,
+        ];
+
+        if ( [] === $this->queue ) {
+            return [
+                'output'        => [],
+                'input_tokens'  => 0,
+                'output_tokens' => 0,
+            ];
+        }
+
+        return array_shift( $this->queue );
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -10,6 +10,7 @@ declare( strict_types=1 );
 
 namespace ArtisanPackUI\CMSFramework\Tests;
 
+use ArtisanPackUI\Ai\AiServiceProvider;
 use ArtisanPackUI\CMSFramework\CMSFrameworkServiceProvider;
 use ArtisanPackUI\CMSFramework\Tests\Support\TestUser;
 use ArtisanPackUI\Hooks\Providers\HooksServiceProvider;
@@ -59,6 +60,7 @@ class TestCase extends \Orchestra\Testbench\TestCase
             SanctumServiceProvider::class,
             CMSFrameworkServiceProvider::class,
             HooksServiceProvider::class,
+            AiServiceProvider::class,
         ];
     }
 


### PR DESCRIPTION
## Description

Implements the CMS branch of the artisanpack-ui AI RFC — five content-authoring agents that hosts (visual-editor, custom admin surfaces, external React/Vue apps) can invoke to produce post titles, excerpts, tags, category picks, and SEO-friendly slugs.

**Closes:** #170, #171, #172, #173, #174

## Type of Change

- [x] New feature (adds new functionality)

## Motivation and Context

The AI RFC asks each package to own the AI features it produces. This adds the CMS-owned five and wires them into every front-end without requiring the shared React/Vue packages to know they exist.

Key design point per the issue request: the REST endpoints under `/api/v1/cms/ai/*` are the framework-agnostic path — React and Vue apps hit them directly via `fetch`, so no changes are required in `@artisanpack-ui/react` or `@artisanpack-ui/vue`. The Livewire component (`ap-cms-ai-tools`) exists purely for Blade/Livewire hosts.

## Changes Made

- Five new agents extending `ArtisanPackAgent`:
  - `PostTitleSuggestionAgent` (`cms.post_title`)
  - `ExcerptGenerationAgent` (`cms.excerpt`)
  - `TagSuggestionAgent` (`cms.suggest_tags`)
  - `CategorySuggestionAgent` (`cms.suggest_category`)
  - `SlugSuggestionAgent` (`cms.suggest_slug`)
- Service provider registers all five via `aiFeatures()` and exposes the canonical `AI_FEATURE_KEYS` constant.
- Livewire component `Livewire\Ai\AiTools` for Blade/Livewire hosts (browser events on `ap-cms-ai:*`).
- REST controller `Http\Controllers\Ai\AiController` + form requests + routes mounted at `/api/v1/cms/ai/*` for React/Vue/any HTTP client.
- Soft dependency on `artisanpack-ui/ai ^1.0` — declared as `suggest`, wired via `interface_exists( FeatureRegistry::class )` and `class_exists( Livewire::class )` guards so the framework still boots without either.
- README section documenting the five features, trigger surfaces, and REST contract.

## How Has This Been Tested?

**Testing Environment:**
- PHP Version: 8.4
- Project Version: 2.3.x

**Tests Performed:**
1. Full package Pest suite — 1023 passed, 7 skipped, 0 failed.
2. 28 new AI feature tests exercising happy paths, output-shape validation, hallucinated-value rejection, feature registration, and input-validation error paths.
3. `php-cs-fixer` clean on all touched files.

**Manual testing (please verify before merge):**
- Wire an app to a real Anthropic key and hit `/api/v1/cms/ai/features` — confirm all five toggle on.
- Fire one agent end-to-end (e.g. `POST /api/v1/cms/ai/post-title`) with a draft body and confirm shaped output.
- Verify the Livewire component emits `ap-cms-ai:cms.post_title:success` when triggered from a Blade surface.

## Accessibility Tests Run

- [x] N/A — backend-only change (no UI surface). Trigger surfaces (Livewire component and REST controller) are transport, not UI.

## Tests Added

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] All tests passing

**Test details:** 28 new Pest tests in `tests/Feature/Ai/` covering all five agents plus feature registration. Uses a shared `FakeAgentPrompter` + `AiAgentTestSetup` (mirrors the ai package's own patterns) so tests never make real model calls.

## Documentation

- [x] Inline code documentation added
- [x] README updated

**Documentation details:** New "AI features" section in `README.md` documenting all five feature keys, their agents, both trigger surfaces (Livewire events + REST endpoints), and the soft-dependency contract.

## Pre-Submission Checklist

- [x] Code passes all tests
- [x] Code has been linted (`php-cs-fixer`)
- [x] Code follows project style guide
- [x] Self-review completed
- [x] No new warnings generated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added five AI-assisted content tools: post title variants, excerpt generation, tag suggestions, category path suggestions, and SEO slug suggestions.
  * Exposed the tools via authenticated REST endpoints under `/api/v1/cms/ai` and a Livewire/browser-event trigger surface.
  * Added endpoint support for checking which AI features are currently enabled.
* **Documentation**
  * Documented the new “AI features” in the README, including request/response behavior and setup requirements.
* **Bug Fixes**
  * Strengthened AI output shaping with stricter trimming, validation, and confidence/limit clamping.
* **Tests**
  * Added end-to-end coverage for agent behavior, feature registration, and input validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->