### PR TITLE
Release v2.3.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: ['8.2', '8.3', '8.4']
+        php: ['8.3', '8.4']
 
     steps:
       - uses: actions/checkout@v4
@@ -77,17 +77,6 @@ jobs:
           key: ${{ runner.os }}-php${{ matrix.php }}-composer-${{ hashFiles('**/composer.json') }}
           restore-keys: ${{ runner.os }}-php${{ matrix.php }}-composer-
 
-      - name: Remove AI dev deps (PHP 8.2)
-        # `artisanpack-ui/ai` (and by extension the AI trigger surface)
-        # requires PHP 8.3+. Strip both it and livewire (which the ai
-        # component surface depends on) on 8.2 so `composer update`
-        # can resolve; the AI test suite is excluded below via
-        # `--exclude-testsuite=Ai`.
-        if: matrix.php == '8.2'
-        run: |
-          jq 'del(.["require-dev"]["artisanpack-ui/ai"], .["require-dev"]["livewire/livewire"])' composer.json > composer.json.tmp
-          mv composer.json.tmp composer.json
-
       - name: Install dependencies
         run: composer update --no-interaction --prefer-dist
 
@@ -99,10 +88,9 @@ jobs:
       - name: Run Feature tests
         env:
           XDEBUG_MODE: off
-        run: |
-          if [ "${{ matrix.php }}" = "8.2" ]; then
-            vendor/bin/pest --testsuite=Feature --no-coverage
-          else
-            vendor/bin/pest --testsuite=Feature --no-coverage
-            vendor/bin/pest --testsuite=Ai --no-coverage
-          fi
+        run: vendor/bin/pest --testsuite=Feature --no-coverage
+
+      - name: Run AI tests
+        env:
+          XDEBUG_MODE: off
+        run: vendor/bin/pest --testsuite=Ai --no-coverage

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,15 +77,32 @@ jobs:
           key: ${{ runner.os }}-php${{ matrix.php }}-composer-${{ hashFiles('**/composer.json') }}
           restore-keys: ${{ runner.os }}-php${{ matrix.php }}-composer-
 
+      - name: Remove AI dev deps (PHP 8.2)
+        # `artisanpack-ui/ai` (and by extension the AI trigger surface)
+        # requires PHP 8.3+. Strip both it and livewire (which the ai
+        # component surface depends on) on 8.2 so `composer update`
+        # can resolve; the AI test suite is excluded below via
+        # `--exclude-testsuite=Ai`.
+        if: matrix.php == '8.2'
+        run: |
+          jq 'del(.["require-dev"]["artisanpack-ui/ai"], .["require-dev"]["livewire/livewire"])' composer.json > composer.json.tmp
+          mv composer.json.tmp composer.json
+
       - name: Install dependencies
         run: composer update --no-interaction --prefer-dist
 
       - name: Run Unit tests
         env:
           XDEBUG_MODE: off
-        run: vendor/bin/pest tests/Unit --no-coverage
+        run: vendor/bin/pest --testsuite=Unit --no-coverage
 
       - name: Run Feature tests
         env:
           XDEBUG_MODE: off
-        run: vendor/bin/pest tests/Feature --no-coverage
+        run: |
+          if [ "${{ matrix.php }}" = "8.2" ]; then
+            vendor/bin/pest --testsuite=Feature --no-coverage
+          else
+            vendor/bin/pest --testsuite=Feature --no-coverage
+            vendor/bin/pest --testsuite=Ai --no-coverage
+          fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Minimum PHP raised to 8.3** ([#175](https://github.com/ArtisanPack-UI/cms-framework/pull/175)) — the `artisanpack-ui/ai` foundation this release depends on requires PHP 8.3+, and running a Composer resolution across the two constraints is not possible on PHP 8.2. Hosts still on PHP 8.2 should stay on the 2.2.x line until they can upgrade the runtime. No API changes; the codebase itself does not yet require 8.3-only syntax.
 - **Dependencies** — `artisanpack-ui/ai ^1.0` added as `suggest` + `require-dev`. Without it the AI Livewire component and REST routes stay unregistered and the framework boots normally.
 
 ## [2.2.3] - 2026-06-14

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+## [2.3.0] - 2026-07-09
+
+### Added
+
+- **AI content-authoring agents** ([#170](https://github.com/ArtisanPack-UI/cms-framework/issues/170), [#171](https://github.com/ArtisanPack-UI/cms-framework/issues/171), [#172](https://github.com/ArtisanPack-UI/cms-framework/issues/172), [#173](https://github.com/ArtisanPack-UI/cms-framework/issues/173), [#174](https://github.com/ArtisanPack-UI/cms-framework/issues/174), [#175](https://github.com/ArtisanPack-UI/cms-framework/pull/175)) — Five new agents built on the `artisanpack-ui/ai` v1.0 foundation:
+  - `PostTitleSuggestionAgent` (`cms.post_title`) — generate 3–5 title variants from a draft body.
+  - `ExcerptGenerationAgent` (`cms.excerpt`) — generate a natural excerpt (default ≤200 chars) from full post content.
+  - `TagSuggestionAgent` (`cms.suggest_tags`) — pick tags from an existing taxonomy, optionally propose new ones.
+  - `CategorySuggestionAgent` (`cms.suggest_category`) — pick one category (slash-delimited path) from a hierarchical tree.
+  - `SlugSuggestionAgent` (`cms.suggest_slug`) — produce an SEO-friendly kebab-case slug from a title, delegating ASCII folding to `Str::slug()`.
+
+  Every agent honors the `artisanpack.ai.features.<key>.enabled` toggle and is auto-discovered via `CMSFrameworkServiceProvider::aiFeatures()`.
+
+- **AI trigger surfaces** — two consumer surfaces expose the same five agents:
+  - Livewire component `ap-cms-ai-tools` (`ArtisanPackUI\CMSFramework\Livewire\Ai\AiTools`) — dispatch `ap-cms-ai:{action}` browser events, receive results on `ap-cms-ai:{featureKey}:{status}`.
+  - REST controller mounted at `/api/v1/cms/ai/*` (`ArtisanPackUI\CMSFramework\Http\Controllers\Ai\AiController`) — framework-agnostic path for React, Vue, or any HTTP client. Endpoints are guarded by `auth:sanctum` so bearer-token SPAs can authenticate. Adding a new CMS AI feature never requires touching the `@artisanpack-ui/react` or `@artisanpack-ui/vue` packages.
+
+- **`AI_FEATURE_KEYS` constant** on `CMSFrameworkServiceProvider` — canonical list of the five `cms.*` feature keys, consumed by both trigger surfaces.
+
+### Changed
+
+- **Dependencies** — `artisanpack-ui/ai ^1.0` added as `suggest` + `require-dev`. Without it the AI Livewire component and REST routes stay unregistered and the framework boots normally.
+
 ## [2.2.3] - 2026-06-14
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -226,6 +226,50 @@ Permissions are registered but not yet enforced by visual-editor's policies — 
 
 cms-framework and visual-editor ship as a version pair — the supported combinations are tracked in visual-editor's [Version compatibility](https://github.com/ArtisanPack-UI/visual-editor/blob/release/1.0/README.md#version-compatibility) matrix. Bumping the major on either package without bumping the partner is unsupported.
 
+## AI features
+
+The framework ships five AI-powered content-authoring agents (added in 2.3.0). Each maps to a feature key in the `artisanpack-ui/ai` foundation and is registered automatically via the service provider's `aiFeatures()` hook — no wiring required in host apps.
+
+| Feature key            | Agent                          | What it does                                                            |
+|------------------------|--------------------------------|-------------------------------------------------------------------------|
+| `cms.post_title`       | `PostTitleSuggestionAgent`     | Generate 3–5 title variants from a draft body.                          |
+| `cms.excerpt`          | `ExcerptGenerationAgent`       | Generate a natural excerpt (default ≤200 chars) from full content.      |
+| `cms.suggest_tags`     | `TagSuggestionAgent`           | Select tags from an existing taxonomy (optionally propose new ones).    |
+| `cms.suggest_category` | `CategorySuggestionAgent`      | Pick a single category (as a slash-delimited path) from a tree.         |
+| `cms.suggest_slug`     | `SlugSuggestionAgent`          | Produce an SEO-friendly slug (short, keyword-forward, no stop words).   |
+
+Every agent honors the feature toggle configured in `artisanpack.ai.features.<key>.enabled` — when the toggle is off, the agent throws `FeatureDisabledException` and no model call is made.
+
+### Trigger surfaces
+
+The same five agents are exposed to every front-end framework:
+
+- **Livewire**: dispatch `ap-cms-ai:{action}` browser events at the `ap-cms-ai-tools` component (`ArtisanPackUI\CMSFramework\Livewire\Ai\AiTools`). Results come back on `ap-cms-ai:{featureKey}:{success|invalid-input|disabled|missing-credentials|error}`.
+- **React / Vue / anything else**: `POST` to the REST endpoints mounted under `/api/v1/cms/ai` (`AiController`). This keeps `@artisanpack-ui/react` and `@artisanpack-ui/vue` framework-agnostic — those packages do NOT need to know anything about CMS AI features.
+
+Available endpoints (all `auth` middleware, JSON body):
+
+| Method | Path                                | Body                                                   |
+|--------|-------------------------------------|--------------------------------------------------------|
+| GET    | `/api/v1/cms/ai/features`           | —                                                      |
+| POST   | `/api/v1/cms/ai/post-title`         | `{ content, tone?, count? }`                           |
+| POST   | `/api/v1/cms/ai/excerpt`            | `{ content, max_chars? }`                              |
+| POST   | `/api/v1/cms/ai/suggest-tags`       | `{ content, available_tags, allow_new?, max_selected? }` |
+| POST   | `/api/v1/cms/ai/suggest-category`   | `{ content, category_tree }`                           |
+| POST   | `/api/v1/cms/ai/suggest-slug`       | `{ title, excerpt?, max_chars? }`                      |
+
+Error responses use consistent status codes: `403 feature_disabled`, `422 invalid_input`, `503 missing_credentials`, `500 internal_error`.
+
+### Requirements
+
+The AI features require `artisanpack-ui/ai ^1.0`. It's declared as a `suggest` in `composer.json` — install it explicitly to opt in:
+
+```bash
+composer require artisanpack-ui/ai:^1.0
+```
+
+Without it, the agents, the Livewire component, and the REST endpoints stay unregistered — the framework boots normally.
+
 ## Experimental Features
 
 The following features are **experimental** in the 1.0.0 release and should be used with caution in production environments:

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ A comprehensive Laravel package that provides back-end support for building a CM
 
 ## Requirements
 
-- PHP 8.2 or higher (PHP 8.3+ required for Laravel 13)
+- PHP 8.3 or higher
 - Laravel 12.0 or 13.0
 - Laravel Sanctum 4.1 or higher
 

--- a/composer.json
+++ b/composer.json
@@ -57,7 +57,12 @@
     "orchestra/testbench": "^10.2",
     "artisanpack-ui/code-style": "^1.1",
     "artisanpack-ui/code-style-pint": "^1.1",
-    "dealerdirect/phpcodesniffer-composer-installer": "^1.0"
+    "artisanpack-ui/ai": "^1.0",
+    "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
+    "livewire/livewire": "^3.6"
+  },
+  "suggest": {
+    "artisanpack-ui/ai": "Recommended ^1.0 — enables the AI content-authoring agents (post-title suggestions, excerpt generation, tag/category suggestion, SEO slug suggestion). Without it the `aiFeatures()` service-provider hook is a no-op and the AI trigger surfaces (Livewire component + REST endpoints) stay hidden."
   },
   "config": {
     "allow-plugins": {

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
   ],
   "prefer-stable": true,
   "require": {
-    "php": "^8.2",
+    "php": "^8.3",
     "illuminate/support": "^12.17.0|^13.0",
     "laravel/framework": "^12.0|^13.0",
     "laravel/tinker": "^2.10.1|^3.0",

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "description": "Adds in the back end support for building a CMS with any front end framework.",
   "type": "library",
   "license": "MIT",
-  "version": "2.2.3",
+  "version": "2.3.0",
   "autoload": {
     "psr-4": {
       "ArtisanPackUI\\CMSFramework\\": "src/",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "881a116002a27db56125280cb2bb2ae0",
+    "content-hash": "b016a26ece3cf19d5daefc11acdb90f8",
     "packages": [
         {
             "name": "artisanpack-ui/accessibility",
@@ -12582,7 +12582,7 @@
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
-        "php": "^8.2"
+        "php": "^8.3"
     },
     "platform-dev": {},
     "plugin-api-version": "2.9.0"

--- a/composer.lock
+++ b/composer.lock
@@ -8729,6 +8729,82 @@
             "time": "2026-06-18T08:54:14+00:00"
         },
         {
+            "name": "livewire/livewire",
+            "version": "v3.8.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/livewire/livewire.git",
+                "reference": "e77fce60d0615d68dc6b8fafe98a6739d9752a24"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/livewire/livewire/zipball/e77fce60d0615d68dc6b8fafe98a6739d9752a24",
+                "reference": "e77fce60d0615d68dc6b8fafe98a6739d9752a24",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/database": "^10.0|^11.0|^12.0|^13.0",
+                "illuminate/routing": "^10.0|^11.0|^12.0|^13.0",
+                "illuminate/support": "^10.0|^11.0|^12.0|^13.0",
+                "illuminate/validation": "^10.0|^11.0|^12.0|^13.0",
+                "laravel/prompts": "^0.1.24|^0.2|^0.3",
+                "league/mime-type-detection": "^1.9",
+                "php": "^8.1",
+                "symfony/console": "^6.0|^7.0|^8.0",
+                "symfony/http-kernel": "^6.2|^7.0|^8.0"
+            },
+            "require-dev": {
+                "calebporzio/sushi": "^2.1",
+                "laravel/framework": "^10.15.0|^11.0|^12.0|^13.0",
+                "mockery/mockery": "^1.3.1",
+                "orchestra/testbench": "^8.21.0|^9.0|^10.0|^11.0",
+                "orchestra/testbench-dusk": "^8.24|^9.1|^10.0|^11.0",
+                "phpunit/phpunit": "^10.4|^11.5|^12.5",
+                "psy/psysh": "^0.11.22|^0.12"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "aliases": {
+                        "Livewire": "Livewire\\Livewire"
+                    },
+                    "providers": [
+                        "Livewire\\LivewireServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/helpers.php"
+                ],
+                "psr-4": {
+                    "Livewire\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Caleb Porzio",
+                    "email": "calebporzio@gmail.com"
+                }
+            ],
+            "description": "A front-end framework for Laravel.",
+            "support": {
+                "issues": "https://github.com/livewire/livewire/issues",
+                "source": "https://github.com/livewire/livewire/tree/v3.8.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/livewire",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-06-27T03:14:20+00:00"
+        },
+        {
             "name": "mockery/mockery",
             "version": "1.6.12",
             "source": {

--- a/composer.lock
+++ b/composer.lock
@@ -8,22 +8,23 @@
     "packages": [
         {
             "name": "artisanpack-ui/accessibility",
-            "version": "2.1.2",
+            "version": "2.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ArtisanPack-UI/accessibility.git",
-                "reference": "423385cf51c3a4938cbe6d7bf7b7464bdf87867f"
+                "reference": "78606976a841cb42bfbfe505a5119fa60b65bdcc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ArtisanPack-UI/accessibility/zipball/423385cf51c3a4938cbe6d7bf7b7464bdf87867f",
-                "reference": "423385cf51c3a4938cbe6d7bf7b7464bdf87867f",
+                "url": "https://api.github.com/repos/ArtisanPack-UI/accessibility/zipball/78606976a841cb42bfbfe505a5119fa60b65bdcc",
+                "reference": "78606976a841cb42bfbfe505a5119fa60b65bdcc",
                 "shasum": ""
             },
             "require": {
+                "artisanpack-ui/ai": "^1.0",
                 "artisanpack-ui/core": "^1.0",
-                "illuminate/support": "^11.44.1|^12.0|^13.0",
-                "php": "^8.2"
+                "illuminate/support": "^12.0|^13.0",
+                "php": "^8.3"
             },
             "require-dev": {
                 "artisanpack-ui/code-style": "^1.0",
@@ -31,12 +32,16 @@
                 "dealerdirect/phpcodesniffer-composer-installer": "^1.1",
                 "laravel/pint": "^1.25",
                 "laravel/sanctum": "^4.0",
+                "livewire/livewire": "^3.0",
                 "orchestra/testbench": "^9.0|^10.2|^11.0",
                 "pestphp/pest": "^3.8|^4.0",
                 "pestphp/pest-plugin-laravel": "^3.1|^4.0",
                 "phpbench/phpbench": "^1.2",
                 "squizlabs/php_codesniffer": "^3.13",
                 "symfony/http-foundation": "^7.3.7"
+            },
+            "suggest": {
+                "livewire/livewire": "Required (^3.0) to use the shipped Livewire trigger surfaces for the AI agents."
             },
             "type": "library",
             "extra": {
@@ -55,11 +60,13 @@
                 ],
                 "psr-4": {
                     "ArtisanPack\\Accessibility\\": "src/",
+                    "ArtisanPack\\Accessibility\\Ai\\": "src/Ai/",
                     "ArtisanPack\\Accessibility\\Core\\": "src/Core/",
                     "ArtisanPack\\Accessibility\\Http\\": "src/Http/",
                     "ArtisanPack\\Accessibility\\Events\\": "src/Events/",
                     "ArtisanPack\\Accessibility\\Models\\": "src/Models/",
                     "ArtisanPack\\Accessibility\\Laravel\\": "src/Laravel/",
+                    "ArtisanPack\\Accessibility\\Livewire\\": "src/Livewire/",
                     "ArtisanPack\\Accessibility\\Listeners\\": "src/Listeners/",
                     "ArtisanPack\\Accessibility\\Reporting\\": "src/Reporting/",
                     "ArtisanPack\\Accessibility\\Core\\Caching\\": "src/Core/Caching/",
@@ -70,7 +77,7 @@
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
-                "GPL-3.0-or-later"
+                "MIT"
             ],
             "authors": [
                 {
@@ -81,9 +88,81 @@
             "description": "A package for all accessibility functions for ArtisanPack UI.",
             "support": {
                 "issues": "https://github.com/ArtisanPack-UI/accessibility/issues",
-                "source": "https://github.com/ArtisanPack-UI/accessibility/tree/v2.1.2"
+                "source": "https://github.com/ArtisanPack-UI/accessibility/tree/v2.2.0"
             },
-            "time": "2026-06-09T03:47:16+00:00"
+            "time": "2026-07-08T16:42:55+00:00"
+        },
+        {
+            "name": "artisanpack-ui/ai",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ArtisanPack-UI/ai.git",
+                "reference": "082f1cd337742d34b8035d116c6c5ad8e5453fca"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ArtisanPack-UI/ai/zipball/082f1cd337742d34b8035d116c6c5ad8e5453fca",
+                "reference": "082f1cd337742d34b8035d116c6c5ad8e5453fca",
+                "shasum": ""
+            },
+            "require": {
+                "artisanpack-ui/core": "^1.0",
+                "illuminate/support": "^12.0|^13.0",
+                "laravel/ai": "^0.8",
+                "php": "^8.3"
+            },
+            "require-dev": {
+                "artisanpack-ui/code-style": "^1.1",
+                "artisanpack-ui/code-style-pint": "^1.1",
+                "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
+                "friendsofphp/php-cs-fixer": "^3.75",
+                "laravel/pint": "^1.26",
+                "livewire/livewire": "^3.6",
+                "orchestra/testbench": "^10.2|^11.0",
+                "pestphp/pest": "^3.8|^4.0",
+                "pestphp/pest-plugin-laravel": "^3.2|^4.1"
+            },
+            "suggest": {
+                "artisanpack-ui/cms-framework": "Automatically registers AI credentials, features, budget and cache setting groups under the CMS admin surface.",
+                "artisanpack-ui/livewire-ui-components": "Renders the AI Settings and Usage admin surfaces using x-artisanpack-* components.",
+                "livewire/livewire": "Required to mount the AI Settings and Usage dashboard Livewire components under cms-framework's admin nav."
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "aliases": {
+                        "Ai": "ArtisanPackUI\\Ai\\Facades\\Ai"
+                    },
+                    "providers": [
+                        "ArtisanPackUI\\Ai\\AiServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/helpers.php"
+                ],
+                "psr-4": {
+                    "ArtisanPackUI\\Ai\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jacob Martella",
+                    "email": "me@jacobmartella.com"
+                }
+            ],
+            "description": "Shared AI foundation for the ArtisanPack UI ecosystem, built on top of laravel/ai.",
+            "support": {
+                "issues": "https://github.com/ArtisanPack-UI/ai/issues",
+                "source": "https://github.com/ArtisanPack-UI/ai/tree/v1.0.0"
+            },
+            "time": "2026-07-06T21:25:38+00:00"
         },
         {
             "name": "artisanpack-ui/core",
@@ -222,21 +301,21 @@
         },
         {
             "name": "artisanpack-ui/rbac",
-            "version": "1.0.0",
+            "version": "1.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ArtisanPack-UI/rbac.git",
-                "reference": "43f7c5a250d9a6189ba7d53db332e36340503d84"
+                "reference": "7f9f7d153ba014a7cbd1495a025d29d4b49a75a5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ArtisanPack-UI/rbac/zipball/43f7c5a250d9a6189ba7d53db332e36340503d84",
-                "reference": "43f7c5a250d9a6189ba7d53db332e36340503d84",
+                "url": "https://api.github.com/repos/ArtisanPack-UI/rbac/zipball/7f9f7d153ba014a7cbd1495a025d29d4b49a75a5",
+                "reference": "7f9f7d153ba014a7cbd1495a025d29d4b49a75a5",
                 "shasum": ""
             },
             "require": {
                 "artisanpack-ui/core": "^1.0",
-                "illuminate/support": "^10.0|^11.0|^12.0",
+                "illuminate/support": "^10.0|^11.0|^12.0|^13.0",
                 "php": "^8.2"
             },
             "require-dev": {
@@ -245,9 +324,9 @@
                 "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
                 "friendsofphp/php-cs-fixer": "^3.75",
                 "laravel/pint": "^1.26",
-                "orchestra/testbench": "^10.2",
-                "pestphp/pest": "^3.8",
-                "pestphp/pest-plugin-laravel": "^3.2"
+                "orchestra/testbench": "^10.2|^11.0",
+                "pestphp/pest": "^3.8|^4.0",
+                "pestphp/pest-plugin-laravel": "^3.2|^4.0"
             },
             "type": "library",
             "extra": {
@@ -290,27 +369,27 @@
             ],
             "support": {
                 "issues": "https://github.com/ArtisanPack-UI/rbac/issues",
-                "source": "https://github.com/ArtisanPack-UI/rbac/tree/v1.0.0"
+                "source": "https://github.com/ArtisanPack-UI/rbac/tree/v1.0.1"
             },
-            "time": "2026-05-19T19:17:08+00:00"
+            "time": "2026-06-14T21:16:16+00:00"
         },
         {
             "name": "artisanpack-ui/security",
-            "version": "2.0.1",
+            "version": "2.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ArtisanPack-UI/security.git",
-                "reference": "6f34c08d74d1dec57127a54eb9998e3faeae9a07"
+                "reference": "bcdf27fd5d5577a9199af5caec51b70b8bdc7bca"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ArtisanPack-UI/security/zipball/6f34c08d74d1dec57127a54eb9998e3faeae9a07",
-                "reference": "6f34c08d74d1dec57127a54eb9998e3faeae9a07",
+                "url": "https://api.github.com/repos/ArtisanPack-UI/security/zipball/bcdf27fd5d5577a9199af5caec51b70b8bdc7bca",
+                "reference": "bcdf27fd5d5577a9199af5caec51b70b8bdc7bca",
                 "shasum": ""
             },
             "require": {
                 "artisanpack-ui/core": "^1.0",
-                "illuminate/support": "^10.0|^11.0|^12.0",
+                "illuminate/support": "^10.0|^11.0|^12.0|^13.0",
                 "laminas/laminas-escaper": "^2.16",
                 "laravel/sanctum": "^4.0",
                 "php": "^8.2"
@@ -322,7 +401,7 @@
                 "friendsofphp/php-cs-fixer": "^3.75",
                 "laravel/pint": "^1.26",
                 "livewire/livewire": "^3.6|^4.0",
-                "orchestra/testbench": "^10.2",
+                "orchestra/testbench": "^10.2|^11.0",
                 "pestphp/pest": "^3.8",
                 "pestphp/pest-plugin-laravel": "^3.1"
             },
@@ -379,9 +458,160 @@
             ],
             "support": {
                 "issues": "https://github.com/ArtisanPack-UI/security/issues",
-                "source": "https://github.com/ArtisanPack-UI/security/tree/v2.0.1"
+                "source": "https://github.com/ArtisanPack-UI/security/tree/v2.0.2"
             },
-            "time": "2026-05-21T15:10:59+00:00"
+            "time": "2026-06-09T22:50:49+00:00"
+        },
+        {
+            "name": "aws/aws-crt-php",
+            "version": "v1.2.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/awslabs/aws-crt-php.git",
+                "reference": "d71d9906c7bb63a28295447ba12e74723bd3730e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/awslabs/aws-crt-php/zipball/d71d9906c7bb63a28295447ba12e74723bd3730e",
+                "reference": "d71d9906c7bb63a28295447ba12e74723bd3730e",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.8.35||^5.6.3||^9.5",
+                "yoast/phpunit-polyfills": "^1.0"
+            },
+            "suggest": {
+                "ext-awscrt": "Make sure you install awscrt native extension to use any of the functionality."
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "AWS SDK Common Runtime Team",
+                    "email": "aws-sdk-common-runtime@amazon.com"
+                }
+            ],
+            "description": "AWS Common Runtime for PHP",
+            "homepage": "https://github.com/awslabs/aws-crt-php",
+            "keywords": [
+                "amazon",
+                "aws",
+                "crt",
+                "sdk"
+            ],
+            "support": {
+                "issues": "https://github.com/awslabs/aws-crt-php/issues",
+                "source": "https://github.com/awslabs/aws-crt-php/tree/v1.2.7"
+            },
+            "time": "2024-10-18T22:15:13+00:00"
+        },
+        {
+            "name": "aws/aws-sdk-php",
+            "version": "3.388.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/aws/aws-sdk-php.git",
+                "reference": "d48fe5eabeda0cf58025636f78ac8dcd8e60a724"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/d48fe5eabeda0cf58025636f78ac8dcd8e60a724",
+                "reference": "d48fe5eabeda0cf58025636f78ac8dcd8e60a724",
+                "shasum": ""
+            },
+            "require": {
+                "aws/aws-crt-php": "^1.2.3",
+                "ext-json": "*",
+                "ext-pcre": "*",
+                "ext-simplexml": "*",
+                "guzzlehttp/guzzle": "^7.4.5",
+                "guzzlehttp/promises": "^2.0",
+                "guzzlehttp/psr7": "^2.4.5",
+                "mtdowling/jmespath.php": "^2.9.1",
+                "php": ">=8.1",
+                "psr/http-message": "^1.0 || ^2.0",
+                "symfony/filesystem": "^v5.4.45 || ^v6.4.3 || ^v7.1.0 || ^v8.0.0"
+            },
+            "require-dev": {
+                "andrewsville/php-token-reflection": "^1.4",
+                "aws/aws-php-sns-message-validator": "~1.0",
+                "behat/behat": "~3.0",
+                "composer/composer": "^2.7.8",
+                "dms/phpunit-arraysubset-asserts": "^v0.5.0",
+                "doctrine/cache": "~1.4",
+                "ext-dom": "*",
+                "ext-openssl": "*",
+                "ext-sockets": "*",
+                "phpunit/phpunit": "^10.0",
+                "psr/cache": "^2.0 || ^3.0",
+                "psr/simple-cache": "^2.0 || ^3.0",
+                "sebastian/comparator": "^1.2.3 || ^4.0 || ^5.0",
+                "yoast/phpunit-polyfills": "^2.0"
+            },
+            "suggest": {
+                "aws/aws-php-sns-message-validator": "To validate incoming SNS notifications",
+                "doctrine/cache": "To use the DoctrineCacheAdapter",
+                "ext-curl": "To send requests using cURL",
+                "ext-openssl": "Allows working with CloudFront private distributions and verifying received SNS messages",
+                "ext-pcntl": "To use client-side monitoring",
+                "ext-sockets": "To use client-side monitoring"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/functions.php"
+                ],
+                "psr-4": {
+                    "Aws\\": "src/"
+                },
+                "exclude-from-classmap": [
+                    "src/data/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Amazon Web Services",
+                    "homepage": "https://aws.amazon.com"
+                }
+            ],
+            "description": "AWS SDK for PHP - Use Amazon Web Services in your PHP project",
+            "homepage": "https://aws.amazon.com/sdk-for-php",
+            "keywords": [
+                "amazon",
+                "aws",
+                "cloud",
+                "dynamodb",
+                "ec2",
+                "glacier",
+                "s3",
+                "sdk"
+            ],
+            "support": {
+                "forum": "https://github.com/aws/aws-sdk-php/discussions",
+                "issues": "https://github.com/aws/aws-sdk-php/issues",
+                "source": "https://github.com/aws/aws-sdk-php/tree/3.388.2"
+            },
+            "time": "2026-07-08T23:12:50+00:00"
         },
         {
             "name": "brick/math",
@@ -591,16 +821,16 @@
         },
         {
             "name": "dedoc/scramble",
-            "version": "v0.13.26",
+            "version": "v0.13.32",
             "source": {
                 "type": "git",
                 "url": "https://github.com/dedoc/scramble.git",
-                "reference": "5ca42b5e23b9d5c120607138f790b51e22d8b4a1"
+                "reference": "546a727720d4c38f2248e7c63b43178fbea7a96e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/dedoc/scramble/zipball/5ca42b5e23b9d5c120607138f790b51e22d8b4a1",
-                "reference": "5ca42b5e23b9d5c120607138f790b51e22d8b4a1",
+                "url": "https://api.github.com/repos/dedoc/scramble/zipball/546a727720d4c38f2248e7c63b43178fbea7a96e",
+                "reference": "546a727720d4c38f2248e7c63b43178fbea7a96e",
                 "shasum": ""
             },
             "require": {
@@ -614,6 +844,7 @@
             "require-dev": {
                 "larastan/larastan": "^3.3",
                 "laravel/pint": "^v1.1.0",
+                "laravel/scout": "^10.0|^11.0",
                 "nunomaduro/collision": "^7.0|^8.0",
                 "orchestra/testbench": "^8.0|^9.0|^10.0|^11.0",
                 "pestphp/pest": "^2.34|^3.7|^4.4",
@@ -659,7 +890,7 @@
             ],
             "support": {
                 "issues": "https://github.com/dedoc/scramble/issues",
-                "source": "https://github.com/dedoc/scramble/tree/v0.13.26"
+                "source": "https://github.com/dedoc/scramble/tree/v0.13.32"
             },
             "funding": [
                 {
@@ -667,7 +898,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-06-02T14:43:17+00:00"
+            "time": "2026-07-09T09:04:02+00:00"
         },
         {
             "name": "dflydev/dot-access-data",
@@ -1508,21 +1739,21 @@
         },
         {
             "name": "guzzlehttp/uri-template",
-            "version": "v1.0.6",
+            "version": "v1.0.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/uri-template.git",
-                "reference": "eef7f87bab6f204eba3c39224d8075c70c637946"
+                "reference": "d7580af6d3f8384325d9cd3e99b21c3ed1848176"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/uri-template/zipball/eef7f87bab6f204eba3c39224d8075c70c637946",
-                "reference": "eef7f87bab6f204eba3c39224d8075c70c637946",
+                "url": "https://api.github.com/repos/guzzle/uri-template/zipball/d7580af6d3f8384325d9cd3e99b21c3ed1848176",
+                "reference": "d7580af6d3f8384325d9cd3e99b21c3ed1848176",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.2.5 || ^8.0",
-                "symfony/polyfill-php80": "^1.24"
+                "symfony/polyfill-php80": "^1.25"
             },
             "require-dev": {
                 "bamarni/composer-bin-plugin": "^1.8.2",
@@ -1574,7 +1805,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/uri-template/issues",
-                "source": "https://github.com/guzzle/uri-template/tree/v1.0.6"
+                "source": "https://github.com/guzzle/uri-template/tree/v1.0.9"
             },
             "funding": [
                 {
@@ -1590,20 +1821,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-23T22:00:21+00:00"
+            "time": "2026-07-08T16:19:22+00:00"
         },
         {
             "name": "justinrainbow/json-schema",
-            "version": "6.9.0",
+            "version": "6.10.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/jsonrainbow/json-schema.git",
-                "reference": "bd1bda2ebfc8bff418565941771ea8f03c557886"
+                "reference": "8b1308a9d7bdbdb20ce87ef920f82b4564bb2d33"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/jsonrainbow/json-schema/zipball/bd1bda2ebfc8bff418565941771ea8f03c557886",
-                "reference": "bd1bda2ebfc8bff418565941771ea8f03c557886",
+                "url": "https://api.github.com/repos/jsonrainbow/json-schema/zipball/8b1308a9d7bdbdb20ce87ef920f82b4564bb2d33",
+                "reference": "8b1308a9d7bdbdb20ce87ef920f82b4564bb2d33",
                 "shasum": ""
             },
             "require": {
@@ -1613,7 +1844,7 @@
             },
             "require-dev": {
                 "friendsofphp/php-cs-fixer": "3.3.0",
-                "json-schema/json-schema-test-suite": "^23.2",
+                "json-schema/json-schema-test-suite": "dev-main",
                 "marc-mabe/php-enum-phpstan": "^2.0",
                 "phpspec/prophecy": "^1.19",
                 "phpstan/phpstan": "^1.12",
@@ -1663,9 +1894,9 @@
             ],
             "support": {
                 "issues": "https://github.com/jsonrainbow/json-schema/issues",
-                "source": "https://github.com/jsonrainbow/json-schema/tree/6.9.0"
+                "source": "https://github.com/jsonrainbow/json-schema/tree/6.10.0"
             },
-            "time": "2026-06-05T14:05:24+00:00"
+            "time": "2026-06-16T20:50:26+00:00"
         },
         {
             "name": "laminas/laminas-escaper",
@@ -1729,17 +1960,91 @@
             "time": "2025-10-14T18:31:13+00:00"
         },
         {
-            "name": "laravel/framework",
-            "version": "v12.62.0",
+            "name": "laravel/ai",
+            "version": "v0.8.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/laravel/framework.git",
-                "reference": "f7e61eb1e0e06a38996802b769bce9127aec227c"
+                "url": "https://github.com/laravel/ai.git",
+                "reference": "b23bc857576d7c4b3bb52ffd8be936ae74005d23"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/framework/zipball/f7e61eb1e0e06a38996802b769bce9127aec227c",
-                "reference": "f7e61eb1e0e06a38996802b769bce9127aec227c",
+                "url": "https://api.github.com/repos/laravel/ai/zipball/b23bc857576d7c4b3bb52ffd8be936ae74005d23",
+                "reference": "b23bc857576d7c4b3bb52ffd8be936ae74005d23",
+                "shasum": ""
+            },
+            "require": {
+                "aws/aws-sdk-php": "^3.339",
+                "illuminate/console": "^12.0|^13.0",
+                "illuminate/container": "^12.0|^13.0",
+                "illuminate/contracts": "^12.0|^13.0",
+                "illuminate/database": "^12.0|^13.0",
+                "illuminate/filesystem": "^12.0|^13.0",
+                "illuminate/json-schema": "^12.62|^13.15",
+                "illuminate/support": "^12.0|^13.0",
+                "laravel/prompts": "^0.3.6",
+                "laravel/serializable-closure": "^2.0",
+                "php": "^8.3"
+            },
+            "require-dev": {
+                "laravel/mcp": "^0.8",
+                "laravel/pint": "^1.26",
+                "mockery/mockery": "^1.6.12",
+                "orchestra/testbench": "^10.6|^11.0",
+                "pestphp/pest": "^3.0|^4.0",
+                "pestphp/pest-plugin-laravel": "^3.0|^4.0",
+                "phpstan/phpstan": "^2.1"
+            },
+            "suggest": {
+                "laravel/mcp": "Required to use MCP client tools or MCP server tools with Laravel AI agents."
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Laravel\\Ai\\AiServiceProvider"
+                    ]
+                },
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "functions.php"
+                ],
+                "psr-4": {
+                    "Laravel\\Ai\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "The official AI SDK for Laravel.",
+            "homepage": "https://github.com/laravel/ai",
+            "keywords": [
+                "ai",
+                "laravel"
+            ],
+            "support": {
+                "issues": "https://github.com/laravel/ai/issues",
+                "source": "https://github.com/laravel/ai"
+            },
+            "time": "2026-06-10T11:23:35+00:00"
+        },
+        {
+            "name": "laravel/framework",
+            "version": "v12.63.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laravel/framework.git",
+                "reference": "7adfddbf4738f2e6cae5419b0e6bc46d4cccfbcf"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laravel/framework/zipball/7adfddbf4738f2e6cae5419b0e6bc46d4cccfbcf",
+                "reference": "7adfddbf4738f2e6cae5419b0e6bc46d4cccfbcf",
                 "shasum": ""
             },
             "require": {
@@ -1948,20 +2253,20 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2026-06-09T13:50:13+00:00"
+            "time": "2026-07-07T14:16:35+00:00"
         },
         {
             "name": "laravel/prompts",
-            "version": "v0.3.18",
+            "version": "v0.3.21",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/prompts.git",
-                "reference": "a19af51bb144bf87f08397921fa619f85c7d4e72"
+                "reference": "7753c65c281c2550c7c183f14e18062073b7d821"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/prompts/zipball/a19af51bb144bf87f08397921fa619f85c7d4e72",
-                "reference": "a19af51bb144bf87f08397921fa619f85c7d4e72",
+                "url": "https://api.github.com/repos/laravel/prompts/zipball/7753c65c281c2550c7c183f14e18062073b7d821",
+                "reference": "7753c65c281c2550c7c183f14e18062073b7d821",
                 "shasum": ""
             },
             "require": {
@@ -2005,9 +2310,9 @@
             "description": "Add beautiful and user-friendly forms to your command-line applications.",
             "support": {
                 "issues": "https://github.com/laravel/prompts/issues",
-                "source": "https://github.com/laravel/prompts/tree/v0.3.18"
+                "source": "https://github.com/laravel/prompts/tree/v0.3.21"
             },
-            "time": "2026-05-19T00:47:18+00:00"
+            "time": "2026-06-26T00:11:25+00:00"
         },
         {
             "name": "laravel/sanctum",
@@ -2390,16 +2695,16 @@
         },
         {
             "name": "league/flysystem",
-            "version": "3.34.0",
+            "version": "3.35.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/flysystem.git",
-                "reference": "2daaac3b0d4c83ea7ed5d8586e786f5d00f3540e"
+                "reference": "b277b5dc3d56650b68904117124e79c851e12376"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/flysystem/zipball/2daaac3b0d4c83ea7ed5d8586e786f5d00f3540e",
-                "reference": "2daaac3b0d4c83ea7ed5d8586e786f5d00f3540e",
+                "url": "https://api.github.com/repos/thephpleague/flysystem/zipball/b277b5dc3d56650b68904117124e79c851e12376",
+                "reference": "b277b5dc3d56650b68904117124e79c851e12376",
                 "shasum": ""
             },
             "require": {
@@ -2467,9 +2772,9 @@
             ],
             "support": {
                 "issues": "https://github.com/thephpleague/flysystem/issues",
-                "source": "https://github.com/thephpleague/flysystem/tree/3.34.0"
+                "source": "https://github.com/thephpleague/flysystem/tree/3.35.2"
             },
-            "time": "2026-05-14T10:28:08+00:00"
+            "time": "2026-07-06T14:42:07+00:00"
         },
         {
             "name": "league/flysystem-local",
@@ -2522,16 +2827,16 @@
         },
         {
             "name": "league/mime-type-detection",
-            "version": "1.16.0",
+            "version": "1.17.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/mime-type-detection.git",
-                "reference": "2d6702ff215bf922936ccc1ad31007edc76451b9"
+                "reference": "f5f47eff7c48ed1003069a2ca67f316fb4021c76"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/mime-type-detection/zipball/2d6702ff215bf922936ccc1ad31007edc76451b9",
-                "reference": "2d6702ff215bf922936ccc1ad31007edc76451b9",
+                "url": "https://api.github.com/repos/thephpleague/mime-type-detection/zipball/f5f47eff7c48ed1003069a2ca67f316fb4021c76",
+                "reference": "f5f47eff7c48ed1003069a2ca67f316fb4021c76",
                 "shasum": ""
             },
             "require": {
@@ -2541,7 +2846,7 @@
             "require-dev": {
                 "friendsofphp/php-cs-fixer": "^3.2",
                 "phpstan/phpstan": "^0.12.68",
-                "phpunit/phpunit": "^8.5.8 || ^9.3 || ^10.0"
+                "phpunit/phpunit": "^8.5.8 || ^9.3 || ^10.0 || ^11.0 || ^12.0"
             },
             "type": "library",
             "autoload": {
@@ -2562,7 +2867,7 @@
             "description": "Mime-type detection for Flysystem",
             "support": {
                 "issues": "https://github.com/thephpleague/mime-type-detection/issues",
-                "source": "https://github.com/thephpleague/mime-type-detection/tree/1.16.0"
+                "source": "https://github.com/thephpleague/mime-type-detection/tree/1.17.0"
             },
             "funding": [
                 {
@@ -2574,7 +2879,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-21T08:32:55+00:00"
+            "time": "2026-07-09T11:49:27+00:00"
         },
         {
             "name": "league/uri",
@@ -2935,6 +3240,72 @@
             "time": "2026-01-02T08:56:05+00:00"
         },
         {
+            "name": "mtdowling/jmespath.php",
+            "version": "2.9.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/jmespath/jmespath.php.git",
+                "reference": "2157c5e50e813ec6a96c1eed3be7f64a20fb32a8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/jmespath/jmespath.php/zipball/2157c5e50e813ec6a96c1eed3be7f64a20fb32a8",
+                "reference": "2157c5e50e813ec6a96c1eed3be7f64a20fb32a8",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2.5 || ^8.0",
+                "symfony/polyfill-mbstring": "^1.17"
+            },
+            "require-dev": {
+                "composer/xdebug-handler": "^3.0.3",
+                "phpunit/phpunit": "^8.5.52"
+            },
+            "bin": [
+                "bin/jp.php"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.9-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/JmesPath.php"
+                ],
+                "psr-4": {
+                    "JmesPath\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Graham Campbell",
+                    "email": "hello@gjcampbell.co.uk",
+                    "homepage": "https://github.com/GrahamCampbell"
+                },
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                }
+            ],
+            "description": "Declaratively specify how to extract elements from a JSON document",
+            "keywords": [
+                "json",
+                "jsonpath"
+            ],
+            "support": {
+                "issues": "https://github.com/jmespath/jmespath.php/issues",
+                "source": "https://github.com/jmespath/jmespath.php/tree/2.9.2"
+            },
+            "time": "2026-07-06T18:56:19+00:00"
+        },
+        {
             "name": "myclabs/deep-copy",
             "version": "1.13.4",
             "source": {
@@ -2996,16 +3367,16 @@
         },
         {
             "name": "nesbot/carbon",
-            "version": "3.11.4",
+            "version": "3.13.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/CarbonPHP/carbon.git",
-                "reference": "e890471a3494740f7d9326d72ce6a8c559ffee60"
+                "reference": "40f6618f052df16b545f626fbf9a878e6497d16a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/CarbonPHP/carbon/zipball/e890471a3494740f7d9326d72ce6a8c559ffee60",
-                "reference": "e890471a3494740f7d9326d72ce6a8c559ffee60",
+                "url": "https://api.github.com/repos/CarbonPHP/carbon/zipball/40f6618f052df16b545f626fbf9a878e6497d16a",
+                "reference": "40f6618f052df16b545f626fbf9a878e6497d16a",
                 "shasum": ""
             },
             "require": {
@@ -3097,7 +3468,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-07T09:57:54+00:00"
+            "time": "2026-06-18T13:49:15+00:00"
         },
         {
             "name": "nette/schema",
@@ -3259,20 +3630,19 @@
         },
         {
             "name": "nikic/php-parser",
-            "version": "v5.7.0",
+            "version": "v5.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "dca41cd15c2ac9d055ad70dbfd011130757d1f82"
+                "reference": "044a6a392ff8ad0d61f14370a5fbbd0a0107152f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/dca41cd15c2ac9d055ad70dbfd011130757d1f82",
-                "reference": "dca41cd15c2ac9d055ad70dbfd011130757d1f82",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/044a6a392ff8ad0d61f14370a5fbbd0a0107152f",
+                "reference": "044a6a392ff8ad0d61f14370a5fbbd0a0107152f",
                 "shasum": ""
             },
             "require": {
-                "ext-ctype": "*",
                 "ext-json": "*",
                 "ext-tokenizer": "*",
                 "php": ">=7.4"
@@ -3311,9 +3681,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v5.7.0"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v5.8.0"
             },
-            "time": "2025-12-06T11:56:16+00:00"
+            "time": "2026-07-04T14:30:18+00:00"
         },
         {
             "name": "nunomaduro/termwind",
@@ -3479,16 +3849,16 @@
         },
         {
             "name": "phpstan/phpdoc-parser",
-            "version": "2.3.2",
+            "version": "2.3.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpdoc-parser.git",
-                "reference": "a004701b11273a26cd7955a61d67a7f1e525a45a"
+                "reference": "fb19eedd2bb67ff8cf7a5502ad329e701d6398a3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/a004701b11273a26cd7955a61d67a7f1e525a45a",
-                "reference": "a004701b11273a26cd7955a61d67a7f1e525a45a",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/fb19eedd2bb67ff8cf7a5502ad329e701d6398a3",
+                "reference": "fb19eedd2bb67ff8cf7a5502ad329e701d6398a3",
                 "shasum": ""
             },
             "require": {
@@ -3520,9 +3890,9 @@
             "description": "PHPDoc parser with support for nullable, intersection and generic types",
             "support": {
                 "issues": "https://github.com/phpstan/phpdoc-parser/issues",
-                "source": "https://github.com/phpstan/phpdoc-parser/tree/2.3.2"
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/2.3.3"
             },
-            "time": "2026-01-25T14:56:51+00:00"
+            "time": "2026-07-08T07:01:06+00:00"
         },
         {
             "name": "psr/clock",
@@ -3938,16 +4308,16 @@
         },
         {
             "name": "psy/psysh",
-            "version": "v0.12.23",
+            "version": "v0.12.24",
             "source": {
                 "type": "git",
                 "url": "https://github.com/bobthecow/psysh.git",
-                "reference": "4dcc0f08047d52bbde475eda481146fd8e27e1a4"
+                "reference": "ca0fdcf8a7617afa3adfdf1b5fef573dffb69ca1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/bobthecow/psysh/zipball/4dcc0f08047d52bbde475eda481146fd8e27e1a4",
-                "reference": "4dcc0f08047d52bbde475eda481146fd8e27e1a4",
+                "url": "https://api.github.com/repos/bobthecow/psysh/zipball/ca0fdcf8a7617afa3adfdf1b5fef573dffb69ca1",
+                "reference": "ca0fdcf8a7617afa3adfdf1b5fef573dffb69ca1",
                 "shasum": ""
             },
             "require": {
@@ -4011,9 +4381,9 @@
             ],
             "support": {
                 "issues": "https://github.com/bobthecow/psysh/issues",
-                "source": "https://github.com/bobthecow/psysh/tree/v0.12.23"
+                "source": "https://github.com/bobthecow/psysh/tree/v0.12.24"
             },
-            "time": "2026-05-23T13:41:31+00:00"
+            "time": "2026-06-29T15:41:09+00:00"
         },
         {
             "name": "ralouphie/getallheaders",
@@ -4137,20 +4507,20 @@
         },
         {
             "name": "ramsey/uuid",
-            "version": "4.9.2",
+            "version": "4.9.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ramsey/uuid.git",
-                "reference": "8429c78ca35a09f27565311b98101e2826affde0"
+                "reference": "1df15849d00943a67d677dc9cfd80795f038c9f8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ramsey/uuid/zipball/8429c78ca35a09f27565311b98101e2826affde0",
-                "reference": "8429c78ca35a09f27565311b98101e2826affde0",
+                "url": "https://api.github.com/repos/ramsey/uuid/zipball/1df15849d00943a67d677dc9cfd80795f038c9f8",
+                "reference": "1df15849d00943a67d677dc9cfd80795f038c9f8",
                 "shasum": ""
             },
             "require": {
-                "brick/math": "^0.8.16 || ^0.9 || ^0.10 || ^0.11 || ^0.12 || ^0.13 || ^0.14",
+                "brick/math": ">=0.8.16 <=0.18",
                 "php": "^8.0",
                 "ramsey/collection": "^1.2 || ^2.0"
             },
@@ -4209,9 +4579,9 @@
             ],
             "support": {
                 "issues": "https://github.com/ramsey/uuid/issues",
-                "source": "https://github.com/ramsey/uuid/tree/4.9.2"
+                "source": "https://github.com/ramsey/uuid/tree/4.9.3"
             },
-            "time": "2025-12-14T04:43:48+00:00"
+            "time": "2026-06-18T03:57:49+00:00"
         },
         {
             "name": "spatie/laravel-package-tools",
@@ -4353,16 +4723,16 @@
         },
         {
             "name": "symfony/console",
-            "version": "v7.4.13",
+            "version": "v7.4.14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "85095d2573eaefaf35e40b9513a9bf09f72cd217"
+                "reference": "92f58bc4bf97a92ed1b9f367f0cd44f20bde0e87"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/85095d2573eaefaf35e40b9513a9bf09f72cd217",
-                "reference": "85095d2573eaefaf35e40b9513a9bf09f72cd217",
+                "url": "https://api.github.com/repos/symfony/console/zipball/92f58bc4bf97a92ed1b9f367f0cd44f20bde0e87",
+                "reference": "92f58bc4bf97a92ed1b9f367f0cd44f20bde0e87",
                 "shasum": ""
             },
             "require": {
@@ -4427,7 +4797,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v7.4.13"
+                "source": "https://github.com/symfony/console/tree/v7.4.14"
             },
             "funding": [
                 {
@@ -4447,7 +4817,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-24T08:56:14+00:00"
+            "time": "2026-06-16T11:50:14+00:00"
         },
         {
             "name": "symfony/css-selector",
@@ -4591,16 +4961,16 @@
         },
         {
             "name": "symfony/error-handler",
-            "version": "v7.4.8",
+            "version": "v7.4.14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/error-handler.git",
-                "reference": "8dd79d8af777ee6cba2fd4d98da6ffb839f3c0fa"
+                "reference": "4e1a093b481f323e6e326451f9760c3868430673"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/error-handler/zipball/8dd79d8af777ee6cba2fd4d98da6ffb839f3c0fa",
-                "reference": "8dd79d8af777ee6cba2fd4d98da6ffb839f3c0fa",
+                "url": "https://api.github.com/repos/symfony/error-handler/zipball/4e1a093b481f323e6e326451f9760c3868430673",
+                "reference": "4e1a093b481f323e6e326451f9760c3868430673",
                 "shasum": ""
             },
             "require": {
@@ -4649,7 +5019,7 @@
             "description": "Provides tools to manage errors and ease debugging PHP code",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/error-handler/tree/v7.4.8"
+                "source": "https://github.com/symfony/error-handler/tree/v7.4.14"
             },
             "funding": [
                 {
@@ -4669,20 +5039,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-24T13:12:05+00:00"
+            "time": "2026-06-05T06:22:21+00:00"
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v8.1.0",
+            "version": "v8.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
-                "reference": "f249ae3f680958b6f1f9dd76e5747cf0695b4102"
+                "reference": "abd6c11dc468725d1627302ad10f6cd486e9e3d0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/f249ae3f680958b6f1f9dd76e5747cf0695b4102",
-                "reference": "f249ae3f680958b6f1f9dd76e5747cf0695b4102",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/abd6c11dc468725d1627302ad10f6cd486e9e3d0",
+                "reference": "abd6c11dc468725d1627302ad10f6cd486e9e3d0",
                 "shasum": ""
             },
             "require": {
@@ -4735,7 +5105,7 @@
             "description": "Provides tools that allow your application components to communicate with each other by dispatching events and listening to them",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/event-dispatcher/tree/v8.1.0"
+                "source": "https://github.com/symfony/event-dispatcher/tree/v8.1.1"
             },
             "funding": [
                 {
@@ -4755,20 +5125,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-29T05:06:50+00:00"
+            "time": "2026-06-09T12:28:30+00:00"
         },
         {
             "name": "symfony/event-dispatcher-contracts",
-            "version": "v3.7.0",
+            "version": "v3.7.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher-contracts.git",
-                "reference": "ccba7060602b7fed0b03c85bf025257f76d9ef32"
+                "reference": "c7de7a00ffb67842132da02ea92988a39ccd9f4e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher-contracts/zipball/ccba7060602b7fed0b03c85bf025257f76d9ef32",
-                "reference": "ccba7060602b7fed0b03c85bf025257f76d9ef32",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher-contracts/zipball/c7de7a00ffb67842132da02ea92988a39ccd9f4e",
+                "reference": "c7de7a00ffb67842132da02ea92988a39ccd9f4e",
                 "shasum": ""
             },
             "require": {
@@ -4815,7 +5185,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/event-dispatcher-contracts/tree/v3.7.0"
+                "source": "https://github.com/symfony/event-dispatcher-contracts/tree/v3.7.1"
             },
             "funding": [
                 {
@@ -4835,20 +5205,91 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-01-05T13:30:16+00:00"
+            "time": "2026-06-05T06:23:12+00:00"
         },
         {
-            "name": "symfony/finder",
-            "version": "v7.4.8",
+            "name": "symfony/filesystem",
+            "version": "v8.1.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/finder.git",
-                "reference": "e0be088d22278583a82da281886e8c3592fbf149"
+                "url": "https://github.com/symfony/filesystem.git",
+                "reference": "99aec13b82b4967ec5088222c4a3ecca955949c2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/e0be088d22278583a82da281886e8c3592fbf149",
-                "reference": "e0be088d22278583a82da281886e8c3592fbf149",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/99aec13b82b4967ec5088222c4a3ecca955949c2",
+                "reference": "99aec13b82b4967ec5088222c4a3ecca955949c2",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.4.1",
+                "symfony/deprecation-contracts": "^2.5|^3",
+                "symfony/polyfill-ctype": "~1.8",
+                "symfony/polyfill-mbstring": "~1.8"
+            },
+            "require-dev": {
+                "symfony/process": "^7.4|^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Filesystem\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides basic utilities for the filesystem",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/filesystem/tree/v8.1.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-05-29T05:06:50+00:00"
+        },
+        {
+            "name": "symfony/finder",
+            "version": "v7.4.14",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/finder.git",
+                "reference": "13b38720174286f55d1761152b575a8d1436fc25"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/13b38720174286f55d1761152b575a8d1436fc25",
+                "reference": "13b38720174286f55d1761152b575a8d1436fc25",
                 "shasum": ""
             },
             "require": {
@@ -4883,7 +5324,7 @@
             "description": "Finds files and directories via an intuitive fluent interface",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/finder/tree/v7.4.8"
+                "source": "https://github.com/symfony/finder/tree/v7.4.14"
             },
             "funding": [
                 {
@@ -4903,20 +5344,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-24T13:12:05+00:00"
+            "time": "2026-06-27T08:31:18+00:00"
         },
         {
             "name": "symfony/http-foundation",
-            "version": "v7.4.13",
+            "version": "v7.4.14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-foundation.git",
-                "reference": "bc354f47c62301e990b7874fa662326368508e2c"
+                "reference": "06db5ae1552177bf8572f8908839f12e3c06aed3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/bc354f47c62301e990b7874fa662326368508e2c",
-                "reference": "bc354f47c62301e990b7874fa662326368508e2c",
+                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/06db5ae1552177bf8572f8908839f12e3c06aed3",
+                "reference": "06db5ae1552177bf8572f8908839f12e3c06aed3",
                 "shasum": ""
             },
             "require": {
@@ -4965,7 +5406,7 @@
             "description": "Defines an object-oriented layer for the HTTP specification",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/http-foundation/tree/v7.4.13"
+                "source": "https://github.com/symfony/http-foundation/tree/v7.4.14"
             },
             "funding": [
                 {
@@ -4985,20 +5426,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-24T11:20:33+00:00"
+            "time": "2026-06-11T07:31:44+00:00"
         },
         {
             "name": "symfony/http-kernel",
-            "version": "v7.4.13",
+            "version": "v7.4.14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-kernel.git",
-                "reference": "9df847980c436451f4f51d1284491bb4356dd989"
+                "reference": "e99af79b1e776646eda0e1c23b7b45c184ff99be"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/9df847980c436451f4f51d1284491bb4356dd989",
-                "reference": "9df847980c436451f4f51d1284491bb4356dd989",
+                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/e99af79b1e776646eda0e1c23b7b45c184ff99be",
+                "reference": "e99af79b1e776646eda0e1c23b7b45c184ff99be",
                 "shasum": ""
             },
             "require": {
@@ -5084,7 +5525,7 @@
             "description": "Provides a structured process for converting a Request into a Response",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/http-kernel/tree/v7.4.13"
+                "source": "https://github.com/symfony/http-kernel/tree/v7.4.14"
             },
             "funding": [
                 {
@@ -5104,20 +5545,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-27T08:31:43+00:00"
+            "time": "2026-06-27T09:14:35+00:00"
         },
         {
             "name": "symfony/mailer",
-            "version": "v7.4.12",
+            "version": "v7.4.14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/mailer.git",
-                "reference": "5cefb712a25f320579615ba9e1942abaeade7dff"
+                "reference": "f88ce03ae73e3edb5c176ce1f337709996e88495"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/mailer/zipball/5cefb712a25f320579615ba9e1942abaeade7dff",
-                "reference": "5cefb712a25f320579615ba9e1942abaeade7dff",
+                "url": "https://api.github.com/repos/symfony/mailer/zipball/f88ce03ae73e3edb5c176ce1f337709996e88495",
+                "reference": "f88ce03ae73e3edb5c176ce1f337709996e88495",
                 "shasum": ""
             },
             "require": {
@@ -5168,7 +5609,7 @@
             "description": "Helps sending emails",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/mailer/tree/v7.4.12"
+                "source": "https://github.com/symfony/mailer/tree/v7.4.14"
             },
             "funding": [
                 {
@@ -5188,7 +5629,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-20T07:20:23+00:00"
+            "time": "2026-06-13T08:51:35+00:00"
         },
         {
             "name": "symfony/mime",
@@ -6260,16 +6701,16 @@
         },
         {
             "name": "symfony/service-contracts",
-            "version": "v3.7.0",
+            "version": "v3.7.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/service-contracts.git",
-                "reference": "d25d82433a80eba6aa0e6c24b61d7370d99e444a"
+                "reference": "c0a284bab1ed8aa0417e3d69250ab437739563a0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/d25d82433a80eba6aa0e6c24b61d7370d99e444a",
-                "reference": "d25d82433a80eba6aa0e6c24b61d7370d99e444a",
+                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/c0a284bab1ed8aa0417e3d69250ab437739563a0",
+                "reference": "c0a284bab1ed8aa0417e3d69250ab437739563a0",
                 "shasum": ""
             },
             "require": {
@@ -6323,7 +6764,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/service-contracts/tree/v3.7.0"
+                "source": "https://github.com/symfony/service-contracts/tree/v3.7.1"
             },
             "funding": [
                 {
@@ -6343,7 +6784,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-28T09:44:51+00:00"
+            "time": "2026-06-16T09:55:08+00:00"
         },
         {
             "name": "symfony/string",
@@ -6437,16 +6878,16 @@
         },
         {
             "name": "symfony/translation",
-            "version": "v8.1.0",
+            "version": "v8.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/translation.git",
-                "reference": "b2bd012ca28c4acae830ee1206a5b6e35dd99693"
+                "reference": "342b4218630dc2cf284cedcb2080c80b13404014"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/translation/zipball/b2bd012ca28c4acae830ee1206a5b6e35dd99693",
-                "reference": "b2bd012ca28c4acae830ee1206a5b6e35dd99693",
+                "url": "https://api.github.com/repos/symfony/translation/zipball/342b4218630dc2cf284cedcb2080c80b13404014",
+                "reference": "342b4218630dc2cf284cedcb2080c80b13404014",
                 "shasum": ""
             },
             "require": {
@@ -6506,7 +6947,7 @@
             "description": "Provides tools to internationalize your application",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/translation/tree/v8.1.0"
+                "source": "https://github.com/symfony/translation/tree/v8.1.1"
             },
             "funding": [
                 {
@@ -6526,20 +6967,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-29T05:06:50+00:00"
+            "time": "2026-06-06T11:11:44+00:00"
         },
         {
             "name": "symfony/translation-contracts",
-            "version": "v3.7.0",
+            "version": "v3.7.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/translation-contracts.git",
-                "reference": "0ab302977a952b42fd51475c4ebac81f8da0a95d"
+                "reference": "ccb206b98faccc511ebae8e5fad50f2dc0b30621"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/translation-contracts/zipball/0ab302977a952b42fd51475c4ebac81f8da0a95d",
-                "reference": "0ab302977a952b42fd51475c4ebac81f8da0a95d",
+                "url": "https://api.github.com/repos/symfony/translation-contracts/zipball/ccb206b98faccc511ebae8e5fad50f2dc0b30621",
+                "reference": "ccb206b98faccc511ebae8e5fad50f2dc0b30621",
                 "shasum": ""
             },
             "require": {
@@ -6588,7 +7029,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/translation-contracts/tree/v3.7.0"
+                "source": "https://github.com/symfony/translation-contracts/tree/v3.7.1"
             },
             "funding": [
                 {
@@ -6608,7 +7049,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-01-05T13:30:16+00:00"
+            "time": "2026-06-05T06:23:12+00:00"
         },
         {
             "name": "symfony/uid",
@@ -6690,16 +7131,16 @@
         },
         {
             "name": "symfony/var-dumper",
-            "version": "v7.4.8",
+            "version": "v7.4.14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/var-dumper.git",
-                "reference": "9510c3966f749a1d1ff0059e1eabef6cc621e7fd"
+                "reference": "9a3a56a4a1e65a5cb4f8d13801fe8ab0a170e358"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/9510c3966f749a1d1ff0059e1eabef6cc621e7fd",
-                "reference": "9510c3966f749a1d1ff0059e1eabef6cc621e7fd",
+                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/9a3a56a4a1e65a5cb4f8d13801fe8ab0a170e358",
+                "reference": "9a3a56a4a1e65a5cb4f8d13801fe8ab0a170e358",
                 "shasum": ""
             },
             "require": {
@@ -6753,7 +7194,7 @@
                 "dump"
             ],
             "support": {
-                "source": "https://github.com/symfony/var-dumper/tree/v7.4.8"
+                "source": "https://github.com/symfony/var-dumper/tree/v7.4.14"
             },
             "funding": [
                 {
@@ -6773,7 +7214,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-30T13:44:50+00:00"
+            "time": "2026-06-08T20:24:16+00:00"
         },
         {
             "name": "tijsverkoyen/css-to-inline-styles",
@@ -6832,16 +7273,16 @@
         },
         {
             "name": "vlucas/phpdotenv",
-            "version": "v5.6.3",
+            "version": "v5.6.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/vlucas/phpdotenv.git",
-                "reference": "955e7815d677a3eaa7075231212f2110983adecc"
+                "reference": "416df702837983f8d5ff48c9c3fee4f5f57b980b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/vlucas/phpdotenv/zipball/955e7815d677a3eaa7075231212f2110983adecc",
-                "reference": "955e7815d677a3eaa7075231212f2110983adecc",
+                "url": "https://api.github.com/repos/vlucas/phpdotenv/zipball/416df702837983f8d5ff48c9c3fee4f5f57b980b",
+                "reference": "416df702837983f8d5ff48c9c3fee4f5f57b980b",
                 "shasum": ""
             },
             "require": {
@@ -6900,7 +7341,7 @@
             ],
             "support": {
                 "issues": "https://github.com/vlucas/phpdotenv/issues",
-                "source": "https://github.com/vlucas/phpdotenv/tree/v5.6.3"
+                "source": "https://github.com/vlucas/phpdotenv/tree/v5.6.4"
             },
             "funding": [
                 {
@@ -6912,7 +7353,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-12-27T19:49:13+00:00"
+            "time": "2026-07-06T19:11:50+00:00"
         },
         {
             "name": "voku/portable-ascii",
@@ -6990,78 +7431,6 @@
         }
     ],
     "packages-dev": [
-        {
-            "name": "artisanpack-ui/ai",
-            "version": "1.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/ArtisanPack-UI/ai.git",
-                "reference": "082f1cd337742d34b8035d116c6c5ad8e5453fca"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/ArtisanPack-UI/ai/zipball/082f1cd337742d34b8035d116c6c5ad8e5453fca",
-                "reference": "082f1cd337742d34b8035d116c6c5ad8e5453fca",
-                "shasum": ""
-            },
-            "require": {
-                "artisanpack-ui/core": "^1.0",
-                "illuminate/support": "^12.0|^13.0",
-                "laravel/ai": "^0.8",
-                "php": "^8.3"
-            },
-            "require-dev": {
-                "artisanpack-ui/code-style": "^1.1",
-                "artisanpack-ui/code-style-pint": "^1.1",
-                "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
-                "friendsofphp/php-cs-fixer": "^3.75",
-                "laravel/pint": "^1.26",
-                "livewire/livewire": "^3.6",
-                "orchestra/testbench": "^10.2|^11.0",
-                "pestphp/pest": "^3.8|^4.0",
-                "pestphp/pest-plugin-laravel": "^3.2|^4.1"
-            },
-            "suggest": {
-                "artisanpack-ui/cms-framework": "Automatically registers AI credentials, features, budget and cache setting groups under the CMS admin surface.",
-                "artisanpack-ui/livewire-ui-components": "Renders the AI Settings and Usage admin surfaces using x-artisanpack-* components.",
-                "livewire/livewire": "Required to mount the AI Settings and Usage dashboard Livewire components under cms-framework's admin nav."
-            },
-            "type": "library",
-            "extra": {
-                "laravel": {
-                    "aliases": {
-                        "Ai": "ArtisanPackUI\\Ai\\Facades\\Ai"
-                    },
-                    "providers": [
-                        "ArtisanPackUI\\Ai\\AiServiceProvider"
-                    ]
-                }
-            },
-            "autoload": {
-                "files": [
-                    "src/helpers.php"
-                ],
-                "psr-4": {
-                    "ArtisanPackUI\\Ai\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Jacob Martella",
-                    "email": "me@jacobmartella.com"
-                }
-            ],
-            "description": "Shared AI foundation for the ArtisanPack UI ecosystem, built on top of laravel/ai.",
-            "support": {
-                "issues": "https://github.com/ArtisanPack-UI/ai/issues",
-                "source": "https://github.com/ArtisanPack-UI/ai/tree/v1.0.0"
-            },
-            "time": "2026-07-06T21:25:38+00:00"
-        },
         {
             "name": "artisanpack-ui/code-style",
             "version": "1.1.1",
@@ -7177,157 +7546,6 @@
                 "source": "https://github.com/ArtisanPack-UI/code-style-pint/tree/v1.1.1"
             },
             "time": "2026-06-09T00:58:49+00:00"
-        },
-        {
-            "name": "aws/aws-crt-php",
-            "version": "v1.2.7",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/awslabs/aws-crt-php.git",
-                "reference": "d71d9906c7bb63a28295447ba12e74723bd3730e"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/awslabs/aws-crt-php/zipball/d71d9906c7bb63a28295447ba12e74723bd3730e",
-                "reference": "d71d9906c7bb63a28295447ba12e74723bd3730e",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.5"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^4.8.35||^5.6.3||^9.5",
-                "yoast/phpunit-polyfills": "^1.0"
-            },
-            "suggest": {
-                "ext-awscrt": "Make sure you install awscrt native extension to use any of the functionality."
-            },
-            "type": "library",
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "Apache-2.0"
-            ],
-            "authors": [
-                {
-                    "name": "AWS SDK Common Runtime Team",
-                    "email": "aws-sdk-common-runtime@amazon.com"
-                }
-            ],
-            "description": "AWS Common Runtime for PHP",
-            "homepage": "https://github.com/awslabs/aws-crt-php",
-            "keywords": [
-                "amazon",
-                "aws",
-                "crt",
-                "sdk"
-            ],
-            "support": {
-                "issues": "https://github.com/awslabs/aws-crt-php/issues",
-                "source": "https://github.com/awslabs/aws-crt-php/tree/v1.2.7"
-            },
-            "time": "2024-10-18T22:15:13+00:00"
-        },
-        {
-            "name": "aws/aws-sdk-php",
-            "version": "3.388.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/aws/aws-sdk-php.git",
-                "reference": "d48fe5eabeda0cf58025636f78ac8dcd8e60a724"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/d48fe5eabeda0cf58025636f78ac8dcd8e60a724",
-                "reference": "d48fe5eabeda0cf58025636f78ac8dcd8e60a724",
-                "shasum": ""
-            },
-            "require": {
-                "aws/aws-crt-php": "^1.2.3",
-                "ext-json": "*",
-                "ext-pcre": "*",
-                "ext-simplexml": "*",
-                "guzzlehttp/guzzle": "^7.4.5",
-                "guzzlehttp/promises": "^2.0",
-                "guzzlehttp/psr7": "^2.4.5",
-                "mtdowling/jmespath.php": "^2.9.1",
-                "php": ">=8.1",
-                "psr/http-message": "^1.0 || ^2.0",
-                "symfony/filesystem": "^v5.4.45 || ^v6.4.3 || ^v7.1.0 || ^v8.0.0"
-            },
-            "require-dev": {
-                "andrewsville/php-token-reflection": "^1.4",
-                "aws/aws-php-sns-message-validator": "~1.0",
-                "behat/behat": "~3.0",
-                "composer/composer": "^2.7.8",
-                "dms/phpunit-arraysubset-asserts": "^v0.5.0",
-                "doctrine/cache": "~1.4",
-                "ext-dom": "*",
-                "ext-openssl": "*",
-                "ext-sockets": "*",
-                "phpunit/phpunit": "^10.0",
-                "psr/cache": "^2.0 || ^3.0",
-                "psr/simple-cache": "^2.0 || ^3.0",
-                "sebastian/comparator": "^1.2.3 || ^4.0 || ^5.0",
-                "yoast/phpunit-polyfills": "^2.0"
-            },
-            "suggest": {
-                "aws/aws-php-sns-message-validator": "To validate incoming SNS notifications",
-                "doctrine/cache": "To use the DoctrineCacheAdapter",
-                "ext-curl": "To send requests using cURL",
-                "ext-openssl": "Allows working with CloudFront private distributions and verifying received SNS messages",
-                "ext-pcntl": "To use client-side monitoring",
-                "ext-sockets": "To use client-side monitoring"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.0-dev"
-                }
-            },
-            "autoload": {
-                "files": [
-                    "src/functions.php"
-                ],
-                "psr-4": {
-                    "Aws\\": "src/"
-                },
-                "exclude-from-classmap": [
-                    "src/data/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "Apache-2.0"
-            ],
-            "authors": [
-                {
-                    "name": "Amazon Web Services",
-                    "homepage": "https://aws.amazon.com"
-                }
-            ],
-            "description": "AWS SDK for PHP - Use Amazon Web Services in your PHP project",
-            "homepage": "https://aws.amazon.com/sdk-for-php",
-            "keywords": [
-                "amazon",
-                "aws",
-                "cloud",
-                "dynamodb",
-                "ec2",
-                "glacier",
-                "s3",
-                "sdk"
-            ],
-            "support": {
-                "forum": "https://github.com/aws/aws-sdk-php/discussions",
-                "issues": "https://github.com/aws/aws-sdk-php/issues",
-                "source": "https://github.com/aws/aws-sdk-php/tree/3.388.2"
-            },
-            "time": "2026-07-08T23:12:50+00:00"
         },
         {
             "name": "brianium/paratest",
@@ -7488,28 +7706,29 @@
         },
         {
             "name": "composer/pcre",
-            "version": "3.3.2",
+            "version": "3.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/pcre.git",
-                "reference": "b2bed4734f0cc156ee1fe9c0da2550420d99a21e"
+                "reference": "d5a341b3fb61f3001970940afb1d332968a183ed"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/pcre/zipball/b2bed4734f0cc156ee1fe9c0da2550420d99a21e",
-                "reference": "b2bed4734f0cc156ee1fe9c0da2550420d99a21e",
+                "url": "https://api.github.com/repos/composer/pcre/zipball/d5a341b3fb61f3001970940afb1d332968a183ed",
+                "reference": "d5a341b3fb61f3001970940afb1d332968a183ed",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.4 || ^8.0"
             },
             "conflict": {
-                "phpstan/phpstan": "<1.11.10"
+                "phpstan/phpstan": "<2.2.2"
             },
             "require-dev": {
-                "phpstan/phpstan": "^1.12 || ^2",
-                "phpstan/phpstan-strict-rules": "^1 || ^2",
-                "phpunit/phpunit": "^8 || ^9"
+                "phpstan/phpstan": "^2",
+                "phpstan/phpstan-deprecation-rules": "^2",
+                "phpstan/phpstan-strict-rules": "^2",
+                "phpunit/phpunit": "^9"
             },
             "type": "library",
             "extra": {
@@ -7547,7 +7766,7 @@
             ],
             "support": {
                 "issues": "https://github.com/composer/pcre/issues",
-                "source": "https://github.com/composer/pcre/tree/3.3.2"
+                "source": "https://github.com/composer/pcre/tree/3.4.0"
             },
             "funding": [
                 {
@@ -7557,13 +7776,9 @@
                 {
                     "url": "https://github.com/composer",
                     "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
-                    "type": "tidelift"
                 }
             ],
-            "time": "2024-11-12T16:29:46+00:00"
+            "time": "2026-06-07T11:47:49+00:00"
         },
         {
             "name": "composer/xdebug-handler",
@@ -8088,16 +8303,16 @@
         },
         {
             "name": "friendsofphp/php-cs-fixer",
-            "version": "v3.95.5",
+            "version": "v3.95.12",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer.git",
-                "reference": "7f86d8763063f5d2e2e2d0e1e45bb2f15895361d"
+                "reference": "b1b9055997a98dce3c2338e884626e718a25a923"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHP-CS-Fixer/PHP-CS-Fixer/zipball/7f86d8763063f5d2e2e2d0e1e45bb2f15895361d",
-                "reference": "7f86d8763063f5d2e2e2d0e1e45bb2f15895361d",
+                "url": "https://api.github.com/repos/PHP-CS-Fixer/PHP-CS-Fixer/zipball/b1b9055997a98dce3c2338e884626e718a25a923",
+                "reference": "b1b9055997a98dce3c2338e884626e718a25a923",
                 "shasum": ""
             },
             "require": {
@@ -8131,16 +8346,16 @@
             "require-dev": {
                 "facile-it/paraunit": "^1.3.1 || ^2.11.0",
                 "infection/infection": "^0.32.7",
-                "justinrainbow/json-schema": "^6.8.0",
+                "justinrainbow/json-schema": "^6.10.0",
                 "keradus/cli-executor": "^2.3",
                 "mikey179/vfsstream": "^1.6.12",
                 "php-coveralls/php-coveralls": "^2.9.1",
                 "php-cs-fixer/phpunit-constraint-isidenticalstring": "^1.8",
                 "php-cs-fixer/phpunit-constraint-xmlmatchesxsd": "^1.8",
-                "phpunit/phpunit": "^9.6.34 || ^10.5.63 || ^11.5.55",
-                "symfony/polyfill-php85": "^1.37",
-                "symfony/var-dumper": "^5.4.48 || ^6.4.32 || ^7.4.4 || ^8.0.8",
-                "symfony/yaml": "^5.4.45 || ^6.4.30 || ^7.4.1 || ^8.0.11"
+                "phpunit/phpunit": "^9.6.35 || ^10.5.64 || ^11.5.56",
+                "symfony/polyfill-php85": "^1.38",
+                "symfony/var-dumper": "^5.4.48 || ^6.4.36 || ^7.4.8 || ^8.1.0",
+                "symfony/yaml": "^5.4.53 || ^6.4.41 || ^7.4.13 || ^8.1.0"
             },
             "suggest": {
                 "ext-dom": "For handling output formats in XML",
@@ -8181,7 +8396,7 @@
             ],
             "support": {
                 "issues": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues",
-                "source": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/tree/v3.95.5"
+                "source": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/tree/v3.95.12"
             },
             "funding": [
                 {
@@ -8189,7 +8404,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-06-09T14:55:16+00:00"
+            "time": "2026-07-07T13:29:36+00:00"
         },
         {
             "name": "hamcrest/hamcrest-php",
@@ -8303,80 +8518,6 @@
             "time": "2025-03-19T14:43:43+00:00"
         },
         {
-            "name": "laravel/ai",
-            "version": "v0.8.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/laravel/ai.git",
-                "reference": "b23bc857576d7c4b3bb52ffd8be936ae74005d23"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/laravel/ai/zipball/b23bc857576d7c4b3bb52ffd8be936ae74005d23",
-                "reference": "b23bc857576d7c4b3bb52ffd8be936ae74005d23",
-                "shasum": ""
-            },
-            "require": {
-                "aws/aws-sdk-php": "^3.339",
-                "illuminate/console": "^12.0|^13.0",
-                "illuminate/container": "^12.0|^13.0",
-                "illuminate/contracts": "^12.0|^13.0",
-                "illuminate/database": "^12.0|^13.0",
-                "illuminate/filesystem": "^12.0|^13.0",
-                "illuminate/json-schema": "^12.62|^13.15",
-                "illuminate/support": "^12.0|^13.0",
-                "laravel/prompts": "^0.3.6",
-                "laravel/serializable-closure": "^2.0",
-                "php": "^8.3"
-            },
-            "require-dev": {
-                "laravel/mcp": "^0.8",
-                "laravel/pint": "^1.26",
-                "mockery/mockery": "^1.6.12",
-                "orchestra/testbench": "^10.6|^11.0",
-                "pestphp/pest": "^3.0|^4.0",
-                "pestphp/pest-plugin-laravel": "^3.0|^4.0",
-                "phpstan/phpstan": "^2.1"
-            },
-            "suggest": {
-                "laravel/mcp": "Required to use MCP client tools or MCP server tools with Laravel AI agents."
-            },
-            "type": "library",
-            "extra": {
-                "laravel": {
-                    "providers": [
-                        "Laravel\\Ai\\AiServiceProvider"
-                    ]
-                },
-                "branch-alias": {
-                    "dev-master": "1.x-dev"
-                }
-            },
-            "autoload": {
-                "files": [
-                    "functions.php"
-                ],
-                "psr-4": {
-                    "Laravel\\Ai\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "description": "The official AI SDK for Laravel.",
-            "homepage": "https://github.com/laravel/ai",
-            "keywords": [
-                "ai",
-                "laravel"
-            ],
-            "support": {
-                "issues": "https://github.com/laravel/ai/issues",
-                "source": "https://github.com/laravel/ai"
-            },
-            "time": "2026-06-10T11:23:35+00:00"
-        },
-        {
             "name": "laravel/pail",
             "version": "v1.2.7",
             "source": {
@@ -8458,16 +8599,16 @@
         },
         {
             "name": "laravel/pint",
-            "version": "v1.29.1",
+            "version": "v1.29.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/pint.git",
-                "reference": "0770e9b7fafd50d4586881d456d6eb41c9247a80"
+                "reference": "da1d1111a6aa2e082d2a388b194afe1ba0a05d14"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/pint/zipball/0770e9b7fafd50d4586881d456d6eb41c9247a80",
-                "reference": "0770e9b7fafd50d4586881d456d6eb41c9247a80",
+                "url": "https://api.github.com/repos/laravel/pint/zipball/da1d1111a6aa2e082d2a388b194afe1ba0a05d14",
+                "reference": "da1d1111a6aa2e082d2a388b194afe1ba0a05d14",
                 "shasum": ""
             },
             "require": {
@@ -8478,14 +8619,14 @@
                 "php": "^8.2.0"
             },
             "require-dev": {
-                "friendsofphp/php-cs-fixer": "^3.95.1",
-                "illuminate/view": "^12.56.0",
-                "larastan/larastan": "^3.9.6",
+                "friendsofphp/php-cs-fixer": "^3.95.8",
+                "illuminate/view": "^12.62.0",
+                "larastan/larastan": "^3.10.0",
                 "laravel-zero/framework": "^12.1.0",
+                "laravel/agent-detector": "^2.0.2",
                 "mockery/mockery": "^1.6.12",
                 "nunomaduro/termwind": "^2.4.0",
-                "pestphp/pest": "^3.8.6",
-                "shipfastlabs/agent-detector": "^1.1.3"
+                "pestphp/pest": "^3.8.6"
             },
             "bin": [
                 "builds/pint"
@@ -8522,20 +8663,20 @@
                 "issues": "https://github.com/laravel/pint/issues",
                 "source": "https://github.com/laravel/pint"
             },
-            "time": "2026-04-20T15:26:14+00:00"
+            "time": "2026-06-16T15:34:04+00:00"
         },
         {
             "name": "laravel/sail",
-            "version": "v1.62.0",
+            "version": "v1.63.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/sail.git",
-                "reference": "3aaeefc979f8ba6586fbc5b6e0b1b3638058f98e"
+                "reference": "51bbce3f803c1d386cabbb44e618c955a12ff5fc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/sail/zipball/3aaeefc979f8ba6586fbc5b6e0b1b3638058f98e",
-                "reference": "3aaeefc979f8ba6586fbc5b6e0b1b3638058f98e",
+                "url": "https://api.github.com/repos/laravel/sail/zipball/51bbce3f803c1d386cabbb44e618c955a12ff5fc",
+                "reference": "51bbce3f803c1d386cabbb44e618c955a12ff5fc",
                 "shasum": ""
             },
             "require": {
@@ -8585,83 +8726,7 @@
                 "issues": "https://github.com/laravel/sail/issues",
                 "source": "https://github.com/laravel/sail"
             },
-            "time": "2026-05-27T04:02:01+00:00"
-        },
-        {
-            "name": "livewire/livewire",
-            "version": "v3.8.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/livewire/livewire.git",
-                "reference": "e77fce60d0615d68dc6b8fafe98a6739d9752a24"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/livewire/livewire/zipball/e77fce60d0615d68dc6b8fafe98a6739d9752a24",
-                "reference": "e77fce60d0615d68dc6b8fafe98a6739d9752a24",
-                "shasum": ""
-            },
-            "require": {
-                "illuminate/database": "^10.0|^11.0|^12.0|^13.0",
-                "illuminate/routing": "^10.0|^11.0|^12.0|^13.0",
-                "illuminate/support": "^10.0|^11.0|^12.0|^13.0",
-                "illuminate/validation": "^10.0|^11.0|^12.0|^13.0",
-                "laravel/prompts": "^0.1.24|^0.2|^0.3",
-                "league/mime-type-detection": "^1.9",
-                "php": "^8.1",
-                "symfony/console": "^6.0|^7.0|^8.0",
-                "symfony/http-kernel": "^6.2|^7.0|^8.0"
-            },
-            "require-dev": {
-                "calebporzio/sushi": "^2.1",
-                "laravel/framework": "^10.15.0|^11.0|^12.0|^13.0",
-                "mockery/mockery": "^1.3.1",
-                "orchestra/testbench": "^8.21.0|^9.0|^10.0|^11.0",
-                "orchestra/testbench-dusk": "^8.24|^9.1|^10.0|^11.0",
-                "phpunit/phpunit": "^10.4|^11.5|^12.5",
-                "psy/psysh": "^0.11.22|^0.12"
-            },
-            "type": "library",
-            "extra": {
-                "laravel": {
-                    "aliases": {
-                        "Livewire": "Livewire\\Livewire"
-                    },
-                    "providers": [
-                        "Livewire\\LivewireServiceProvider"
-                    ]
-                }
-            },
-            "autoload": {
-                "files": [
-                    "src/helpers.php"
-                ],
-                "psr-4": {
-                    "Livewire\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Caleb Porzio",
-                    "email": "calebporzio@gmail.com"
-                }
-            ],
-            "description": "A front-end framework for Laravel.",
-            "support": {
-                "issues": "https://github.com/livewire/livewire/issues",
-                "source": "https://github.com/livewire/livewire/tree/v3.8.2"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/livewire",
-                    "type": "github"
-                }
-            ],
-            "time": "2026-06-27T03:14:20+00:00"
+            "time": "2026-06-18T08:54:14+00:00"
         },
         {
             "name": "mockery/mockery",
@@ -8745,72 +8810,6 @@
                 "source": "https://github.com/mockery/mockery"
             },
             "time": "2024-05-16T03:13:13+00:00"
-        },
-        {
-            "name": "mtdowling/jmespath.php",
-            "version": "2.9.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/jmespath/jmespath.php.git",
-                "reference": "2157c5e50e813ec6a96c1eed3be7f64a20fb32a8"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/jmespath/jmespath.php/zipball/2157c5e50e813ec6a96c1eed3be7f64a20fb32a8",
-                "reference": "2157c5e50e813ec6a96c1eed3be7f64a20fb32a8",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.2.5 || ^8.0",
-                "symfony/polyfill-mbstring": "^1.17"
-            },
-            "require-dev": {
-                "composer/xdebug-handler": "^3.0.3",
-                "phpunit/phpunit": "^8.5.52"
-            },
-            "bin": [
-                "bin/jp.php"
-            ],
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.9-dev"
-                }
-            },
-            "autoload": {
-                "files": [
-                    "src/JmesPath.php"
-                ],
-                "psr-4": {
-                    "JmesPath\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Graham Campbell",
-                    "email": "hello@gjcampbell.co.uk",
-                    "homepage": "https://github.com/GrahamCampbell"
-                },
-                {
-                    "name": "Michael Dowling",
-                    "email": "mtdowling@gmail.com",
-                    "homepage": "https://github.com/mtdowling"
-                }
-            ],
-            "description": "Declaratively specify how to extract elements from a JSON document",
-            "keywords": [
-                "json",
-                "jsonpath"
-            ],
-            "support": {
-                "issues": "https://github.com/jmespath/jmespath.php/issues",
-                "source": "https://github.com/jmespath/jmespath.php/tree/2.9.2"
-            },
-            "time": "2026-07-06T18:56:19+00:00"
         },
         {
             "name": "nunomaduro/collision",
@@ -9329,38 +9328,38 @@
         },
         {
             "name": "pestphp/pest",
-            "version": "v3.8.6",
+            "version": "v3.8.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/pestphp/pest.git",
-                "reference": "8871a6f5ef1de8e7c8dee2a270991449a7b6af73"
+                "reference": "f108313b52e8c28dc7121ce34303f817a3790202"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/pestphp/pest/zipball/8871a6f5ef1de8e7c8dee2a270991449a7b6af73",
-                "reference": "8871a6f5ef1de8e7c8dee2a270991449a7b6af73",
+                "url": "https://api.github.com/repos/pestphp/pest/zipball/f108313b52e8c28dc7121ce34303f817a3790202",
+                "reference": "f108313b52e8c28dc7121ce34303f817a3790202",
                 "shasum": ""
             },
             "require": {
                 "brianium/paratest": "^7.8.5",
-                "nunomaduro/collision": "^8.9.1",
+                "nunomaduro/collision": "^8.9.4",
                 "nunomaduro/termwind": "^2.4.0",
                 "pestphp/pest-plugin": "^3.0.0",
                 "pestphp/pest-plugin-arch": "^3.1.1",
                 "pestphp/pest-plugin-mutate": "^3.0.5",
                 "php": "^8.2.0",
-                "phpunit/phpunit": "^11.5.50"
+                "phpunit/phpunit": "^11.5.56"
             },
             "conflict": {
                 "filp/whoops": "<2.16.0",
-                "phpunit/phpunit": ">11.5.50",
+                "phpunit/phpunit": ">11.5.56",
                 "sebastian/exporter": "<6.0.0",
                 "webmozart/assert": "<1.11.0"
             },
             "require-dev": {
                 "pestphp/pest-dev-tools": "^3.4.0",
                 "pestphp/pest-plugin-type-coverage": "^3.6.1",
-                "symfony/process": "^7.4.5"
+                "symfony/process": "^7.4.13"
             },
             "bin": [
                 "bin/pest"
@@ -9425,7 +9424,7 @@
             ],
             "support": {
                 "issues": "https://github.com/pestphp/pest/issues",
-                "source": "https://github.com/pestphp/pest/tree/v3.8.6"
+                "source": "https://github.com/pestphp/pest/tree/v3.8.7"
             },
             "funding": [
                 {
@@ -9437,7 +9436,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-03-10T21:04:33+00:00"
+            "time": "2026-07-06T17:04:21+00:00"
         },
         {
             "name": "pestphp/pest-plugin",
@@ -10368,31 +10367,31 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "11.5.50",
+            "version": "11.5.56",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "fdfc727f0fcacfeb8fcb30c7e5da173125b58be3"
+                "reference": "5f83edffa6967c3db468d48a695ec7bcb02e9256"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/fdfc727f0fcacfeb8fcb30c7e5da173125b58be3",
-                "reference": "fdfc727f0fcacfeb8fcb30c7e5da173125b58be3",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/5f83edffa6967c3db468d48a695ec7bcb02e9256",
+                "reference": "5f83edffa6967c3db468d48a695ec7bcb02e9256",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
+                "ext-filter": "*",
                 "ext-json": "*",
                 "ext-libxml": "*",
                 "ext-mbstring": "*",
-                "ext-xml": "*",
                 "ext-xmlwriter": "*",
                 "myclabs/deep-copy": "^1.13.4",
                 "phar-io/manifest": "^2.0.4",
                 "phar-io/version": "^3.2.1",
                 "php": ">=8.2",
                 "phpunit/php-code-coverage": "^11.0.12",
-                "phpunit/php-file-iterator": "^5.1.0",
+                "phpunit/php-file-iterator": "^5.1.1",
                 "phpunit/php-invoker": "^5.0.1",
                 "phpunit/php-text-template": "^4.0.1",
                 "phpunit/php-timer": "^7.0.1",
@@ -10404,6 +10403,7 @@
                 "sebastian/exporter": "^6.3.2",
                 "sebastian/global-state": "^7.0.2",
                 "sebastian/object-enumerator": "^6.0.1",
+                "sebastian/recursion-context": "^6.0.3",
                 "sebastian/type": "^5.1.3",
                 "sebastian/version": "^5.0.2",
                 "staabm/side-effects-detector": "^1.0.5"
@@ -10449,31 +10449,15 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/11.5.50"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/11.5.56"
             },
             "funding": [
                 {
-                    "url": "https://phpunit.de/sponsors.html",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/sebastianbergmann",
-                    "type": "github"
-                },
-                {
-                    "url": "https://liberapay.com/sebastianbergmann",
-                    "type": "liberapay"
-                },
-                {
-                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
-                    "type": "thanks_dev"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/phpunit/phpunit",
-                    "type": "tidelift"
+                    "url": "https://phpunit.de/sponsoring.html",
+                    "type": "other"
                 }
             ],
-            "time": "2026-01-27T05:59:18+00:00"
+            "time": "2026-07-06T14:52:39+00:00"
         },
         {
             "name": "react/cache",
@@ -12124,77 +12108,6 @@
             "time": "2024-10-20T05:08:20+00:00"
         },
         {
-            "name": "symfony/filesystem",
-            "version": "v8.1.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/filesystem.git",
-                "reference": "99aec13b82b4967ec5088222c4a3ecca955949c2"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/99aec13b82b4967ec5088222c4a3ecca955949c2",
-                "reference": "99aec13b82b4967ec5088222c4a3ecca955949c2",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.4.1",
-                "symfony/deprecation-contracts": "^2.5|^3",
-                "symfony/polyfill-ctype": "~1.8",
-                "symfony/polyfill-mbstring": "~1.8"
-            },
-            "require-dev": {
-                "symfony/process": "^7.4|^8.0"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\Filesystem\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Provides basic utilities for the filesystem",
-            "homepage": "https://symfony.com",
-            "support": {
-                "source": "https://github.com/symfony/filesystem/tree/v8.1.0"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://github.com/nicolas-grekas",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2026-05-29T05:06:50+00:00"
-        },
-        {
             "name": "symfony/options-resolver",
             "version": "v8.1.0",
             "source": {
@@ -12413,16 +12326,16 @@
         },
         {
             "name": "symfony/yaml",
-            "version": "v7.4.13",
+            "version": "v7.4.14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "a7ec3b1156faf8815db7683ec7c1e7338e6f977c"
+                "reference": "f8f328665ace2370d1e10645b807ba1646dc7dcc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/a7ec3b1156faf8815db7683ec7c1e7338e6f977c",
-                "reference": "a7ec3b1156faf8815db7683ec7c1e7338e6f977c",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/f8f328665ace2370d1e10645b807ba1646dc7dcc",
+                "reference": "f8f328665ace2370d1e10645b807ba1646dc7dcc",
                 "shasum": ""
             },
             "require": {
@@ -12465,7 +12378,7 @@
             "description": "Loads and dumps YAML files",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/yaml/tree/v7.4.13"
+                "source": "https://github.com/symfony/yaml/tree/v7.4.14"
             },
             "funding": [
                 {
@@ -12485,7 +12398,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-25T06:06:12+00:00"
+            "time": "2026-06-08T20:24:16+00:00"
         },
         {
             "name": "ta-tikoma/phpunit-architecture-test",
@@ -12598,16 +12511,16 @@
         },
         {
             "name": "webmozart/assert",
-            "version": "2.4.0",
+            "version": "2.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/webmozarts/assert.git",
-                "reference": "9007ea6f45ecf352a9422b36644e4bfc039b9155"
+                "reference": "2ccb7c2e821038c03a3e6e1700c570c158c55f70"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webmozarts/assert/zipball/9007ea6f45ecf352a9422b36644e4bfc039b9155",
-                "reference": "9007ea6f45ecf352a9422b36644e4bfc039b9155",
+                "url": "https://api.github.com/repos/webmozarts/assert/zipball/2ccb7c2e821038c03a3e6e1700c570c158c55f70",
+                "reference": "2ccb7c2e821038c03a3e6e1700c570c158c55f70",
                 "shasum": ""
             },
             "require": {
@@ -12658,9 +12571,9 @@
             ],
             "support": {
                 "issues": "https://github.com/webmozarts/assert/issues",
-                "source": "https://github.com/webmozarts/assert/tree/2.4.0"
+                "source": "https://github.com/webmozarts/assert/tree/2.4.1"
             },
-            "time": "2026-05-20T13:07:01+00:00"
+            "time": "2026-06-15T15:31:57+00:00"
         }
     ],
     "aliases": [],

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ab9f8b35abd79d21e96ed037564dd6c4",
+    "content-hash": "c71262b357fb68a3161113c27bec3d58",
     "packages": [
         {
             "name": "artisanpack-ui/accessibility",
@@ -6991,6 +6991,78 @@
     ],
     "packages-dev": [
         {
+            "name": "artisanpack-ui/ai",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ArtisanPack-UI/ai.git",
+                "reference": "082f1cd337742d34b8035d116c6c5ad8e5453fca"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ArtisanPack-UI/ai/zipball/082f1cd337742d34b8035d116c6c5ad8e5453fca",
+                "reference": "082f1cd337742d34b8035d116c6c5ad8e5453fca",
+                "shasum": ""
+            },
+            "require": {
+                "artisanpack-ui/core": "^1.0",
+                "illuminate/support": "^12.0|^13.0",
+                "laravel/ai": "^0.8",
+                "php": "^8.3"
+            },
+            "require-dev": {
+                "artisanpack-ui/code-style": "^1.1",
+                "artisanpack-ui/code-style-pint": "^1.1",
+                "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
+                "friendsofphp/php-cs-fixer": "^3.75",
+                "laravel/pint": "^1.26",
+                "livewire/livewire": "^3.6",
+                "orchestra/testbench": "^10.2|^11.0",
+                "pestphp/pest": "^3.8|^4.0",
+                "pestphp/pest-plugin-laravel": "^3.2|^4.1"
+            },
+            "suggest": {
+                "artisanpack-ui/cms-framework": "Automatically registers AI credentials, features, budget and cache setting groups under the CMS admin surface.",
+                "artisanpack-ui/livewire-ui-components": "Renders the AI Settings and Usage admin surfaces using x-artisanpack-* components.",
+                "livewire/livewire": "Required to mount the AI Settings and Usage dashboard Livewire components under cms-framework's admin nav."
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "aliases": {
+                        "Ai": "ArtisanPackUI\\Ai\\Facades\\Ai"
+                    },
+                    "providers": [
+                        "ArtisanPackUI\\Ai\\AiServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/helpers.php"
+                ],
+                "psr-4": {
+                    "ArtisanPackUI\\Ai\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jacob Martella",
+                    "email": "me@jacobmartella.com"
+                }
+            ],
+            "description": "Shared AI foundation for the ArtisanPack UI ecosystem, built on top of laravel/ai.",
+            "support": {
+                "issues": "https://github.com/ArtisanPack-UI/ai/issues",
+                "source": "https://github.com/ArtisanPack-UI/ai/tree/v1.0.0"
+            },
+            "time": "2026-07-06T21:25:38+00:00"
+        },
+        {
             "name": "artisanpack-ui/code-style",
             "version": "1.1.1",
             "source": {
@@ -7105,6 +7177,157 @@
                 "source": "https://github.com/ArtisanPack-UI/code-style-pint/tree/v1.1.1"
             },
             "time": "2026-06-09T00:58:49+00:00"
+        },
+        {
+            "name": "aws/aws-crt-php",
+            "version": "v1.2.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/awslabs/aws-crt-php.git",
+                "reference": "d71d9906c7bb63a28295447ba12e74723bd3730e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/awslabs/aws-crt-php/zipball/d71d9906c7bb63a28295447ba12e74723bd3730e",
+                "reference": "d71d9906c7bb63a28295447ba12e74723bd3730e",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.8.35||^5.6.3||^9.5",
+                "yoast/phpunit-polyfills": "^1.0"
+            },
+            "suggest": {
+                "ext-awscrt": "Make sure you install awscrt native extension to use any of the functionality."
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "AWS SDK Common Runtime Team",
+                    "email": "aws-sdk-common-runtime@amazon.com"
+                }
+            ],
+            "description": "AWS Common Runtime for PHP",
+            "homepage": "https://github.com/awslabs/aws-crt-php",
+            "keywords": [
+                "amazon",
+                "aws",
+                "crt",
+                "sdk"
+            ],
+            "support": {
+                "issues": "https://github.com/awslabs/aws-crt-php/issues",
+                "source": "https://github.com/awslabs/aws-crt-php/tree/v1.2.7"
+            },
+            "time": "2024-10-18T22:15:13+00:00"
+        },
+        {
+            "name": "aws/aws-sdk-php",
+            "version": "3.388.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/aws/aws-sdk-php.git",
+                "reference": "d48fe5eabeda0cf58025636f78ac8dcd8e60a724"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/d48fe5eabeda0cf58025636f78ac8dcd8e60a724",
+                "reference": "d48fe5eabeda0cf58025636f78ac8dcd8e60a724",
+                "shasum": ""
+            },
+            "require": {
+                "aws/aws-crt-php": "^1.2.3",
+                "ext-json": "*",
+                "ext-pcre": "*",
+                "ext-simplexml": "*",
+                "guzzlehttp/guzzle": "^7.4.5",
+                "guzzlehttp/promises": "^2.0",
+                "guzzlehttp/psr7": "^2.4.5",
+                "mtdowling/jmespath.php": "^2.9.1",
+                "php": ">=8.1",
+                "psr/http-message": "^1.0 || ^2.0",
+                "symfony/filesystem": "^v5.4.45 || ^v6.4.3 || ^v7.1.0 || ^v8.0.0"
+            },
+            "require-dev": {
+                "andrewsville/php-token-reflection": "^1.4",
+                "aws/aws-php-sns-message-validator": "~1.0",
+                "behat/behat": "~3.0",
+                "composer/composer": "^2.7.8",
+                "dms/phpunit-arraysubset-asserts": "^v0.5.0",
+                "doctrine/cache": "~1.4",
+                "ext-dom": "*",
+                "ext-openssl": "*",
+                "ext-sockets": "*",
+                "phpunit/phpunit": "^10.0",
+                "psr/cache": "^2.0 || ^3.0",
+                "psr/simple-cache": "^2.0 || ^3.0",
+                "sebastian/comparator": "^1.2.3 || ^4.0 || ^5.0",
+                "yoast/phpunit-polyfills": "^2.0"
+            },
+            "suggest": {
+                "aws/aws-php-sns-message-validator": "To validate incoming SNS notifications",
+                "doctrine/cache": "To use the DoctrineCacheAdapter",
+                "ext-curl": "To send requests using cURL",
+                "ext-openssl": "Allows working with CloudFront private distributions and verifying received SNS messages",
+                "ext-pcntl": "To use client-side monitoring",
+                "ext-sockets": "To use client-side monitoring"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/functions.php"
+                ],
+                "psr-4": {
+                    "Aws\\": "src/"
+                },
+                "exclude-from-classmap": [
+                    "src/data/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Amazon Web Services",
+                    "homepage": "https://aws.amazon.com"
+                }
+            ],
+            "description": "AWS SDK for PHP - Use Amazon Web Services in your PHP project",
+            "homepage": "https://aws.amazon.com/sdk-for-php",
+            "keywords": [
+                "amazon",
+                "aws",
+                "cloud",
+                "dynamodb",
+                "ec2",
+                "glacier",
+                "s3",
+                "sdk"
+            ],
+            "support": {
+                "forum": "https://github.com/aws/aws-sdk-php/discussions",
+                "issues": "https://github.com/aws/aws-sdk-php/issues",
+                "source": "https://github.com/aws/aws-sdk-php/tree/3.388.2"
+            },
+            "time": "2026-07-08T23:12:50+00:00"
         },
         {
             "name": "brianium/paratest",
@@ -8080,6 +8303,80 @@
             "time": "2025-03-19T14:43:43+00:00"
         },
         {
+            "name": "laravel/ai",
+            "version": "v0.8.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laravel/ai.git",
+                "reference": "b23bc857576d7c4b3bb52ffd8be936ae74005d23"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laravel/ai/zipball/b23bc857576d7c4b3bb52ffd8be936ae74005d23",
+                "reference": "b23bc857576d7c4b3bb52ffd8be936ae74005d23",
+                "shasum": ""
+            },
+            "require": {
+                "aws/aws-sdk-php": "^3.339",
+                "illuminate/console": "^12.0|^13.0",
+                "illuminate/container": "^12.0|^13.0",
+                "illuminate/contracts": "^12.0|^13.0",
+                "illuminate/database": "^12.0|^13.0",
+                "illuminate/filesystem": "^12.0|^13.0",
+                "illuminate/json-schema": "^12.62|^13.15",
+                "illuminate/support": "^12.0|^13.0",
+                "laravel/prompts": "^0.3.6",
+                "laravel/serializable-closure": "^2.0",
+                "php": "^8.3"
+            },
+            "require-dev": {
+                "laravel/mcp": "^0.8",
+                "laravel/pint": "^1.26",
+                "mockery/mockery": "^1.6.12",
+                "orchestra/testbench": "^10.6|^11.0",
+                "pestphp/pest": "^3.0|^4.0",
+                "pestphp/pest-plugin-laravel": "^3.0|^4.0",
+                "phpstan/phpstan": "^2.1"
+            },
+            "suggest": {
+                "laravel/mcp": "Required to use MCP client tools or MCP server tools with Laravel AI agents."
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Laravel\\Ai\\AiServiceProvider"
+                    ]
+                },
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "functions.php"
+                ],
+                "psr-4": {
+                    "Laravel\\Ai\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "The official AI SDK for Laravel.",
+            "homepage": "https://github.com/laravel/ai",
+            "keywords": [
+                "ai",
+                "laravel"
+            ],
+            "support": {
+                "issues": "https://github.com/laravel/ai/issues",
+                "source": "https://github.com/laravel/ai"
+            },
+            "time": "2026-06-10T11:23:35+00:00"
+        },
+        {
             "name": "laravel/pail",
             "version": "v1.2.7",
             "source": {
@@ -8291,6 +8588,82 @@
             "time": "2026-05-27T04:02:01+00:00"
         },
         {
+            "name": "livewire/livewire",
+            "version": "v3.8.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/livewire/livewire.git",
+                "reference": "e77fce60d0615d68dc6b8fafe98a6739d9752a24"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/livewire/livewire/zipball/e77fce60d0615d68dc6b8fafe98a6739d9752a24",
+                "reference": "e77fce60d0615d68dc6b8fafe98a6739d9752a24",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/database": "^10.0|^11.0|^12.0|^13.0",
+                "illuminate/routing": "^10.0|^11.0|^12.0|^13.0",
+                "illuminate/support": "^10.0|^11.0|^12.0|^13.0",
+                "illuminate/validation": "^10.0|^11.0|^12.0|^13.0",
+                "laravel/prompts": "^0.1.24|^0.2|^0.3",
+                "league/mime-type-detection": "^1.9",
+                "php": "^8.1",
+                "symfony/console": "^6.0|^7.0|^8.0",
+                "symfony/http-kernel": "^6.2|^7.0|^8.0"
+            },
+            "require-dev": {
+                "calebporzio/sushi": "^2.1",
+                "laravel/framework": "^10.15.0|^11.0|^12.0|^13.0",
+                "mockery/mockery": "^1.3.1",
+                "orchestra/testbench": "^8.21.0|^9.0|^10.0|^11.0",
+                "orchestra/testbench-dusk": "^8.24|^9.1|^10.0|^11.0",
+                "phpunit/phpunit": "^10.4|^11.5|^12.5",
+                "psy/psysh": "^0.11.22|^0.12"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "aliases": {
+                        "Livewire": "Livewire\\Livewire"
+                    },
+                    "providers": [
+                        "Livewire\\LivewireServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/helpers.php"
+                ],
+                "psr-4": {
+                    "Livewire\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Caleb Porzio",
+                    "email": "calebporzio@gmail.com"
+                }
+            ],
+            "description": "A front-end framework for Laravel.",
+            "support": {
+                "issues": "https://github.com/livewire/livewire/issues",
+                "source": "https://github.com/livewire/livewire/tree/v3.8.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/livewire",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-06-27T03:14:20+00:00"
+        },
+        {
             "name": "mockery/mockery",
             "version": "1.6.12",
             "source": {
@@ -8372,6 +8745,72 @@
                 "source": "https://github.com/mockery/mockery"
             },
             "time": "2024-05-16T03:13:13+00:00"
+        },
+        {
+            "name": "mtdowling/jmespath.php",
+            "version": "2.9.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/jmespath/jmespath.php.git",
+                "reference": "2157c5e50e813ec6a96c1eed3be7f64a20fb32a8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/jmespath/jmespath.php/zipball/2157c5e50e813ec6a96c1eed3be7f64a20fb32a8",
+                "reference": "2157c5e50e813ec6a96c1eed3be7f64a20fb32a8",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2.5 || ^8.0",
+                "symfony/polyfill-mbstring": "^1.17"
+            },
+            "require-dev": {
+                "composer/xdebug-handler": "^3.0.3",
+                "phpunit/phpunit": "^8.5.52"
+            },
+            "bin": [
+                "bin/jp.php"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.9-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/JmesPath.php"
+                ],
+                "psr-4": {
+                    "JmesPath\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Graham Campbell",
+                    "email": "hello@gjcampbell.co.uk",
+                    "homepage": "https://github.com/GrahamCampbell"
+                },
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                }
+            ],
+            "description": "Declaratively specify how to extract elements from a JSON document",
+            "keywords": [
+                "json",
+                "jsonpath"
+            ],
+            "support": {
+                "issues": "https://github.com/jmespath/jmespath.php/issues",
+                "source": "https://github.com/jmespath/jmespath.php/tree/2.9.2"
+            },
+            "time": "2026-07-06T18:56:19+00:00"
         },
         {
             "name": "nunomaduro/collision",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c71262b357fb68a3161113c27bec3d58",
+    "content-hash": "881a116002a27db56125280cb2bb2ae0",
     "packages": [
         {
             "name": "artisanpack-ui/accessibility",
@@ -1177,26 +1177,26 @@
         },
         {
             "name": "guzzlehttp/guzzle",
-            "version": "7.11.1",
+            "version": "7.14.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "5af96f374e0ab4ebd747b8310888c99d3adb0a8c"
+                "reference": "aef242412e13128b5049864867bb49fc37dd39de"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/5af96f374e0ab4ebd747b8310888c99d3adb0a8c",
-                "reference": "5af96f374e0ab4ebd747b8310888c99d3adb0a8c",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/aef242412e13128b5049864867bb49fc37dd39de",
+                "reference": "aef242412e13128b5049864867bb49fc37dd39de",
                 "shasum": ""
             },
             "require": {
                 "ext-json": "*",
-                "guzzlehttp/promises": "^2.5",
-                "guzzlehttp/psr7": "^2.11",
+                "guzzlehttp/promises": "^2.5.1",
+                "guzzlehttp/psr7": "^2.12.4",
                 "php": "^7.2.5 || ^8.0",
                 "psr/http-client": "^1.0",
                 "symfony/deprecation-contracts": "^2.5 || ^3.0",
-                "symfony/polyfill-php80": "^1.24"
+                "symfony/polyfill-php80": "^1.25"
             },
             "provide": {
                 "psr/http-client-implementation": "1.0"
@@ -1204,8 +1204,8 @@
             "require-dev": {
                 "bamarni/composer-bin-plugin": "^1.8.2",
                 "ext-curl": "*",
-                "guzzle/client-integration-tests": "3.0.2",
-                "guzzlehttp/test-server": "^0.5",
+                "guzzle/client-integration-tests": "3.0.3",
+                "guzzlehttp/test-server": "^0.6",
                 "php-http/message-factory": "^1.1",
                 "phpunit/phpunit": "^8.5.52 || ^9.6.34",
                 "psr/log": "^1.1 || ^2.0 || ^3.0"
@@ -1285,7 +1285,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/guzzle/issues",
-                "source": "https://github.com/guzzle/guzzle/tree/7.11.1"
+                "source": "https://github.com/guzzle/guzzle/tree/7.14.0"
             },
             "funding": [
                 {
@@ -1301,20 +1301,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-06-07T22:54:06+00:00"
+            "time": "2026-07-08T22:54:09+00:00"
         },
         {
             "name": "guzzlehttp/promises",
-            "version": "2.5.0",
+            "version": "2.5.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/promises.git",
-                "reference": "4360e982f87f5f258bf872d094647791db2f4c8e"
+                "reference": "9ad1e4fc607446a055b95870c7f668e93b5cff29"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/promises/zipball/4360e982f87f5f258bf872d094647791db2f4c8e",
-                "reference": "4360e982f87f5f258bf872d094647791db2f4c8e",
+                "url": "https://api.github.com/repos/guzzle/promises/zipball/9ad1e4fc607446a055b95870c7f668e93b5cff29",
+                "reference": "9ad1e4fc607446a055b95870c7f668e93b5cff29",
                 "shasum": ""
             },
             "require": {
@@ -1369,7 +1369,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/promises/issues",
-                "source": "https://github.com/guzzle/promises/tree/2.5.0"
+                "source": "https://github.com/guzzle/promises/tree/2.5.1"
             },
             "funding": [
                 {
@@ -1385,20 +1385,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-06-02T12:23:43+00:00"
+            "time": "2026-07-08T15:48:39+00:00"
         },
         {
             "name": "guzzlehttp/psr7",
-            "version": "2.11.0",
+            "version": "2.12.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/psr7.git",
-                "reference": "bbb5e61349fa5cb822b3e87842b951088b76b81f"
+                "reference": "51e27f9e2b332ab3e72f4520d5ff4f3c68c3577c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/psr7/zipball/bbb5e61349fa5cb822b3e87842b951088b76b81f",
-                "reference": "bbb5e61349fa5cb822b3e87842b951088b76b81f",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/51e27f9e2b332ab3e72f4520d5ff4f3c68c3577c",
+                "reference": "51e27f9e2b332ab3e72f4520d5ff4f3c68c3577c",
                 "shasum": ""
             },
             "require": {
@@ -1407,7 +1407,7 @@
                 "psr/http-message": "^1.1 || ^2.0",
                 "ralouphie/getallheaders": "^3.0",
                 "symfony/deprecation-contracts": "^2.5 || ^3.0",
-                "symfony/polyfill-php80": "^1.24"
+                "symfony/polyfill-php80": "^1.25"
             },
             "provide": {
                 "psr/http-factory-implementation": "1.0",
@@ -1488,7 +1488,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/psr7/issues",
-                "source": "https://github.com/guzzle/psr7/tree/2.11.0"
+                "source": "https://github.com/guzzle/psr7/tree/2.12.4"
             },
             "funding": [
                 {
@@ -1504,7 +1504,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-06-02T12:30:48+00:00"
+            "time": "2026-07-08T15:56:20+00:00"
         },
         {
             "name": "guzzlehttp/uri-template",
@@ -4520,16 +4520,16 @@
         },
         {
             "name": "symfony/deprecation-contracts",
-            "version": "v3.7.0",
+            "version": "v3.7.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/deprecation-contracts.git",
-                "reference": "50f59d1f3ca46d41ac911f97a78626b6756af35b"
+                "reference": "f3202fa1b5097b0af062dc978b32ecf63404e31d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/50f59d1f3ca46d41ac911f97a78626b6756af35b",
-                "reference": "50f59d1f3ca46d41ac911f97a78626b6756af35b",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/f3202fa1b5097b0af062dc978b32ecf63404e31d",
+                "reference": "f3202fa1b5097b0af062dc978b32ecf63404e31d",
                 "shasum": ""
             },
             "require": {
@@ -4567,7 +4567,7 @@
             "description": "A generic function and convention to trigger deprecation notices",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.7.0"
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.7.1"
             },
             "funding": [
                 {
@@ -4587,7 +4587,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-13T15:52:40+00:00"
+            "time": "2026-06-05T06:23:12+00:00"
         },
         {
             "name": "symfony/error-handler",

--- a/config/cms-framework.php
+++ b/config/cms-framework.php
@@ -32,7 +32,7 @@ return [
 
         'info' => [
             'title'       => 'ArtisanPack CMS Framework API',
-            'version'     => '2.2.3',
+            'version'     => '2.3.0',
             'description' => 'RESTful API for the ArtisanPack CMS Framework. Provides endpoints for managing posts, pages, content types, users, roles, permissions, settings, notifications, plugins, and themes.',
         ],
 

--- a/docs/AI-Features.md
+++ b/docs/AI-Features.md
@@ -1,0 +1,250 @@
+---
+title: AI Features
+---
+
+# AI Features
+
+*Added in 2.3.0.*
+
+The CMS Framework ships five AI-powered content-authoring agents built on top of the [`artisanpack-ui/ai`](https://github.com/ArtisanPack-UI/ai) foundation. Each agent maps to a feature key, validates its own input and output, and is auto-discovered by the AI package's `FeatureRegistry` at boot — hosts get the surfaces for free once the AI package is installed.
+
+## Feature keys
+
+| Feature key            | Agent                                                              | Purpose                                                                 |
+|------------------------|--------------------------------------------------------------------|-------------------------------------------------------------------------|
+| `cms.post_title`       | `ArtisanPackUI\CMSFramework\Ai\Agents\PostTitleSuggestionAgent`    | Generate 3–5 title variants from a draft body.                          |
+| `cms.excerpt`          | `ArtisanPackUI\CMSFramework\Ai\Agents\ExcerptGenerationAgent`      | Generate a natural excerpt (default ≤200 chars) from full post content. |
+| `cms.suggest_tags`     | `ArtisanPackUI\CMSFramework\Ai\Agents\TagSuggestionAgent`          | Pick tags from an existing taxonomy (optionally propose new ones).      |
+| `cms.suggest_category` | `ArtisanPackUI\CMSFramework\Ai\Agents\CategorySuggestionAgent`     | Pick one category (slash-delimited path) from a hierarchical tree.      |
+| `cms.suggest_slug`     | `ArtisanPackUI\CMSFramework\Ai\Agents\SlugSuggestionAgent`         | Produce an SEO-friendly kebab-case slug from a title.                   |
+
+Every agent honors the toggle in `artisanpack.ai.features.<key>.enabled`. When the toggle is off, the agent throws `FeatureDisabledException` before any model call.
+
+The canonical list is exposed as `CMSFrameworkServiceProvider::AI_FEATURE_KEYS` — the Livewire component, the REST controller, and any host bundle wiring read from there so a future 6th feature only lands in one place.
+
+---
+
+## Installation
+
+The AI foundation is a soft dependency, declared in `composer.json` under `suggest` and `require-dev`. To unlock the AI features in a host application:
+
+```bash
+composer require artisanpack-ui/ai:^1.0
+```
+
+Without it, `aiFeatures()` returns and the AI Livewire component + REST routes stay unregistered — the framework still boots normally.
+
+Configure credentials on the AI package side. See the [AI package's Configuration guide](https://github.com/ArtisanPack-UI/ai/blob/main/docs/configuration.md) for details.
+
+---
+
+## Trigger surfaces
+
+The same five agents are reachable through two independent transports, so the AI features work uniformly across Livewire, React, and Vue front-ends.
+
+### Livewire component
+
+`ArtisanPackUI\CMSFramework\Livewire\Ai\AiTools`, registered as `ap-cms-ai-tools`:
+
+```blade
+<livewire:ap-cms-ai-tools />
+```
+
+The component holds no state — it's a transport. Front-end code dispatches browser events; the component runs the agent and dispatches a status event back:
+
+```javascript
+Livewire.dispatch('ap-cms-ai:suggest-post-titles', {
+    content: draft.body,
+    tone: 'authoritative',
+    count: 5,
+});
+
+Livewire.on('ap-cms-ai:cms.post_title:success', ({ output }) => {
+    // output.titles → [{ title, rationale }, ...]
+});
+```
+
+Status suffixes: `success`, `disabled`, `missing-credentials`, `invalid-input`, `error`.
+
+### REST endpoints
+
+Mounted at `/api/v1/cms/ai/*` and protected by `auth:sanctum` so React and Vue SPAs with bearer tokens can hit them directly:
+
+| Method | Path                                | Body                                                                 |
+|--------|-------------------------------------|----------------------------------------------------------------------|
+| `GET`  | `/api/v1/cms/ai/features`           | *(none)* — returns `{ features: { [key]: boolean } }`                |
+| `POST` | `/api/v1/cms/ai/post-title`         | `{ content, tone?, count? }`                                         |
+| `POST` | `/api/v1/cms/ai/excerpt`            | `{ content, max_chars? }`                                            |
+| `POST` | `/api/v1/cms/ai/suggest-tags`       | `{ content, available_tags, allow_new?, max_selected? }`             |
+| `POST` | `/api/v1/cms/ai/suggest-category`   | `{ content, category_tree }`                                         |
+| `POST` | `/api/v1/cms/ai/suggest-slug`       | `{ title, excerpt?, max_chars? }`                                    |
+
+Success responses: `200 { feature, output }`. Error envelopes:
+
+| Status | `error`                | Meaning                                            |
+|--------|------------------------|----------------------------------------------------|
+| `403`  | `feature_disabled`     | Feature toggle is off.                             |
+| `422`  | `invalid_input`        | Input failed the agent's validation.               |
+| `503`  | `missing_credentials`  | No credentials resolved for the feature/provider.  |
+| `500`  | `internal_error`       | Unexpected exception — details in `Log::error`.    |
+
+Because the transport is plain HTTP, `@artisanpack-ui/react` and `@artisanpack-ui/vue` do NOT need to know anything about CMS AI features — hosts add a new capability entirely on the backend.
+
+---
+
+## Agent contracts
+
+Each agent validates input and shapes output; front-ends and controllers can trust the returned envelope.
+
+### `cms.post_title` — `PostTitleSuggestionAgent`
+
+**Input**
+
+| Field     | Type          | Required | Notes                                       |
+|-----------|---------------|----------|---------------------------------------------|
+| `content` | `string`      | yes      | Draft body.                                 |
+| `tone`    | `string\|null`| no       | Optional tone hint (e.g. `authoritative`).  |
+| `count`   | `int\|null`   | no       | 3–5 (default 5).                            |
+
+**Output**
+
+```php
+[
+    'titles' => [
+        [ 'title' => string, 'rationale' => string ],
+        // ...
+    ],
+]
+```
+
+Titles longer than 80 characters are clamped; entries with an empty title or rationale are dropped.
+
+### `cms.excerpt` — `ExcerptGenerationAgent`
+
+**Input**
+
+| Field       | Type         | Required | Notes                              |
+|-------------|--------------|----------|------------------------------------|
+| `content`   | `string`     | yes      | Full post body.                    |
+| `max_chars` | `int\|null`  | no       | 80–400 (default 200).              |
+
+**Output**
+
+```php
+[
+    'excerpt'    => string,
+    'char_count' => int, // recomputed from returned excerpt, not model-reported
+]
+```
+
+### `cms.suggest_tags` — `TagSuggestionAgent`
+
+**Input**
+
+| Field            | Type         | Required | Notes                                                                    |
+|------------------|--------------|----------|--------------------------------------------------------------------------|
+| `content`        | `string`     | yes      | Content to tag.                                                          |
+| `available_tags` | `string[]`   | yes      | Existing taxonomy tag names.                                             |
+| `allow_new`      | `bool\|null` | no       | Default `false`. When `true`, the agent may return `suggested_new`.      |
+| `max_selected`   | `int\|null`  | no       | 1–10 (default 5).                                                        |
+
+**Output**
+
+```php
+[
+    'selected' => [
+        [ 'tag' => string, 'confidence' => float ], // 0.0-1.0
+        // ...
+    ],
+    // Only present when allow_new is true:
+    'suggested_new' => string[],
+]
+```
+
+Tags returned by the model that are not in `available_tags` are silently dropped. Confidence values are clamped to `[0, 1]`. Whitespace on model-returned tags is trimmed before the allow-list lookup.
+
+### `cms.suggest_category` — `CategorySuggestionAgent`
+
+**Input**
+
+| Field           | Type    | Required | Notes                                              |
+|-----------------|---------|----------|----------------------------------------------------|
+| `content`       | `string`| yes      | Content to categorize.                             |
+| `category_tree` | `array` | yes      | Nested list of `{name, children?}` nodes.          |
+
+**Output**
+
+```php
+[
+    'selected'   => string, // slash-delimited path or '' if no fit
+    'confidence' => float,  // 0.0-1.0, forced to 0 when selected is ''
+    'rationale'  => string,
+]
+```
+
+Nodes whose `name` contains a `/` are rejected during path collection — they would collide with real parent/child paths and make the model pick ambiguous.
+
+### `cms.suggest_slug` — `SlugSuggestionAgent`
+
+**Input**
+
+| Field       | Type            | Required | Notes                                          |
+|-------------|-----------------|----------|------------------------------------------------|
+| `title`     | `string`        | yes      | Post title.                                    |
+| `excerpt`   | `string\|null`  | no       | Optional excerpt for disambiguation.           |
+| `max_chars` | `int\|null`     | no       | 20–100 (default 60).                           |
+
+**Output**
+
+```php
+[
+    'slug'       => string, // sanitized kebab-case, <= max_chars
+    'alternates' => string[], // 0-2 backup slugs for uniqueness collisions
+]
+```
+
+Slug sanitization delegates to `Illuminate\Support\Str::slug()` — non-ASCII characters are transliterated (`café` → `cafe`), and the length cap is applied on a hyphen boundary so words aren't truncated mid-token.
+
+Uniqueness against your existing slugs is intentionally NOT part of the agent's contract — callers enforce uniqueness (Eloquent lookup, DB constraint, ...) using the returned slug.
+
+---
+
+## Extending
+
+### Override an agent
+
+Bind a subclass in the container to replace an agent globally:
+
+```php
+use ArtisanPackUI\CMSFramework\Ai\Agents\SlugSuggestionAgent;
+use App\Ai\Agents\OpusSlugSuggestionAgent;
+
+$this->app->bind(SlugSuggestionAgent::class, OpusSlugSuggestionAgent::class);
+```
+
+`SlugSuggestionAgent::for(…)` resolves through the container, so the subclass takes over on every consumer without touching the trigger surfaces.
+
+### Register additional CMS AI features
+
+Add a `aiFeatures()` method to your own service provider — the AI foundation walks every loaded provider and merges the results:
+
+```php
+public function aiFeatures(): array
+{
+    return [
+        'myapp.suggest_seo_meta' => [
+            'agent'   => \App\Ai\Agents\SeoMetaAgent::class,
+            'package' => 'myapp/seo',
+        ],
+    ];
+}
+```
+
+Then hook it into `AiTools` / `AiController` (or your own controller) the same way the five built-ins do.
+
+---
+
+## Related
+
+- [`artisanpack-ui/ai` documentation](https://github.com/ArtisanPack-UI/ai/tree/main/docs)
+- [`artisanpack-ui/visual-editor` AI features](https://github.com/ArtisanPack-UI/visual-editor/blob/release/1.x/README.md) — cross-cutting `ai.alt_text`, `ai.content_rewrite`, and the visual-editor-owned `visual_editor.*` agents.

--- a/docs/Installation-Guide.md
+++ b/docs/Installation-Guide.md
@@ -8,7 +8,7 @@ This guide will walk you through installing and setting up the CMS Framework in 
 
 ## Requirements
 
-- PHP 8.2 or higher
+- PHP 8.3 or higher
 - Laravel 12.0 or higher
 - MySQL 8.0+ or PostgreSQL 10.0+
 

--- a/docs/home.md
+++ b/docs/home.md
@@ -19,6 +19,7 @@ The CMS Framework is designed to help developers quickly build content managemen
 - **Admin Framework**: Menu system, widgets, and authorization helpers
 - **Theme & Plugin Architecture**: Theme discovery, activation, ZIP upload, lifecycle hooks, and plugin support
 - **RBAC** *(2.0.0)*: Roles and permissions powered by the shared `artisanpack-ui/rbac` package
+- **AI Features** *(2.3.0)*: Five content-authoring agents (title, excerpt, tags, category, slug) exposed via Livewire and REST for React/Vue front-ends
 - **RESTful API**: Clean API endpoints for all operations with standardized error responses
 - **Bulk Actions**: Bulk operations for posts, pages, and users
 - **On-Demand Relationships**: Control eager loading via the `include` query parameter
@@ -146,6 +147,14 @@ Custom content type builder for extensible content.
 - [[developer/taxonomies]] - Creating custom taxonomies
 - [[developer/enums]] - ContentStatus, FieldType, and ColumnType enums
 - [[developer/traits]] - HasContentStatus and HasContentFilters traits
+
+---
+
+## AI Features *(2.3.0)*
+
+Content-authoring agents built on the `artisanpack-ui/ai` foundation. Five agents (post title, excerpt, tag/category suggestion, SEO slug) exposed through a Livewire component and REST endpoints so Livewire, React, and Vue front-ends can all trigger them without any framework-specific glue.
+
+- [[AI Features]] — Feature keys, trigger surfaces, per-agent contracts, and extension points
 
 ---
 

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -5,8 +5,22 @@
          colors="true"
          cacheDirectory=".phpunit.cache">
     <testsuites>
-        <testsuite name="CMS Framework Test Suite">
-            <directory>tests</directory>
+        <testsuite name="Unit">
+            <directory>tests/Unit</directory>
+        </testsuite>
+        <testsuite name="Feature">
+            <directory>tests/Feature</directory>
+            <!--
+                AI suite depends on artisanpack-ui/ai which requires
+                PHP 8.3+. Excluded here and re-registered under a
+                dedicated `Ai` suite so CI on PHP 8.2 can skip it via
+                the exclude-testsuite CLI flag without losing the
+                rest of the Feature coverage.
+            -->
+            <exclude>tests/Feature/Ai</exclude>
+        </testsuite>
+        <testsuite name="Ai">
+            <directory>tests/Feature/Ai</directory>
         </testsuite>
     </testsuites>
     <source>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -11,11 +11,10 @@
         <testsuite name="Feature">
             <directory>tests/Feature</directory>
             <!--
-                AI suite depends on artisanpack-ui/ai which requires
-                PHP 8.3+. Excluded here and re-registered under a
-                dedicated `Ai` suite so CI on PHP 8.2 can skip it via
-                the exclude-testsuite CLI flag without losing the
-                rest of the Feature coverage.
+                AI tests live under a dedicated `Ai` suite so hosts
+                that opt out of the artisanpack-ui/ai foundation can
+                skip them without losing the rest of the Feature
+                coverage.
             -->
             <exclude>tests/Feature/Ai</exclude>
         </testsuite>

--- a/src/Ai/Agents/CategorySuggestionAgent.php
+++ b/src/Ai/Agents/CategorySuggestionAgent.php
@@ -1,0 +1,272 @@
+<?php
+
+/**
+ * Category suggestion agent.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage CMSFramework
+ *
+ * @since      2.3.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Ai\Agents;
+
+use ArtisanPackUI\Ai\Agents\ArtisanPackAgent;
+use ArtisanPackUI\Ai\Contracts\AgentPrompter;
+use ArtisanPackUI\Ai\Credentials\Credentials;
+use ArtisanPackUI\Ai\Exceptions\FeatureError;
+use JsonException;
+
+/**
+ * Suggest a single category for a post from a hierarchical taxonomy.
+ * Unlike tags, category assignment is usually single-select and picks
+ * the most specific matching node — the returned string is the full
+ * slash-delimited path (e.g. `News/Product Updates`) so parent
+ * disambiguation is unambiguous.
+ *
+ * ## Input
+ *
+ * ```
+ * [
+ *   'content'       => string,   // required
+ *   'category_tree' => array,    // required, nested list of {name, children?}
+ * ]
+ * ```
+ *
+ * ## Output schema
+ *
+ * ```
+ * {
+ *   selected:   string,      // slash-delimited path into category_tree, or "" if none fit
+ *   confidence: float,       // 0.0 - 1.0
+ *   rationale:  string       // single sentence
+ * }
+ * ```
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage CMSFramework
+ *
+ * @since      2.3.0
+ */
+class CategorySuggestionAgent extends ArtisanPackAgent
+{
+    /**
+     * {@inheritDoc}
+     */
+    public string $featureKey = 'cms.suggest_category';
+
+    /**
+     * {@inheritDoc}
+     */
+    public string $package = 'artisanpack-ui/cms-framework';
+
+    /**
+     * {@inheritDoc}
+     */
+    public string $defaultModel = 'claude-haiku-4-5';
+
+    /**
+     * {@inheritDoc}
+     */
+    public function instructions(): string
+    {
+        return <<<'PROMPT'
+You pick a single category for a piece of content from a hierarchical taxonomy.
+
+Requirements:
+- `selected` MUST be a slash-delimited path whose segments each match a `name` from `category_tree`, walked from a root down through any children. Case must match exactly.
+- Prefer the most specific matching leaf. Only pick an ancestor when no descendant fits.
+- If no category fits with reasonable confidence, return `selected` as an empty string, `confidence` as 0, and explain why in `rationale`. Never guess.
+- `confidence` is 0.0 (weak signal) to 1.0 (strong signal).
+- `rationale` is a single sentence tying the choice back to specific evidence in the content.
+
+Return a JSON object with keys: `selected` (string), `confidence` (float 0..1), `rationale` (string).
+PROMPT;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function outputSchema(): array
+    {
+        return [
+            'type'                 => 'object',
+            'additionalProperties' => false,
+            'required'             => [ 'selected', 'confidence', 'rationale' ],
+            'properties'           => [
+                'selected'   => [ 'type' => 'string' ],
+                'confidence' => [
+                    'type'    => 'number',
+                    'minimum' => 0,
+                    'maximum' => 1,
+                ],
+                'rationale'  => [ 'type' => 'string' ],
+            ],
+        ];
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function execute( Credentials $credentials, string $model, string $instructions ): array
+    {
+        $normalized = $this->normalizeInput( $this->input() );
+
+        $prompter = app( AgentPrompter::class );
+
+        $result = $prompter->prompt(
+            credentials: $credentials,
+            model: $model,
+            instructions: $instructions,
+            message: $this->buildMessage( $normalized ),
+            outputSchema: $this->outputSchema(),
+        );
+
+        return [
+            'output'        => $this->validateOutput( $result['output'], $normalized['valid_paths'] ),
+            'input_tokens'  => (int) ( $result['input_tokens'] ?? 0 ),
+            'output_tokens' => (int) ( $result['output_tokens'] ?? 0 ),
+        ];
+    }
+
+    /**
+     * Validate and shape-check the raw agent input.
+     *
+     * @since 2.3.0
+     *
+     * @param  mixed  $input  Raw agent input.
+     *
+     * @return array{ content: string, category_tree: array<int, mixed>, valid_paths: array<string, true> }
+     */
+    protected function normalizeInput( mixed $input ): array
+    {
+        if ( ! is_array( $input ) ) {
+            throw FeatureError::forFeature(
+                $this->featureKey,
+                'input must be an array with `content` and `category_tree` keys.',
+            );
+        }
+
+        $content = isset( $input['content'] ) && is_string( $input['content'] ) ? trim( $input['content'] ) : '';
+
+        if ( '' === $content ) {
+            throw FeatureError::forFeature( $this->featureKey, '`content` must be a non-empty string.' );
+        }
+
+        if ( ! isset( $input['category_tree'] ) || ! is_array( $input['category_tree'] ) ) {
+            throw FeatureError::forFeature( $this->featureKey, '`category_tree` must be an array.' );
+        }
+
+        $tree        = array_values( $input['category_tree'] );
+        $validPaths  = [];
+        $this->collectPaths( $tree, '', $validPaths );
+
+        return [
+            'content'       => $content,
+            'category_tree' => $tree,
+            'valid_paths'   => $validPaths,
+        ];
+    }
+
+    /**
+     * Walk the category tree, building a flat lookup of every valid
+     * slash-delimited path. Entries without a `name` are silently
+     * skipped so a malformed leaf can't reject the whole tree.
+     *
+     * @since 2.3.0
+     *
+     * @param  array<int, mixed>    $nodes    Sibling nodes at this depth.
+     * @param  string               $prefix   Accumulated path prefix.
+     * @param  array<string, true>  $paths    Accumulator (by reference).
+     *
+     * @return void
+     */
+    protected function collectPaths( array $nodes, string $prefix, array &$paths ): void
+    {
+        foreach ( $nodes as $node ) {
+            if ( ! is_array( $node ) ) {
+                continue;
+            }
+
+            $name = isset( $node['name'] ) && is_string( $node['name'] ) ? trim( $node['name'] ) : '';
+            if ( '' === $name ) {
+                continue;
+            }
+
+            $path            = '' === $prefix ? $name : $prefix . '/' . $name;
+            $paths[ $path ]  = true;
+
+            if ( isset( $node['children'] ) && is_array( $node['children'] ) ) {
+                $this->collectPaths( $node['children'], $path, $paths );
+            }
+        }
+    }
+
+    /**
+     * Assemble the structured message body for the prompter.
+     *
+     * @since 2.3.0
+     *
+     * @param  array{ content: string, category_tree: array<int, mixed>, valid_paths: array<string, true> }  $input  Normalized input.
+     *
+     * @return array<int, array<string, string>>
+     */
+    protected function buildMessage( array $input ): array
+    {
+        try {
+            $encoded = json_encode(
+                $input['category_tree'],
+                JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR,
+            );
+        } catch ( JsonException $exception ) {
+            throw FeatureError::forFeature(
+                $this->featureKey,
+                sprintf( 'category_tree could not be serialized: %s', $exception->getMessage() ),
+                $exception,
+            );
+        }
+
+        return [
+            [ 'type' => 'text', 'text' => 'category_tree: ' . $encoded ],
+            [ 'type' => 'text', 'text' => "Content:\n" . $input['content'] ],
+        ];
+    }
+
+    /**
+     * Enforce output invariants — drop hallucinated paths, clamp
+     * confidence, and coerce an empty selection to zero confidence so
+     * downstream callers can trust the pair.
+     *
+     * @since 2.3.0
+     *
+     * @param  array<string, mixed>  $output       Decoded model output.
+     * @param  array<string, true>   $validPaths   Set of legal slash-paths.
+     *
+     * @return array{ selected: string, confidence: float, rationale: string }
+     */
+    protected function validateOutput( array $output, array $validPaths ): array
+    {
+        $selected = isset( $output['selected'] ) ? trim( (string) $output['selected'] ) : '';
+
+        if ( '' !== $selected && ! isset( $validPaths[ $selected ] ) ) {
+            $selected = '';
+        }
+
+        $confidence = isset( $output['confidence'] ) ? (float) $output['confidence'] : 0.0;
+        $confidence = max( 0.0, min( 1.0, $confidence ) );
+
+        if ( '' === $selected ) {
+            $confidence = 0.0;
+        }
+
+        $rationale = isset( $output['rationale'] ) ? trim( (string) $output['rationale'] ) : '';
+
+        return [
+            'selected'   => $selected,
+            'confidence' => $confidence,
+            'rationale'  => $rationale,
+        ];
+    }
+}

--- a/src/Ai/Agents/CategorySuggestionAgent.php
+++ b/src/Ai/Agents/CategorySuggestionAgent.php
@@ -195,8 +195,18 @@ PROMPT;
                 continue;
             }
 
-            $path            = '' === $prefix ? $name : $prefix . '/' . $name;
-            $paths[ $path ]  = true;
+            // Reject names containing the path separator. If we accepted them
+            // we would produce paths indistinguishable from real parent/child
+            // paths — e.g. `{name: 'News/Updates'}` and `{name: 'News',
+            // children: [{name: 'Updates'}]}` both serialize to `News/Updates`
+            // and the validator would be unable to disambiguate a hallucinated
+            // model pick from a real one.
+            if ( str_contains( $name, '/' ) ) {
+                continue;
+            }
+
+            $path           = '' === $prefix ? $name : $prefix . '/' . $name;
+            $paths[ $path ] = true;
 
             if ( isset( $node['children'] ) && is_array( $node['children'] ) ) {
                 $this->collectPaths( $node['children'], $path, $paths );

--- a/src/Ai/Agents/ExcerptGenerationAgent.php
+++ b/src/Ai/Agents/ExcerptGenerationAgent.php
@@ -1,0 +1,212 @@
+<?php
+
+/**
+ * Excerpt generation agent.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage CMSFramework
+ *
+ * @since      2.3.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Ai\Agents;
+
+use ArtisanPackUI\Ai\Agents\ArtisanPackAgent;
+use ArtisanPackUI\Ai\Contracts\AgentPrompter;
+use ArtisanPackUI\Ai\Credentials\Credentials;
+use ArtisanPackUI\Ai\Exceptions\FeatureError;
+
+/**
+ * Generate a natural-sounding excerpt (default `<= 200 chars`) from a
+ * post's full content. Callers may raise the length cap up to 400 chars
+ * for longer meta descriptions.
+ *
+ * ## Input
+ *
+ * ```
+ * [
+ *   'content'    => string,       // required, full post body
+ *   'max_chars'  => int|null,     // optional, 80-400 (default 200)
+ * ]
+ * ```
+ *
+ * ## Output schema
+ *
+ * ```
+ * {
+ *   excerpt: string,   // <= max_chars
+ *   char_count: int    // actual excerpt length
+ * }
+ * ```
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage CMSFramework
+ *
+ * @since      2.3.0
+ */
+class ExcerptGenerationAgent extends ArtisanPackAgent
+{
+    /**
+     * {@inheritDoc}
+     */
+    public string $featureKey = 'cms.excerpt';
+
+    /**
+     * {@inheritDoc}
+     */
+    public string $package = 'artisanpack-ui/cms-framework';
+
+    /**
+     * {@inheritDoc}
+     */
+    public string $defaultModel = 'claude-haiku-4-5';
+
+    /**
+     * {@inheritDoc}
+     */
+    public function instructions(): string
+    {
+        return <<<'PROMPT'
+You summarize a post's body into a single-paragraph excerpt suitable for a listing page or a meta description.
+
+Requirements:
+- Return one paragraph, at most `max_chars` characters (see the accompanying instruction). Prefer to end on a sentence boundary.
+- Base the excerpt strictly on the supplied content. Do NOT invent facts.
+- Do NOT start with "This post" / "In this article" / "The author" — write the excerpt as if it were the standalone description of the content.
+- Preserve neutral, factual tone; do not editorialize or add calls to action unless the source content itself does.
+- If the content is too short to summarize (e.g. a one-sentence post), return the content verbatim (or truncated at max_chars) rather than padding it out.
+
+Return a JSON object with keys `excerpt` (string) and `char_count` (integer, the length of `excerpt`).
+PROMPT;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function outputSchema(): array
+    {
+        return [
+            'type'                 => 'object',
+            'additionalProperties' => false,
+            'required'             => [ 'excerpt', 'char_count' ],
+            'properties'           => [
+                'excerpt'    => [ 'type' => 'string' ],
+                'char_count' => [
+                    'type'    => 'integer',
+                    'minimum' => 0,
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function execute( Credentials $credentials, string $model, string $instructions ): array
+    {
+        $normalized = $this->normalizeInput( $this->input() );
+
+        $prompter = app( AgentPrompter::class );
+
+        $result = $prompter->prompt(
+            credentials: $credentials,
+            model: $model,
+            instructions: $instructions,
+            message: $this->buildMessage( $normalized ),
+            outputSchema: $this->outputSchema(),
+        );
+
+        return [
+            'output'        => $this->validateOutput( $result['output'], $normalized['max_chars'] ),
+            'input_tokens'  => (int) ( $result['input_tokens'] ?? 0 ),
+            'output_tokens' => (int) ( $result['output_tokens'] ?? 0 ),
+        ];
+    }
+
+    /**
+     * Validate and shape-check the raw agent input.
+     *
+     * @since 2.3.0
+     *
+     * @param  mixed  $input  Raw agent input.
+     *
+     * @return array{ content: string, max_chars: int }
+     */
+    protected function normalizeInput( mixed $input ): array
+    {
+        if ( ! is_array( $input ) ) {
+            throw FeatureError::forFeature(
+                $this->featureKey,
+                'input must be an array with a `content` key.',
+            );
+        }
+
+        $content = isset( $input['content'] ) && is_string( $input['content'] ) ? trim( $input['content'] ) : '';
+
+        if ( '' === $content ) {
+            throw FeatureError::forFeature( $this->featureKey, '`content` must be a non-empty string.' );
+        }
+
+        $maxChars = 200;
+        if ( isset( $input['max_chars'] ) ) {
+            $parsed = filter_var(
+                $input['max_chars'],
+                FILTER_VALIDATE_INT,
+                [ 'options' => [ 'min_range' => 80, 'max_range' => 400 ] ],
+            );
+
+            if ( false !== $parsed ) {
+                $maxChars = $parsed;
+            }
+        }
+
+        return [
+            'content'   => $content,
+            'max_chars' => $maxChars,
+        ];
+    }
+
+    /**
+     * Assemble the structured message body for the prompter.
+     *
+     * @since 2.3.0
+     *
+     * @param  array{ content: string, max_chars: int }  $input  Normalized input.
+     *
+     * @return array<int, array<string, string>>
+     */
+    protected function buildMessage( array $input ): array
+    {
+        return [
+            [ 'type' => 'text', 'text' => sprintf( 'max_chars: %d', $input['max_chars'] ) ],
+            [ 'type' => 'text', 'text' => "Content:\n" . $input['content'] ],
+        ];
+    }
+
+    /**
+     * Enforce output invariants — clamp excerpt length and recompute
+     * `char_count` from the returned excerpt so callers can trust it.
+     *
+     * @since 2.3.0
+     *
+     * @param  array<string, mixed>  $output    Decoded model output.
+     * @param  int                   $maxChars  Requested cap.
+     *
+     * @return array{ excerpt: string, char_count: int }
+     */
+    protected function validateOutput( array $output, int $maxChars ): array
+    {
+        $excerpt = isset( $output['excerpt'] ) ? trim( (string) $output['excerpt'] ) : '';
+
+        if ( mb_strlen( $excerpt ) > $maxChars ) {
+            $excerpt = mb_substr( $excerpt, 0, $maxChars );
+        }
+
+        return [
+            'excerpt'    => $excerpt,
+            'char_count' => mb_strlen( $excerpt ),
+        ];
+    }
+}

--- a/src/Ai/Agents/PostTitleSuggestionAgent.php
+++ b/src/Ai/Agents/PostTitleSuggestionAgent.php
@@ -1,0 +1,257 @@
+<?php
+
+/**
+ * Post title suggestion agent.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage CMSFramework
+ *
+ * @since      2.3.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Ai\Agents;
+
+use ArtisanPackUI\Ai\Agents\ArtisanPackAgent;
+use ArtisanPackUI\Ai\Contracts\AgentPrompter;
+use ArtisanPackUI\Ai\Credentials\Credentials;
+use ArtisanPackUI\Ai\Exceptions\FeatureError;
+
+/**
+ * Content-authoring helper. Generate 3–5 title variants from the draft
+ * body of a post. Consumable by any package that authors long-form
+ * content (visual-editor, custom CMS surfaces, etc.).
+ *
+ * ## Input
+ *
+ * ```
+ * [
+ *   'content' => string,        // required, draft body
+ *   'tone'    => string|null,   // optional, e.g. "playful", "authoritative"
+ *   'count'   => int|null,      // optional, 3–5 (default 5)
+ * ]
+ * ```
+ *
+ * ## Output schema
+ *
+ * ```
+ * {
+ *   titles: [ { title: string, rationale: string } ]
+ * }
+ * ```
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage CMSFramework
+ *
+ * @since      2.3.0
+ */
+class PostTitleSuggestionAgent extends ArtisanPackAgent
+{
+    /**
+     * {@inheritDoc}
+     */
+    public string $featureKey = 'cms.post_title';
+
+    /**
+     * {@inheritDoc}
+     */
+    public string $package = 'artisanpack-ui/cms-framework';
+
+    /**
+     * {@inheritDoc}
+     */
+    public string $defaultModel = 'claude-haiku-4-5';
+
+    /**
+     * {@inheritDoc}
+     */
+    public function instructions(): string
+    {
+        return <<<'PROMPT'
+You generate title variants for a piece of long-form content.
+
+Requirements:
+- Return between 3 and 5 titles, ordered strongest-first.
+- Every title must be <= 80 characters and free of trailing punctuation (except a question mark when the title is a question).
+- Base every title strictly on the supplied content. Do NOT invent facts, statistics, names, or quotes.
+- Vary the shape across the set — one direct/descriptive, one benefit-led, one curiosity/question if appropriate. Avoid clickbait.
+- If a `tone` is supplied, bias all variants toward it without abandoning accuracy.
+- `rationale` is a single sentence explaining why the title fits.
+
+Return a JSON object with key `titles` (array of {title, rationale}).
+PROMPT;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function outputSchema(): array
+    {
+        return [
+            'type'                 => 'object',
+            'additionalProperties' => false,
+            'required'             => [ 'titles' ],
+            'properties'           => [
+                'titles' => [
+                    'type'     => 'array',
+                    'minItems' => 1,
+                    'maxItems' => 5,
+                    'items'    => [
+                        'type'                 => 'object',
+                        'additionalProperties' => false,
+                        'required'             => [ 'title', 'rationale' ],
+                        'properties'           => [
+                            'title'     => [
+                                'type'      => 'string',
+                                'maxLength' => 80,
+                            ],
+                            'rationale' => [ 'type' => 'string' ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function execute( Credentials $credentials, string $model, string $instructions ): array
+    {
+        $normalized = $this->normalizeInput( $this->input() );
+
+        $prompter = app( AgentPrompter::class );
+
+        $result = $prompter->prompt(
+            credentials: $credentials,
+            model: $model,
+            instructions: $instructions,
+            message: $this->buildMessage( $normalized ),
+            outputSchema: $this->outputSchema(),
+        );
+
+        return [
+            'output'        => $this->validateOutput( $result['output'], $normalized['count'] ),
+            'input_tokens'  => (int) ( $result['input_tokens'] ?? 0 ),
+            'output_tokens' => (int) ( $result['output_tokens'] ?? 0 ),
+        ];
+    }
+
+    /**
+     * Validate and shape-check the raw agent input.
+     *
+     * @since 2.3.0
+     *
+     * @param  mixed  $input  Raw agent input.
+     *
+     * @return array{ content: string, tone: string|null, count: int }
+     */
+    protected function normalizeInput( mixed $input ): array
+    {
+        if ( ! is_array( $input ) ) {
+            throw FeatureError::forFeature(
+                $this->featureKey,
+                'input must be an array with a `content` key.',
+            );
+        }
+
+        $content = isset( $input['content'] ) && is_string( $input['content'] ) ? trim( $input['content'] ) : '';
+
+        if ( '' === $content ) {
+            throw FeatureError::forFeature( $this->featureKey, '`content` must be a non-empty string.' );
+        }
+
+        $tone = null;
+        if ( isset( $input['tone'] ) && is_string( $input['tone'] ) && '' !== trim( $input['tone'] ) ) {
+            $tone = trim( $input['tone'] );
+        }
+
+        $count = 5;
+        if ( isset( $input['count'] ) ) {
+            $parsed = filter_var(
+                $input['count'],
+                FILTER_VALIDATE_INT,
+                [ 'options' => [ 'min_range' => 3, 'max_range' => 5 ] ],
+            );
+
+            if ( false !== $parsed ) {
+                $count = $parsed;
+            }
+        }
+
+        return [
+            'content' => $content,
+            'tone'    => $tone,
+            'count'   => $count,
+        ];
+    }
+
+    /**
+     * Assemble the structured message body for the prompter.
+     *
+     * @since 2.3.0
+     *
+     * @param  array{ content: string, tone: string|null, count: int }  $input  Normalized input.
+     *
+     * @return array<int, array<string, string>>
+     */
+    protected function buildMessage( array $input ): array
+    {
+        $parts = [
+            [ 'type' => 'text', 'text' => sprintf( 'Requested count: %d', $input['count'] ) ],
+        ];
+
+        if ( null !== $input['tone'] ) {
+            $parts[] = [ 'type' => 'text', 'text' => sprintf( 'Tone: %s', $input['tone'] ) ];
+        }
+
+        $parts[] = [ 'type' => 'text', 'text' => "Content:\n" . $input['content'] ];
+
+        return $parts;
+    }
+
+    /**
+     * Enforce output invariants and clamp to the requested count.
+     *
+     * @since 2.3.0
+     *
+     * @param  array<string, mixed>  $output  Decoded model output.
+     * @param  int                   $count   Requested title count.
+     *
+     * @return array{ titles: array<int, array{ title: string, rationale: string }> }
+     */
+    protected function validateOutput( array $output, int $count ): array
+    {
+        $raw = isset( $output['titles'] ) && is_array( $output['titles'] ) ? $output['titles'] : [];
+
+        $clean = [];
+        foreach ( $raw as $entry ) {
+            if ( ! is_array( $entry ) ) {
+                continue;
+            }
+
+            $title     = isset( $entry['title'] ) ? trim( (string) $entry['title'] ) : '';
+            $rationale = isset( $entry['rationale'] ) ? trim( (string) $entry['rationale'] ) : '';
+
+            if ( '' === $title || '' === $rationale ) {
+                continue;
+            }
+
+            if ( mb_strlen( $title ) > 80 ) {
+                $title = mb_substr( $title, 0, 80 );
+            }
+
+            $clean[] = [
+                'title'     => $title,
+                'rationale' => $rationale,
+            ];
+
+            if ( count( $clean ) === $count ) {
+                break;
+            }
+        }
+
+        return [ 'titles' => $clean ];
+    }
+}

--- a/src/Ai/Agents/SlugSuggestionAgent.php
+++ b/src/Ai/Agents/SlugSuggestionAgent.php
@@ -17,6 +17,7 @@ use ArtisanPackUI\Ai\Agents\ArtisanPackAgent;
 use ArtisanPackUI\Ai\Contracts\AgentPrompter;
 use ArtisanPackUI\Ai\Credentials\Credentials;
 use ArtisanPackUI\Ai\Exceptions\FeatureError;
+use Illuminate\Support\Str;
 
 /**
  * Suggest a URL slug for a post from its title (and optional excerpt).
@@ -251,6 +252,13 @@ PROMPT;
      * clamp it to `max_chars`, cutting on a hyphen boundary when
      * possible so we don't truncate mid-word.
      *
+     * Delegates the ASCII-folding + kebab-case pipeline to `Str::slug()`.
+     * The previous byte-oriented `preg_replace( '/[^a-z0-9-]+/', '-', … )`
+     * collapsed every non-ASCII byte to a hyphen, so a model return like
+     * `cafe-culture` (with an acute-e) became `caf-culture`. `Str::slug`
+     * transliterates instead, matching the agent's documented
+     * "transliterate non-ASCII" contract.
+     *
      * @since 2.3.0
      *
      * @param  string  $raw       Raw candidate slug.
@@ -260,10 +268,7 @@ PROMPT;
      */
     protected function sanitizeSlug( string $raw, int $maxChars ): string
     {
-        $slug = strtolower( trim( $raw ) );
-        $slug = preg_replace( '/[^a-z0-9-]+/', '-', $slug ) ?? '';
-        $slug = preg_replace( '/-+/', '-', $slug ) ?? '';
-        $slug = trim( $slug, '-' );
+        $slug = Str::slug( $raw, '-' );
 
         if ( strlen( $slug ) <= $maxChars ) {
             return $slug;

--- a/src/Ai/Agents/SlugSuggestionAgent.php
+++ b/src/Ai/Agents/SlugSuggestionAgent.php
@@ -1,0 +1,285 @@
+<?php
+
+/**
+ * Slug suggestion agent.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage CMSFramework
+ *
+ * @since      2.3.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Ai\Agents;
+
+use ArtisanPackUI\Ai\Agents\ArtisanPackAgent;
+use ArtisanPackUI\Ai\Contracts\AgentPrompter;
+use ArtisanPackUI\Ai\Credentials\Credentials;
+use ArtisanPackUI\Ai\Exceptions\FeatureError;
+
+/**
+ * Suggest a URL slug for a post from its title (and optional excerpt).
+ * Unlike a straight kebab-case of the title, this agent optimizes for
+ * SEO: it drops stop words, keeps the keyword-forward tokens, and stays
+ * short (default 60 char cap).
+ *
+ * Uniqueness against existing slugs is intentionally NOT part of the
+ * agent's contract — the caller enforces uniqueness (Eloquent lookup,
+ * database constraint, ...) with the returned slug.
+ *
+ * ## Input
+ *
+ * ```
+ * [
+ *   'title'     => string,       // required
+ *   'excerpt'   => string|null,  // optional, helps disambiguate short titles
+ *   'max_chars' => int|null,     // optional, 20-100 (default 60)
+ * ]
+ * ```
+ *
+ * ## Output schema
+ *
+ * ```
+ * {
+ *   slug:       string,      // sanitized kebab-case slug, <= max_chars
+ *   alternates: string[]     // 0-2 backup slugs for uniqueness collisions
+ * }
+ * ```
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage CMSFramework
+ *
+ * @since      2.3.0
+ */
+class SlugSuggestionAgent extends ArtisanPackAgent
+{
+    /**
+     * {@inheritDoc}
+     */
+    public string $featureKey = 'cms.suggest_slug';
+
+    /**
+     * {@inheritDoc}
+     */
+    public string $package = 'artisanpack-ui/cms-framework';
+
+    /**
+     * {@inheritDoc}
+     */
+    public string $defaultModel = 'claude-haiku-4-5';
+
+    /**
+     * {@inheritDoc}
+     */
+    public function instructions(): string
+    {
+        return <<<'PROMPT'
+You generate a URL slug from a post title.
+
+Requirements:
+- The slug MUST be lowercase kebab-case (ASCII letters, digits, and hyphens only). No leading, trailing, or consecutive hyphens.
+- Drop stop words (the, a, an, and, or, but, for, on, of, to, with, in, at, by, from, is, are, was, were, be, been, being) unless removing them would obscure meaning.
+- Prefer the noun/keyword-carrying tokens of the title over filler.
+- Do NOT translate. Transliterate non-ASCII characters into their closest ASCII equivalent.
+- Stay within `max_chars` characters. Cut a whole trailing word rather than truncating mid-word.
+- Return up to 2 `alternates` — each also compliant with the rules above — as fallback options a caller can try on a uniqueness collision. Zero alternates is fine when only one obvious slug fits.
+
+Return a JSON object with keys `slug` (string) and `alternates` (array of strings).
+PROMPT;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function outputSchema(): array
+    {
+        return [
+            'type'                 => 'object',
+            'additionalProperties' => false,
+            'required'             => [ 'slug', 'alternates' ],
+            'properties'           => [
+                'slug'       => [ 'type' => 'string' ],
+                'alternates' => [
+                    'type'     => 'array',
+                    'maxItems' => 2,
+                    'items'    => [ 'type' => 'string' ],
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function execute( Credentials $credentials, string $model, string $instructions ): array
+    {
+        $normalized = $this->normalizeInput( $this->input() );
+
+        $prompter = app( AgentPrompter::class );
+
+        $result = $prompter->prompt(
+            credentials: $credentials,
+            model: $model,
+            instructions: $instructions,
+            message: $this->buildMessage( $normalized ),
+            outputSchema: $this->outputSchema(),
+        );
+
+        return [
+            'output'        => $this->validateOutput( $result['output'], $normalized['max_chars'] ),
+            'input_tokens'  => (int) ( $result['input_tokens'] ?? 0 ),
+            'output_tokens' => (int) ( $result['output_tokens'] ?? 0 ),
+        ];
+    }
+
+    /**
+     * Validate and shape-check the raw agent input.
+     *
+     * @since 2.3.0
+     *
+     * @param  mixed  $input  Raw agent input.
+     *
+     * @return array{ title: string, excerpt: string|null, max_chars: int }
+     */
+    protected function normalizeInput( mixed $input ): array
+    {
+        if ( ! is_array( $input ) ) {
+            throw FeatureError::forFeature(
+                $this->featureKey,
+                'input must be an array with a `title` key.',
+            );
+        }
+
+        $title = isset( $input['title'] ) && is_string( $input['title'] ) ? trim( $input['title'] ) : '';
+
+        if ( '' === $title ) {
+            throw FeatureError::forFeature( $this->featureKey, '`title` must be a non-empty string.' );
+        }
+
+        $excerpt = null;
+        if ( isset( $input['excerpt'] ) && is_string( $input['excerpt'] ) && '' !== trim( $input['excerpt'] ) ) {
+            $excerpt = trim( $input['excerpt'] );
+        }
+
+        $maxChars = 60;
+        if ( isset( $input['max_chars'] ) ) {
+            $parsed = filter_var(
+                $input['max_chars'],
+                FILTER_VALIDATE_INT,
+                [ 'options' => [ 'min_range' => 20, 'max_range' => 100 ] ],
+            );
+
+            if ( false !== $parsed ) {
+                $maxChars = $parsed;
+            }
+        }
+
+        return [
+            'title'     => $title,
+            'excerpt'   => $excerpt,
+            'max_chars' => $maxChars,
+        ];
+    }
+
+    /**
+     * Assemble the structured message body for the prompter.
+     *
+     * @since 2.3.0
+     *
+     * @param  array{ title: string, excerpt: string|null, max_chars: int }  $input  Normalized input.
+     *
+     * @return array<int, array<string, string>>
+     */
+    protected function buildMessage( array $input ): array
+    {
+        $parts = [
+            [ 'type' => 'text', 'text' => sprintf( 'max_chars: %d', $input['max_chars'] ) ],
+            [ 'type' => 'text', 'text' => 'Title: ' . $input['title'] ],
+        ];
+
+        if ( null !== $input['excerpt'] ) {
+            $parts[] = [ 'type' => 'text', 'text' => "Excerpt:\n" . $input['excerpt'] ];
+        }
+
+        return $parts;
+    }
+
+    /**
+     * Enforce output invariants — sanitize each slug so a hallucinated
+     * uppercase-with-underscores string can't leak through.
+     *
+     * @since 2.3.0
+     *
+     * @param  array<string, mixed>  $output    Decoded model output.
+     * @param  int                   $maxChars  Requested cap.
+     *
+     * @return array{ slug: string, alternates: array<int, string> }
+     */
+    protected function validateOutput( array $output, int $maxChars ): array
+    {
+        $slug = $this->sanitizeSlug( isset( $output['slug'] ) ? (string) $output['slug'] : '', $maxChars );
+
+        $alternates = [];
+        $rawAlts    = isset( $output['alternates'] ) && is_array( $output['alternates'] ) ? $output['alternates'] : [];
+
+        foreach ( $rawAlts as $candidate ) {
+            if ( ! is_string( $candidate ) ) {
+                continue;
+            }
+
+            $clean = $this->sanitizeSlug( $candidate, $maxChars );
+            if ( '' === $clean || $clean === $slug || in_array( $clean, $alternates, true ) ) {
+                continue;
+            }
+
+            $alternates[] = $clean;
+
+            if ( 2 === count( $alternates ) ) {
+                break;
+            }
+        }
+
+        return [
+            'slug'       => $slug,
+            'alternates' => $alternates,
+        ];
+    }
+
+    /**
+     * Coerce a raw string into a compliant lowercase kebab-case slug and
+     * clamp it to `max_chars`, cutting on a hyphen boundary when
+     * possible so we don't truncate mid-word.
+     *
+     * @since 2.3.0
+     *
+     * @param  string  $raw       Raw candidate slug.
+     * @param  int     $maxChars  Length cap.
+     *
+     * @return string
+     */
+    protected function sanitizeSlug( string $raw, int $maxChars ): string
+    {
+        $slug = strtolower( trim( $raw ) );
+        $slug = preg_replace( '/[^a-z0-9-]+/', '-', $slug ) ?? '';
+        $slug = preg_replace( '/-+/', '-', $slug ) ?? '';
+        $slug = trim( $slug, '-' );
+
+        if ( strlen( $slug ) <= $maxChars ) {
+            return $slug;
+        }
+
+        $truncated  = substr( $slug, 0, $maxChars );
+        $lastHyphen = strrpos( $truncated, '-' );
+
+        // Prefer cutting on a hyphen so we don't leave a partial word
+        // hanging at the end of the slug — but only when doing so keeps
+        // a meaningful portion of the string (guard against a single
+        // leading word blowing past the cap).
+        if ( false !== $lastHyphen && $lastHyphen > 0 ) {
+            $truncated = substr( $truncated, 0, $lastHyphen );
+        }
+
+        return trim( $truncated, '-' );
+    }
+}

--- a/src/Ai/Agents/TagSuggestionAgent.php
+++ b/src/Ai/Agents/TagSuggestionAgent.php
@@ -1,0 +1,301 @@
+<?php
+
+/**
+ * Tag suggestion agent.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage CMSFramework
+ *
+ * @since      2.3.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Ai\Agents;
+
+use ArtisanPackUI\Ai\Agents\ArtisanPackAgent;
+use ArtisanPackUI\Ai\Contracts\AgentPrompter;
+use ArtisanPackUI\Ai\Credentials\Credentials;
+use ArtisanPackUI\Ai\Exceptions\FeatureError;
+
+/**
+ * Suggest tags for a post from an existing taxonomy. By default the
+ * agent MUST pick from `available_tags` and never invents new tags. Set
+ * `allow_new: true` to unlock a `suggested_new` array of candidate tag
+ * names — hosts remain responsible for creating them.
+ *
+ * ## Input
+ *
+ * ```
+ * [
+ *   'content'        => string,          // required
+ *   'available_tags' => string[],        // required, existing tag names
+ *   'allow_new'      => bool|null,       // optional, default false
+ *   'max_selected'   => int|null,        // optional, 1-10 (default 5)
+ * ]
+ * ```
+ *
+ * ## Output schema
+ *
+ * ```
+ * {
+ *   selected:      [ { tag: string, confidence: float } ],
+ *   suggested_new: string[]              // only when allow_new is true
+ * }
+ * ```
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage CMSFramework
+ *
+ * @since      2.3.0
+ */
+class TagSuggestionAgent extends ArtisanPackAgent
+{
+    /**
+     * {@inheritDoc}
+     */
+    public string $featureKey = 'cms.suggest_tags';
+
+    /**
+     * {@inheritDoc}
+     */
+    public string $package = 'artisanpack-ui/cms-framework';
+
+    /**
+     * {@inheritDoc}
+     */
+    public string $defaultModel = 'claude-haiku-4-5';
+
+    /**
+     * {@inheritDoc}
+     */
+    public function instructions(): string
+    {
+        return <<<'PROMPT'
+You select tags for a piece of content from a fixed taxonomy.
+
+Requirements:
+- Every entry in `selected.tag` MUST come from the supplied `available_tags` list, matched by exact string. Case must match.
+- `confidence` is 0.0 (weak signal) to 1.0 (strong signal). Prefer omitting a tag over guessing — an empty `selected` array is a valid answer.
+- Return at most `max_selected` entries, ordered by confidence descending.
+- Base every selection on evidence in the supplied content. Do NOT project topics that are not present.
+- If `allow_new` is true, you MAY additionally return `suggested_new` — a short list of tag names that would meaningfully cover a topic present in the content but missing from `available_tags`. Do not repeat names that are already in `available_tags` (case-insensitive). Each new name must be a short, lowercase, kebab-case slug (2–4 words at most). Omit `suggested_new` entirely (or return an empty array) when nothing is missing.
+- If `allow_new` is false or absent, do NOT include `suggested_new` at all — the taxonomy is closed.
+
+Return a JSON object with keys: `selected` (array of {tag, confidence}) and optionally `suggested_new` (array of strings).
+PROMPT;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function outputSchema(): array
+    {
+        return [
+            'type'                 => 'object',
+            'additionalProperties' => false,
+            'required'             => [ 'selected' ],
+            'properties'           => [
+                'selected'      => [
+                    'type'  => 'array',
+                    'items' => [
+                        'type'                 => 'object',
+                        'additionalProperties' => false,
+                        'required'             => [ 'tag', 'confidence' ],
+                        'properties'           => [
+                            'tag'        => [ 'type' => 'string' ],
+                            'confidence' => [
+                                'type'    => 'number',
+                                'minimum' => 0,
+                                'maximum' => 1,
+                            ],
+                        ],
+                    ],
+                ],
+                'suggested_new' => [
+                    'type'  => 'array',
+                    'items' => [ 'type' => 'string' ],
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function execute( Credentials $credentials, string $model, string $instructions ): array
+    {
+        $normalized = $this->normalizeInput( $this->input() );
+
+        $prompter = app( AgentPrompter::class );
+
+        $result = $prompter->prompt(
+            credentials: $credentials,
+            model: $model,
+            instructions: $instructions,
+            message: $this->buildMessage( $normalized ),
+            outputSchema: $this->outputSchema(),
+        );
+
+        return [
+            'output'        => $this->validateOutput( $result['output'], $normalized ),
+            'input_tokens'  => (int) ( $result['input_tokens'] ?? 0 ),
+            'output_tokens' => (int) ( $result['output_tokens'] ?? 0 ),
+        ];
+    }
+
+    /**
+     * Validate and shape-check the raw agent input.
+     *
+     * @since 2.3.0
+     *
+     * @param  mixed  $input  Raw agent input.
+     *
+     * @return array{ content: string, available_tags: array<int, string>, allow_new: bool, max_selected: int }
+     */
+    protected function normalizeInput( mixed $input ): array
+    {
+        if ( ! is_array( $input ) ) {
+            throw FeatureError::forFeature(
+                $this->featureKey,
+                'input must be an array with `content` and `available_tags` keys.',
+            );
+        }
+
+        $content = isset( $input['content'] ) && is_string( $input['content'] ) ? trim( $input['content'] ) : '';
+
+        if ( '' === $content ) {
+            throw FeatureError::forFeature( $this->featureKey, '`content` must be a non-empty string.' );
+        }
+
+        if ( ! isset( $input['available_tags'] ) || ! is_array( $input['available_tags'] ) ) {
+            throw FeatureError::forFeature( $this->featureKey, '`available_tags` must be an array of strings.' );
+        }
+
+        $tags = [];
+        foreach ( $input['available_tags'] as $tag ) {
+            if ( is_string( $tag ) && '' !== trim( $tag ) ) {
+                $tags[] = trim( $tag );
+            }
+        }
+
+        $allowNew = isset( $input['allow_new'] ) && filter_var( $input['allow_new'], FILTER_VALIDATE_BOOLEAN );
+
+        $maxSelected = 5;
+        if ( isset( $input['max_selected'] ) ) {
+            $parsed = filter_var(
+                $input['max_selected'],
+                FILTER_VALIDATE_INT,
+                [ 'options' => [ 'min_range' => 1, 'max_range' => 10 ] ],
+            );
+
+            if ( false !== $parsed ) {
+                $maxSelected = $parsed;
+            }
+        }
+
+        return [
+            'content'        => $content,
+            'available_tags' => $tags,
+            'allow_new'      => $allowNew,
+            'max_selected'   => $maxSelected,
+        ];
+    }
+
+    /**
+     * Assemble the structured message body for the prompter.
+     *
+     * @since 2.3.0
+     *
+     * @param  array{ content: string, available_tags: array<int, string>, allow_new: bool, max_selected: int }  $input  Normalized input.
+     *
+     * @return array<int, array<string, string>>
+     */
+    protected function buildMessage( array $input ): array
+    {
+        return [
+            [ 'type' => 'text', 'text' => sprintf( 'allow_new: %s', $input['allow_new'] ? 'true' : 'false' ) ],
+            [ 'type' => 'text', 'text' => sprintf( 'max_selected: %d', $input['max_selected'] ) ],
+            [ 'type' => 'text', 'text' => 'available_tags: ' . implode( ', ', $input['available_tags'] ) ],
+            [ 'type' => 'text', 'text' => "Content:\n" . $input['content'] ],
+        ];
+    }
+
+    /**
+     * Enforce output invariants — drop hallucinated tags, clamp size,
+     * and only include `suggested_new` when the caller allowed it.
+     *
+     * @since 2.3.0
+     *
+     * @param  array<string, mixed>                                                                              $output      Decoded model output.
+     * @param  array{ content: string, available_tags: array<int, string>, allow_new: bool, max_selected: int }  $normalized  Normalized input.
+     *
+     * @return array{ selected: array<int, array{ tag: string, confidence: float }>, suggested_new?: array<int, string> }
+     */
+    protected function validateOutput( array $output, array $normalized ): array
+    {
+        $allowed = array_flip( $normalized['available_tags'] );
+
+        $selected    = [];
+        $rawSelected = isset( $output['selected'] ) && is_array( $output['selected'] ) ? $output['selected'] : [];
+
+        foreach ( $rawSelected as $entry ) {
+            if ( ! is_array( $entry ) ) {
+                continue;
+            }
+
+            $tag = isset( $entry['tag'] ) ? (string) $entry['tag'] : '';
+
+            if ( '' === $tag || ! isset( $allowed[ $tag ] ) ) {
+                continue;
+            }
+
+            $confidence = isset( $entry['confidence'] ) ? (float) $entry['confidence'] : 0.0;
+            $confidence = max( 0.0, min( 1.0, $confidence ) );
+
+            $selected[] = [
+                'tag'        => $tag,
+                'confidence' => $confidence,
+            ];
+
+            if ( count( $selected ) === $normalized['max_selected'] ) {
+                break;
+            }
+        }
+
+        $result = [ 'selected' => $selected ];
+
+        if ( $normalized['allow_new'] ) {
+            $existingLower = array_flip( array_map( 'strtolower', $normalized['available_tags'] ) );
+            $seen          = [];
+            $new           = [];
+
+            $rawNew = isset( $output['suggested_new'] ) && is_array( $output['suggested_new'] )
+                ? $output['suggested_new']
+                : [];
+
+            foreach ( $rawNew as $candidate ) {
+                if ( ! is_string( $candidate ) ) {
+                    continue;
+                }
+
+                $trimmed = trim( $candidate );
+                if ( '' === $trimmed ) {
+                    continue;
+                }
+
+                $lower = strtolower( $trimmed );
+                if ( isset( $existingLower[ $lower ] ) || isset( $seen[ $lower ] ) ) {
+                    continue;
+                }
+
+                $seen[ $lower ] = true;
+                $new[]          = $trimmed;
+            }
+
+            $result['suggested_new'] = $new;
+        }
+
+        return $result;
+    }
+}

--- a/src/Ai/Agents/TagSuggestionAgent.php
+++ b/src/Ai/Agents/TagSuggestionAgent.php
@@ -244,7 +244,11 @@ PROMPT;
                 continue;
             }
 
-            $tag = isset( $entry['tag'] ) ? (string) $entry['tag'] : '';
+            // Trim BEFORE the allow-list lookup — `normalizeInput` trimmed
+            // every `available_tags` entry, so a model return of `"laravel "`
+            // (with incidental whitespace) would silently fail the isset
+            // check and drop an otherwise-valid selection.
+            $tag = isset( $entry['tag'] ) ? trim( (string) $entry['tag'] ) : '';
 
             if ( '' === $tag || ! isset( $allowed[ $tag ] ) ) {
                 continue;

--- a/src/CMSFrameworkServiceProvider.php
+++ b/src/CMSFrameworkServiceProvider.php
@@ -14,6 +14,13 @@ declare( strict_types=1 );
 
 namespace ArtisanPackUI\CMSFramework;
 
+use ArtisanPackUI\Ai\Contracts\FeatureRegistry;
+use ArtisanPackUI\CMSFramework\Ai\Agents\CategorySuggestionAgent;
+use ArtisanPackUI\CMSFramework\Ai\Agents\ExcerptGenerationAgent;
+use ArtisanPackUI\CMSFramework\Ai\Agents\PostTitleSuggestionAgent;
+use ArtisanPackUI\CMSFramework\Ai\Agents\SlugSuggestionAgent;
+use ArtisanPackUI\CMSFramework\Ai\Agents\TagSuggestionAgent;
+use ArtisanPackUI\CMSFramework\Livewire\Ai\AiTools;
 use ArtisanPackUI\CMSFramework\Modules\Admin\Providers\AdminServiceProvider;
 use ArtisanPackUI\CMSFramework\Modules\AdminWidgets\Providers\AdminWidgetServiceProvider;
 use ArtisanPackUI\CMSFramework\Modules\Blog\Models\Post;
@@ -34,9 +41,11 @@ use ArtisanPackUI\CMSFramework\Modules\Users\Providers\UserServiceProvider;
 use ArtisanPackUI\VisualEditor\Concerns\HasBlockContent;
 use ArtisanPackUI\VisualEditor\VisualEditor;
 use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\ServiceProvider;
 use InvalidArgumentException;
+use Livewire\Livewire;
 
 /**
  * Registers and bootstraps the CMS Framework within the application.
@@ -49,6 +58,26 @@ use InvalidArgumentException;
  */
 class CMSFrameworkServiceProvider extends ServiceProvider
 {
+
+    /**
+     * The full set of AI feature keys the cms-framework exposes.
+     *
+     * Single source of truth: {@see AiController::features()},
+     * {@see AiTools::enabledFeatures()}, and any host bundle wiring
+     * (React/Vue apps that hit `/api/v1/cms/ai/features`) all read from
+     * here so a future CMS AI feature only lands in one place.
+     *
+     * @since 2.3.0
+     *
+     * @var array<int, string>
+     */
+    public const AI_FEATURE_KEYS = [
+        'cms.post_title',
+        'cms.excerpt',
+        'cms.suggest_tags',
+        'cms.suggest_category',
+        'cms.suggest_slug',
+    ];
     /**
      * Permission slugs and human-readable names registered into
      * cms-framework's RBAC tables when visual-editor is detected.
@@ -72,6 +101,45 @@ class CMSFrameworkServiceProvider extends ServiceProvider
         'visual_editor.global-styles.edit'  => 'Edit Global Styles in Visual Editor',
         'visual_editor.navigation.edit'     => 'Edit Navigation in Visual Editor',
     ];
+
+    /**
+     * Declare the AI features this package owns.
+     *
+     * Auto-discovered by `artisanpack-ui/ai`'s `FeatureRegistry` (see
+     * AI RFC — GitHub discussion #8). When the AI package is absent
+     * this method is simply never called and has no effect — the
+     * cms-framework still boots without AI wiring, and the AI Livewire
+     * component + REST endpoints stay unregistered.
+     *
+     * @since 2.3.0
+     *
+     * @return array<string, array{ agent: class-string, package: string }>
+     */
+    public function aiFeatures(): array
+    {
+        return [
+            'cms.post_title'       => [
+                'agent'   => PostTitleSuggestionAgent::class,
+                'package' => 'artisanpack-ui/cms-framework',
+            ],
+            'cms.excerpt'          => [
+                'agent'   => ExcerptGenerationAgent::class,
+                'package' => 'artisanpack-ui/cms-framework',
+            ],
+            'cms.suggest_tags'     => [
+                'agent'   => TagSuggestionAgent::class,
+                'package' => 'artisanpack-ui/cms-framework',
+            ],
+            'cms.suggest_category' => [
+                'agent'   => CategorySuggestionAgent::class,
+                'package' => 'artisanpack-ui/cms-framework',
+            ],
+            'cms.suggest_slug'     => [
+                'agent'   => SlugSuggestionAgent::class,
+                'package' => 'artisanpack-ui/cms-framework',
+            ],
+        ];
+    }
 
     /**
      * Boots the CMS framework and loads database migration files.
@@ -101,6 +169,8 @@ class CMSFrameworkServiceProvider extends ServiceProvider
         $this->loadMigrationsFrom( __DIR__ . '/../database/migrations' );
 
         $this->registerVisualEditorBridge();
+
+        $this->registerAiSurfaces();
     }
 
     /**
@@ -172,6 +242,36 @@ class CMSFrameworkServiceProvider extends ServiceProvider
         $this->app->register( SiteEditorServiceProvider::class );
         $this->app->register( PluginsServiceProvider::class );
         $this->app->register( OpenApiServiceProvider::class );
+    }
+
+    /**
+     * Registers the CMS AI trigger surfaces (Livewire component +
+     * `/api/v1/cms/ai/*` REST endpoints).
+     *
+     * Both are guarded on the {@see FeatureRegistry} contract from
+     * `artisanpack-ui/ai`: when the AI package isn't installed the
+     * registrations are skipped so the cms-framework still boots.
+     *
+     * The REST endpoints are the framework-agnostic path — React and
+     * Vue apps hit them directly without either shared package
+     * (`@artisanpack-ui/react`, `@artisanpack-ui/vue`) needing to know
+     * anything about CMS AI features.
+     *
+     * @since 2.3.0
+     */
+    protected function registerAiSurfaces(): void
+    {
+        if ( ! interface_exists( FeatureRegistry::class ) ) {
+            return;
+        }
+
+        if ( class_exists( Livewire::class ) ) {
+            Livewire::component( 'ap-cms-ai-tools', AiTools::class );
+        }
+
+        Route::prefix( 'api/v1/cms/ai' )
+            ->middleware( 'api' )
+            ->group( __DIR__ . '/Http/routes/ai.php' );
     }
 
     /**

--- a/src/Http/Controllers/Ai/AiController.php
+++ b/src/Http/Controllers/Ai/AiController.php
@@ -1,0 +1,208 @@
+<?php
+
+/**
+ * JSON API controller for the cms-framework AI trigger surface.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage CMSFramework
+ *
+ * @since      2.3.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Http\Controllers\Ai;
+
+use ArtisanPackUI\Ai\Contracts\FeatureRegistry;
+use ArtisanPackUI\Ai\Exceptions\FeatureDisabledException;
+use ArtisanPackUI\Ai\Exceptions\FeatureError;
+use ArtisanPackUI\Ai\Exceptions\MissingCredentialsException;
+use ArtisanPackUI\CMSFramework\Ai\Agents\CategorySuggestionAgent;
+use ArtisanPackUI\CMSFramework\Ai\Agents\ExcerptGenerationAgent;
+use ArtisanPackUI\CMSFramework\Ai\Agents\PostTitleSuggestionAgent;
+use ArtisanPackUI\CMSFramework\Ai\Agents\SlugSuggestionAgent;
+use ArtisanPackUI\CMSFramework\Ai\Agents\TagSuggestionAgent;
+use ArtisanPackUI\CMSFramework\CMSFrameworkServiceProvider;
+use ArtisanPackUI\CMSFramework\Http\Requests\Ai\ExcerptRequest;
+use ArtisanPackUI\CMSFramework\Http\Requests\Ai\PostTitleRequest;
+use ArtisanPackUI\CMSFramework\Http\Requests\Ai\SuggestCategoryRequest;
+use ArtisanPackUI\CMSFramework\Http\Requests\Ai\SuggestSlugRequest;
+use ArtisanPackUI\CMSFramework\Http\Requests\Ai\SuggestTagsRequest;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\Log;
+use Throwable;
+
+/**
+ * REST surface used by non-Livewire front-ends. Each endpoint runs one
+ * agent against a validated body and returns the shaped output.
+ *
+ * Kept intentionally framework-agnostic — React and Vue apps consume
+ * these endpoints directly via `fetch`, so adding a CMS AI feature does
+ * not require any changes to the `@artisanpack-ui/react` or
+ * `@artisanpack-ui/vue` packages. Feature-toggle enforcement lives
+ * inside the agents themselves; this controller only wraps errors in a
+ * consistent JSON envelope.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage CMSFramework
+ *
+ * @since      2.3.0
+ */
+class AiController
+{
+    /**
+     * Return the enabled state of the five cms.* features so a
+     * front-end can decide which affordances to render.
+     *
+     * @since 2.3.0
+     *
+     * @return JsonResponse
+     */
+    public function features(): JsonResponse
+    {
+        /** @var FeatureRegistry $registry */
+        $registry = app( FeatureRegistry::class );
+
+        $state = [];
+        foreach ( CMSFrameworkServiceProvider::AI_FEATURE_KEYS as $key ) {
+            $state[ $key ] = null !== $registry->get( $key ) && $registry->isToggleOn( $key );
+        }
+
+        return new JsonResponse( [ 'features' => $state ] );
+    }
+
+    /**
+     * POST /post-title.
+     *
+     * @since 2.3.0
+     *
+     * @param  PostTitleRequest  $request  Validated request.
+     *
+     * @return JsonResponse
+     */
+    public function postTitle( PostTitleRequest $request ): JsonResponse
+    {
+        return $this->runAgent(
+            'cms.post_title',
+            fn () => PostTitleSuggestionAgent::for( $request->validated() )->run(),
+        );
+    }
+
+    /**
+     * POST /excerpt.
+     *
+     * @since 2.3.0
+     *
+     * @param  ExcerptRequest  $request  Validated request.
+     *
+     * @return JsonResponse
+     */
+    public function excerpt( ExcerptRequest $request ): JsonResponse
+    {
+        return $this->runAgent(
+            'cms.excerpt',
+            fn () => ExcerptGenerationAgent::for( $request->validated() )->run(),
+        );
+    }
+
+    /**
+     * POST /suggest-tags.
+     *
+     * @since 2.3.0
+     *
+     * @param  SuggestTagsRequest  $request  Validated request.
+     *
+     * @return JsonResponse
+     */
+    public function suggestTags( SuggestTagsRequest $request ): JsonResponse
+    {
+        return $this->runAgent(
+            'cms.suggest_tags',
+            fn () => TagSuggestionAgent::for( $request->validated() )->run(),
+        );
+    }
+
+    /**
+     * POST /suggest-category.
+     *
+     * @since 2.3.0
+     *
+     * @param  SuggestCategoryRequest  $request  Validated request.
+     *
+     * @return JsonResponse
+     */
+    public function suggestCategory( SuggestCategoryRequest $request ): JsonResponse
+    {
+        return $this->runAgent(
+            'cms.suggest_category',
+            fn () => CategorySuggestionAgent::for( $request->validated() )->run(),
+        );
+    }
+
+    /**
+     * POST /suggest-slug.
+     *
+     * @since 2.3.0
+     *
+     * @param  SuggestSlugRequest  $request  Validated request.
+     *
+     * @return JsonResponse
+     */
+    public function suggestSlug( SuggestSlugRequest $request ): JsonResponse
+    {
+        return $this->runAgent(
+            'cms.suggest_slug',
+            fn () => SlugSuggestionAgent::for( $request->validated() )->run(),
+        );
+    }
+
+    /**
+     * Shared wrapper — normalizes the four agent-exception categories
+     * into consistent status codes + JSON envelopes.
+     *
+     * @since 2.3.0
+     *
+     * @param  string    $featureKey  Feature key (for logging + envelope).
+     * @param  callable  $callback    Callable returning the agent output.
+     *
+     * @return JsonResponse
+     */
+    private function runAgent( string $featureKey, callable $callback ): JsonResponse
+    {
+        try {
+            $output = $callback();
+            return new JsonResponse( [
+                'feature' => $featureKey,
+                'output'  => $output,
+            ] );
+        } catch ( FeatureDisabledException $e ) {
+            return new JsonResponse( [
+                'feature' => $featureKey,
+                'error'   => 'feature_disabled',
+                'message' => $e->getMessage(),
+            ], 403 );
+        } catch ( MissingCredentialsException $e ) {
+            return new JsonResponse( [
+                'feature' => $featureKey,
+                'error'   => 'missing_credentials',
+                'message' => $e->getMessage(),
+            ], 503 );
+        } catch ( FeatureError $e ) {
+            return new JsonResponse( [
+                'feature' => $featureKey,
+                'error'   => 'invalid_input',
+                'message' => $e->getMessage(),
+            ], 422 );
+        } catch ( Throwable $e ) {
+            Log::error( 'cms-framework AI API call failed', [
+                'feature' => $featureKey,
+                'error'   => $e->getMessage(),
+            ] );
+            return new JsonResponse( [
+                'feature' => $featureKey,
+                'error'   => 'internal_error',
+                'message' => 'Unexpected error running AI feature.',
+            ], 500 );
+        }
+    }
+}

--- a/src/Http/Requests/Ai/ExcerptRequest.php
+++ b/src/Http/Requests/Ai/ExcerptRequest.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * Form request for the excerpt AI endpoint.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage CMSFramework
+ *
+ * @since      2.3.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Http\Requests\Ai;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class ExcerptRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'content'   => [ 'required', 'string' ],
+            'max_chars' => [ 'nullable', 'integer', 'between:80,400' ],
+        ];
+    }
+}

--- a/src/Http/Requests/Ai/PostTitleRequest.php
+++ b/src/Http/Requests/Ai/PostTitleRequest.php
@@ -1,0 +1,36 @@
+<?php
+
+/**
+ * Form request for the post-title AI endpoint.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage CMSFramework
+ *
+ * @since      2.3.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Http\Requests\Ai;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class PostTitleRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'content' => [ 'required', 'string' ],
+            'tone'    => [ 'nullable', 'string', 'max:120' ],
+            'count'   => [ 'nullable', 'integer', 'between:3,5' ],
+        ];
+    }
+}

--- a/src/Http/Requests/Ai/SuggestCategoryRequest.php
+++ b/src/Http/Requests/Ai/SuggestCategoryRequest.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * Form request for the category suggestion AI endpoint.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage CMSFramework
+ *
+ * @since      2.3.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Http\Requests\Ai;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class SuggestCategoryRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'content'       => [ 'required', 'string' ],
+            'category_tree' => [ 'required', 'array' ],
+        ];
+    }
+}

--- a/src/Http/Requests/Ai/SuggestSlugRequest.php
+++ b/src/Http/Requests/Ai/SuggestSlugRequest.php
@@ -1,0 +1,36 @@
+<?php
+
+/**
+ * Form request for the slug suggestion AI endpoint.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage CMSFramework
+ *
+ * @since      2.3.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Http\Requests\Ai;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class SuggestSlugRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'title'     => [ 'required', 'string' ],
+            'excerpt'   => [ 'nullable', 'string' ],
+            'max_chars' => [ 'nullable', 'integer', 'between:20,100' ],
+        ];
+    }
+}

--- a/src/Http/Requests/Ai/SuggestTagsRequest.php
+++ b/src/Http/Requests/Ai/SuggestTagsRequest.php
@@ -1,0 +1,38 @@
+<?php
+
+/**
+ * Form request for the tag suggestion AI endpoint.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage CMSFramework
+ *
+ * @since      2.3.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Http\Requests\Ai;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class SuggestTagsRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'content'          => [ 'required', 'string' ],
+            'available_tags'   => [ 'required', 'array' ],
+            'available_tags.*' => [ 'string' ],
+            'allow_new'        => [ 'nullable', 'boolean' ],
+            'max_selected'     => [ 'nullable', 'integer', 'between:1,10' ],
+        ];
+    }
+}

--- a/src/Http/routes/ai.php
+++ b/src/Http/routes/ai.php
@@ -1,0 +1,25 @@
+<?php
+
+declare( strict_types=1 );
+
+/**
+ * CMS Framework AI API Routes.
+ *
+ * Mounted at `/api/v1/cms/ai` by CMSFrameworkServiceProvider so that
+ * React and Vue front-ends can trigger the five cms.* AI agents
+ * (post title, excerpt, tags, category, slug) via plain HTTP.
+ *
+ * @since 2.3.0
+ */
+
+use ArtisanPackUI\CMSFramework\Http\Controllers\Ai\AiController;
+use Illuminate\Support\Facades\Route;
+
+Route::middleware( 'auth' )->group( function (): void {
+    Route::get( '/features', [ AiController::class, 'features' ] );
+    Route::post( '/post-title', [ AiController::class, 'postTitle' ] );
+    Route::post( '/excerpt', [ AiController::class, 'excerpt' ] );
+    Route::post( '/suggest-tags', [ AiController::class, 'suggestTags' ] );
+    Route::post( '/suggest-category', [ AiController::class, 'suggestCategory' ] );
+    Route::post( '/suggest-slug', [ AiController::class, 'suggestSlug' ] );
+} );

--- a/src/Http/routes/ai.php
+++ b/src/Http/routes/ai.php
@@ -15,7 +15,11 @@ declare( strict_types=1 );
 use ArtisanPackUI\CMSFramework\Http\Controllers\Ai\AiController;
 use Illuminate\Support\Facades\Route;
 
-Route::middleware( 'auth' )->group( function (): void {
+// `auth:sanctum` (not plain `auth`) — the parent group is mounted under
+// the `api` middleware stack which strips session state, so the default
+// web-guard would reject Sanctum bearer tokens from React/Vue SPAs and
+// silently 401 exactly the callers this surface is designed for.
+Route::middleware( 'auth:sanctum' )->group( function (): void {
     Route::get( '/features', [ AiController::class, 'features' ] );
     Route::post( '/post-title', [ AiController::class, 'postTitle' ] );
     Route::post( '/excerpt', [ AiController::class, 'excerpt' ] );

--- a/src/Livewire/Ai/AiTools.php
+++ b/src/Livewire/Ai/AiTools.php
@@ -1,0 +1,268 @@
+<?php
+
+/**
+ * Livewire trigger surface for the cms-framework AI features.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage CMSFramework
+ *
+ * @since      2.3.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Livewire\Ai;
+
+use ArtisanPackUI\Ai\Contracts\FeatureRegistry;
+use ArtisanPackUI\Ai\Exceptions\FeatureDisabledException;
+use ArtisanPackUI\Ai\Exceptions\FeatureError;
+use ArtisanPackUI\Ai\Exceptions\MissingCredentialsException;
+use ArtisanPackUI\CMSFramework\Ai\Agents\CategorySuggestionAgent;
+use ArtisanPackUI\CMSFramework\Ai\Agents\ExcerptGenerationAgent;
+use ArtisanPackUI\CMSFramework\Ai\Agents\PostTitleSuggestionAgent;
+use ArtisanPackUI\CMSFramework\Ai\Agents\SlugSuggestionAgent;
+use ArtisanPackUI\CMSFramework\Ai\Agents\TagSuggestionAgent;
+use ArtisanPackUI\CMSFramework\CMSFrameworkServiceProvider;
+use Illuminate\Support\Facades\Log;
+use Livewire\Attributes\On;
+use Livewire\Component;
+use Throwable;
+
+/**
+ * Thin Livewire wrapper that runs any of the five cms-framework AI
+ * agents and dispatches the shaped result via a browser event. Admin
+ * Blade surfaces (and any host embedding the CMS) listen for
+ * `ap-cms-ai:{featureKey}:{status}` and fold the payload into the UI.
+ *
+ * React and Vue front-ends do NOT need this component — they call the
+ * REST endpoints registered under `/api/v1/cms/ai/*` directly (see
+ * `AiController`). This keeps `@artisanpack-ui/react` and
+ * `@artisanpack-ui/vue` framework-agnostic: adding a new AI trigger
+ * only touches the backend package.
+ *
+ * The component intentionally holds no persistent state — a Livewire
+ * class was picked so CSRF, auth, and rate limiting come "for free"
+ * via the standard Livewire endpoint, and feature-toggle checks live
+ * in one place.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage CMSFramework
+ *
+ * @since      2.3.0
+ */
+class AiTools extends Component
+{
+    /**
+     * Generate 3–5 title variants from a draft body.
+     *
+     * @since 2.3.0
+     *
+     * @param  string       $content  Draft body.
+     * @param  string|null  $tone     Optional tone hint.
+     * @param  int|null     $count    Optional variant count (3-5).
+     *
+     * @return void
+     */
+    #[On( 'ap-cms-ai:suggest-post-titles' )]
+    public function suggestPostTitles( string $content, ?string $tone = null, ?int $count = null ): void
+    {
+        $this->run(
+            'cms.post_title',
+            fn () => PostTitleSuggestionAgent::for( [
+                'content' => $content,
+                'tone'    => $tone,
+                'count'   => $count,
+            ] )->run(),
+        );
+    }
+
+    /**
+     * Generate an excerpt from full post content.
+     *
+     * @since 2.3.0
+     *
+     * @param  string    $content   Full post body.
+     * @param  int|null  $maxChars  Optional length cap (80-400).
+     *
+     * @return void
+     */
+    #[On( 'ap-cms-ai:generate-excerpt' )]
+    public function generateExcerpt( string $content, ?int $maxChars = null ): void
+    {
+        $this->run(
+            'cms.excerpt',
+            fn () => ExcerptGenerationAgent::for( [
+                'content'   => $content,
+                'max_chars' => $maxChars,
+            ] )->run(),
+        );
+    }
+
+    /**
+     * Suggest tags from an existing taxonomy.
+     *
+     * @since 2.3.0
+     *
+     * @param  string             $content        Content to tag.
+     * @param  array<int, string> $availableTags  Existing tag names.
+     * @param  bool               $allowNew       Whether to include suggested_new.
+     * @param  int|null           $maxSelected    Optional cap on selected tags (1-10).
+     *
+     * @return void
+     */
+    #[On( 'ap-cms-ai:suggest-tags' )]
+    public function suggestTags(
+        string $content,
+        array $availableTags,
+        bool $allowNew = false,
+        ?int $maxSelected = null,
+    ): void {
+        $this->run(
+            'cms.suggest_tags',
+            fn () => TagSuggestionAgent::for( [
+                'content'        => $content,
+                'available_tags' => $availableTags,
+                'allow_new'      => $allowNew,
+                'max_selected'   => $maxSelected,
+            ] )->run(),
+        );
+    }
+
+    /**
+     * Suggest a single category from a hierarchical taxonomy.
+     *
+     * @since 2.3.0
+     *
+     * @param  string             $content       Content to categorize.
+     * @param  array<int, mixed>  $categoryTree  Nested list of {name, children?} nodes.
+     *
+     * @return void
+     */
+    #[On( 'ap-cms-ai:suggest-category' )]
+    public function suggestCategory( string $content, array $categoryTree ): void
+    {
+        $this->run(
+            'cms.suggest_category',
+            fn () => CategorySuggestionAgent::for( [
+                'content'       => $content,
+                'category_tree' => $categoryTree,
+            ] )->run(),
+        );
+    }
+
+    /**
+     * Suggest an SEO-friendly slug from a title.
+     *
+     * @since 2.3.0
+     *
+     * @param  string       $title     Post title.
+     * @param  string|null  $excerpt   Optional excerpt for disambiguation.
+     * @param  int|null     $maxChars  Optional length cap (20-100).
+     *
+     * @return void
+     */
+    #[On( 'ap-cms-ai:suggest-slug' )]
+    public function suggestSlug( string $title, ?string $excerpt = null, ?int $maxChars = null ): void
+    {
+        $this->run(
+            'cms.suggest_slug',
+            fn () => SlugSuggestionAgent::for( [
+                'title'     => $title,
+                'excerpt'   => $excerpt,
+                'max_chars' => $maxChars,
+            ] )->run(),
+        );
+    }
+
+    /**
+     * Return the currently-enabled feature toggle map so the front-end
+     * knows which affordances to render.
+     *
+     * @since 2.3.0
+     *
+     * @return array<string, bool>
+     */
+    public function enabledFeatures(): array
+    {
+        /** @var FeatureRegistry $registry */
+        $registry = app( FeatureRegistry::class );
+
+        $state = [];
+        foreach ( CMSFrameworkServiceProvider::AI_FEATURE_KEYS as $key ) {
+            $state[ $key ] = null !== $registry->get( $key ) && $registry->isToggleOn( $key );
+        }
+        return $state;
+    }
+
+    /**
+     * Blade shell — hosts can override the view or inline the component
+     * without body. The default view is intentionally empty; this is a
+     * transport component, not a UI.
+     *
+     * @since 2.3.0
+     *
+     * @return string
+     */
+    public function render(): string
+    {
+        return '<div class="ap-cms-ai-tools" data-testid="ap-cms-ai-tools"></div>';
+    }
+
+    /**
+     * Shared run-and-emit path. Kept private so callers can only reach
+     * agents through the five public entry points, each of which
+     * pre-shapes its input.
+     *
+     * @since 2.3.0
+     *
+     * @param  string   $featureKey  Feature key (for status events).
+     * @param  callable $callback    Callable that runs the agent and returns its output.
+     *
+     * @return void
+     */
+    private function run( string $featureKey, callable $callback ): void
+    {
+        try {
+            $output = $callback();
+
+            $this->dispatch(
+                sprintf( 'ap-cms-ai:%s:success', $featureKey ),
+                feature: $featureKey,
+                output: $output,
+            );
+        } catch ( FeatureDisabledException $e ) {
+            $this->dispatch(
+                sprintf( 'ap-cms-ai:%s:disabled', $featureKey ),
+                feature: $featureKey,
+                message: $e->getMessage(),
+            );
+        } catch ( MissingCredentialsException $e ) {
+            $this->dispatch(
+                sprintf( 'ap-cms-ai:%s:missing-credentials', $featureKey ),
+                feature: $featureKey,
+                message: $e->getMessage(),
+            );
+        } catch ( FeatureError $e ) {
+            // Validation-style failure (missing required field, hallucinated
+            // tag, etc.). Emit under a distinct event so front-ends can
+            // route it to a form-level warning instead of a generic
+            // error toast — mirrors the HTTP surface's 422 status.
+            $this->dispatch(
+                sprintf( 'ap-cms-ai:%s:invalid-input', $featureKey ),
+                feature: $featureKey,
+                message: $e->getMessage(),
+            );
+        } catch ( Throwable $e ) {
+            Log::error( 'cms-framework AI trigger failed', [
+                'feature' => $featureKey,
+                'error'   => $e->getMessage(),
+            ] );
+
+            $this->dispatch(
+                sprintf( 'ap-cms-ai:%s:error', $featureKey ),
+                feature: $featureKey,
+                message: 'Unexpected error running AI feature.',
+            );
+        }
+    }
+}

--- a/src/Modules/OpenApi/Providers/OpenApiServiceProvider.php
+++ b/src/Modules/OpenApi/Providers/OpenApiServiceProvider.php
@@ -113,7 +113,7 @@ class OpenApiServiceProvider extends ServiceProvider
         $scrambleConfig['ui']       = ['title' => $info['title'] ?? 'ArtisanPack CMS Framework API'];
 
         $scrambleConfig['info'] = [
-            'version'     => $info['version'] ?? '2.2.3',
+            'version'     => $info['version'] ?? '2.3.0',
             'description' => $info['description'] ?? '',
         ];
 

--- a/tests/Feature/Ai/AiAgentTestSetup.php
+++ b/tests/Feature/Ai/AiAgentTestSetup.php
@@ -1,0 +1,59 @@
+<?php
+
+/**
+ * Shared bootstrap for cms-framework AI agent tests.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage CMSFramework
+ *
+ * @since      2.3.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Tests\Feature\Ai;
+
+use ArtisanPackUI\Ai\Contracts\AgentPrompter;
+use ArtisanPackUI\Ai\Contracts\CredentialResolver;
+use ArtisanPackUI\Ai\Credentials\ChainedCredentialResolver;
+use ArtisanPackUI\Ai\Credentials\Credentials;
+use ArtisanPackUI\CMSFramework\CMSFrameworkServiceProvider;
+use ArtisanPackUI\CMSFramework\Tests\Support\FakeAgentPrompter;
+
+/**
+ * Registers a fake prompter, stub credentials, and enables the five
+ * feature toggles the CMS AI surface cares about.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage CMSFramework
+ *
+ * @since      2.3.0
+ */
+final class AiAgentTestSetup
+{
+    /**
+     * @since 2.3.0
+     *
+     * @param  \Illuminate\Foundation\Application  $app  Application instance.
+     *
+     * @return FakeAgentPrompter The bound fake prompter.
+     */
+    public static function bootstrap( $app ): FakeAgentPrompter
+    {
+        /** @var ChainedCredentialResolver $resolver */
+        $resolver = $app->make( CredentialResolver::class );
+        $resolver->setOverride(
+            new Credentials( provider: 'anthropic', apiKey: 'sk-test', defaultModel: 'claude-haiku-4-5' ),
+        );
+        $resolver->useStore( fn () => null );
+
+        $prompter = new FakeAgentPrompter();
+        $app->instance( AgentPrompter::class, $prompter );
+
+        foreach ( CMSFrameworkServiceProvider::AI_FEATURE_KEYS as $key ) {
+            $app['config']->set( "artisanpack.ai.features.{$key}.enabled", true );
+        }
+
+        return $prompter;
+    }
+}

--- a/tests/Feature/Ai/CategorySuggestionAgentTest.php
+++ b/tests/Feature/Ai/CategorySuggestionAgentTest.php
@@ -84,6 +84,33 @@ it( 'clamps confidence to [0, 1]', function (): void {
     expect( $result['confidence'] )->toBe( 1.0 );
 } );
 
+it( 'ignores category nodes whose name contains the path separator', function (): void {
+    $ambiguousTree = [
+        [ 'name' => 'News/Updates' ], // rejected — would collide with the nested form
+        [
+            'name'     => 'News',
+            'children' => [
+                [ 'name' => 'Updates' ],
+            ],
+        ],
+    ];
+
+    $this->prompter->queue( [
+        'selected'   => 'News/Updates',
+        'confidence' => 0.9,
+        'rationale'  => 'nested form',
+    ] );
+
+    $result = CategorySuggestionAgent::for( [
+        'content'       => 'body',
+        'category_tree' => $ambiguousTree,
+    ] )->run();
+
+    // The path resolves unambiguously via the nested form; the ambiguous root
+    // never entered valid_paths, so a hallucination there could not survive.
+    expect( $result['selected'] )->toBe( 'News/Updates' );
+} );
+
 it( 'raises FeatureError on invalid input', function (): void {
     expect( fn () => CategorySuggestionAgent::for( 'nope' )->run() )->toThrow( FeatureError::class );
 

--- a/tests/Feature/Ai/CategorySuggestionAgentTest.php
+++ b/tests/Feature/Ai/CategorySuggestionAgentTest.php
@@ -1,0 +1,95 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Tests\Feature\Ai;
+
+use ArtisanPackUI\Ai\Exceptions\FeatureError;
+use ArtisanPackUI\CMSFramework\Ai\Agents\CategorySuggestionAgent;
+
+beforeEach( function (): void {
+    $this->prompter = AiAgentTestSetup::bootstrap( $this->app );
+
+    $this->tree = [
+        [
+            'name'     => 'News',
+            'children' => [
+                [ 'name' => 'Product Updates' ],
+                [ 'name' => 'Company' ],
+            ],
+        ],
+        [ 'name' => 'Tutorials' ],
+    ];
+} );
+
+it( 'accepts a valid slash-delimited path', function (): void {
+    $this->prompter->queue( [
+        'selected'   => 'News/Product Updates',
+        'confidence' => 0.9,
+        'rationale'  => 'body announces a new feature',
+    ] );
+
+    $result = CategorySuggestionAgent::for( [
+        'content'       => 'We just shipped X.',
+        'category_tree' => $this->tree,
+    ] )->run();
+
+    expect( $result['selected'] )->toBe( 'News/Product Updates' );
+    expect( $result['confidence'] )->toBe( 0.9 );
+} );
+
+it( 'drops hallucinated paths and zeros confidence when no fit is chosen', function (): void {
+    $this->prompter->queue( [
+        'selected'   => 'News/Not A Real Child',
+        'confidence' => 0.8,
+        'rationale'  => 'guessed',
+    ] );
+
+    $result = CategorySuggestionAgent::for( [
+        'content'       => 'body',
+        'category_tree' => $this->tree,
+    ] )->run();
+
+    expect( $result['selected'] )->toBe( '' );
+    expect( $result['confidence'] )->toBe( 0.0 );
+} );
+
+it( 'accepts a root-level path', function (): void {
+    $this->prompter->queue( [
+        'selected'   => 'Tutorials',
+        'confidence' => 0.7,
+        'rationale'  => 'looks like a tutorial',
+    ] );
+
+    $result = CategorySuggestionAgent::for( [
+        'content'       => 'body',
+        'category_tree' => $this->tree,
+    ] )->run();
+
+    expect( $result['selected'] )->toBe( 'Tutorials' );
+} );
+
+it( 'clamps confidence to [0, 1]', function (): void {
+    $this->prompter->queue( [
+        'selected'   => 'Tutorials',
+        'confidence' => 2.5,
+        'rationale'  => 'r',
+    ] );
+
+    $result = CategorySuggestionAgent::for( [
+        'content'       => 'body',
+        'category_tree' => $this->tree,
+    ] )->run();
+
+    expect( $result['confidence'] )->toBe( 1.0 );
+} );
+
+it( 'raises FeatureError on invalid input', function (): void {
+    expect( fn () => CategorySuggestionAgent::for( 'nope' )->run() )->toThrow( FeatureError::class );
+
+    expect( fn () => CategorySuggestionAgent::for( [ 'content' => 'ok' ] )->run() )
+        ->toThrow( FeatureError::class );
+
+    expect( fn () => CategorySuggestionAgent::for( [ 'category_tree' => [] ] )->run() )
+        ->toThrow( FeatureError::class );
+} );

--- a/tests/Feature/Ai/ExcerptGenerationAgentTest.php
+++ b/tests/Feature/Ai/ExcerptGenerationAgentTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Tests\Feature\Ai;
+
+use ArtisanPackUI\Ai\Exceptions\FeatureError;
+use ArtisanPackUI\CMSFramework\Ai\Agents\ExcerptGenerationAgent;
+
+beforeEach( function (): void {
+    $this->prompter = AiAgentTestSetup::bootstrap( $this->app );
+} );
+
+it( 'returns the excerpt and computes char_count from the returned string', function (): void {
+    $this->prompter->queue( [
+        'excerpt'    => 'A short excerpt.',
+        'char_count' => 999, // model lying — validator must recompute
+    ] );
+
+    $result = ExcerptGenerationAgent::for( [ 'content' => 'A long post about many things.' ] )->run();
+
+    expect( $result['excerpt'] )->toBe( 'A short excerpt.' );
+    expect( $result['char_count'] )->toBe( mb_strlen( 'A short excerpt.' ) );
+} );
+
+it( 'truncates excerpts longer than max_chars', function (): void {
+    $long = str_repeat( 'x', 300 );
+    $this->prompter->queue( [ 'excerpt' => $long, 'char_count' => 300 ] );
+
+    $result = ExcerptGenerationAgent::for( [
+        'content'   => 'body',
+        'max_chars' => 150,
+    ] )->run();
+
+    expect( mb_strlen( $result['excerpt'] ) )->toBe( 150 );
+    expect( $result['char_count'] )->toBe( 150 );
+} );
+
+it( 'forwards max_chars into the prompter message', function (): void {
+    $this->prompter->queue( [ 'excerpt' => 'ok', 'char_count' => 2 ] );
+
+    ExcerptGenerationAgent::for( [
+        'content'   => 'body',
+        'max_chars' => 250,
+    ] )->run();
+
+    $parts = collect( $this->prompter->calls[0]['message'] )->pluck( 'text' );
+    expect( $parts->contains( fn ( string $t ): bool => str_contains( $t, 'max_chars: 250' ) ) )->toBeTrue();
+} );
+
+it( 'raises FeatureError on invalid input', function (): void {
+    expect( fn () => ExcerptGenerationAgent::for( 'not-an-array' )->run() )
+        ->toThrow( FeatureError::class );
+
+    expect( fn () => ExcerptGenerationAgent::for( [ 'content' => '' ] )->run() )
+        ->toThrow( FeatureError::class );
+} );

--- a/tests/Feature/Ai/FeatureRegistrationTest.php
+++ b/tests/Feature/Ai/FeatureRegistrationTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Tests\Feature\Ai;
+
+use ArtisanPackUI\Ai\Contracts\FeatureRegistry;
+use ArtisanPackUI\CMSFramework\Ai\Agents\CategorySuggestionAgent;
+use ArtisanPackUI\CMSFramework\Ai\Agents\ExcerptGenerationAgent;
+use ArtisanPackUI\CMSFramework\Ai\Agents\PostTitleSuggestionAgent;
+use ArtisanPackUI\CMSFramework\Ai\Agents\SlugSuggestionAgent;
+use ArtisanPackUI\CMSFramework\Ai\Agents\TagSuggestionAgent;
+use ArtisanPackUI\CMSFramework\CMSFrameworkServiceProvider;
+
+it( 'declares five cms.* features from the service provider', function (): void {
+    $provider = new CMSFrameworkServiceProvider( $this->app );
+    $features = $provider->aiFeatures();
+
+    expect( $features )->toHaveKeys( [
+        'cms.post_title',
+        'cms.excerpt',
+        'cms.suggest_tags',
+        'cms.suggest_category',
+        'cms.suggest_slug',
+    ] );
+
+    expect( $features['cms.post_title']['agent'] )->toBe( PostTitleSuggestionAgent::class );
+    expect( $features['cms.excerpt']['agent'] )->toBe( ExcerptGenerationAgent::class );
+    expect( $features['cms.suggest_tags']['agent'] )->toBe( TagSuggestionAgent::class );
+    expect( $features['cms.suggest_category']['agent'] )->toBe( CategorySuggestionAgent::class );
+    expect( $features['cms.suggest_slug']['agent'] )->toBe( SlugSuggestionAgent::class );
+
+    foreach ( $features as $definition ) {
+        expect( $definition['package'] )->toBe( 'artisanpack-ui/cms-framework' );
+    }
+} );
+
+it( 'registers the five features with the FeatureRegistry at boot', function (): void {
+    /** @var FeatureRegistry $registry */
+    $registry = $this->app->make( FeatureRegistry::class );
+
+    foreach ( CMSFrameworkServiceProvider::AI_FEATURE_KEYS as $key ) {
+        expect( $registry->get( $key ) )->not->toBeNull();
+    }
+} );

--- a/tests/Feature/Ai/PostTitleSuggestionAgentTest.php
+++ b/tests/Feature/Ai/PostTitleSuggestionAgentTest.php
@@ -1,0 +1,90 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Tests\Feature\Ai;
+
+use ArtisanPackUI\Ai\Exceptions\FeatureError;
+use ArtisanPackUI\CMSFramework\Ai\Agents\PostTitleSuggestionAgent;
+
+beforeEach( function (): void {
+    $this->prompter = AiAgentTestSetup::bootstrap( $this->app );
+} );
+
+it( 'returns shaped titles when the prompter responds', function (): void {
+    $this->prompter->queue( [
+        'titles' => [
+            [ 'title' => 'How to Ship Faster', 'rationale' => 'benefit-led' ],
+            [ 'title' => 'What Makes a Great CMS?', 'rationale' => 'curiosity question' ],
+            [ 'title' => 'Ship Faster with the CMS Framework', 'rationale' => 'direct/descriptive' ],
+        ],
+    ] );
+
+    $result = PostTitleSuggestionAgent::for( [
+        'content' => 'A long draft about shipping faster with the CMS framework.',
+    ] )->run();
+
+    expect( $result['titles'] )->toHaveCount( 3 );
+    expect( $result['titles'][0]['title'] )->toBe( 'How to Ship Faster' );
+} );
+
+it( 'drops titles missing required fields', function (): void {
+    $this->prompter->queue( [
+        'titles' => [
+            [ 'title' => 'Ok', 'rationale' => 'direct' ],
+            [ 'title'     => '', 'rationale' => 'empty title' ],
+            [ 'rationale' => 'no title at all' ],
+        ],
+    ] );
+
+    $result = PostTitleSuggestionAgent::for( [ 'content' => 'body' ] )->run();
+
+    expect( $result['titles'] )->toHaveCount( 1 );
+    expect( $result['titles'][0]['title'] )->toBe( 'Ok' );
+} );
+
+it( 'clamps titles longer than 80 chars', function (): void {
+    $long = str_repeat( 'a', 120 );
+    $this->prompter->queue( [
+        'titles' => [ [ 'title' => $long, 'rationale' => 'too long' ] ],
+    ] );
+
+    $result = PostTitleSuggestionAgent::for( [ 'content' => 'body' ] )->run();
+
+    expect( mb_strlen( $result['titles'][0]['title'] ) )->toBe( 80 );
+} );
+
+it( 'honors the requested count', function (): void {
+    $queued = [ 'titles' => [] ];
+    for ( $i = 0; $i < 5; $i++ ) {
+        $queued['titles'][] = [ 'title' => "Title {$i}", 'rationale' => 'ok' ];
+    }
+    $this->prompter->queue( $queued );
+
+    $result = PostTitleSuggestionAgent::for( [
+        'content' => 'body',
+        'count'   => 3,
+    ] )->run();
+
+    expect( $result['titles'] )->toHaveCount( 3 );
+} );
+
+it( 'forwards tone into the prompter message when set', function (): void {
+    $this->prompter->queue( [ 'titles' => [ [ 'title' => 't', 'rationale' => 'r' ] ] ] );
+
+    PostTitleSuggestionAgent::for( [
+        'content' => 'body',
+        'tone'    => 'playful',
+    ] )->run();
+
+    $parts = collect( $this->prompter->calls[0]['message'] )->pluck( 'text' );
+    expect( $parts->contains( fn ( string $t ): bool => str_contains( $t, 'Tone: playful' ) ) )->toBeTrue();
+} );
+
+it( 'raises FeatureError on invalid input', function (): void {
+    expect( fn () => PostTitleSuggestionAgent::for( 'not-an-array' )->run() )
+        ->toThrow( FeatureError::class );
+
+    expect( fn () => PostTitleSuggestionAgent::for( [ 'content' => '' ] )->run() )
+        ->toThrow( FeatureError::class );
+} );

--- a/tests/Feature/Ai/SlugSuggestionAgentTest.php
+++ b/tests/Feature/Ai/SlugSuggestionAgentTest.php
@@ -34,6 +34,19 @@ it( 'sanitizes non-kebab output from the model', function (): void {
     expect( $result['slug'] )->toBe( 'how-to-ship-faster' );
 } );
 
+it( 'transliterates non-ASCII characters instead of collapsing them to hyphens', function (): void {
+    $this->prompter->queue( [
+        'slug'       => 'café-culture-año',
+        'alternates' => [],
+    ] );
+
+    $result = SlugSuggestionAgent::for( [ 'title' => 'Café Culture — Año Nuevo' ] )->run();
+
+    // A byte-oriented regex would produce 'caf-culture-a-o' or similar.
+    // Str::slug() transliterates é→e and ñ→n instead.
+    expect( $result['slug'] )->toBe( 'cafe-culture-ano' );
+} );
+
 it( 'clamps the slug to max_chars on a hyphen boundary when possible', function (): void {
     $this->prompter->queue( [
         'slug'       => 'a-b-c-d-e-f-g-h-i-j-k-l-m-n-o-p-q-r-s-t-u-v-w-x-y-z',

--- a/tests/Feature/Ai/SlugSuggestionAgentTest.php
+++ b/tests/Feature/Ai/SlugSuggestionAgentTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Tests\Feature\Ai;
+
+use ArtisanPackUI\Ai\Exceptions\FeatureError;
+use ArtisanPackUI\CMSFramework\Ai\Agents\SlugSuggestionAgent;
+
+beforeEach( function (): void {
+    $this->prompter = AiAgentTestSetup::bootstrap( $this->app );
+} );
+
+it( 'returns the model slug and any alternates', function (): void {
+    $this->prompter->queue( [
+        'slug'       => 'ship-faster-cms',
+        'alternates' => [ 'faster-cms', 'cms-shipping' ],
+    ] );
+
+    $result = SlugSuggestionAgent::for( [ 'title' => 'How to Ship Faster with the CMS' ] )->run();
+
+    expect( $result['slug'] )->toBe( 'ship-faster-cms' );
+    expect( $result['alternates'] )->toBe( [ 'faster-cms', 'cms-shipping' ] );
+} );
+
+it( 'sanitizes non-kebab output from the model', function (): void {
+    $this->prompter->queue( [
+        'slug'       => 'How To_Ship__Faster!!',
+        'alternates' => [],
+    ] );
+
+    $result = SlugSuggestionAgent::for( [ 'title' => 'Anything' ] )->run();
+
+    expect( $result['slug'] )->toBe( 'how-to-ship-faster' );
+} );
+
+it( 'clamps the slug to max_chars on a hyphen boundary when possible', function (): void {
+    $this->prompter->queue( [
+        'slug'       => 'a-b-c-d-e-f-g-h-i-j-k-l-m-n-o-p-q-r-s-t-u-v-w-x-y-z',
+        'alternates' => [],
+    ] );
+
+    $result = SlugSuggestionAgent::for( [
+        'title'     => 'title',
+        'max_chars' => 20,
+    ] )->run();
+
+    expect( strlen( $result['slug'] ) )->toBeLessThanOrEqual( 20 );
+    expect( str_ends_with( $result['slug'], '-' ) )->toBeFalse();
+} );
+
+it( 'drops alternates that duplicate the primary slug or each other', function (): void {
+    $this->prompter->queue( [
+        'slug'       => 'ship-faster',
+        'alternates' => [ 'ship-faster', 'faster-shipping', 'faster-shipping' ],
+    ] );
+
+    $result = SlugSuggestionAgent::for( [ 'title' => 't' ] )->run();
+
+    expect( $result['alternates'] )->toBe( [ 'faster-shipping' ] );
+} );
+
+it( 'raises FeatureError on invalid input', function (): void {
+    expect( fn () => SlugSuggestionAgent::for( 'nope' )->run() )->toThrow( FeatureError::class );
+
+    expect( fn () => SlugSuggestionAgent::for( [ 'title' => '' ] )->run() )
+        ->toThrow( FeatureError::class );
+} );

--- a/tests/Feature/Ai/TagSuggestionAgentTest.php
+++ b/tests/Feature/Ai/TagSuggestionAgentTest.php
@@ -1,0 +1,109 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Tests\Feature\Ai;
+
+use ArtisanPackUI\Ai\Exceptions\FeatureError;
+use ArtisanPackUI\CMSFramework\Ai\Agents\TagSuggestionAgent;
+
+beforeEach( function (): void {
+    $this->prompter = AiAgentTestSetup::bootstrap( $this->app );
+} );
+
+it( 'returns only tags that appear in available_tags', function (): void {
+    $this->prompter->queue( [
+        'selected' => [
+            [ 'tag' => 'laravel', 'confidence' => 0.9 ],
+            [ 'tag' => 'not-a-real-tag', 'confidence' => 0.7 ], // must be dropped
+            [ 'tag' => 'cms', 'confidence' => 0.6 ],
+        ],
+    ] );
+
+    $result = TagSuggestionAgent::for( [
+        'content'        => 'post body',
+        'available_tags' => [ 'laravel', 'cms', 'php' ],
+    ] )->run();
+
+    expect( $result['selected'] )->toHaveCount( 2 );
+    expect( collect( $result['selected'] )->pluck( 'tag' )->all() )->toBe( [ 'laravel', 'cms' ] );
+} );
+
+it( 'omits suggested_new when allow_new is false', function (): void {
+    $this->prompter->queue( [
+        'selected'      => [],
+        'suggested_new' => [ 'brand-new-tag' ],
+    ] );
+
+    $result = TagSuggestionAgent::for( [
+        'content'        => 'body',
+        'available_tags' => [ 'a' ],
+    ] )->run();
+
+    expect( $result )->not->toHaveKey( 'suggested_new' );
+} );
+
+it( 'returns suggested_new when allow_new is true, dropping duplicates', function (): void {
+    $this->prompter->queue( [
+        'selected'      => [],
+        'suggested_new' => [
+            'brand-new-tag',
+            'Laravel', // already exists case-insensitively
+            'brand-new-tag', // duplicate within response
+            'another-new',
+        ],
+    ] );
+
+    $result = TagSuggestionAgent::for( [
+        'content'        => 'body',
+        'available_tags' => [ 'laravel' ],
+        'allow_new'      => true,
+    ] )->run();
+
+    expect( $result['suggested_new'] )->toBe( [ 'brand-new-tag', 'another-new' ] );
+} );
+
+it( 'clamps confidences to [0, 1]', function (): void {
+    $this->prompter->queue( [
+        'selected' => [
+            [ 'tag' => 'a', 'confidence' => 1.7 ],
+            [ 'tag' => 'b', 'confidence' => -0.3 ],
+        ],
+    ] );
+
+    $result = TagSuggestionAgent::for( [
+        'content'        => 'body',
+        'available_tags' => [ 'a', 'b' ],
+    ] )->run();
+
+    expect( $result['selected'][0]['confidence'] )->toBe( 1.0 );
+    expect( $result['selected'][1]['confidence'] )->toBe( 0.0 );
+} );
+
+it( 'honors max_selected', function (): void {
+    $this->prompter->queue( [
+        'selected' => [
+            [ 'tag' => 'a', 'confidence' => 1.0 ],
+            [ 'tag' => 'b', 'confidence' => 0.9 ],
+            [ 'tag' => 'c', 'confidence' => 0.8 ],
+        ],
+    ] );
+
+    $result = TagSuggestionAgent::for( [
+        'content'        => 'body',
+        'available_tags' => [ 'a', 'b', 'c' ],
+        'max_selected'   => 2,
+    ] )->run();
+
+    expect( $result['selected'] )->toHaveCount( 2 );
+} );
+
+it( 'raises FeatureError on invalid input', function (): void {
+    expect( fn () => TagSuggestionAgent::for( 'nope' )->run() )->toThrow( FeatureError::class );
+
+    expect( fn () => TagSuggestionAgent::for( [ 'available_tags' => [] ] )->run() )
+        ->toThrow( FeatureError::class );
+
+    expect( fn () => TagSuggestionAgent::for( [ 'content' => 'ok' ] )->run() )
+        ->toThrow( FeatureError::class );
+} );

--- a/tests/Feature/Ai/TagSuggestionAgentTest.php
+++ b/tests/Feature/Ai/TagSuggestionAgentTest.php
@@ -29,6 +29,22 @@ it( 'returns only tags that appear in available_tags', function (): void {
     expect( collect( $result['selected'] )->pluck( 'tag' )->all() )->toBe( [ 'laravel', 'cms' ] );
 } );
 
+it( 'trims incidental whitespace from model-returned tags before allow-list lookup', function (): void {
+    $this->prompter->queue( [
+        'selected' => [
+            [ 'tag' => 'laravel ', 'confidence' => 0.9 ],
+            [ 'tag' => "\tcms\n", 'confidence' => 0.8 ],
+        ],
+    ] );
+
+    $result = TagSuggestionAgent::for( [
+        'content'        => 'body',
+        'available_tags' => [ 'laravel', 'cms' ],
+    ] )->run();
+
+    expect( collect( $result['selected'] )->pluck( 'tag' )->all() )->toBe( [ 'laravel', 'cms' ] );
+} );
+
 it( 'omits suggested_new when allow_new is false', function (): void {
     $this->prompter->queue( [
         'selected'      => [],

--- a/tests/Support/FakeAgentPrompter.php
+++ b/tests/Support/FakeAgentPrompter.php
@@ -1,0 +1,93 @@
+<?php
+
+/**
+ * Test fake for the AgentPrompter contract.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage CMSFramework
+ *
+ * @since      2.3.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Tests\Support;
+
+use ArtisanPackUI\Ai\Contracts\AgentPrompter;
+use ArtisanPackUI\Ai\Credentials\Credentials;
+
+/**
+ * Records every prompter call and returns queued responses in FIFO
+ * order. Mirrors the fakes shipped by the ai package's own suite and
+ * by visual-editor.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage CMSFramework
+ *
+ * @since      2.3.0
+ */
+final class FakeAgentPrompter implements AgentPrompter
+{
+    /**
+     * Recorded calls, in invocation order.
+     *
+     * @var array<int, array<string, mixed>>
+     */
+    public array $calls = [];
+
+    /**
+     * Queued responses (FIFO).
+     *
+     * @var array<int, array<string, mixed>>
+     */
+    private array $queue = [];
+
+    /**
+     * Push a canned response onto the queue.
+     *
+     * @since 2.3.0
+     *
+     * @param  array<string, mixed>  $output        Structured output body.
+     * @param  int                   $inputTokens   Reported input tokens.
+     * @param  int                   $outputTokens  Reported output tokens.
+     *
+     * @return void
+     */
+    public function queue( array $output, int $inputTokens = 100, int $outputTokens = 50 ): void
+    {
+        $this->queue[] = [
+            'output'        => $output,
+            'input_tokens'  => $inputTokens,
+            'output_tokens' => $outputTokens,
+        ];
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function prompt(
+        Credentials $credentials,
+        string $model,
+        string $instructions,
+        string|array $message,
+        array $outputSchema,
+    ): array {
+        $this->calls[] = [
+            'credentials'   => $credentials,
+            'model'         => $model,
+            'instructions'  => $instructions,
+            'message'       => $message,
+            'output_schema' => $outputSchema,
+        ];
+
+        if ( [] === $this->queue ) {
+            return [
+                'output'        => [],
+                'input_tokens'  => 0,
+                'output_tokens' => 0,
+            ];
+        }
+
+        return array_shift( $this->queue );
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -10,6 +10,7 @@ declare( strict_types=1 );
 
 namespace ArtisanPackUI\CMSFramework\Tests;
 
+use ArtisanPackUI\Ai\AiServiceProvider;
 use ArtisanPackUI\CMSFramework\CMSFrameworkServiceProvider;
 use ArtisanPackUI\CMSFramework\Tests\Support\TestUser;
 use ArtisanPackUI\Hooks\Providers\HooksServiceProvider;
@@ -59,6 +60,7 @@ class TestCase extends \Orchestra\Testbench\TestCase
             SanctumServiceProvider::class,
             CMSFrameworkServiceProvider::class,
             HooksServiceProvider::class,
+            AiServiceProvider::class,
         ];
     }
 

--- a/tests/Unit/OpenApi/OpenApiServiceProviderTest.php
+++ b/tests/Unit/OpenApi/OpenApiServiceProviderTest.php
@@ -36,7 +36,7 @@ test( 'openapi config has default values', function (): void {
 
     expect( $config['enabled'] )->toBeTrue();
     expect( $config['info']['title'] )->toBe( 'ArtisanPack CMS Framework API' );
-    expect( $config['info']['version'] )->toBe( '2.2.3' );
+    expect( $config['info']['version'] )->toBe( '2.3.0' );
     expect( $config['ui_path'] )->toBe( '/docs/api/cms' );
     expect( $config['document_path'] )->toBe( '/docs/api/cms.json' );
 } );


### PR DESCRIPTION
## Release Information

- **Release Version:** v2.3.0
- **Release Date:** 2026-07-09
- **Release Type:** Minor
- **Release Branch:** `release/2.3.0`
- **Target Branch:** `main`

## Release Summary

This release adds a full **AI content-authoring surface** to the CMS Framework: five agents that generate post titles, excerpts, tag/category picks, and SEO-friendly slugs on top of the shared `artisanpack-ui/ai` foundation.

The key design decision is transport-first: the same five agents are reachable through a Livewire component (`ap-cms-ai-tools`) AND a REST controller (`/api/v1/cms/ai/*`), so React and Vue front-ends consume them via plain HTTP without any changes to `@artisanpack-ui/react` or `@artisanpack-ui/vue`. Adding a new CMS AI feature never requires touching those shared packages.

## Changelog

### Added

- **Five AI content-authoring agents** built on `artisanpack-ui/ai` v1.0:
  - `cms.post_title` — `PostTitleSuggestionAgent`
  - `cms.excerpt` — `ExcerptGenerationAgent`
  - `cms.suggest_tags` — `TagSuggestionAgent`
  - `cms.suggest_category` — `CategorySuggestionAgent`
  - `cms.suggest_slug` — `SlugSuggestionAgent`
- **Livewire trigger surface** — `ap-cms-ai-tools` component dispatching `ap-cms-ai:{featureKey}:{status}` browser events.
- **REST trigger surface** — `AiController` mounted at `/api/v1/cms/ai/*` under `auth:sanctum` for React/Vue SPAs.
- **`CMSFrameworkServiceProvider::AI_FEATURE_KEYS`** constant — canonical list consumed by both trigger surfaces.
- **`docs/AI-Features.md`** — new documentation page covering feature keys, install, trigger surfaces, per-agent contracts, and extension points.

### Changed

- **Minimum PHP raised to 8.3.** The `artisanpack-ui/ai` foundation requires PHP 8.3+, and there is no composer resolution that satisfies both constraints on 8.2 — hosts still on PHP 8.2 should stay on the 2.2.x line. Aligns with the same choice other ecosystem packages made when picking up the AI foundation.
- `artisanpack-ui/ai ^1.0` added as `suggest` + `require-dev`. Without it the AI surfaces stay unregistered and the framework boots normally.
- Bumped OpenAPI info `version` fallback from `2.2.3` to `2.3.0`.

### Security

- Patched `guzzlehttp/guzzle` (7.11.1 → 7.14.0) and `guzzlehttp/psr7` (2.11.0 → 2.12.4) to close three medium-severity CVEs (CVE-2026-55767 dot-only cookie domains, CVE-2026-55568 silent HTTPS proxy downgrade, CVE-2026-55766 CRLF injection in HTTP start-line). Post-patch `composer audit` is clean.

## Issues and Pull Requests

**Issues Fixed:**
- Closes #170 (PostTitleSuggestionAgent)
- Closes #171 (ExcerptGenerationAgent)
- Closes #172 (TagSuggestionAgent)
- Closes #173 (CategorySuggestionAgent)
- Closes #174 (SlugSuggestionAgent)

**Related PRs:**
- #175 — feat(ai): add five CMS content-authoring AI agents

**Follow-ups filed:**
- ArtisanPack-UI/ai#43 — Extract shared AI feature-response handler trait
- ArtisanPack-UI/ai#44 — Move `FakeAgentPrompter` to `src/Testing/`
- #176 — Consume feature keys from agent `$featureKey` instead of hardcoding

## Breaking Changes

- [x] Breaking changes documented below

**Breaking changes:**

- **PHP 8.2 support dropped.** New minimum is PHP 8.3. This is a support-window change, not an API change — the codebase itself does not require 8.3-only syntax and hosts on 8.3+ upgrade in place.

**Migration guide:**

- Hosts on PHP 8.2: stay on the 2.2.x line (still receives bug/security patches) until the runtime can be upgraded.
- Hosts on PHP 8.3+: `composer require artisanpack-ui/cms-framework:^2.3` upgrades cleanly. To enable the new AI features, additionally `composer require artisanpack-ui/ai:^1.0`.

## Testing Checklist

- [x] All automated tests passing (**1026 pass / 7 skip / 0 fail**)
- [x] Manual testing completed via `ai-issues-test` surfaces in the dev app for all five agents (happy, noisy, edge modes)
- [x] Accessibility tests passing — n/a for this release (backend-only)
- [x] Security scan completed — post-patch `composer audit`: 0 vulnerabilities
- [ ] Tested in staging environment
- [x] Database migrations tested — no migrations in this release

**Testing notes:**

Post-review, additional correctness fixes were pushed onto #175 before merge:
- Route guard `auth` → `auth:sanctum` so Sanctum SPAs actually authenticate.
- `TagSuggestionAgent::validateOutput` trims model-returned tags before allow-list lookup.
- `SlugSuggestionAgent::sanitizeSlug` delegates to `Str::slug()` — non-ASCII now transliterates instead of collapsing to hyphens.
- `CategorySuggestionAgent::collectPaths` rejects nodes with `/` in the name to prevent path collisions.

Three regression tests cover each of the last three.

CI matrix is now `[8.3, 8.4]`. `phpunit.xml` splits tests into Unit / Feature / Ai suites so hosts that opt out of `artisanpack-ui/ai` can skip the AI-only tests without losing Feature coverage.

## Documentation Checklist

- [x] CHANGELOG updated
- [x] README updated in #175 (AI Features section) and this PR (PHP requirement)
- [x] API documentation updated (`docs/AI-Features.md` added, linked from `docs/home.md`)
- [x] Migration guide written — support-window change only, see above
- [x] Release notes written (this PR body)
- [x] Wiki updated — auto-synced from `docs/` on merge

## Pre-Release Checklist

- [x] Version number updated in all necessary files (`composer.json`, `config/cms-framework.php`, `OpenApiServiceProvider`, test)
- [x] Git tag prepared: `v2.3.0` (created on merge)
- [x] Release branch created: `release/2.3.0`
- [x] Dependencies updated and tested (`composer update --lock`; targeted guzzle patch; full suite green)
- [x] Build artifacts generated — n/a (library package)
- [x] Deployment plan reviewed — see below
- [x] Rollback plan prepared — see below
- [ ] Stakeholders notified

## Deployment

**Deployment steps:**
1. Merge this PR into `main`
2. Tag `v2.3.0` on the merge commit
3. Push tag; Packagist picks it up automatically

**Rollback plan:**
1. Delete the `v2.3.0` tag on GitHub + Packagist
2. Revert the merge commit on `main`
3. Publish `2.3.1` with the revert

**Configuration changes:**
- None required. Hosts that want the AI features install `artisanpack-ui/ai:^1.0` explicitly.

**Environment variables:**
- None added by this release. AI credentials are configured through the `artisanpack-ui/ai` package.

## Post-Release Tasks

- [ ] Tag created: `v2.3.0`
- [ ] Release notes published
- [ ] Documentation deployed
- [ ] Announcement sent
- [ ] Monitoring verified
- [ ] Previous version support documented — 2.2.x line continues to receive bug/security patches for PHP 8.2 hosts

## Notes

**Outdated dependencies (informational only, not blocking):**
- `laravel/framework` 12.62.0 → 13.19.0 available (major, out of scope)
- `livewire/livewire` 3.8.2 → 4.3.3 available (major, tracked separately)
- `pestphp/pest` 3.8.6 → 4.7.5 available (major, dev-only)
- Several minor updates available for direct deps; deferred to a chore PR post-release.

---

**Release Manager:** @jacobmartella