### PR TITLE
feat(dynamic-content): add data model, resolver, and admin surface (#178)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
       "src/Modules/Users/helpers.php",
       "src/Modules/Admin/helpers.php",
       "src/Modules/Core/helpers.php",
-      "src/Modules/Settings/helpers.php"
+      "src/Modules/Settings/helpers.php",
+      "src/Modules/DynamicContent/helpers.php"
     ]
   },
   "autoload-dev": {

--- a/src/CMSFrameworkServiceProvider.php
+++ b/src/CMSFrameworkServiceProvider.php
@@ -28,6 +28,7 @@ use ArtisanPackUI\CMSFramework\Modules\Blog\Providers\BlogServiceProvider;
 use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Managers\ContentTypeManager;
 use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Providers\ContentTypesServiceProvider;
 use ArtisanPackUI\CMSFramework\Modules\Core\Providers\CoreServiceProvider;
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Providers\DynamicContentServiceProvider;
 use ArtisanPackUI\CMSFramework\Modules\Notifications\Providers\NotificationServiceProvider;
 use ArtisanPackUI\CMSFramework\Modules\OpenApi\Providers\OpenApiServiceProvider;
 use ArtisanPackUI\CMSFramework\Modules\Pages\Models\Page;
@@ -236,6 +237,7 @@ class CMSFrameworkServiceProvider extends ServiceProvider
         $this->app->register( SettingsServiceProvider::class );
         $this->app->register( NotificationServiceProvider::class );
         $this->app->register( ContentTypesServiceProvider::class );
+        $this->app->register( DynamicContentServiceProvider::class );
         $this->app->register( BlogServiceProvider::class );
         $this->app->register( PagesServiceProvider::class );
         $this->app->register( ThemesServiceProvider::class );

--- a/src/Modules/ContentTypes/Models/Concerns/HasRenderedBlockContent.php
+++ b/src/Modules/ContentTypes/Models/Concerns/HasRenderedBlockContent.php
@@ -117,6 +117,32 @@ trait HasRenderedBlockContent
             }
         }
 
-        return is_string( $content ) ? $content : '';
+        $rendered = is_string( $content ) ? $content : '';
+
+        return $this->resolveDynamicContentTokens( $rendered );
+    }
+
+    /**
+     * Pass rendered content through the dynamic-content resolver when the
+     * DynamicContent module is loaded. Kept as a soft integration so this
+     * trait doesn't hard-depend on the DynamicContent module.
+     *
+     * @since 2.4.0
+     */
+    protected function resolveDynamicContentTokens( string $rendered ): string
+    {
+        if ( '' === $rendered || ! function_exists( 'apRenderContent' ) ) {
+            return $rendered;
+        }
+
+        try {
+            return apRenderContent( $rendered, [
+                'model'    => static::class,
+                'model_id' => $this->getKey(),
+            ] );
+        } catch ( Throwable ) {
+            // Never let a resolver failure hide the underlying content.
+            return $rendered;
+        }
     }
 }

--- a/src/Modules/DynamicContent/Casts/DynamicContentCast.php
+++ b/src/Modules/DynamicContent/Casts/DynamicContentCast.php
@@ -1,0 +1,62 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Modules\DynamicContent\Casts;
+
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Services\DynamicContentResolver;
+use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * Eloquent cast that auto-resolves dynamic-content tokens on attribute access.
+ *
+ * Usage in a model:
+ *   protected function casts(): array {
+ *       return [ 'body' => DynamicContentCast::class ];
+ *   }
+ *
+ * SECURITY: dynamic content is a **public content pipeline** by design —
+ * every record and every field is readable by anyone who can write a
+ * token to a casted attribute. Do NOT store secrets (API keys, credentials,
+ * private user data) in dynamic content records. If a low-trust author can
+ * write to a casted attribute, they can render any dynamic-content field
+ * into the resolved output. Restrict `manage_dynamic_content` accordingly
+ * and keep sensitive configuration in {@see \ArtisanPackUI\CMSFramework\Modules\Settings\Models\Setting}
+ * or environment variables instead.
+ *
+ * The resolver escapes text-shaped field values at render time (see
+ * {@see \ArtisanPackUI\CMSFramework\Modules\DynamicContent\FieldTypes\AbstractFieldType})
+ * — rich-text fields are NOT escaped because that's their point. Hosts
+ * accepting untrusted rich-text authors must sanitize at save time
+ * (e.g. via `artisanpack-ui/security`'s `kses()` helper).
+ *
+ * @implements CastsAttributes<string, string>
+ *
+ * @since 2.4.0
+ */
+class DynamicContentCast implements CastsAttributes
+{
+    /**
+     * @param  array<string, mixed>  $attributes
+     */
+    public function get( Model $model, string $key, mixed $value, array $attributes ): ?string
+    {
+        if ( null === $value ) {
+            return null;
+        }
+
+        return app( DynamicContentResolver::class )->render(
+            (string) $value,
+            [ 'model' => $model::class, 'model_id' => $model->getKey(), 'attribute' => $key ],
+        );
+    }
+
+    /**
+     * @param  array<string, mixed>  $attributes
+     */
+    public function set( Model $model, string $key, mixed $value, array $attributes ): mixed
+    {
+        return $value;
+    }
+}

--- a/src/Modules/DynamicContent/Casts/RecordValueCast.php
+++ b/src/Modules/DynamicContent/Casts/RecordValueCast.php
@@ -1,0 +1,49 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Modules\DynamicContent\Casts;
+
+use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * Cast for {@see \ArtisanPackUI\CMSFramework\Modules\DynamicContent\Models\DynamicContentRecordValue}
+ * that transparently round-trips scalars, arrays, and null through the JSON
+ * column without a sentinel wrapper.
+ *
+ * Storage rules:
+ *   - null                        → SQL NULL
+ *   - scalar (string|int|float|bool) → its JSON-encoded literal (`"foo"`, `42`, `true`)
+ *   - array                       → its JSON-encoded object/array
+ *
+ * @implements CastsAttributes<mixed, mixed>
+ *
+ * @since 2.4.0
+ */
+class RecordValueCast implements CastsAttributes
+{
+    public function get( Model $model, string $key, mixed $value, array $attributes ): mixed
+    {
+        if ( null === $value ) {
+            return null;
+        }
+
+        if ( ! is_string( $value ) ) {
+            return $value;
+        }
+
+        $decoded = json_decode( $value, true );
+
+        return JSON_ERROR_NONE === json_last_error() ? $decoded : $value;
+    }
+
+    public function set( Model $model, string $key, mixed $value, array $attributes ): mixed
+    {
+        if ( null === $value ) {
+            return null;
+        }
+
+        return json_encode( $value );
+    }
+}

--- a/src/Modules/DynamicContent/Contracts/FieldType.php
+++ b/src/Modules/DynamicContent/Contracts/FieldType.php
@@ -1,0 +1,40 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Modules\DynamicContent\Contracts;
+
+use Illuminate\Support\HtmlString;
+
+/**
+ * Contract for a dynamic-content field type.
+ *
+ * @since 2.4.0
+ */
+interface FieldType
+{
+    /**
+     * The type slug (e.g. "text", "email", "image").
+     */
+    public function slug(): string;
+
+    /**
+     * The human label used in the admin UI.
+     */
+    public function label(): string;
+
+    /**
+     * Cast a raw stored value into its runtime representation.
+     */
+    public function cast( mixed $value, array $options = [] ): mixed;
+
+    /**
+     * Render the value as HTML-safe output.
+     *
+     * Implementations MUST return output that is safe to echo into an HTML
+     * context — either intentionally-authored HTML (rich text) or escaped
+     * plain text. Callers echo the result raw via `@dynamicContent`, so
+     * anything unsafe returned here is a stored-XSS sink.
+     */
+    public function render( mixed $value, array $options = [] ): HtmlString;
+}

--- a/src/Modules/DynamicContent/Contracts/Modifier.php
+++ b/src/Modules/DynamicContent/Contracts/Modifier.php
@@ -1,0 +1,22 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Modules\DynamicContent\Contracts;
+
+/**
+ * Contract for a token modifier (e.g. `|upper`, `|truncate:100`).
+ *
+ * @since 2.4.0
+ */
+interface Modifier
+{
+    public function slug(): string;
+
+    /**
+     * Apply the modifier to a value.
+     *
+     * @param  array<int, string>  $args
+     */
+    public function apply( mixed $value, array $args ): mixed;
+}

--- a/src/Modules/DynamicContent/Enums/Cardinality.php
+++ b/src/Modules/DynamicContent/Enums/Cardinality.php
@@ -1,0 +1,16 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Modules\DynamicContent\Enums;
+
+/**
+ * Cardinality of a dynamic content type.
+ *
+ * @since 2.4.0
+ */
+enum Cardinality: string
+{
+    case Singleton  = 'singleton';
+    case Collection = 'collection';
+}

--- a/src/Modules/DynamicContent/Enums/Source.php
+++ b/src/Modules/DynamicContent/Enums/Source.php
@@ -1,0 +1,16 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Modules\DynamicContent\Enums;
+
+/**
+ * Source of a dynamic content type registration.
+ *
+ * @since 2.4.0
+ */
+enum Source: string
+{
+    case Db   = 'db';
+    case Code = 'code';
+}

--- a/src/Modules/DynamicContent/FieldTypes/AbstractFieldType.php
+++ b/src/Modules/DynamicContent/FieldTypes/AbstractFieldType.php
@@ -1,0 +1,46 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Modules\DynamicContent\FieldTypes;
+
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Contracts\FieldType;
+use Illuminate\Support\HtmlString;
+
+/**
+ * Shared behavior for built-in text-shaped field types.
+ *
+ * Renders scalar values as HTML-escaped strings so the resolver's raw
+ * output path can't leak stored XSS. Field types that emit intentional
+ * HTML (rich text) or safe URLs override `render()`.
+ *
+ * @since 2.4.0
+ */
+abstract class AbstractFieldType implements FieldType
+{
+    public function cast( mixed $value, array $options = [] ): mixed
+    {
+        return $value;
+    }
+
+    public function render( mixed $value, array $options = [] ): HtmlString
+    {
+        if ( $value instanceof HtmlString ) {
+            return $value;
+        }
+
+        if ( null === $value ) {
+            return new HtmlString( '' );
+        }
+
+        if ( is_bool( $value ) ) {
+            return new HtmlString( $value ? '1' : '0' );
+        }
+
+        if ( is_scalar( $value ) ) {
+            return new HtmlString( e( (string) $value ) );
+        }
+
+        return new HtmlString( '' );
+    }
+}

--- a/src/Modules/DynamicContent/FieldTypes/AddressFieldType.php
+++ b/src/Modules/DynamicContent/FieldTypes/AddressFieldType.php
@@ -1,0 +1,44 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Modules\DynamicContent\FieldTypes;
+
+use Illuminate\Support\HtmlString;
+
+/**
+ * Compound address field.
+ *
+ * Value shape:
+ *   [ 'line1' => ..., 'line2' => ..., 'city' => ..., 'region' => ..., 'postal_code' => ..., 'country' => ... ]
+ *
+ * @since 2.4.0
+ */
+class AddressFieldType extends AbstractFieldType
+{
+    public function slug(): string
+    {
+        return 'address';
+    }
+
+    public function label(): string
+    {
+        return __( 'Address' );
+    }
+
+    public function render( mixed $value, array $options = [] ): HtmlString
+    {
+        if ( ! is_array( $value ) ) {
+            return new HtmlString( '' );
+        }
+
+        $parts = array_filter( [
+            $value['line1'] ?? null,
+            $value['line2'] ?? null,
+            trim( ( $value['city'] ?? '' ) . ', ' . ( $value['region'] ?? '' ) . ' ' . ( $value['postal_code'] ?? '' ) ),
+            $value['country'] ?? null,
+        ], fn ( $part ) => null !== $part && '' !== trim( (string) $part, ', ' ) );
+
+        return new HtmlString( e( implode( ', ', $parts ) ) );
+    }
+}

--- a/src/Modules/DynamicContent/FieldTypes/ImageFieldType.php
+++ b/src/Modules/DynamicContent/FieldTypes/ImageFieldType.php
@@ -1,0 +1,58 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Modules\DynamicContent\FieldTypes;
+
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\HtmlString;
+
+/**
+ * Image field: value is a media library id.
+ *
+ * When rendered as a token, resolves to the media URL (default size),
+ * HTML-escaped so it's safe in an attribute context.
+ * Block-binding integrations consume the raw media id directly.
+ *
+ * @since 2.4.0
+ */
+class ImageFieldType extends AbstractFieldType
+{
+    public function slug(): string
+    {
+        return 'image';
+    }
+
+    public function label(): string
+    {
+        return __( 'Image' );
+    }
+
+    public function render( mixed $value, array $options = [] ): HtmlString
+    {
+        if ( null === $value || '' === $value ) {
+            return new HtmlString( '' );
+        }
+
+        $mediaId = is_numeric( $value ) ? (int) $value : null;
+
+        if ( null === $mediaId ) {
+            return new HtmlString( '' );
+        }
+
+        if ( ! function_exists( 'apGetMediaUrl' ) ) {
+            Log::channel(
+                config( 'logging.channels.dynamic-content' ) ? 'dynamic-content' : 'stack',
+            )->warning(
+                'Dynamic content: image field rendered but apGetMediaUrl() is unavailable — media-library package likely missing',
+                [ 'media_id' => $mediaId ],
+            );
+
+            return new HtmlString( '' );
+        }
+
+        $url = apGetMediaUrl( $mediaId, $options['size'] ?? 'full' );
+
+        return new HtmlString( null === $url ? '' : e( (string) $url ) );
+    }
+}

--- a/src/Modules/DynamicContent/FieldTypes/NumberFieldType.php
+++ b/src/Modules/DynamicContent/FieldTypes/NumberFieldType.php
@@ -1,0 +1,27 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Modules\DynamicContent\FieldTypes;
+
+class NumberFieldType extends AbstractFieldType
+{
+    public function slug(): string
+    {
+        return 'number';
+    }
+
+    public function label(): string
+    {
+        return __( 'Number' );
+    }
+
+    public function cast( mixed $value, array $options = [] ): mixed
+    {
+        if ( null === $value || '' === $value ) {
+            return null;
+        }
+
+        return is_numeric( $value ) ? $value + 0 : null;
+    }
+}

--- a/src/Modules/DynamicContent/FieldTypes/RichTextFieldType.php
+++ b/src/Modules/DynamicContent/FieldTypes/RichTextFieldType.php
@@ -1,0 +1,43 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Modules\DynamicContent\FieldTypes;
+
+use Illuminate\Support\HtmlString;
+
+/**
+ * Rich-text field: content is author-supplied HTML. Not escaped on render.
+ *
+ * If a host application accepts untrusted authors for this field type, it
+ * must sanitize the input at save time (e.g. via `artisanpack-ui/security`'s
+ * `kses()` helper) before it reaches the resolver — see the security note
+ * on {@see \ArtisanPackUI\CMSFramework\Modules\DynamicContent\Casts\DynamicContentCast}.
+ *
+ * @since 2.4.0
+ */
+class RichTextFieldType extends AbstractFieldType
+{
+    public function slug(): string
+    {
+        return 'rich_text';
+    }
+
+    public function label(): string
+    {
+        return __( 'Rich Text' );
+    }
+
+    public function render( mixed $value, array $options = [] ): HtmlString
+    {
+        if ( $value instanceof HtmlString ) {
+            return $value;
+        }
+
+        if ( null === $value || ! is_scalar( $value ) ) {
+            return new HtmlString( '' );
+        }
+
+        return new HtmlString( (string) $value );
+    }
+}

--- a/src/Modules/DynamicContent/FieldTypes/ScalarFieldType.php
+++ b/src/Modules/DynamicContent/FieldTypes/ScalarFieldType.php
@@ -1,0 +1,33 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Modules\DynamicContent\FieldTypes;
+
+/**
+ * Data-driven field type for plain scalar values.
+ *
+ * Text, email, phone, URL, date, datetime, and select all share the same
+ * "cast raw, render escaped" behavior — this class holds them so we don't
+ * ship seven byte-identical shells.
+ *
+ * @since 2.4.0
+ */
+class ScalarFieldType extends AbstractFieldType
+{
+    public function __construct(
+        protected string $slug,
+        protected string $translationKey,
+    ) {
+    }
+
+    public function slug(): string
+    {
+        return $this->slug;
+    }
+
+    public function label(): string
+    {
+        return __( $this->translationKey );
+    }
+}

--- a/src/Modules/DynamicContent/Http/Controllers/DynamicContentRecordController.php
+++ b/src/Modules/DynamicContent/Http/Controllers/DynamicContentRecordController.php
@@ -1,0 +1,72 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Modules\DynamicContent\Http\Controllers;
+
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Http\Requests\DynamicContentRecordRequest;
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Http\Resources\DynamicContentRecordResource;
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Managers\DynamicContentRecordManager;
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Models\DynamicContentRecord;
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Models\DynamicContentType;
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
+use Illuminate\Http\Response;
+use Illuminate\Routing\Controller;
+
+class DynamicContentRecordController extends Controller
+{
+    use AuthorizesRequests;
+
+    public function __construct( protected DynamicContentRecordManager $manager )
+    {
+    }
+
+    public function index( DynamicContentType $type ): AnonymousResourceCollection
+    {
+        $this->authorize( 'viewAnyForType', [ DynamicContentRecord::class, $type ] );
+
+        $records = $type->records()->with( 'values.field', 'type.fields' )->get();
+
+        return DynamicContentRecordResource::collection( $records );
+    }
+
+    public function store( DynamicContentRecordRequest $request, DynamicContentType $type ): DynamicContentRecordResource
+    {
+        $this->authorize( 'createForType', [ DynamicContentRecord::class, $type ] );
+
+        return new DynamicContentRecordResource( $this->manager->create( $type, $request->validated() ) );
+    }
+
+    public function show( DynamicContentType $type, DynamicContentRecord $record ): DynamicContentRecordResource
+    {
+        $this->authorize( 'view', $record );
+
+        abort_unless( $record->dynamic_content_type_id === $type->id, 404 );
+
+        return new DynamicContentRecordResource( $record->load( 'values.field', 'type.fields' ) );
+    }
+
+    public function update(
+        DynamicContentRecordRequest $request,
+        DynamicContentType $type,
+        DynamicContentRecord $record,
+    ): DynamicContentRecordResource {
+        $this->authorize( 'update', $record );
+
+        abort_unless( $record->dynamic_content_type_id === $type->id, 404 );
+
+        return new DynamicContentRecordResource( $this->manager->update( $record, $request->validated() ) );
+    }
+
+    public function destroy( DynamicContentType $type, DynamicContentRecord $record ): Response
+    {
+        $this->authorize( 'delete', $record );
+
+        abort_unless( $record->dynamic_content_type_id === $type->id, 404 );
+
+        $this->manager->delete( $record );
+
+        return response()->noContent();
+    }
+}

--- a/src/Modules/DynamicContent/Http/Controllers/DynamicContentResolverController.php
+++ b/src/Modules/DynamicContent/Http/Controllers/DynamicContentResolverController.php
@@ -1,0 +1,46 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Modules\DynamicContent\Http\Controllers;
+
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Models\DynamicContentType;
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Services\DynamicContentResolver;
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Routing\Controller;
+
+class DynamicContentResolverController extends Controller
+{
+    use AuthorizesRequests;
+
+    /**
+     * Cap on the size of a single preview payload.
+     *
+     * 65 KB is generous for post bodies + templates but short-circuits
+     * any megabyte-scale token-bomb payload before the resolver's
+     * `preg_replace_callback` gets to iterate.
+     */
+    public const MAX_CONTENT_LENGTH = 65_535;
+
+    public function __construct( protected DynamicContentResolver $resolver )
+    {
+    }
+
+    public function resolve( Request $request ): JsonResponse
+    {
+        $this->authorize( 'viewAny', DynamicContentType::class );
+
+        $validated = $request->validate( [
+            'content' => [ 'required', 'string', 'max:' . self::MAX_CONTENT_LENGTH ],
+        ] );
+
+        return response()->json( [
+            'data' => [
+                'rendered'  => $this->resolver->render( $validated['content'] ),
+                'signature' => $this->resolver->signatureFor( $validated['content'] ),
+            ],
+        ] );
+    }
+}

--- a/src/Modules/DynamicContent/Http/Controllers/DynamicContentTypeController.php
+++ b/src/Modules/DynamicContent/Http/Controllers/DynamicContentTypeController.php
@@ -1,0 +1,91 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Modules\DynamicContent\Http\Controllers;
+
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Http\Requests\DynamicContentTypeRequest;
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Http\Resources\DynamicContentTypeResource;
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Managers\DynamicContentTypeManager;
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Managers\DynamicContentTypeRegistry;
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Models\DynamicContentType;
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
+use Illuminate\Http\Response;
+use Illuminate\Routing\Controller;
+
+class DynamicContentTypeController extends Controller
+{
+    use AuthorizesRequests;
+
+    public function __construct(
+        protected DynamicContentTypeManager $manager,
+        protected DynamicContentTypeRegistry $registry,
+    ) {
+    }
+
+    public function index(): AnonymousResourceCollection|JsonResponse
+    {
+        $this->authorize( 'viewAny', DynamicContentType::class );
+
+        return DynamicContentTypeResource::collection(
+            DynamicContentType::with( 'fields' )->orderBy( 'name' )->get(),
+        );
+    }
+
+    public function registered(): JsonResponse
+    {
+        $this->authorize( 'viewAny', DynamicContentType::class );
+
+        $types = [];
+
+        foreach ( $this->registry->all() as $slug => $type ) {
+            $types[] = [
+                'slug'        => $slug,
+                'name'        => $type['name'],
+                'cardinality' => $type['cardinality']->value,
+                'source'      => $type['source']->value,
+                'fields'      => array_map( fn ( $f ) => [
+                    'slug'  => $f['slug'],
+                    'label' => $f['label'],
+                    'type'  => $f['type'],
+                ], $type['fields'] ),
+            ];
+        }
+
+        return response()->json( [ 'data' => $types ] );
+    }
+
+    public function store( DynamicContentTypeRequest $request ): DynamicContentTypeResource
+    {
+        $this->authorize( 'create', DynamicContentType::class );
+
+        $type = $this->manager->create( $request->validated() );
+
+        return new DynamicContentTypeResource( $type );
+    }
+
+    public function show( DynamicContentType $type ): DynamicContentTypeResource
+    {
+        $this->authorize( 'view', $type );
+
+        return new DynamicContentTypeResource( $type->load( 'fields' ) );
+    }
+
+    public function update( DynamicContentTypeRequest $request, DynamicContentType $type ): DynamicContentTypeResource
+    {
+        $this->authorize( 'update', $type );
+
+        return new DynamicContentTypeResource( $this->manager->update( $type, $request->validated() ) );
+    }
+
+    public function destroy( DynamicContentType $type ): Response
+    {
+        $this->authorize( 'delete', $type );
+
+        $this->manager->delete( $type );
+
+        return response()->noContent();
+    }
+}

--- a/src/Modules/DynamicContent/Http/Requests/DynamicContentRecordRequest.php
+++ b/src/Modules/DynamicContent/Http/Requests/DynamicContentRecordRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Modules\DynamicContent\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class DynamicContentRecordRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'label'    => [ 'nullable', 'string', 'max:255' ],
+            'order'    => [ 'nullable', 'integer' ],
+            'values'   => [ 'array' ],
+            'values.*' => [ 'nullable' ],
+        ];
+    }
+}

--- a/src/Modules/DynamicContent/Http/Requests/DynamicContentTypeRequest.php
+++ b/src/Modules/DynamicContent/Http/Requests/DynamicContentTypeRequest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Modules\DynamicContent\Http\Requests;
+
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Enums\Cardinality;
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Managers\FieldTypeRegistry;
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Models\DynamicContentType;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class DynamicContentTypeRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        $existing = $this->route( 'type' );
+        $isUpdate = $existing instanceof DynamicContentType;
+
+        $fieldTypeSlugs = array_keys( app( FieldTypeRegistry::class )->all() );
+
+        $slugRules = [ 'required', 'string', 'max:64', 'regex:/^[a-z][a-z0-9_]*$/' ];
+
+        if ( $isUpdate ) {
+            // Slug is immutable post-create: changing it would silently break every
+            // persisted `{{oldslug.field}}` token across the site.
+            $slugRules[] = Rule::in( [ $existing->slug ] );
+        } else {
+            $slugRules[] = Rule::unique( 'dynamic_content_types', 'slug' );
+        }
+
+        return [
+            'slug'              => $slugRules,
+            'name'              => [ 'required', 'string', 'max:255' ],
+            'cardinality'       => [ 'required', Rule::in( array_column( Cardinality::cases(), 'value' ) ) ],
+            'description'       => [ 'nullable', 'string' ],
+            'icon'              => [ 'nullable', 'string', 'max:64' ],
+            'fields'            => [ 'array' ],
+            'fields.*.slug'     => [ 'required', 'string', 'max:64', 'regex:/^[a-z][a-z0-9_]*$/' ],
+            'fields.*.label'    => [ 'required', 'string', 'max:255' ],
+            'fields.*.type'     => [ 'required', 'string', Rule::in( $fieldTypeSlugs ) ],
+            'fields.*.options'  => [ 'nullable', 'array' ],
+            'fields.*.default'  => [ 'nullable' ],
+            'fields.*.required' => [ 'nullable', 'boolean' ],
+        ];
+    }
+
+    public function messages(): array
+    {
+        return [
+            'slug.in'          => __( 'Type slug is immutable; changing it would break existing tokens.' ),
+            'fields.*.type.in' => __( 'The field type is not registered.' ),
+        ];
+    }
+}

--- a/src/Modules/DynamicContent/Http/Resources/DynamicContentRecordResource.php
+++ b/src/Modules/DynamicContent/Http/Resources/DynamicContentRecordResource.php
@@ -1,0 +1,28 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Modules\DynamicContent\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * @property-read \ArtisanPackUI\CMSFramework\Modules\DynamicContent\Models\DynamicContentRecord $resource
+ */
+class DynamicContentRecordResource extends JsonResource
+{
+    public function toArray( Request $request ): array
+    {
+        return [
+            'id'     => $this->resource->id,
+            'label'  => $this->resource->label,
+            'order'  => $this->resource->order,
+            'values' => $this->resource->fieldValues(),
+            'type'   => [
+                'slug' => $this->resource->type?->slug,
+                'name' => $this->resource->type?->name,
+            ],
+        ];
+    }
+}

--- a/src/Modules/DynamicContent/Http/Resources/DynamicContentTypeResource.php
+++ b/src/Modules/DynamicContent/Http/Resources/DynamicContentTypeResource.php
@@ -1,0 +1,39 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Modules\DynamicContent\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * @property-read \ArtisanPackUI\CMSFramework\Modules\DynamicContent\Models\DynamicContentType $resource
+ */
+class DynamicContentTypeResource extends JsonResource
+{
+    public function toArray( Request $request ): array
+    {
+        return [
+            'id'          => $this->resource->id,
+            'slug'        => $this->resource->slug,
+            'name'        => $this->resource->name,
+            'cardinality' => $this->resource->cardinality->value,
+            'source'      => $this->resource->source->value,
+            'description' => $this->resource->description,
+            'icon'        => $this->resource->icon,
+            'fields'      => $this->whenLoaded( 'fields', function () {
+                return $this->resource->fields->map( fn ( $f ) => [
+                    'id'       => $f->id,
+                    'slug'     => $f->slug,
+                    'label'    => $f->label,
+                    'type'     => $f->type,
+                    'options'  => $f->options ?? [],
+                    'default'  => $f->default_value,
+                    'required' => $f->required,
+                    'order'    => $f->order,
+                ] )->all();
+            } ),
+        ];
+    }
+}

--- a/src/Modules/DynamicContent/Livewire/CollectionEditor.php
+++ b/src/Modules/DynamicContent/Livewire/CollectionEditor.php
@@ -1,0 +1,117 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Modules\DynamicContent\Livewire;
+
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Managers\DynamicContentRecordManager;
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Models\DynamicContentRecord;
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Models\DynamicContentType;
+use Illuminate\Contracts\View\View;
+use Illuminate\Support\Facades\Gate;
+use Livewire\Component;
+use Livewire\WithPagination;
+
+/**
+ * Edits records of a collection type: paginated list + inline editor.
+ *
+ * @since 2.4.0
+ */
+class CollectionEditor extends Component
+{
+    use WithPagination;
+
+    public int $typeId;
+
+    public ?int $editingRecordId = null;
+
+    public ?string $editingLabel = null;
+
+    /**
+     * @var array<string, mixed>
+     */
+    public array $editingValues = [];
+
+    public function mount( int $typeId ): void
+    {
+        $this->typeId = $typeId;
+
+        $type = DynamicContentType::findOrFail( $typeId );
+
+        abort_unless( $type->isCollection(), 404 );
+        Gate::authorize( 'update', $type );
+    }
+
+    public function edit( int $recordId ): void
+    {
+        $record = DynamicContentRecord::with( 'values.field', 'type.fields' )->findOrFail( $recordId );
+
+        abort_unless( $record->dynamic_content_type_id === $this->typeId, 404 );
+        Gate::authorize( 'update', $record );
+
+        $this->editingRecordId = $recordId;
+        $this->editingLabel    = $record->label;
+        $this->editingValues   = $record->fieldValues();
+    }
+
+    public function create(): void
+    {
+        $type = DynamicContentType::with( 'fields' )->findOrFail( $this->typeId );
+
+        Gate::authorize( 'create', DynamicContentRecord::class );
+
+        $this->editingRecordId = null;
+        $this->editingLabel    = null;
+        $this->editingValues   = [];
+
+        foreach ( $type->fields as $field ) {
+            $this->editingValues[ $field->slug ] = $field->default_value;
+        }
+    }
+
+    public function save(): void
+    {
+        $type    = DynamicContentType::with( 'fields' )->findOrFail( $this->typeId );
+        $manager = app( DynamicContentRecordManager::class );
+
+        $data = [ 'label' => $this->editingLabel, 'values' => $this->editingValues ];
+
+        if ( null === $this->editingRecordId ) {
+            Gate::authorize( 'create', DynamicContentRecord::class );
+            $manager->create( $type, $data );
+        } else {
+            $record = DynamicContentRecord::findOrFail( $this->editingRecordId );
+            Gate::authorize( 'update', $record );
+            $manager->update( $record, $data );
+        }
+
+        $this->editingRecordId = null;
+        $this->editingLabel    = null;
+        $this->editingValues   = [];
+        $this->dispatch( 'dynamic-content-record-saved' );
+    }
+
+    public function delete( int $recordId ): void
+    {
+        $record = DynamicContentRecord::findOrFail( $recordId );
+
+        abort_unless( $record->dynamic_content_type_id === $this->typeId, 404 );
+        Gate::authorize( 'delete', $record );
+
+        $record->delete();
+    }
+
+    public function render(): View
+    {
+        $type = DynamicContentType::with( 'fields' )->findOrFail( $this->typeId );
+
+        $records = $type->records()
+            ->with( 'values.field' )
+            ->paginate( 20 );
+
+        return view( 'ap-cms-dynamic-content::livewire.collection-editor', [
+            'type'    => $type,
+            'records' => $records,
+        ] );
+    }
+}

--- a/src/Modules/DynamicContent/Livewire/FieldBuilder.php
+++ b/src/Modules/DynamicContent/Livewire/FieldBuilder.php
@@ -1,0 +1,134 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Modules\DynamicContent\Livewire;
+
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Managers\DynamicContentTypeManager;
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Managers\FieldTypeRegistry;
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Models\DynamicContentType;
+use Illuminate\Contracts\View\View;
+use Illuminate\Support\Facades\Gate;
+use Livewire\Attributes\Validate;
+use Livewire\Component;
+
+/**
+ * Type + field builder — drag-to-order fields, per-type-field option panel.
+ *
+ * @since 2.4.0
+ */
+class FieldBuilder extends Component
+{
+    public ?int $typeId = null;
+
+    #[Validate( 'required|string|max:64|regex:/^[a-z][a-z0-9_]*$/' )]
+    public string $slug = '';
+
+    #[Validate( 'required|string|max:255' )]
+    public string $name = '';
+
+    #[Validate( 'required|in:singleton,collection' )]
+    public string $cardinality = 'singleton';
+
+    public ?string $description = null;
+
+    /**
+     * @var array<int, array{slug:string, label:string, type:string, required:bool, default:?string, options:array}>
+     */
+    public array $fields = [];
+
+    public function mount( ?int $typeId = null ): void
+    {
+        $this->typeId = $typeId;
+
+        if ( null !== $typeId ) {
+            $type = DynamicContentType::with( 'fields' )->findOrFail( $typeId );
+
+            Gate::authorize( 'update', $type );
+
+            $this->slug        = $type->slug;
+            $this->name        = $type->name;
+            $this->cardinality = $type->cardinality->value;
+            $this->description = $type->description;
+            $this->fields      = $type->fields->map( fn ( $f ) => [
+                'slug'     => $f->slug,
+                'label'    => $f->label,
+                'type'     => $f->type,
+                'required' => $f->required,
+                'default'  => $f->default_value,
+                'options'  => $f->options ?? [],
+            ] )->all();
+        } else {
+            Gate::authorize( 'create', DynamicContentType::class );
+        }
+    }
+
+    public function addField(): void
+    {
+        $this->fields[] = [
+            'slug'     => '',
+            'label'    => '',
+            'type'     => 'text',
+            'required' => false,
+            'default'  => null,
+            'options'  => [],
+        ];
+    }
+
+    public function removeField( int $index ): void
+    {
+        unset( $this->fields[ $index ] );
+        $this->fields = array_values( $this->fields );
+    }
+
+    public function moveUp( int $index ): void
+    {
+        if ( $index <= 0 || ! isset( $this->fields[ $index ] ) ) {
+            return;
+        }
+
+        [ $this->fields[ $index - 1 ], $this->fields[ $index ] ] = [ $this->fields[ $index ], $this->fields[ $index - 1 ] ];
+    }
+
+    public function moveDown( int $index ): void
+    {
+        if ( ! isset( $this->fields[ $index + 1 ] ) ) {
+            return;
+        }
+
+        [ $this->fields[ $index ], $this->fields[ $index + 1 ] ] = [ $this->fields[ $index + 1 ], $this->fields[ $index ] ];
+    }
+
+    public function save(): void
+    {
+        $this->validate();
+
+        $data = [
+            'slug'        => $this->slug,
+            'name'        => $this->name,
+            'cardinality' => $this->cardinality,
+            'description' => $this->description,
+            'fields'      => $this->fields,
+        ];
+
+        $manager = app( DynamicContentTypeManager::class );
+
+        if ( null === $this->typeId ) {
+            $type         = $manager->create( $data );
+            $this->typeId = $type->id;
+        } else {
+            $type = DynamicContentType::findOrFail( $this->typeId );
+            Gate::authorize( 'update', $type );
+            $manager->update( $type, $data );
+        }
+
+        $this->dispatch( 'dynamic-content-type-saved', typeId: $this->typeId );
+    }
+
+    public function render(): View
+    {
+        return view( 'ap-cms-dynamic-content::livewire.field-builder', [
+            'fieldTypes' => app( FieldTypeRegistry::class )->all(),
+        ] );
+    }
+}

--- a/src/Modules/DynamicContent/Livewire/SingletonEditor.php
+++ b/src/Modules/DynamicContent/Livewire/SingletonEditor.php
@@ -1,0 +1,73 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Modules\DynamicContent\Livewire;
+
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Managers\DynamicContentRecordManager;
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Models\DynamicContentType;
+use Illuminate\Contracts\View\View;
+use Illuminate\Support\Facades\Gate;
+use Livewire\Component;
+
+/**
+ * Edits the single record of a singleton type.
+ *
+ * @since 2.4.0
+ */
+class SingletonEditor extends Component
+{
+    public int $typeId;
+
+    /**
+     * @var array<string, mixed>
+     */
+    public array $values = [];
+
+    public function mount( int $typeId ): void
+    {
+        $this->typeId = $typeId;
+
+        $type = DynamicContentType::with( 'fields', 'records.values.field' )->findOrFail( $typeId );
+
+        abort_unless( $type->isSingleton(), 404 );
+        Gate::authorize( 'update', $type );
+
+        $record = $type->records->first();
+
+        if ( null !== $record ) {
+            $this->values = $record->fieldValues();
+        } else {
+            foreach ( $type->fields as $field ) {
+                $this->values[ $field->slug ] = $field->default_value;
+            }
+        }
+    }
+
+    public function save(): void
+    {
+        $type = DynamicContentType::with( 'fields', 'records' )->findOrFail( $this->typeId );
+
+        Gate::authorize( 'update', $type );
+
+        $manager = app( DynamicContentRecordManager::class );
+        $record  = $type->records->first();
+
+        if ( null === $record ) {
+            $manager->create( $type, [ 'values' => $this->values ] );
+        } else {
+            $manager->update( $record, [ 'values' => $this->values ] );
+        }
+
+        $this->dispatch( 'dynamic-content-record-saved' );
+    }
+
+    public function render(): View
+    {
+        $type = DynamicContentType::with( 'fields' )->findOrFail( $this->typeId );
+
+        return view( 'ap-cms-dynamic-content::livewire.singleton-editor', [
+            'type' => $type,
+        ] );
+    }
+}

--- a/src/Modules/DynamicContent/Livewire/TypeList.php
+++ b/src/Modules/DynamicContent/Livewire/TypeList.php
@@ -1,0 +1,38 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Modules\DynamicContent\Livewire;
+
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Managers\DynamicContentTypeManager;
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Managers\DynamicContentTypeRegistry;
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Models\DynamicContentType;
+use Illuminate\Contracts\View\View;
+use Illuminate\Support\Facades\Gate;
+use Livewire\Component;
+
+/**
+ * Admin type list — shows admin-created + code-registered types.
+ *
+ * @since 2.4.0
+ */
+class TypeList extends Component
+{
+    public function delete( int $typeId ): void
+    {
+        $type = DynamicContentType::findOrFail( $typeId );
+
+        Gate::authorize( 'delete', $type );
+
+        app( DynamicContentTypeManager::class )->delete( $type );
+    }
+
+    public function render(): View
+    {
+        Gate::authorize( 'viewAny', DynamicContentType::class );
+
+        return view( 'ap-cms-dynamic-content::livewire.type-list', [
+            'types' => app( DynamicContentTypeRegistry::class )->all(),
+        ] );
+    }
+}

--- a/src/Modules/DynamicContent/Managers/DynamicContentRecordManager.php
+++ b/src/Modules/DynamicContent/Managers/DynamicContentRecordManager.php
@@ -1,0 +1,77 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Modules\DynamicContent\Managers;
+
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Models\DynamicContentRecord;
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Models\DynamicContentType;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Writes / reads dynamic content records.
+ *
+ * @since 2.4.0
+ */
+class DynamicContentRecordManager
+{
+    /**
+     * @param  array{label?:?string, order?:int, values?:array<string,mixed>}  $data
+     */
+    public function create( DynamicContentType $type, array $data ): DynamicContentRecord
+    {
+        return DB::transaction( function () use ( $type, $data ): DynamicContentRecord {
+            $record = $type->records()->create( [
+                'label' => $data['label'] ?? null,
+                'order' => $data['order'] ?? 0,
+            ] );
+
+            $this->syncValues( $record, $type, $data['values'] ?? [] );
+
+            return $record->fresh( 'values.field' );
+        } );
+    }
+
+    /**
+     * @param  array{label?:?string, order?:int, values?:array<string,mixed>}  $data
+     */
+    public function update( DynamicContentRecord $record, array $data ): DynamicContentRecord
+    {
+        return DB::transaction( function () use ( $record, $data ): DynamicContentRecord {
+            $record->update( [
+                'label' => $data['label'] ?? $record->label,
+                'order' => $data['order'] ?? $record->order,
+            ] );
+
+            if ( array_key_exists( 'values', $data ) ) {
+                $this->syncValues( $record, $record->type, $data['values'] );
+            }
+
+            return $record->fresh( 'values.field' );
+        } );
+    }
+
+    public function delete( DynamicContentRecord $record ): void
+    {
+        $record->delete();
+    }
+
+    /**
+     * @param  array<string, mixed>  $values  Values keyed by field slug.
+     */
+    protected function syncValues( DynamicContentRecord $record, DynamicContentType $type, array $values ): void
+    {
+        $type->loadMissing( 'fields' );
+
+        foreach ( $type->fields as $field ) {
+            if ( ! array_key_exists( $field->slug, $values ) ) {
+                continue;
+            }
+
+            $record->values()->updateOrCreate(
+                [ 'dynamic_content_field_id' => $field->id ],
+                [ 'value' => $values[ $field->slug ] ],
+            );
+        }
+    }
+}

--- a/src/Modules/DynamicContent/Managers/DynamicContentTypeManager.php
+++ b/src/Modules/DynamicContent/Managers/DynamicContentTypeManager.php
@@ -1,0 +1,113 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Modules\DynamicContent\Managers;
+
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Enums\Source;
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Models\DynamicContentField;
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Models\DynamicContentType;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Writes / reads DB-backed dynamic content types.
+ *
+ * @since 2.4.0
+ */
+class DynamicContentTypeManager
+{
+    public function __construct( protected DynamicContentTypeRegistry $registry )
+    {
+    }
+
+    /**
+     * Create a type from validated input.
+     *
+     * @param  array<string, mixed>  $data
+     */
+    public function create( array $data ): DynamicContentType
+    {
+        return DB::transaction( function () use ( $data ): DynamicContentType {
+            $type = DynamicContentType::create( [
+                'slug'        => $data['slug'],
+                'name'        => $data['name'],
+                'cardinality' => $data['cardinality'],
+                'source'      => Source::Db->value,
+                'description' => $data['description'] ?? null,
+                'icon'        => $data['icon'] ?? null,
+            ] );
+
+            $this->syncFields( $type, $data['fields'] ?? [] );
+
+            $this->registry->forget();
+
+            return $type->fresh( 'fields' );
+        } );
+    }
+
+    /**
+     * Update an existing type.
+     *
+     * @param  array<string, mixed>  $data
+     */
+    public function update( DynamicContentType $type, array $data ): DynamicContentType
+    {
+        return DB::transaction( function () use ( $type, $data ): DynamicContentType {
+            // Slug is intentionally not updated: mutating it would silently
+            // break every persisted `{{oldslug.field}}` token across the site.
+            $type->update( [
+                'name'        => $data['name'] ?? $type->name,
+                'cardinality' => $data['cardinality'] ?? $type->cardinality->value,
+                'description' => $data['description'] ?? $type->description,
+                'icon'        => $data['icon'] ?? $type->icon,
+            ] );
+
+            if ( array_key_exists( 'fields', $data ) ) {
+                $this->syncFields( $type, $data['fields'] );
+            }
+
+            $this->registry->forget();
+
+            return $type->fresh( 'fields' );
+        } );
+    }
+
+    public function delete( DynamicContentType $type ): void
+    {
+        DB::transaction( function () use ( $type ): void {
+            $type->delete();
+            $this->registry->forget();
+        } );
+    }
+
+    /**
+     * Replace the type's fields with the given definition.
+     *
+     * @param  array<int, array<string, mixed>>  $fields
+     */
+    protected function syncFields( DynamicContentType $type, array $fields ): void
+    {
+        $seen = [];
+
+        foreach ( $fields as $order => $field ) {
+            $model = $type->fields()->updateOrCreate(
+                [ 'slug' => $field['slug'] ],
+                [
+                    'label'         => $field['label'],
+                    'type'          => $field['type'],
+                    'options'       => $field['options'] ?? null,
+                    'default_value' => $field['default'] ?? null,
+                    'required'      => (bool) ( $field['required'] ?? false ),
+                    'order'         => (int) ( $field['order'] ?? $order ),
+                ],
+            );
+
+            $seen[] = $model->id;
+        }
+
+        DynamicContentField::query()
+            ->where( 'dynamic_content_type_id', $type->id )
+            ->whereNotIn( 'id', $seen )
+            ->delete();
+    }
+}

--- a/src/Modules/DynamicContent/Managers/DynamicContentTypeRegistry.php
+++ b/src/Modules/DynamicContent/Managers/DynamicContentTypeRegistry.php
@@ -1,0 +1,190 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Modules\DynamicContent\Managers;
+
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Enums\Cardinality;
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Enums\Source;
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Models\DynamicContentType;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Schema;
+use Throwable;
+
+/**
+ * In-memory registry of dynamic content types.
+ *
+ * Merges admin-created types (from the DB) with code-registered types.
+ * Code-registered types win on slug conflict; a warning is logged.
+ *
+ * @since 2.4.0
+ */
+class DynamicContentTypeRegistry
+{
+    /**
+     * Code-registered type definitions keyed by slug.
+     *
+     * Each definition is an array:
+     *   [
+     *     'slug' => string,
+     *     'name' => string,
+     *     'cardinality' => Cardinality,
+     *     'description' => ?string,
+     *     'icon' => ?string,
+     *     'fields' => list<array{slug:string, label:string, type:string, options?:array, default?:mixed, required?:bool}>,
+     *     'records' => callable():iterable<array<string,mixed>>|iterable<array<string,mixed>>|null,
+     *   ]
+     *
+     * @var array<string, array<string, mixed>>
+     */
+    protected array $codeTypes = [];
+
+    protected ?array $mergedCache = null;
+
+    /**
+     * Register a type in code.
+     *
+     * @param  array<string, mixed>  $definition
+     */
+    public function registerCodeType( string $slug, array $definition ): void
+    {
+        $definition['slug']        = $slug;
+        $definition['source']      = Source::Code;
+        $definition['cardinality'] = $definition['cardinality'] ?? Cardinality::Singleton;
+
+        $this->codeTypes[ $slug ] = $definition;
+        $this->mergedCache        = null;
+    }
+
+    /**
+     * All registered types keyed by slug.
+     *
+     * @return array<string, array<string, mixed>>
+     */
+    public function all(): array
+    {
+        if ( null !== $this->mergedCache ) {
+            return $this->mergedCache;
+        }
+
+        $out = [];
+
+        // Pull DB types only if the table exists (guards early-boot / migrations).
+        if ( Schema::hasTable( 'dynamic_content_types' ) ) {
+            foreach ( DynamicContentType::with( 'fields' )->get() as $dbType ) {
+                $out[ $dbType->slug ] = $this->normalizeDbType( $dbType );
+            }
+        }
+
+        // Merge in code-registered — invoke filter first so packages can contribute.
+        $codeTypes = $this->codeTypes;
+
+        if ( function_exists( 'applyFilters' ) ) {
+            try {
+                $filtered = applyFilters( 'ap.dynamic_content.register-types', $codeTypes );
+
+                if ( is_array( $filtered ) ) {
+                    $codeTypes = $filtered;
+                }
+            } catch ( Throwable $e ) {
+                // A third-party filter callback threw. Fall back to the pre-filter
+                // set so one buggy plugin can't take down every token resolution.
+                Log::channel( $this->logChannel() )->warning(
+                    'Dynamic content: register-types filter threw; falling back to unfiltered set',
+                    [ 'exception' => $e->getMessage() ],
+                );
+            }
+        }
+
+        foreach ( $codeTypes as $slug => $definition ) {
+            if ( isset( $out[ $slug ] ) ) {
+                Log::channel( $this->logChannel() )->warning(
+                    'Dynamic content: code-registered type shadows admin-created type',
+                    [ 'slug' => $slug ],
+                );
+            }
+
+            $out[ $slug ] = $this->normalizeCodeType( $slug, $definition );
+        }
+
+        return $this->mergedCache = $out;
+    }
+
+    public function get( string $slug ): ?array
+    {
+        return $this->all()[ $slug ] ?? null;
+    }
+
+    public function forget(): void
+    {
+        $this->mergedCache = null;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    protected function normalizeDbType( DynamicContentType $type ): array
+    {
+        return [
+            'slug'        => $type->slug,
+            'name'        => $type->name,
+            'cardinality' => $type->cardinality,
+            'source'      => Source::Db,
+            'description' => $type->description,
+            'icon'        => $type->icon,
+            'fields'      => $type->fields->map( fn ( $f ) => [
+                'slug'     => $f->slug,
+                'label'    => $f->label,
+                'type'     => $f->type,
+                'options'  => $f->options ?? [],
+                'default'  => $f->default_value,
+                'required' => $f->required,
+            ] )->all(),
+            'db_id'   => $type->id,
+            'records' => null,
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $definition
+     *
+     * @return array<string, mixed>
+     */
+    protected function normalizeCodeType( string $slug, array $definition ): array
+    {
+        $cardinality = $definition['cardinality'] ?? Cardinality::Singleton;
+
+        if ( is_string( $cardinality ) ) {
+            $cardinality = Cardinality::from( $cardinality );
+        }
+
+        $fields = [];
+
+        foreach ( $definition['fields'] ?? [] as $field ) {
+            $fields[] = [
+                'slug'     => $field['slug'],
+                'label'    => $field['label'] ?? $field['slug'],
+                'type'     => $field['type'] ?? 'text',
+                'options'  => $field['options'] ?? [],
+                'default'  => $field['default'] ?? null,
+                'required' => (bool) ( $field['required'] ?? false ),
+            ];
+        }
+
+        return [
+            'slug'        => $slug,
+            'name'        => $definition['name'] ?? $slug,
+            'cardinality' => $cardinality,
+            'source'      => Source::Code,
+            'description' => $definition['description'] ?? null,
+            'icon'        => $definition['icon'] ?? null,
+            'fields'      => $fields,
+            'records'     => $definition['records'] ?? null,
+        ];
+    }
+
+    protected function logChannel(): string
+    {
+        return config( 'logging.channels.dynamic-content' ) ? 'dynamic-content' : 'stack';
+    }
+}

--- a/src/Modules/DynamicContent/Managers/FieldTypeRegistry.php
+++ b/src/Modules/DynamicContent/Managers/FieldTypeRegistry.php
@@ -1,0 +1,62 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Modules\DynamicContent\Managers;
+
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Contracts\FieldType;
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\FieldTypes\AddressFieldType;
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\FieldTypes\ImageFieldType;
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\FieldTypes\NumberFieldType;
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\FieldTypes\RichTextFieldType;
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\FieldTypes\ScalarFieldType;
+
+/**
+ * Registry of available field-type classes keyed by slug.
+ *
+ * @since 2.4.0
+ */
+class FieldTypeRegistry
+{
+    /**
+     * @var array<string, FieldType>
+     */
+    protected array $types = [];
+
+    public function __construct()
+    {
+        foreach ( [
+            new ScalarFieldType( 'text', 'Text' ),
+            new ScalarFieldType( 'url', 'URL' ),
+            new ScalarFieldType( 'email', 'Email' ),
+            new ScalarFieldType( 'phone', 'Phone' ),
+            new ScalarFieldType( 'date', 'Date' ),
+            new ScalarFieldType( 'datetime', 'Date & Time' ),
+            new ScalarFieldType( 'select', 'Select' ),
+            new RichTextFieldType(),
+            new ImageFieldType(),
+            new NumberFieldType(),
+            new AddressFieldType(),
+        ] as $type ) {
+            $this->register( $type );
+        }
+    }
+
+    public function register( FieldType $type ): void
+    {
+        $this->types[ $type->slug() ] = $type;
+    }
+
+    public function get( string $slug ): ?FieldType
+    {
+        return $this->types[ $slug ] ?? null;
+    }
+
+    /**
+     * @return array<string, FieldType>
+     */
+    public function all(): array
+    {
+        return $this->types;
+    }
+}

--- a/src/Modules/DynamicContent/Managers/ModifierRegistry.php
+++ b/src/Modules/DynamicContent/Managers/ModifierRegistry.php
@@ -1,0 +1,57 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Modules\DynamicContent\Managers;
+
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Contracts\Modifier;
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Modifiers\DateModifier;
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Modifiers\DefaultModifier;
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Modifiers\LowerModifier;
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Modifiers\Nl2brModifier;
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Modifiers\TimeModifier;
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Modifiers\TruncateModifier;
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Modifiers\UpperModifier;
+
+/**
+ * Registry of built-in token modifiers.
+ *
+ * Sealed to public API in v1: only the built-in modifiers are exposed.
+ *
+ * @since 2.4.0
+ */
+class ModifierRegistry
+{
+    /**
+     * @var array<string, Modifier>
+     */
+    protected array $modifiers = [];
+
+    public function __construct()
+    {
+        foreach ( [
+            new DefaultModifier(),
+            new UpperModifier(),
+            new LowerModifier(),
+            new TruncateModifier(),
+            new DateModifier(),
+            new TimeModifier(),
+            new Nl2brModifier(),
+        ] as $modifier ) {
+            $this->modifiers[ $modifier->slug() ] = $modifier;
+        }
+    }
+
+    public function get( string $slug ): ?Modifier
+    {
+        return $this->modifiers[ $slug ] ?? null;
+    }
+
+    /**
+     * @return array<string, Modifier>
+     */
+    public function all(): array
+    {
+        return $this->modifiers;
+    }
+}

--- a/src/Modules/DynamicContent/Models/DynamicContentField.php
+++ b/src/Modules/DynamicContent/Models/DynamicContentField.php
@@ -1,0 +1,54 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Modules\DynamicContent\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * @property int $id
+ * @property int $dynamic_content_type_id
+ * @property string $slug
+ * @property string $label
+ * @property string $type
+ * @property array|null $options
+ * @property string|null $default_value
+ * @property bool $required
+ * @property int $order
+ *
+ * @since 2.4.0
+ */
+class DynamicContentField extends Model
+{
+    use HasFactory;
+
+    protected $table = 'dynamic_content_fields';
+
+    protected $fillable = [
+        'dynamic_content_type_id',
+        'slug',
+        'label',
+        'type',
+        'options',
+        'default_value',
+        'required',
+        'order',
+    ];
+
+    public function type(): BelongsTo
+    {
+        return $this->belongsTo( DynamicContentType::class, 'dynamic_content_type_id' );
+    }
+
+    protected function casts(): array
+    {
+        return [
+            'options'  => 'array',
+            'required' => 'boolean',
+            'order'    => 'integer',
+        ];
+    }
+}

--- a/src/Modules/DynamicContent/Models/DynamicContentRecord.php
+++ b/src/Modules/DynamicContent/Models/DynamicContentRecord.php
@@ -1,0 +1,74 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Modules\DynamicContent\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+/**
+ * @property int $id
+ * @property int $dynamic_content_type_id
+ * @property string|null $label
+ * @property int $order
+ * @property \Illuminate\Support\Carbon $created_at
+ * @property \Illuminate\Support\Carbon $updated_at
+ *
+ * @since 2.4.0
+ */
+class DynamicContentRecord extends Model
+{
+    use HasFactory;
+
+    protected $table = 'dynamic_content_records';
+
+    protected $fillable = [
+        'dynamic_content_type_id',
+        'label',
+        'order',
+    ];
+
+    public function type(): BelongsTo
+    {
+        return $this->belongsTo( DynamicContentType::class, 'dynamic_content_type_id' );
+    }
+
+    public function values(): HasMany
+    {
+        return $this->hasMany( DynamicContentRecordValue::class, 'dynamic_content_record_id' );
+    }
+
+    /**
+     * Return the record's values keyed by field slug.
+     *
+     * @return array<string, mixed>
+     */
+    public function fieldValues(): array
+    {
+        $this->loadMissing( 'values.field', 'type.fields' );
+
+        $out = [];
+
+        foreach ( $this->type->fields as $field ) {
+            $out[ $field->slug ] = $field->default_value;
+        }
+
+        foreach ( $this->values as $value ) {
+            if ( null !== $value->field ) {
+                $out[ $value->field->slug ] = $value->value;
+            }
+        }
+
+        return $out;
+    }
+
+    protected function casts(): array
+    {
+        return [
+            'order' => 'integer',
+        ];
+    }
+}

--- a/src/Modules/DynamicContent/Models/DynamicContentRecordValue.php
+++ b/src/Modules/DynamicContent/Models/DynamicContentRecordValue.php
@@ -1,0 +1,48 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Modules\DynamicContent\Models;
+
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Casts\RecordValueCast;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * @property int $id
+ * @property int $dynamic_content_record_id
+ * @property int $dynamic_content_field_id
+ * @property mixed $value
+ *
+ * @since 2.4.0
+ */
+class DynamicContentRecordValue extends Model
+{
+    use HasFactory;
+
+    protected $table = 'dynamic_content_record_values';
+
+    protected $fillable = [
+        'dynamic_content_record_id',
+        'dynamic_content_field_id',
+        'value',
+    ];
+
+    public function record(): BelongsTo
+    {
+        return $this->belongsTo( DynamicContentRecord::class, 'dynamic_content_record_id' );
+    }
+
+    public function field(): BelongsTo
+    {
+        return $this->belongsTo( DynamicContentField::class, 'dynamic_content_field_id' );
+    }
+
+    protected function casts(): array
+    {
+        return [
+            'value' => RecordValueCast::class,
+        ];
+    }
+}

--- a/src/Modules/DynamicContent/Models/DynamicContentType.php
+++ b/src/Modules/DynamicContent/Models/DynamicContentType.php
@@ -1,0 +1,73 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Modules\DynamicContent\Models;
+
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Enums\Cardinality;
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Enums\Source;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+/**
+ * @property int $id
+ * @property string $slug
+ * @property string $name
+ * @property Cardinality $cardinality
+ * @property Source $source
+ * @property string|null $description
+ * @property string|null $icon
+ * @property \Illuminate\Support\Carbon $created_at
+ * @property \Illuminate\Support\Carbon $updated_at
+ *
+ * @since 2.4.0
+ */
+class DynamicContentType extends Model
+{
+    use HasFactory;
+
+    protected $table = 'dynamic_content_types';
+
+    protected $fillable = [
+        'slug',
+        'name',
+        'cardinality',
+        'source',
+        'description',
+        'icon',
+    ];
+
+    public function fields(): HasMany
+    {
+        return $this->hasMany( DynamicContentField::class, 'dynamic_content_type_id' )->orderBy( 'order' );
+    }
+
+    public function records(): HasMany
+    {
+        return $this->hasMany( DynamicContentRecord::class, 'dynamic_content_type_id' )->orderBy( 'order' );
+    }
+
+    public function getRouteKeyName(): string
+    {
+        return 'slug';
+    }
+
+    public function isSingleton(): bool
+    {
+        return Cardinality::Singleton === $this->cardinality;
+    }
+
+    public function isCollection(): bool
+    {
+        return Cardinality::Collection === $this->cardinality;
+    }
+
+    protected function casts(): array
+    {
+        return [
+            'cardinality' => Cardinality::class,
+            'source'      => Source::class,
+        ];
+    }
+}

--- a/src/Modules/DynamicContent/Modifiers/DateModifier.php
+++ b/src/Modules/DynamicContent/Modifiers/DateModifier.php
@@ -1,0 +1,34 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Modules\DynamicContent\Modifiers;
+
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Contracts\Modifier;
+use Illuminate\Support\Carbon;
+use Throwable;
+
+class DateModifier implements Modifier
+{
+    public function slug(): string
+    {
+        return 'date';
+    }
+
+    public function apply( mixed $value, array $args ): mixed
+    {
+        if ( null === $value || '' === $value ) {
+            return '';
+        }
+
+        // Args arrive already split on ":" by the tokenizer, so rejoin them to
+        // reconstruct multi-part format strings like "g:i a".
+        $format = empty( $args ) ? 'Y-m-d' : implode( ':', $args );
+
+        try {
+            return Carbon::parse( $value )->format( $format );
+        } catch ( Throwable ) {
+            return $value;
+        }
+    }
+}

--- a/src/Modules/DynamicContent/Modifiers/DefaultModifier.php
+++ b/src/Modules/DynamicContent/Modifiers/DefaultModifier.php
@@ -1,0 +1,24 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Modules\DynamicContent\Modifiers;
+
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Contracts\Modifier;
+
+class DefaultModifier implements Modifier
+{
+    public function slug(): string
+    {
+        return 'default';
+    }
+
+    public function apply( mixed $value, array $args ): mixed
+    {
+        if ( null === $value || '' === $value ) {
+            return $args[0] ?? '';
+        }
+
+        return $value;
+    }
+}

--- a/src/Modules/DynamicContent/Modifiers/LowerModifier.php
+++ b/src/Modules/DynamicContent/Modifiers/LowerModifier.php
@@ -1,0 +1,20 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Modules\DynamicContent\Modifiers;
+
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Contracts\Modifier;
+
+class LowerModifier implements Modifier
+{
+    public function slug(): string
+    {
+        return 'lower';
+    }
+
+    public function apply( mixed $value, array $args ): mixed
+    {
+        return is_string( $value ) ? mb_strtolower( $value ) : $value;
+    }
+}

--- a/src/Modules/DynamicContent/Modifiers/Nl2brModifier.php
+++ b/src/Modules/DynamicContent/Modifiers/Nl2brModifier.php
@@ -1,0 +1,37 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Modules\DynamicContent\Modifiers;
+
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Contracts\Modifier;
+use Illuminate\Support\HtmlString;
+
+/**
+ * Converts newlines to `<br>` tags after HTML-escaping the input.
+ *
+ * Returns an {@see HtmlString} so downstream field-type rendering
+ * doesn't double-escape the inserted `<br>` markup.
+ *
+ * @since 2.4.0
+ */
+class Nl2brModifier implements Modifier
+{
+    public function slug(): string
+    {
+        return 'nl2br';
+    }
+
+    public function apply( mixed $value, array $args ): mixed
+    {
+        if ( $value instanceof HtmlString ) {
+            $value = (string) $value;
+        }
+
+        if ( ! is_string( $value ) ) {
+            return $value;
+        }
+
+        return new HtmlString( nl2br( e( $value ), false ) );
+    }
+}

--- a/src/Modules/DynamicContent/Modifiers/TimeModifier.php
+++ b/src/Modules/DynamicContent/Modifiers/TimeModifier.php
@@ -1,0 +1,34 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Modules\DynamicContent\Modifiers;
+
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Contracts\Modifier;
+use Illuminate\Support\Carbon;
+use Throwable;
+
+class TimeModifier implements Modifier
+{
+    public function slug(): string
+    {
+        return 'time';
+    }
+
+    public function apply( mixed $value, array $args ): mixed
+    {
+        if ( null === $value || '' === $value ) {
+            return '';
+        }
+
+        // Args arrive already split on ":" by the tokenizer, so rejoin them to
+        // reconstruct multi-part format strings like "g:i a".
+        $format = empty( $args ) ? 'H:i' : implode( ':', $args );
+
+        try {
+            return Carbon::parse( $value )->format( $format );
+        } catch ( Throwable ) {
+            return $value;
+        }
+    }
+}

--- a/src/Modules/DynamicContent/Modifiers/TruncateModifier.php
+++ b/src/Modules/DynamicContent/Modifiers/TruncateModifier.php
@@ -1,0 +1,30 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Modules\DynamicContent\Modifiers;
+
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Contracts\Modifier;
+
+class TruncateModifier implements Modifier
+{
+    public function slug(): string
+    {
+        return 'truncate';
+    }
+
+    public function apply( mixed $value, array $args ): mixed
+    {
+        if ( ! is_string( $value ) ) {
+            return $value;
+        }
+
+        $length = isset( $args[0] ) ? (int) $args[0] : 100;
+
+        if ( mb_strlen( $value ) <= $length ) {
+            return $value;
+        }
+
+        return mb_substr( $value, 0, $length ) . '…';
+    }
+}

--- a/src/Modules/DynamicContent/Modifiers/UpperModifier.php
+++ b/src/Modules/DynamicContent/Modifiers/UpperModifier.php
@@ -1,0 +1,20 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Modules\DynamicContent\Modifiers;
+
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Contracts\Modifier;
+
+class UpperModifier implements Modifier
+{
+    public function slug(): string
+    {
+        return 'upper';
+    }
+
+    public function apply( mixed $value, array $args ): mixed
+    {
+        return is_string( $value ) ? mb_strtoupper( $value ) : $value;
+    }
+}

--- a/src/Modules/DynamicContent/Policies/DynamicContentRecordPolicy.php
+++ b/src/Modules/DynamicContent/Policies/DynamicContentRecordPolicy.php
@@ -1,0 +1,68 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Modules\DynamicContent\Policies;
+
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Models\DynamicContentRecord;
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Models\DynamicContentType;
+use Illuminate\Contracts\Auth\Authenticatable;
+
+/**
+ * Policy for DynamicContentRecord.
+ *
+ * All checks default to the global `manage_dynamic_content` capability,
+ * but each check invokes an `applyFilters()` hook that receives the
+ * capability slug AND the target {@see DynamicContentType} (when known)
+ * so hosts can gate per-type — e.g. return a type-scoped capability like
+ * `manage_dynamic_content_records.integrations` to keep credential
+ * records off-limits to marketing editors.
+ *
+ * @since 2.4.0
+ */
+class DynamicContentRecordPolicy
+{
+    /**
+     * Type-aware viewAny check. Callers with a known type should invoke
+     * this via `Gate::check('viewAnyForType', $type)` rather than the
+     * type-less {@see viewAny()} — the type-less variant can't be scoped.
+     */
+    public function viewAnyForType( Authenticatable $user, DynamicContentType $type ): bool
+    {
+        return $user->can( applyFilters( 'dynamicContent.record.viewAny', 'manage_dynamic_content', $type ) );
+    }
+
+    public function viewAny( Authenticatable $user ): bool
+    {
+        return $user->can( applyFilters( 'dynamicContent.record.viewAny', 'manage_dynamic_content', null ) );
+    }
+
+    public function view( Authenticatable $user, DynamicContentRecord $record ): bool
+    {
+        return $user->can( applyFilters( 'dynamicContent.record.view', 'manage_dynamic_content', $record->type ) );
+    }
+
+    /**
+     * Type-aware create check. Callers with a known type should invoke
+     * this via `Gate::check('createForType', $type)`.
+     */
+    public function createForType( Authenticatable $user, DynamicContentType $type ): bool
+    {
+        return $user->can( applyFilters( 'dynamicContent.record.create', 'manage_dynamic_content', $type ) );
+    }
+
+    public function create( Authenticatable $user ): bool
+    {
+        return $user->can( applyFilters( 'dynamicContent.record.create', 'manage_dynamic_content', null ) );
+    }
+
+    public function update( Authenticatable $user, DynamicContentRecord $record ): bool
+    {
+        return $user->can( applyFilters( 'dynamicContent.record.update', 'manage_dynamic_content', $record->type ) );
+    }
+
+    public function delete( Authenticatable $user, DynamicContentRecord $record ): bool
+    {
+        return $user->can( applyFilters( 'dynamicContent.record.delete', 'manage_dynamic_content', $record->type ) );
+    }
+}

--- a/src/Modules/DynamicContent/Policies/DynamicContentTypePolicy.php
+++ b/src/Modules/DynamicContent/Policies/DynamicContentTypePolicy.php
@@ -1,0 +1,43 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Modules\DynamicContent\Policies;
+
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Models\DynamicContentType;
+use Illuminate\Contracts\Auth\Authenticatable;
+
+/**
+ * Policy for DynamicContentType.
+ *
+ * All checks gate on the `manage_dynamic_content` capability.
+ *
+ * @since 2.4.0
+ */
+class DynamicContentTypePolicy
+{
+    public function viewAny( Authenticatable $user ): bool
+    {
+        return $user->can( applyFilters( 'dynamicContent.viewAny', 'manage_dynamic_content' ) );
+    }
+
+    public function view( Authenticatable $user, DynamicContentType $type ): bool
+    {
+        return $user->can( applyFilters( 'dynamicContent.view', 'manage_dynamic_content', $type ) );
+    }
+
+    public function create( Authenticatable $user ): bool
+    {
+        return $user->can( applyFilters( 'dynamicContent.create', 'manage_dynamic_content' ) );
+    }
+
+    public function update( Authenticatable $user, DynamicContentType $type ): bool
+    {
+        return $user->can( applyFilters( 'dynamicContent.update', 'manage_dynamic_content', $type ) );
+    }
+
+    public function delete( Authenticatable $user, DynamicContentType $type ): bool
+    {
+        return $user->can( applyFilters( 'dynamicContent.delete', 'manage_dynamic_content', $type ) );
+    }
+}

--- a/src/Modules/DynamicContent/Providers/DynamicContentServiceProvider.php
+++ b/src/Modules/DynamicContent/Providers/DynamicContentServiceProvider.php
@@ -1,0 +1,168 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Modules\DynamicContent\Providers;
+
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Livewire\CollectionEditor;
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Livewire\FieldBuilder;
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Livewire\SingletonEditor;
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Livewire\TypeList;
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Managers\DynamicContentRecordManager;
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Managers\DynamicContentTypeManager;
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Managers\DynamicContentTypeRegistry;
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Managers\FieldTypeRegistry;
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Managers\ModifierRegistry;
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Models\DynamicContentRecord;
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Models\DynamicContentRecordValue;
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Models\DynamicContentType;
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Policies\DynamicContentRecordPolicy;
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Policies\DynamicContentTypePolicy;
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Services\DynamicContentAccessor;
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Services\DynamicContentResolver;
+use ArtisanPackUI\CMSFramework\Modules\Users\Managers\PermissionManager;
+use Illuminate\Support\Facades\Blade;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Gate;
+use Illuminate\Support\Facades\Route;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\ServiceProvider;
+use Livewire\Livewire;
+
+/**
+ * Wires up the DynamicContent module.
+ *
+ * @since 2.4.0
+ */
+class DynamicContentServiceProvider extends ServiceProvider
+{
+    public const CAPABILITY = 'manage_dynamic_content';
+
+    public function register(): void
+    {
+        $this->app->singleton( FieldTypeRegistry::class, fn () => new FieldTypeRegistry() );
+        $this->app->singleton( ModifierRegistry::class, fn () => new ModifierRegistry() );
+        $this->app->singleton( DynamicContentTypeRegistry::class, fn () => new DynamicContentTypeRegistry() );
+
+        $this->app->singleton( DynamicContentTypeManager::class, fn ( $app ) => new DynamicContentTypeManager(
+            $app->make( DynamicContentTypeRegistry::class ),
+        ) );
+
+        $this->app->singleton( DynamicContentRecordManager::class, fn () => new DynamicContentRecordManager() );
+
+        $this->app->singleton( DynamicContentAccessor::class, fn ( $app ) => new DynamicContentAccessor(
+            $app->make( DynamicContentTypeRegistry::class ),
+        ) );
+
+        $this->app->singleton( DynamicContentResolver::class, fn ( $app ) => new DynamicContentResolver(
+            $app->make( DynamicContentTypeRegistry::class ),
+            $app->make( DynamicContentAccessor::class ),
+            $app->make( FieldTypeRegistry::class ),
+            $app->make( ModifierRegistry::class ),
+        ) );
+
+        $this->loadHelpers();
+    }
+
+    public function boot(): void
+    {
+        $this->loadMigrationsFrom( __DIR__ . '/../database/migrations' );
+
+        Route::prefix( 'api/v1' )
+            ->middleware( 'api' )
+            ->group( __DIR__ . '/../routes/api.php' );
+
+        Gate::policy( DynamicContentType::class, DynamicContentTypePolicy::class );
+        Gate::policy( DynamicContentRecord::class, DynamicContentRecordPolicy::class );
+
+        // Resolver output is already HTML-safe: text-shaped field types
+        // escape at render time, rich-text/image stay intentionally raw.
+        // Emit via raw `echo` so rich-text markup isn't double-escaped.
+        Blade::directive( 'dynamicContent', function ( string $expression ): string {
+            return "<?php echo app( \\ArtisanPackUI\\CMSFramework\\Modules\\DynamicContent\\Services\\DynamicContentResolver::class )->render( (string) ( {$expression} ) ); ?>";
+        } );
+
+        $this->deferCapabilityRegistration();
+        $this->registerRecordEvents();
+        $this->registerViews();
+        $this->registerLivewireComponents();
+    }
+
+    protected function registerViews(): void
+    {
+        $this->loadViewsFrom( __DIR__ . '/../resources/views', 'ap-cms-dynamic-content' );
+    }
+
+    protected function registerLivewireComponents(): void
+    {
+        if ( ! class_exists( Livewire::class ) ) {
+            return;
+        }
+
+        Livewire::component( 'ap-cms-dynamic-content.type-list', TypeList::class );
+        Livewire::component( 'ap-cms-dynamic-content.field-builder', FieldBuilder::class );
+        Livewire::component( 'ap-cms-dynamic-content.singleton-editor', SingletonEditor::class );
+        Livewire::component( 'ap-cms-dynamic-content.collection-editor', CollectionEditor::class );
+    }
+
+    protected function loadHelpers(): void
+    {
+        $helpersPath = __DIR__ . '/../helpers.php';
+
+        if ( file_exists( $helpersPath ) ) {
+            require_once $helpersPath;
+        }
+    }
+
+    /**
+     * Defer the `manage_dynamic_content` capability registration until the
+     * app has fully booted. Running `Schema::hasTable('permissions')` inside
+     * a synchronous `boot()` costs one DB round-trip on every request; the
+     * capability only needs to exist once, at real bootstrap time (console
+     * migrations, one-shot bootstrap seeders), so we lift the probe into
+     * `booted()` where it runs once per process.
+     */
+    protected function deferCapabilityRegistration(): void
+    {
+        $this->app->booted( function (): void {
+            if ( ! class_exists( PermissionManager::class ) ) {
+                return;
+            }
+
+            if ( ! Schema::hasTable( 'permissions' ) ) {
+                return;
+            }
+
+            $this->app->make( PermissionManager::class )
+                ->register( self::CAPABILITY, __( 'Manage Dynamic Content' ) );
+        } );
+    }
+
+    /**
+     * Invalidate resolver-level cache AND accessor per-request memo on
+     * record write, so downstream reads see the fresh value.
+     */
+    protected function registerRecordEvents(): void
+    {
+        $bust = function ( DynamicContentRecord|DynamicContentRecordValue $model ): void {
+            $record = $model instanceof DynamicContentRecord ? $model : $model->record;
+
+            if ( null === $record || null === $record->type ) {
+                return;
+            }
+
+            $slug = $record->type->slug;
+
+            Cache::forget( 'dc.sig.' . $slug );
+
+            if ( $this->app->resolved( DynamicContentAccessor::class ) ) {
+                $this->app->make( DynamicContentAccessor::class )->forget( $slug );
+            }
+        };
+
+        DynamicContentRecord::saved( $bust );
+        DynamicContentRecord::deleted( $bust );
+        DynamicContentRecordValue::saved( $bust );
+        DynamicContentRecordValue::deleted( $bust );
+    }
+}

--- a/src/Modules/DynamicContent/Services/DynamicContentAccessor.php
+++ b/src/Modules/DynamicContent/Services/DynamicContentAccessor.php
@@ -1,0 +1,224 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Modules\DynamicContent\Services;
+
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Enums\Cardinality;
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Enums\Source;
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Managers\DynamicContentTypeRegistry;
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Models\DynamicContentRecord;
+use Illuminate\Support\Facades\Cache;
+
+/**
+ * Reads dynamic content records — DB-backed or code-registered.
+ *
+ * All reads flow through here so the resolver, block bindings, and REST
+ * endpoints share a single lazy-loading strategy and cache signature.
+ *
+ * @since 2.4.0
+ */
+class DynamicContentAccessor
+{
+    /**
+     * Per-request memoization: `[$typeSlug => list<array<string,mixed>>]`.
+     *
+     * The accessor is bound as a singleton, so this cache is scoped to a
+     * single HTTP request / job. Kills the N+1 that arises when a body
+     * has multiple tokens against the same collection
+     * (e.g. `{{team[0].name}} {{team[0].role}}`) — the collection now
+     * loads once and every token indexes into the in-memory array.
+     *
+     * Invalidated by {@see forget()}, which fires from the same record
+     * save/delete events that bust the resolver signature cache.
+     *
+     * @var array<string, list<array<string,mixed>>>
+     */
+    protected array $collectionMemo = [];
+
+    /**
+     * Per-request memoization for singleton reads: `[$typeSlug => array<string,mixed>|null]`.
+     *
+     * `null` is a valid memoized value ("no record persisted"), so we use
+     * a sentinel key check (`array_key_exists`) to distinguish memoized
+     * misses from cold entries.
+     *
+     * @var array<string, array<string,mixed>|null>
+     */
+    protected array $singletonMemo = [];
+
+    public function __construct( protected DynamicContentTypeRegistry $registry )
+    {
+    }
+
+    /**
+     * Clear per-request memoization. Called from the record save/delete
+     * event listener registered in {@see \ArtisanPackUI\CMSFramework\Modules\DynamicContent\Providers\DynamicContentServiceProvider}.
+     */
+    public function forget( ?string $typeSlug = null ): void
+    {
+        if ( null === $typeSlug ) {
+            $this->collectionMemo = [];
+            $this->singletonMemo  = [];
+
+            return;
+        }
+
+        unset( $this->collectionMemo[ $typeSlug ], $this->singletonMemo[ $typeSlug ] );
+    }
+
+    /**
+     * Fetch a singleton record's field values by type slug.
+     *
+     * Returns null when the type doesn't exist. Returns [] when the type
+     * exists but has no persisted record yet.
+     *
+     * @return array<string, mixed>|null
+     */
+    public function singleton( string $typeSlug ): ?array
+    {
+        if ( array_key_exists( $typeSlug, $this->singletonMemo ) ) {
+            return $this->singletonMemo[ $typeSlug ];
+        }
+
+        $type = $this->registry->get( $typeSlug );
+
+        if ( null === $type ) {
+            return $this->singletonMemo[ $typeSlug ] = null;
+        }
+
+        if ( Cardinality::Singleton !== $type['cardinality'] ) {
+            return $this->singletonMemo[ $typeSlug ] = null;
+        }
+
+        return $this->singletonMemo[ $typeSlug ] = $this->firstRecord( $type ) ?? $this->defaultsFromFields( $type );
+    }
+
+    /**
+     * Fetch a specific collection record by index (0-based).
+     *
+     * @return array<string, mixed>|null
+     */
+    public function collectionItem( string $typeSlug, int $index ): ?array
+    {
+        // Delegate through the memoized collection load so N tokens against
+        // the same collection (`{{team[0].x}} {{team[0].y}}`) share one query.
+        $records = $this->collection( $typeSlug );
+
+        return $records[ $index ] ?? null;
+    }
+
+    /**
+     * Return every record for a collection type as an array of field-value maps.
+     *
+     * Used by the visual-editor loop block and by REST list endpoints.
+     *
+     * @return list<array<string, mixed>>
+     */
+    public function collection( string $typeSlug ): array
+    {
+        if ( array_key_exists( $typeSlug, $this->collectionMemo ) ) {
+            return $this->collectionMemo[ $typeSlug ];
+        }
+
+        $type = $this->registry->get( $typeSlug );
+
+        if ( null === $type || Cardinality::Collection !== $type['cardinality'] ) {
+            return $this->collectionMemo[ $typeSlug ] = [];
+        }
+
+        if ( Source::Code === $type['source'] ) {
+            return $this->collectionMemo[ $typeSlug ] = $this->resolveCodeRecords( $type );
+        }
+
+        return $this->collectionMemo[ $typeSlug ] = DynamicContentRecord::query()
+            ->with( 'values.field', 'type.fields' )
+            ->where( 'dynamic_content_type_id', $type['db_id'] )
+            ->orderBy( 'order' )
+            ->orderBy( 'id' )
+            ->get()
+            ->map( fn ( DynamicContentRecord $r ) => $r->fieldValues() )
+            ->values()
+            ->all();
+    }
+
+    /**
+     * Return the cache signature for a type — used to key downstream caches.
+     */
+    public function signatureFor( string $typeSlug ): string
+    {
+        $type = $this->registry->get( $typeSlug );
+
+        if ( null === $type ) {
+            return "dc:{$typeSlug}:missing";
+        }
+
+        if ( Source::Code === $type['source'] ) {
+            return "dc:{$typeSlug}:code";
+        }
+
+        $stamp = Cache::rememberForever(
+            "dc.sig.{$typeSlug}",
+            fn () => (string) DynamicContentRecord::query()
+                ->where( 'dynamic_content_type_id', $type['db_id'] )
+                ->max( 'updated_at' ),
+        );
+
+        return "dc:{$typeSlug}:{$stamp}";
+    }
+
+    protected function firstRecord( array $type ): ?array
+    {
+        if ( Source::Code === $type['source'] ) {
+            $records = $this->resolveCodeRecords( $type );
+
+            return $records[0] ?? null;
+        }
+
+        $record = DynamicContentRecord::query()
+            ->with( 'values.field', 'type.fields' )
+            ->where( 'dynamic_content_type_id', $type['db_id'] )
+            ->orderBy( 'order' )
+            ->orderBy( 'id' )
+            ->first();
+
+        return null === $record ? null : $record->fieldValues();
+    }
+
+    protected function defaultsFromFields( array $type ): array
+    {
+        $out = [];
+
+        foreach ( $type['fields'] as $field ) {
+            $out[ $field['slug'] ] = $field['default'] ?? null;
+        }
+
+        return $out;
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    protected function resolveCodeRecords( array $type ): array
+    {
+        $records = $type['records'] ?? null;
+
+        if ( is_callable( $records ) ) {
+            $records = $records();
+        }
+
+        if ( null === $records ) {
+            return [];
+        }
+
+        $out = [];
+
+        foreach ( $records as $record ) {
+            if ( is_array( $record ) ) {
+                $out[] = $record;
+            }
+        }
+
+        return $out;
+    }
+}

--- a/src/Modules/DynamicContent/Services/DynamicContentResolver.php
+++ b/src/Modules/DynamicContent/Services/DynamicContentResolver.php
@@ -1,0 +1,319 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Modules\DynamicContent\Services;
+
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Enums\Cardinality;
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Managers\DynamicContentTypeRegistry;
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Managers\FieldTypeRegistry;
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Managers\ModifierRegistry;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Request;
+use Illuminate\Support\HtmlString;
+use Throwable;
+
+/**
+ * Resolves `{{source.field|modifier:arg}}` tokens in a string.
+ *
+ * Returns **HTML-safe** output: values are routed through their field
+ * type's `render()` which either escapes (text-shaped types) or emits
+ * intentional HTML (rich text). If a token can't be routed to a known
+ * field type the value is escaped defensively before returning.
+ *
+ * Missing sources / fields render as an empty string and log a warning to
+ * the `dynamic-content` channel. Resolution does NOT recurse — resolved
+ * output is not re-scanned for tokens.
+ *
+ * @since 2.4.0
+ */
+class DynamicContentResolver
+{
+    /**
+     * Matches `{{ source.field[.subfield|[index].field][|modifier:arg:arg]* }}`.
+     * The outer non-greedy body is deliberately narrow — no braces inside a token.
+     */
+    public const TOKEN_PATTERN = '/\{\{\s*([^{}]+?)\s*\}\}/';
+
+    public function __construct(
+        protected DynamicContentTypeRegistry $registry,
+        protected DynamicContentAccessor $accessor,
+        protected FieldTypeRegistry $fieldTypes,
+        protected ModifierRegistry $modifiers,
+    ) {
+    }
+
+    public function render( string $content, array $context = [] ): string
+    {
+        if ( '' === $content || ! str_contains( $content, '{{' ) ) {
+            return $content;
+        }
+
+        return (string) preg_replace_callback(
+            self::TOKEN_PATTERN,
+            fn ( array $match ) => $this->resolveOne( $match[0], $match[1], $context ),
+            $content,
+        );
+    }
+
+    /**
+     * Return a signature that summarizes the resolver state for the given content.
+     *
+     * Callers include this in their own cache keys so a token change invalidates
+     * their cached HTML.
+     */
+    public function signatureFor( string $content ): string
+    {
+        if ( ! preg_match_all( self::TOKEN_PATTERN, $content, $matches ) ) {
+            return 'dc:none';
+        }
+
+        $signatures = [];
+
+        foreach ( $matches[1] as $body ) {
+            $parsed = $this->parseToken( $body );
+
+            if ( null === $parsed ) {
+                continue;
+            }
+
+            $signatures[] = $this->accessor->signatureFor( $parsed['source'] );
+        }
+
+        return md5( implode( '|', $signatures ) );
+    }
+
+    protected function resolveOne( string $original, string $body, array $context ): string
+    {
+        $parsed = $this->parseToken( $body );
+
+        if ( null === $parsed ) {
+            $this->logMissing( $original, 'malformed', $context );
+
+            return '';
+        }
+
+        $value = $this->readValue( $parsed );
+
+        if ( null === $value && ! $this->hasDefaultModifier( $parsed['modifiers'] ) ) {
+            $this->logMissing( $original, 'unresolved', $context );
+        }
+
+        $value    = $this->applyModifiers( $value, $parsed['modifiers'] );
+        $rendered = $this->renderFieldValue( $parsed, $value );
+
+        return (string) $rendered;
+    }
+
+    /**
+     * @return array{source:string, path:array<int,int|string>, modifiers:array<int,array{slug:string,args:array<int,string>}>}|null
+     */
+    protected function parseToken( string $body ): ?array
+    {
+        $parts     = explode( '|', $body );
+        $accessor  = trim( array_shift( $parts ) );
+        $modifiers = [];
+
+        foreach ( $parts as $modifier ) {
+            $modifier = trim( $modifier );
+
+            if ( '' === $modifier ) {
+                continue;
+            }
+
+            $segments = explode( ':', $modifier );
+            $slug     = trim( array_shift( $segments ) );
+
+            if ( '' === $slug ) {
+                continue;
+            }
+
+            $modifiers[] = [
+                'slug' => $slug,
+                'args' => array_map( 'trim', $segments ),
+            ];
+        }
+
+        // Path parsing: `source.field.sub` or `source[0].field`
+        $segments = preg_split( '/[.\[\]]+/', $accessor, -1, PREG_SPLIT_NO_EMPTY );
+
+        if ( false === $segments || count( $segments ) < 1 ) {
+            return null;
+        }
+
+        $source = array_shift( $segments );
+        $path   = [];
+
+        foreach ( $segments as $segment ) {
+            $path[] = ctype_digit( $segment ) ? (int) $segment : $segment;
+        }
+
+        return [
+            'source'    => $source,
+            'path'      => $path,
+            'modifiers' => $modifiers,
+        ];
+    }
+
+    protected function readValue( array $parsed ): mixed
+    {
+        $type = $this->registry->get( $parsed['source'] );
+
+        if ( null === $type ) {
+            return null;
+        }
+
+        // Split path into an optional collection index followed by a field path.
+        $path       = $parsed['path'];
+        $firstIsInt = ! empty( $path ) && is_int( $path[0] );
+
+        if ( Cardinality::Collection === $type['cardinality'] ) {
+            $index  = $firstIsInt ? array_shift( $path ) : 0;
+            $record = $this->accessor->collectionItem( $parsed['source'], $index );
+        } else {
+            $record = $this->accessor->singleton( $parsed['source'] );
+        }
+
+        if ( null === $record ) {
+            return null;
+        }
+
+        return $this->traversePath( $record, $path );
+    }
+
+    protected function traversePath( mixed $value, array $path ): mixed
+    {
+        foreach ( $path as $segment ) {
+            if ( is_array( $value ) && array_key_exists( $segment, $value ) ) {
+                $value = $value[ $segment ];
+                continue;
+            }
+
+            return null;
+        }
+
+        return $value;
+    }
+
+    protected function applyModifiers( mixed $value, array $modifiers ): mixed
+    {
+        foreach ( $modifiers as $modifier ) {
+            $impl = $this->modifiers->get( $modifier['slug'] );
+
+            if ( null === $impl ) {
+                continue;
+            }
+
+            $value = $impl->apply( $value, $modifier['args'] );
+        }
+
+        return $value;
+    }
+
+    /**
+     * Route the value through its field type's `render()` so text-shaped
+     * types are HTML-escaped and rich-text stays raw. When we can't
+     * identify a field type (unknown source, no path, unknown field slug),
+     * fall back to escaping the value defensively.
+     */
+    protected function renderFieldValue( array $parsed, mixed $value ): HtmlString
+    {
+        $fieldSlug = $this->trailingFieldSlug( $parsed['path'] );
+        $type      = null === $fieldSlug ? null : $this->registry->get( $parsed['source'] );
+        $fieldMeta = null === $type ? null : ( $this->fieldsBySlug( $type )[ $fieldSlug ] ?? null );
+
+        if ( null !== $fieldMeta ) {
+            $impl = $this->fieldTypes->get( $fieldMeta['type'] );
+
+            if ( null !== $impl ) {
+                return $impl->render( $value, $fieldMeta['options'] ?? [] );
+            }
+        }
+
+        // Defensive fallback: an unroutable value is treated as untrusted text.
+        if ( $value instanceof HtmlString ) {
+            return $value;
+        }
+
+        if ( null === $value || ! is_scalar( $value ) ) {
+            return new HtmlString( '' );
+        }
+
+        return new HtmlString( e( (string) $value ) );
+    }
+
+    /**
+     * Return the last string segment of a path (the field slug), or null
+     * if the path doesn't end in one.
+     */
+    protected function trailingFieldSlug( array $path ): ?string
+    {
+        for ( $i = count( $path ) - 1; $i >= 0; $i-- ) {
+            if ( is_string( $path[ $i ] ) ) {
+                return $path[ $i ];
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Memoized fields-by-slug index for a normalized type definition.
+     *
+     * @param  array{fields:array<int,array<string,mixed>>}  $type
+     *
+     * @return array<string, array<string,mixed>>
+     */
+    protected function fieldsBySlug( array $type ): array
+    {
+        static $cache = [];
+
+        $key = $type['slug'] ?? spl_object_hash( (object) $type );
+
+        if ( isset( $cache[ $key ] ) ) {
+            return $cache[ $key ];
+        }
+
+        $out = [];
+
+        foreach ( $type['fields'] as $field ) {
+            $out[ $field['slug'] ] = $field;
+        }
+
+        return $cache[ $key ] = $out;
+    }
+
+    protected function hasDefaultModifier( array $modifiers ): bool
+    {
+        foreach ( $modifiers as $modifier ) {
+            if ( 'default' === $modifier['slug'] ) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    protected function logMissing( string $token, string $reason, array $context ): void
+    {
+        $channel = config( 'logging.channels.dynamic-content' ) ? 'dynamic-content' : 'stack';
+
+        try {
+            $url = Request::fullUrl();
+        } catch ( Throwable ) {
+            $url = null;
+        }
+
+        Log::channel( $channel )->warning(
+            'Dynamic content token failed to resolve',
+            [
+                'token'   => $token,
+                'reason'  => $reason,
+                'url'     => $url,
+                'user_id' => Auth::id(),
+                'context' => $context,
+            ],
+        );
+    }
+}

--- a/src/Modules/DynamicContent/database/migrations/2026_07_16_000001_create_dynamic_content_types_table.php
+++ b/src/Modules/DynamicContent/database/migrations/2026_07_16_000001_create_dynamic_content_types_table.php
@@ -1,0 +1,31 @@
+<?php
+
+declare( strict_types=1 );
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create( 'dynamic_content_types', function ( Blueprint $table ): void {
+            $table->id();
+            $table->string( 'slug' )->unique();
+            $table->string( 'name' );
+            $table->string( 'cardinality' )->default( 'singleton' );
+            $table->string( 'source' )->default( 'db' );
+            $table->text( 'description' )->nullable();
+            $table->string( 'icon' )->nullable();
+            $table->timestamps();
+
+            $table->index( 'source' );
+            $table->index( 'cardinality' );
+        } );
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists( 'dynamic_content_types' );
+    }
+};

--- a/src/Modules/DynamicContent/database/migrations/2026_07_16_000002_create_dynamic_content_fields_table.php
+++ b/src/Modules/DynamicContent/database/migrations/2026_07_16_000002_create_dynamic_content_fields_table.php
@@ -1,0 +1,35 @@
+<?php
+
+declare( strict_types=1 );
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create( 'dynamic_content_fields', function ( Blueprint $table ): void {
+            $table->id();
+            $table->foreignId( 'dynamic_content_type_id' )
+                ->constrained( 'dynamic_content_types' )
+                ->cascadeOnDelete();
+            $table->string( 'slug' );
+            $table->string( 'label' );
+            $table->string( 'type' );
+            $table->json( 'options' )->nullable();
+            $table->text( 'default_value' )->nullable();
+            $table->boolean( 'required' )->default( false );
+            $table->unsignedInteger( 'order' )->default( 0 );
+            $table->timestamps();
+
+            $table->unique( [ 'dynamic_content_type_id', 'slug' ] );
+            $table->index( 'order' );
+        } );
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists( 'dynamic_content_fields' );
+    }
+};

--- a/src/Modules/DynamicContent/database/migrations/2026_07_16_000003_create_dynamic_content_records_table.php
+++ b/src/Modules/DynamicContent/database/migrations/2026_07_16_000003_create_dynamic_content_records_table.php
@@ -1,0 +1,29 @@
+<?php
+
+declare( strict_types=1 );
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create( 'dynamic_content_records', function ( Blueprint $table ): void {
+            $table->id();
+            $table->foreignId( 'dynamic_content_type_id' )
+                ->constrained( 'dynamic_content_types' )
+                ->cascadeOnDelete();
+            $table->string( 'label' )->nullable();
+            $table->unsignedInteger( 'order' )->default( 0 );
+            $table->timestamps();
+
+            $table->index( [ 'dynamic_content_type_id', 'order' ] );
+        } );
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists( 'dynamic_content_records' );
+    }
+};

--- a/src/Modules/DynamicContent/database/migrations/2026_07_16_000004_create_dynamic_content_record_values_table.php
+++ b/src/Modules/DynamicContent/database/migrations/2026_07_16_000004_create_dynamic_content_record_values_table.php
@@ -1,0 +1,34 @@
+<?php
+
+declare( strict_types=1 );
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create( 'dynamic_content_record_values', function ( Blueprint $table ): void {
+            $table->id();
+            $table->foreignId( 'dynamic_content_record_id' )
+                ->constrained( 'dynamic_content_records' )
+                ->cascadeOnDelete();
+            $table->foreignId( 'dynamic_content_field_id' )
+                ->constrained( 'dynamic_content_fields' )
+                ->cascadeOnDelete();
+            $table->json( 'value' )->nullable();
+            $table->timestamps();
+
+            $table->unique(
+                [ 'dynamic_content_record_id', 'dynamic_content_field_id' ],
+                'dc_record_field_unique',
+            );
+        } );
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists( 'dynamic_content_record_values' );
+    }
+};

--- a/src/Modules/DynamicContent/helpers.php
+++ b/src/Modules/DynamicContent/helpers.php
@@ -1,0 +1,62 @@
+<?php
+
+declare( strict_types=1 );
+
+/**
+ * DynamicContent Module Helper Functions.
+ *
+ * SECURITY: dynamic content is a public content pipeline. `apRenderContent()`
+ * and the `@dynamicContent` Blade directive resolve tokens against every
+ * registered type without a per-request authorization check — the intent is
+ * that any content author who can write a token can substitute any dynamic
+ * content field. Do NOT store secrets in dynamic content records. See
+ * {@see ArtisanPackUI\CMSFramework\Modules\DynamicContent\Casts\DynamicContentCast}
+ * for the full note.
+ *
+ * @since 2.4.0
+ */
+
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Managers\DynamicContentTypeRegistry;
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Services\DynamicContentResolver;
+
+if ( ! function_exists( 'apRegisterDynamicContentType' ) ) {
+    /**
+     * Register a dynamic content type in code.
+     *
+     * @since 2.4.0
+     *
+     * @param  string  $slug  Unique type slug.
+     * @param  array<string, mixed>  $definition  Type definition (name, cardinality, fields, records).
+     */
+    function apRegisterDynamicContentType( string $slug, array $definition ): void
+    {
+        app( DynamicContentTypeRegistry::class )->registerCodeType( $slug, $definition );
+    }
+}
+
+if ( ! function_exists( 'apRenderContent' ) ) {
+    /**
+     * Render dynamic-content tokens inside a string.
+     *
+     * @since 2.4.0
+     *
+     * @param  string  $content  Content containing `{{source.field}}` tokens.
+     * @param  array<string, mixed>  $context  Optional context for logging.
+     */
+    function apRenderContent( string $content, array $context = [] ): string
+    {
+        return app( DynamicContentResolver::class )->render( $content, $context );
+    }
+}
+
+if ( ! function_exists( 'apDynamicContentSignature' ) ) {
+    /**
+     * Signature of the resolver's state for `$content` — for cache keys.
+     *
+     * @since 2.4.0
+     */
+    function apDynamicContentSignature( string $content ): string
+    {
+        return app( DynamicContentResolver::class )->signatureFor( $content );
+    }
+}

--- a/src/Modules/DynamicContent/resources/views/livewire/collection-editor.blade.php
+++ b/src/Modules/DynamicContent/resources/views/livewire/collection-editor.blade.php
@@ -1,0 +1,47 @@
+<div>
+    <h2>{{ $type->name }}</h2>
+
+    <button type="button" wire:click="create">{{ __( 'New Record' ) }}</button>
+
+    <table>
+        <thead>
+            <tr>
+                <th>{{ __( 'Label' ) }}</th>
+                <th>{{ __( 'Order' ) }}</th>
+                <th>{{ __( 'Actions' ) }}</th>
+            </tr>
+        </thead>
+        <tbody>
+            @foreach ( $records as $record )
+                <tr wire:key="record-{{ $record->id }}">
+                    <td>{{ $record->label }}</td>
+                    <td>{{ $record->order }}</td>
+                    <td>
+                        <button type="button" wire:click="edit({{ $record->id }})">{{ __( 'Edit' ) }}</button>
+                        <button type="button" wire:click="delete({{ $record->id }})">{{ __( 'Delete' ) }}</button>
+                    </td>
+                </tr>
+            @endforeach
+        </tbody>
+    </table>
+
+    {{ $records->links() }}
+
+    @if ( null !== $editingRecordId || ! empty( $editingValues ) )
+        <div>
+            <h3>{{ null === $editingRecordId ? __( 'New Record' ) : __( 'Edit Record' ) }}</h3>
+            <label>{{ __( 'Label' ) }}<input type="text" wire:model="editingLabel" /></label>
+
+            @foreach ( $type->fields as $field )
+                <div wire:key="editing-value-{{ $field->slug }}">
+                    <label>
+                        {{ $field->label }}
+                        <input type="text" wire:model="editingValues.{{ $field->slug }}" />
+                    </label>
+                </div>
+            @endforeach
+
+            <button type="button" wire:click="save">{{ __( 'Save' ) }}</button>
+        </div>
+    @endif
+</div>

--- a/src/Modules/DynamicContent/resources/views/livewire/field-builder.blade.php
+++ b/src/Modules/DynamicContent/resources/views/livewire/field-builder.blade.php
@@ -1,0 +1,35 @@
+<div>
+    <div>
+        <label>{{ __( 'Name' ) }}<input type="text" wire:model="name" /></label>
+        <label>{{ __( 'Slug' ) }}<input type="text" wire:model="slug" /></label>
+        <label>{{ __( 'Cardinality' ) }}
+            <select wire:model="cardinality">
+                <option value="singleton">{{ __( 'Singleton' ) }}</option>
+                <option value="collection">{{ __( 'Collection' ) }}</option>
+            </select>
+        </label>
+        <label>{{ __( 'Description' ) }}<textarea wire:model="description"></textarea></label>
+    </div>
+
+    <h3>{{ __( 'Fields' ) }}</h3>
+    @foreach ( $fields as $index => $field )
+        <div wire:key="field-{{ $index }}">
+            <input type="text" wire:model="fields.{{ $index }}.slug" :placeholder="__( 'Slug' )" />
+            <input type="text" wire:model="fields.{{ $index }}.label" :placeholder="__( 'Label' )" />
+            <select wire:model="fields.{{ $index }}.type">
+                @foreach ( $fieldTypes as $slug => $ft )
+                    <option value="{{ $slug }}">{{ $ft->label() }}</option>
+                @endforeach
+            </select>
+            <label><input type="checkbox" wire:model="fields.{{ $index }}.required" /> {{ __( 'Required' ) }}</label>
+            <input type="text" wire:model="fields.{{ $index }}.default" :placeholder="__( 'Default' )" />
+
+            <button type="button" wire:click="moveUp({{ $index }})">{{ __( 'Move up' ) }}</button>
+            <button type="button" wire:click="moveDown({{ $index }})">{{ __( 'Move down' ) }}</button>
+            <button type="button" wire:click="removeField({{ $index }})">{{ __( 'Remove' ) }}</button>
+        </div>
+    @endforeach
+
+    <button type="button" wire:click="addField">{{ __( 'Add Field' ) }}</button>
+    <button type="button" wire:click="save">{{ __( 'Save' ) }}</button>
+</div>

--- a/src/Modules/DynamicContent/resources/views/livewire/singleton-editor.blade.php
+++ b/src/Modules/DynamicContent/resources/views/livewire/singleton-editor.blade.php
@@ -1,0 +1,28 @@
+<div>
+    <h2>{{ $type->name }}</h2>
+
+    @foreach ( $type->fields as $field )
+        <div wire:key="value-{{ $field->slug }}">
+            <label>
+                {{ $field->label }}
+                @if ( 'rich_text' === $field->type )
+                    <textarea wire:model="values.{{ $field->slug }}"></textarea>
+                @elseif ( 'number' === $field->type )
+                    <input type="number" wire:model="values.{{ $field->slug }}" />
+                @elseif ( 'email' === $field->type )
+                    <input type="email" wire:model="values.{{ $field->slug }}" />
+                @elseif ( 'url' === $field->type )
+                    <input type="url" wire:model="values.{{ $field->slug }}" />
+                @elseif ( 'date' === $field->type )
+                    <input type="date" wire:model="values.{{ $field->slug }}" />
+                @elseif ( 'datetime' === $field->type )
+                    <input type="datetime-local" wire:model="values.{{ $field->slug }}" />
+                @else
+                    <input type="text" wire:model="values.{{ $field->slug }}" />
+                @endif
+            </label>
+        </div>
+    @endforeach
+
+    <button type="button" wire:click="save">{{ __( 'Save' ) }}</button>
+</div>

--- a/src/Modules/DynamicContent/resources/views/livewire/type-list.blade.php
+++ b/src/Modules/DynamicContent/resources/views/livewire/type-list.blade.php
@@ -1,0 +1,30 @@
+<div>
+    <table>
+        <thead>
+            <tr>
+                <th>{{ __( 'Name' ) }}</th>
+                <th>{{ __( 'Slug' ) }}</th>
+                <th>{{ __( 'Cardinality' ) }}</th>
+                <th>{{ __( 'Source' ) }}</th>
+                <th>{{ __( 'Actions' ) }}</th>
+            </tr>
+        </thead>
+        <tbody>
+            @foreach ( $types as $slug => $type )
+                <tr wire:key="type-{{ $slug }}">
+                    <td>{{ $type['name'] }}</td>
+                    <td><code>{{ $slug }}</code></td>
+                    <td>{{ $type['cardinality']->value }}</td>
+                    <td>{{ $type['source']->value }}</td>
+                    <td>
+                        @if ( 'db' === $type['source']->value && isset( $type['db_id'] ) )
+                            <button type="button" wire:click="delete({{ $type['db_id'] }})">{{ __( 'Delete' ) }}</button>
+                        @else
+                            <span title="{{ __( 'Code-registered types are read-only' ) }}">{{ __( 'Read-only' ) }}</span>
+                        @endif
+                    </td>
+                </tr>
+            @endforeach
+        </tbody>
+    </table>
+</div>

--- a/src/Modules/DynamicContent/routes/api.php
+++ b/src/Modules/DynamicContent/routes/api.php
@@ -1,0 +1,32 @@
+<?php
+
+declare( strict_types=1 );
+
+/**
+ * Dynamic Content module API routes.
+ *
+ * @since 2.4.0
+ */
+
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Http\Controllers\DynamicContentRecordController;
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Http\Controllers\DynamicContentResolverController;
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Http\Controllers\DynamicContentTypeController;
+use Illuminate\Support\Facades\Route;
+
+Route::prefix( 'dynamic-content' )->middleware( 'auth' )->group( function (): void {
+    Route::get( 'types', [ DynamicContentTypeController::class, 'index' ] );
+    Route::get( 'types/registered', [ DynamicContentTypeController::class, 'registered' ] );
+    Route::post( 'types', [ DynamicContentTypeController::class, 'store' ] );
+    Route::get( 'types/{type}', [ DynamicContentTypeController::class, 'show' ] );
+    Route::put( 'types/{type}', [ DynamicContentTypeController::class, 'update' ] );
+    Route::delete( 'types/{type}', [ DynamicContentTypeController::class, 'destroy' ] );
+
+    Route::get( 'types/{type}/records', [ DynamicContentRecordController::class, 'index' ] );
+    Route::post( 'types/{type}/records', [ DynamicContentRecordController::class, 'store' ] );
+    Route::get( 'types/{type}/records/{record}', [ DynamicContentRecordController::class, 'show' ] );
+    Route::put( 'types/{type}/records/{record}', [ DynamicContentRecordController::class, 'update' ] );
+    Route::delete( 'types/{type}/records/{record}', [ DynamicContentRecordController::class, 'destroy' ] );
+
+    Route::post( 'resolve', [ DynamicContentResolverController::class, 'resolve' ] )
+        ->middleware( 'throttle:60,1' );
+} );

--- a/tests/Feature/DynamicContent/DynamicContentApiTest.php
+++ b/tests/Feature/DynamicContent/DynamicContentApiTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Managers\DynamicContentTypeManager;
+use ArtisanPackUI\CMSFramework\Tests\Support\TestUser;
+use Illuminate\Support\Facades\Gate;
+
+beforeEach( function (): void {
+    $this->user = TestUser::create( [
+        'name'     => 'Admin',
+        'email'    => 'a@example.com',
+        'password' => bcrypt( 'x' ),
+    ] );
+
+    Gate::define( 'manage_dynamic_content', fn () => true );
+} );
+
+test( 'authenticated user can list types', function (): void {
+    app( DynamicContentTypeManager::class )->create( [
+        'slug'        => 'business_info',
+        'name'        => 'Business Info',
+        'cardinality' => 'singleton',
+        'fields'      => [],
+    ] );
+
+    $this->actingAs( $this->user )
+        ->getJson( '/api/v1/dynamic-content/types' )
+        ->assertOk()
+        ->assertJsonStructure( [ 'data' => [ [ 'slug', 'name', 'cardinality', 'source' ] ] ] );
+} );
+
+test( 'unauthenticated user is rejected', function (): void {
+    $this->getJson( '/api/v1/dynamic-content/types' )->assertUnauthorized();
+} );
+
+test( 'resolve preview endpoint returns rendered content', function (): void {
+    $type = app( DynamicContentTypeManager::class )->create( [
+        'slug'        => 'brand',
+        'name'        => 'Brand',
+        'cardinality' => 'singleton',
+        'fields'      => [ [ 'slug' => 'name', 'label' => 'Name', 'type' => 'text' ] ],
+    ] );
+
+    app( ArtisanPackUI\CMSFramework\Modules\DynamicContent\Managers\DynamicContentRecordManager::class )
+        ->create( $type, [ 'values' => [ 'name' => 'Acme' ] ] );
+
+    $this->actingAs( $this->user )
+        ->postJson( '/api/v1/dynamic-content/resolve', [ 'content' => 'Hi from {{brand.name}}' ] )
+        ->assertOk()
+        ->assertJsonPath( 'data.rendered', 'Hi from Acme' );
+} );

--- a/tests/Feature/DynamicContent/ResolverTest.php
+++ b/tests/Feature/DynamicContent/ResolverTest.php
@@ -1,0 +1,203 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Enums\Cardinality;
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Managers\DynamicContentRecordManager;
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Managers\DynamicContentTypeManager;
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Services\DynamicContentResolver;
+
+beforeEach( function (): void {
+    $this->typeManager   = app( DynamicContentTypeManager::class );
+    $this->recordManager = app( DynamicContentRecordManager::class );
+    $this->resolver      = app( DynamicContentResolver::class );
+} );
+
+test( 'resolves singleton tokens', function (): void {
+    $type = $this->typeManager->create( [
+        'slug'        => 'business_info',
+        'name'        => 'Business Info',
+        'cardinality' => 'singleton',
+        'fields'      => [
+            [ 'slug' => 'phone', 'label' => 'Phone', 'type' => 'phone' ],
+            [ 'slug' => 'email', 'label' => 'Email', 'type' => 'email' ],
+        ],
+    ] );
+
+    $this->recordManager->create( $type, [
+        'values' => [ 'phone' => '555-1212', 'email' => 'hi@example.com' ],
+    ] );
+
+    $out = $this->resolver->render(
+        'Call {{business_info.phone}} or email {{business_info.email}}.',
+    );
+
+    expect( $out )->toBe( 'Call 555-1212 or email hi@example.com.' );
+} );
+
+test( 'resolves collection tokens via index', function (): void {
+    $type = $this->typeManager->create( [
+        'slug'        => 'team',
+        'name'        => 'Team',
+        'cardinality' => 'collection',
+        'fields'      => [ [ 'slug' => 'name', 'label' => 'Name', 'type' => 'text' ] ],
+    ] );
+
+    $this->recordManager->create( $type, [ 'label' => 'A', 'values' => [ 'name' => 'Alice' ] ] );
+    $this->recordManager->create( $type, [ 'label' => 'B', 'values' => [ 'name' => 'Bob' ] ] );
+
+    expect( $this->resolver->render( 'Lead: {{team[0].name}}' ) )->toBe( 'Lead: Alice' );
+    expect( $this->resolver->render( 'Second: {{team[1].name}}' ) )->toBe( 'Second: Bob' );
+} );
+
+test( 'missing source renders empty and does not leak braces', function (): void {
+    $out = $this->resolver->render( 'Hello {{unknown.thing}} world' );
+
+    expect( $out )->toBe( 'Hello  world' );
+} );
+
+test( 'default modifier applies when value is missing', function (): void {
+    $type = $this->typeManager->create( [
+        'slug'        => 'site',
+        'name'        => 'Site',
+        'cardinality' => 'singleton',
+        'fields'      => [ [ 'slug' => 'tag', 'label' => 'Tag', 'type' => 'text' ] ],
+    ] );
+
+    $this->recordManager->create( $type, [ 'values' => [ 'tag' => null ] ] );
+
+    expect( $this->resolver->render( '{{site.tag|default:none}}' ) )->toBe( 'none' );
+} );
+
+test( 'upper modifier transforms resolved value', function (): void {
+    $type = $this->typeManager->create( [
+        'slug'        => 'brand',
+        'name'        => 'Brand',
+        'cardinality' => 'singleton',
+        'fields'      => [ [ 'slug' => 'name', 'label' => 'Name', 'type' => 'text' ] ],
+    ] );
+
+    $this->recordManager->create( $type, [ 'values' => [ 'name' => 'acme' ] ] );
+
+    expect( $this->resolver->render( '{{brand.name|upper}}' ) )->toBe( 'ACME' );
+} );
+
+test( 'resolver does not recurse into resolved output', function (): void {
+    $type = $this->typeManager->create( [
+        'slug'        => 'nested',
+        'name'        => 'Nested',
+        'cardinality' => 'singleton',
+        'fields'      => [ [ 'slug' => 'ref', 'label' => 'Ref', 'type' => 'text' ] ],
+    ] );
+
+    $this->recordManager->create( $type, [ 'values' => [ 'ref' => '{{nested.ref}}' ] ] );
+
+    expect( $this->resolver->render( 'Value: {{nested.ref}}' ) )->toBe( 'Value: {{nested.ref}}' );
+} );
+
+test( 'malformed tokens with braces do not throw', function (): void {
+    $out = $this->resolver->render( '{{ }} and {{ .field }}' );
+
+    expect( $out )->toBeString();
+} );
+
+test( 'code-registered types resolve alongside db types', function (): void {
+    apRegisterDynamicContentType( 'from_code', [
+        'name'        => 'From Code',
+        'cardinality' => Cardinality::Singleton,
+        'fields'      => [
+            [ 'slug' => 'greeting', 'label' => 'Greeting', 'type' => 'text' ],
+        ],
+        'records' => [
+            [ 'greeting' => 'Howdy' ],
+        ],
+    ] );
+
+    expect( $this->resolver->render( '{{from_code.greeting}}' ) )->toBe( 'Howdy' );
+} );
+
+test( 'signatureFor returns a stable string when there are no tokens', function (): void {
+    expect( $this->resolver->signatureFor( 'plain content' ) )->toBe( 'dc:none' );
+} );
+
+test( 'text field values are HTML-escaped on render', function (): void {
+    $type = $this->typeManager->create( [
+        'slug'        => 'settings',
+        'name'        => 'Settings',
+        'cardinality' => 'singleton',
+        'fields'      => [ [ 'slug' => 'tagline', 'label' => 'Tagline', 'type' => 'text' ] ],
+    ] );
+
+    $this->recordManager->create( $type, [ 'values' => [ 'tagline' => '<script>alert(1)</script>' ] ] );
+
+    $out = $this->resolver->render( 'Site: {{settings.tagline}}' );
+
+    expect( $out )->not->toContain( '<script>' );
+    expect( $out )->toContain( '&lt;script&gt;' );
+} );
+
+test( 'rich text field values render raw HTML', function (): void {
+    $type = $this->typeManager->create( [
+        'slug'        => 'article',
+        'name'        => 'Article',
+        'cardinality' => 'singleton',
+        'fields'      => [ [ 'slug' => 'body', 'label' => 'Body', 'type' => 'rich_text' ] ],
+    ] );
+
+    $this->recordManager->create( $type, [ 'values' => [ 'body' => '<p>Hello <strong>world</strong></p>' ] ] );
+
+    $out = $this->resolver->render( '{{article.body}}' );
+
+    expect( $out )->toContain( '<p>' );
+    expect( $out )->toContain( '<strong>' );
+} );
+
+test( 'unrouted values are escaped defensively', function (): void {
+    // No such type — value stays null and renders as empty; but if a source
+    // exists without a field-type match, the fallback path must escape.
+    apRegisterDynamicContentType( 'brandcode', [
+        'name'        => 'Brand',
+        'cardinality' => Cardinality::Singleton,
+        'fields'      => [ [ 'slug' => 'raw', 'label' => 'Raw', 'type' => 'nonexistent_type' ] ],
+        'records'     => [ [ 'raw' => '<img src=x onerror=alert(1)>' ] ],
+    ] );
+
+    $out = $this->resolver->render( '{{brandcode.raw}}' );
+
+    expect( $out )->not->toContain( '<img' );
+    expect( $out )->toContain( '&lt;img' );
+} );
+
+test( 'nl2br modifier output is not double-escaped by field renderer', function (): void {
+    $type = $this->typeManager->create( [
+        'slug'        => 'notes',
+        'name'        => 'Notes',
+        'cardinality' => 'singleton',
+        'fields'      => [ [ 'slug' => 'body', 'label' => 'Body', 'type' => 'text' ] ],
+    ] );
+
+    $this->recordManager->create( $type, [ 'values' => [ 'body' => "line1\nline2" ] ] );
+
+    $out = $this->resolver->render( '{{notes.body|nl2br}}' );
+
+    expect( $out )->toContain( '<br' );
+    expect( $out )->toContain( 'line1' );
+    expect( $out )->toContain( 'line2' );
+} );
+
+test( 'slug is immutable on update at the manager level', function (): void {
+    $type = $this->typeManager->create( [
+        'slug'        => 'immutable',
+        'name'        => 'Immutable',
+        'cardinality' => 'singleton',
+        'fields'      => [],
+    ] );
+
+    $this->typeManager->update( $type, [
+        'slug' => 'renamed',
+        'name' => 'Renamed',
+    ] );
+
+    expect( $type->fresh()->slug )->toBe( 'immutable' );
+    expect( $type->fresh()->name )->toBe( 'Renamed' );
+} );

--- a/tests/Unit/DynamicContent/ModifiersTest.php
+++ b/tests/Unit/DynamicContent/ModifiersTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Modifiers\DateModifier;
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Modifiers\DefaultModifier;
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Modifiers\LowerModifier;
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Modifiers\Nl2brModifier;
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Modifiers\TimeModifier;
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Modifiers\TruncateModifier;
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Modifiers\UpperModifier;
+
+test( 'default modifier substitutes when empty', function (): void {
+    $m = new DefaultModifier();
+
+    expect( $m->apply( null, [ 'fallback' ] ) )->toBe( 'fallback' );
+    expect( $m->apply( '', [ 'fallback' ] ) )->toBe( 'fallback' );
+    expect( $m->apply( 'value', [ 'fallback' ] ) )->toBe( 'value' );
+} );
+
+test( 'upper modifier uppercases strings', function (): void {
+    expect( ( new UpperModifier() )->apply( 'abc', [] ) )->toBe( 'ABC' );
+    expect( ( new UpperModifier() )->apply( 42, [] ) )->toBe( 42 );
+} );
+
+test( 'lower modifier lowercases strings', function (): void {
+    expect( ( new LowerModifier() )->apply( 'ABC', [] ) )->toBe( 'abc' );
+} );
+
+test( 'truncate modifier respects length', function (): void {
+    $m = new TruncateModifier();
+    expect( $m->apply( 'short', [ '10' ] ) )->toBe( 'short' );
+    expect( $m->apply( 'this is a long string', [ '4' ] ) )->toBe( 'this…' );
+} );
+
+test( 'date modifier formats parseable input', function (): void {
+    expect( ( new DateModifier() )->apply( '2026-07-16', [ 'Y-m-d' ] ) )->toBe( '2026-07-16' );
+    expect( ( new DateModifier() )->apply( null, [ 'Y-m-d' ] ) )->toBe( '' );
+} );
+
+test( 'time modifier reassembles colon-split args', function (): void {
+    // "time:g:i a" -> args ['g','i a']
+    expect( ( new TimeModifier() )->apply( '2026-07-16 15:04', [ 'g', 'i a' ] ) )->toBe( '3:04 pm' );
+} );
+
+test( 'nl2br modifier converts newlines and returns HtmlString', function (): void {
+    $result = ( new Nl2brModifier() )->apply( "a\nb", [] );
+    expect( $result )->toBeInstanceOf( Illuminate\Support\HtmlString::class );
+    expect( (string) $result )->toContain( '<br' );
+} );
+
+test( 'nl2br modifier escapes HTML in input before adding br tags', function (): void {
+    $result = ( new Nl2brModifier() )->apply( "<img src=x onerror=alert(1)>\nnext", [] );
+    $out    = (string) $result;
+    expect( $out )->not->toContain( '<img' );
+    expect( $out )->toContain( '&lt;img' );
+    expect( $out )->toContain( '<br' );
+} );


### PR DESCRIPTION
## Description

Implements the site-wide dynamic content system in `cms-framework`: site owners define a piece of content once (e.g. Business Info, Team Members) and reference it anywhere via `{{source.field|modifier:arg}}` merge tokens. Edits propagate everywhere the token is used.

**Closes:** #178

## Type of Change

- [x] New feature (adds new functionality)
- [x] Security fix (defense-in-depth on the resolver's output pipeline — see review section below)

## Related Issue

**Issue:** #178

Editor UX (block bindings, inline autocomplete, snippet blocks) is tracked in the companion issue `visual-editor#650`.

## Motivation and Context

Site owners frequently reuse the same content (business hours, contact info, team bios, testimonials) across many pages. Today, editing that information means hunting down every occurrence. This module lets them define it once and reference it via tokens; edits propagate on next render.

## Changes Made

New module at `src/Modules/DynamicContent/`:

- **Data model** — 4 migrations: `dynamic_content_types`, `_fields`, `_records`, `_record_values`. Models + relationships. `RecordValueCast` round-trips scalars/arrays cleanly.
- **Registry** — merges admin-created (DB) and code-registered types via `apRegisterDynamicContentType()` helper and `ap.dynamic_content.register-types` filter hook. Filter is exception-guarded so a bad plugin can't take down every resolution.
- **11 built-in field types** — text, rich_text, url, email, phone, image, date, datetime, number, address, select. Text-shaped types HTML-escape at render time; rich text stays raw by design. Data-driven `ScalarFieldType($slug, $translationKey)` collapses the seven near-identical scalar shells.
- **7 built-in modifiers** — default, upper, lower, truncate, date, time, nl2br. `nl2br` HTML-escapes input before inserting `<br>` and returns `HtmlString` so downstream field rendering doesn't double-escape.
- **`DynamicContentResolver`** — `{{source.field|modifier:arg}}` tokenizer + modifier pipeline + HTML-safe field-type dispatch. Missing tokens render empty and log a warning; no recursion into resolved output.
- **`DynamicContentAccessor`** — per-request memoized reads. Kills the N+1 that arises when a body has multiple tokens against the same collection (e.g. `{{team[0].name}} {{team[0].role}}` — one query, not two).
- **Signature cache** — `apDynamicContentSignature($content)` for downstream cache keys; invalidated on record save/delete alongside the accessor memo.
- **Authorization** — `manage_dynamic_content` capability (registered lazily in `booted()` — no per-request DB probe). Record policy exposes `viewAnyForType` / `createForType` so hosts can gate per-type via the existing filter hook. Slug is immutable on update (would silently break persisted tokens).
- **Content pipeline** — `apRenderContent()` helper, `@dynamicContent` Blade directive (safe by default — text-shaped values are escaped, rich text stays raw), `DynamicContentCast` Eloquent cast. Wired into `HasRenderedBlockContent::renderContent()` so Blog Post, Pages, and any content type using the trait auto-resolve tokens.
- **REST endpoints** — `/api/v1/dynamic-content/*` for types (CRUD), records (CRUD scoped to type), and `POST /resolve` for preview. Types are bound by slug (matches sibling modules' convention). `/resolve` is capped at 65 KB + `throttle:60,1`.
- **Livewire admin surface** — `TypeList`, `FieldBuilder`, `SingletonEditor`, `CollectionEditor` with translation-ready Blade views for host apps to mount or override.

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS Darwin 25.5.0
- PHP Version: 8.4.3
- Project Version: 2.4-dev (branched from `release/2.4`)

**Tests Performed:**
1. Full package test suite: **1051 passing, 7 pre-existing skips**
2. New DynamicContent tests: **25 passing** (parser, all 7 modifiers, singleton/collection resolution, missing sources, code-registered types, escaping, slug immutability, defensive fallback, HTML-safety of `nl2br`, resolve API endpoint)
3. Manual browser exercise via the dev app: created Business Info type, saved a singleton record, rendered `{{business_info.phone}}` from tinker and verified propagation on update

## Tests Added

- [x] Unit tests added — `tests/Unit/DynamicContent/ModifiersTest.php`
- [x] Integration tests added — `tests/Feature/DynamicContent/ResolverTest.php`, `tests/Feature/DynamicContent/DynamicContentApiTest.php`
- [x] All tests passing

**Test details:** 25 new tests cover the resolver (parser, modifier chain, singleton/collection cardinality, missing-source paths, code-registered types, no recursion), field-type-aware HTML escaping (text escaped, rich_text raw, defensive fallback when field type is unroutable), `Nl2brModifier` HTML safety and no double-escape when chained into the field renderer, slug immutability at the manager level, and the REST API (auth gating, resolve preview).

## Documentation

- [x] Inline code documentation added
- [ ] Wiki updated — deferred to a follow-up; the issue calls this out as a task and it deserves its own review pass

**Documentation details:** All public classes have PHPDoc. `DynamicContentCast`, `helpers.php`, and the `@dynamicContent` directive have prominent SECURITY notes: dynamic content is a **public content pipeline** — do NOT store secrets in dynamic content records. Rich-text fields ship raw HTML by design; hosts accepting untrusted rich-text authors must sanitize at save time (e.g. via `artisanpack-ui/security`'s `kses()`).

## Pre-Submission Checklist

- [x] Followed contributing guidelines
- [x] Checked for other open PRs for same update
- [x] Code passes all tests (1051/1058, 7 pre-existing skips)
- [x] Code has been linted (`./vendor/bin/php-cs-fixer fix` clean)
- [x] Code follows project style guide (WordPress-style spacing, Yoda conditions, `declare(strict_types=1)`, translation-ready strings)
- [x] Self-review completed — full `/code-review high --focus security` pass surfaced 17 findings; all 17 addressed in this branch (10 primary security/correctness findings from the review + 7 altitude/cleanup findings)
- [x] Comments added for complex code (security-sensitive paths, cache invalidation, filter exception guarding)
- [x] No new warnings generated

## Security Notes for Reviewers

Because this module resolves untrusted content into HTML, particular attention should go to:

1. **`DynamicContentCast` + `@dynamicContent` are documented as a public content pipeline.** Any user who can write a token to a casted attribute can render any dynamic content field into the resolved output. The design assumes dynamic content records are public. Do not store secrets (API keys, credentials) in dynamic content records. This is called out in the docblock on the cast, the helpers file, and this PR.
2. **FieldType rendering is HTML-safe by default.** `AbstractFieldType::render()` returns `HtmlString(e($value))` for scalars. `RichTextFieldType` intentionally returns raw HTML (that's the point). `ImageFieldType` escapes the URL for attribute-context safety. The resolver's fallback when a field type can't be routed also escapes defensively.
3. **`Nl2brModifier` escapes its input before inserting `<br>` tags** and returns `HtmlString`. Without this, a text field value like `<img src=x onerror=alert(1)>` piped through `|nl2br` would have been a stored-XSS sink.
4. **Per-type record policy scoping** is available via `viewAnyForType($user, $type)` / `createForType($user, $type)`. Hosts can filter the capability slug through `applyFilters('dynamicContent.record.viewAny', 'manage_dynamic_content', $type)` to gate access per type (e.g. keep `integrations` records off-limits to marketing editors).
5. **`/resolve` preview endpoint** is auth-gated, capped at 65 KB, and throttled to 60/min per user.
6. **Slug is immutable on update** — changing a slug would silently break every persisted `{{oldslug.field}}` token across the site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)