### PR TITLE
feat(plugins): plugin system v2.4 — schema, filter, base provider, compat, lifecycle

### DIFF
--- a/src/Modules/Admin/Managers/AdminMenuManager.php
+++ b/src/Modules/Admin/Managers/AdminMenuManager.php
@@ -11,6 +11,8 @@ declare( strict_types=1 );
 namespace ArtisanPackUI\CMSFramework\Modules\Admin\Managers;
 
 use Illuminate\Support\Facades\Gate;
+use Illuminate\Support\Facades\Route;
+use Throwable;
 
 /**
  * Manages the registration and structure of the admin navigation menu.
@@ -83,7 +85,12 @@ class AdminMenuManager
             'icon'       => $options['icon'],
             'capability' => $options['capability'],
             'order'      => $options['order'],
-            'route'      => 'admin.' . $slug,
+            // Route names replace slashes with dots to match what
+            // AdminPageManager::registerRoutes actually names the Laravel
+            // route, so Route::has() lookups (and the decorated `url` field)
+            // resolve correctly for multi-segment slugs like
+            // `packages/visual-editor`.
+            'route'      => 'admin.' . str_replace( '/', '.', $slug ),
             'menuTitle'  => $options['menuTitle'],
         ];
 
@@ -189,8 +196,18 @@ class AdminMenuManager
                 uasort( $item['subItems'], fn ( $a, $b ) => $a['order'] <=> $b['order'] );
             }
         }
+        unset( $item );
 
-        return array_merge( $topLevelItems, $menu );
+        $menu = $this->decorateMenuForConsumers( array_merge( $topLevelItems, $menu ) );
+
+        $menu = applyFilters( 'ap.admin.menu', $menu );
+
+        // Defense-in-depth: re-apply capability filtering AFTER the filter
+        // runs so plugin-injected entries can't bypass the Gate check that
+        // native items go through above. Filter subscribers can push in new
+        // rows freely, but any row declaring a `permission`/`capability` gets
+        // hidden from users who lack it.
+        return $this->enforceCapabilities( $menu );
     }
 
     /**
@@ -205,5 +222,171 @@ class AdminMenuManager
     public function getPageBySlug( string $slug ): ?array
     {
         return $this->items[ $slug ] ?? null;
+    }
+
+    /**
+     * Recursively drop any menu node whose `permission` (or legacy
+     * `capability`) the current user does not hold. Applied after the
+     * `ap.admin.menu` filter so filter-injected entries are gated too.
+     *
+     * @param  array  $menu  The (already-decorated) menu.
+     *
+     * @return array The gated menu.
+     */
+    protected function enforceCapabilities( array $menu ): array
+    {
+        $allowed = [];
+        foreach ( $menu as $key => $node ) {
+            $ability = $node['permission'] ?? ( $node['capability'] ?? null );
+            if ( ! empty( $ability ) && ! Gate::allows( $ability ) ) {
+                continue;
+            }
+
+            if ( isset( $node['items'] ) && is_array( $node['items'] ) ) {
+                $node['items'] = $this->enforceCapabilities( $node['items'] );
+                // Drop sections that end up empty after filtering.
+                if ( empty( $node['items'] ) ) {
+                    continue;
+                }
+            }
+            if ( isset( $node['subItems'] ) && is_array( $node['subItems'] ) ) {
+                $node['subItems'] = $this->enforceCapabilities( $node['subItems'] );
+            }
+
+            $allowed[ $key ] = $node;
+        }
+
+        return $allowed;
+    }
+
+    /**
+     * Add React/Inertia-friendly fields (url, label, iconId, permission, external)
+     * to each menu row while keeping the existing keys for Blade hosts.
+     *
+     * @param  array  $menu  The structured menu.
+     *
+     * @return array The decorated menu.
+     */
+    protected function decorateMenuForConsumers( array $menu ): array
+    {
+        foreach ( $menu as $key => &$node ) {
+            if ( isset( $node['items'] ) && is_array( $node['items'] ) ) {
+                $node['items'] = $this->decorateMenuForConsumers( $node['items'] );
+                continue;
+            }
+
+            $node = $this->decorateItem( $node );
+
+            if ( ! empty( $node['subItems'] ) ) {
+                $node['subItems'] = $this->decorateMenuForConsumers( $node['subItems'] );
+            }
+        }
+
+        return $menu;
+    }
+
+    /**
+     * Resolve consumer-friendly fields for a single menu item.
+     *
+     * @param  array  $item  The menu item as stored in $this->items.
+     *
+     * @return array The item enriched with url/label/iconId/permission/external.
+     */
+    protected function decorateItem( array $item ): array
+    {
+        if ( ! isset( $item['route'] ) ) {
+            return $item;
+        }
+
+        if ( ! isset( $item['url'] ) ) {
+            $item['url'] = $this->resolveRouteUrl( $item['route'], $item['external'] ?? null );
+        } elseif ( is_string( $item['url'] ) ) {
+            // A filter subscriber (e.g. registerNavEntry) may pre-set `url`.
+            // Sanitize regardless so `javascript:` URIs never reach the nav
+            // renderer.
+            $item['url'] = $this->sanitizeExternalUrl( $item['url'] );
+        }
+
+        if ( ! isset( $item['label'] ) ) {
+            $item['label'] = $item['menuTitle'] ?? $item['title'] ?? '';
+        }
+
+        if ( ! isset( $item['iconId'] ) && isset( $item['icon'] ) ) {
+            $item['iconId'] = $item['icon'];
+        }
+
+        if ( ! isset( $item['permission'] ) && ! empty( $item['capability'] ) ) {
+            $item['permission'] = $item['capability'];
+        }
+
+        if ( ! array_key_exists( 'external', $item ) ) {
+            $item['external'] = false;
+        }
+
+        return $item;
+    }
+
+    /**
+     * Resolve a route name to a URL. Falls back to '#' when the route is not
+     * registered (common in test contexts or before admin routes are booted).
+     *
+     * External URLs are only trusted when their scheme is safe — any plugin
+     * or filter subscriber setting a `javascript:` / `data:` / `vbscript:`
+     * URL would otherwise reach the admin nav's `<a href>` and execute in
+     * the authenticated admin session.
+     */
+    protected function resolveRouteUrl( string $routeName, ?bool $external = null ): string
+    {
+        if ( true === $external ) {
+            return $this->sanitizeExternalUrl( $routeName );
+        }
+
+        try {
+            if ( Route::has( $routeName ) ) {
+                return route( $routeName );
+            }
+        } catch ( Throwable $e ) {
+            // Fall through to the safe default below.
+        }
+
+        return '#';
+    }
+
+    /**
+     * Allow only navigation-safe URL forms:
+     *   - Absolute http(s) URLs
+     *   - Same-origin relative URLs (starting with '/')
+     *   - Hash fragments (starting with '#')
+     *
+     * Anything else (javascript:, data:, vbscript:, file:, etc.) collapses to
+     * '#'. Prevents plugin authors from injecting XSS vectors into the admin
+     * sidebar via `registerNavEntry(['external' => true, 'url' => ...])`.
+     */
+    protected function sanitizeExternalUrl( string $url ): string
+    {
+        $trimmed = trim( $url );
+        if ( '' === $trimmed ) {
+            return '#';
+        }
+
+        if ( str_starts_with( $trimmed, '/' ) || str_starts_with( $trimmed, '#' ) ) {
+            return $trimmed;
+        }
+
+        // Match absolute URLs with an explicit scheme.
+        if ( 1 === preg_match( '#^([a-zA-Z][a-zA-Z0-9+.\-]*):#', $trimmed, $matches ) ) {
+            $scheme = strtolower( $matches[1] );
+            if ( in_array( $scheme, ['http', 'https', 'mailto', 'tel'], true ) ) {
+                return $trimmed;
+            }
+
+            logger()->warning( "AdminMenuManager: refused unsafe URL scheme '{$scheme}' in nav entry." );
+
+            return '#';
+        }
+
+        // Scheme-less values that aren't obviously a path — treat as safe
+        // relative reference (e.g., 'docs/index.html').
+        return $trimmed;
     }
 }

--- a/src/Modules/Plugins/Exceptions/IncompatiblePluginException.php
+++ b/src/Modules/Plugins/Exceptions/IncompatiblePluginException.php
@@ -1,0 +1,69 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Modules\Plugins\Exceptions;
+
+use ArtisanPackUI\CMSFramework\Exceptions\CMSFrameworkException;
+
+/**
+ * Raised when a plugin's declared min_host_version is newer than the framework
+ * version installed in the host application.
+ *
+ * @since 2.4.0
+ */
+class IncompatiblePluginException extends CMSFrameworkException
+{
+    /**
+     * Slug of the plugin that failed the compatibility check.
+     *
+     * @since 2.4.0
+     */
+    public readonly string $pluginSlug;
+
+    /**
+     * The min_host_version the plugin manifest declared.
+     *
+     * @since 2.4.0
+     */
+    public readonly string $requiredVersion;
+
+    /**
+     * The framework version currently installed in the host.
+     *
+     * @since 2.4.0
+     */
+    public readonly string $hostVersion;
+
+    /**
+     * Construct with pre-resolved version metadata.
+     *
+     * @since 2.4.0
+     */
+    public function __construct( string $slug, string $requiredVersion, string $hostVersion )
+    {
+        parent::__construct(
+            "Plugin '{$slug}' requires cms-framework {$requiredVersion} or higher; host is running {$hostVersion}.",
+        );
+        $this->pluginSlug      = $slug;
+        $this->requiredVersion = $requiredVersion;
+        $this->hostVersion     = $hostVersion;
+    }
+
+    /**
+     * Named-constructor factory that matches the shape used by sibling plugin
+     * exceptions.
+     *
+     * @since 2.4.0
+     *
+     * @param  string  $slug  Plugin slug.
+     * @param  string  $requiredVersion  Semver declared as min_host_version.
+     * @param  string  $hostVersion  Framework version resolved from the host.
+     *
+     * @return self
+     */
+    public static function forVersion( string $slug, string $requiredVersion, string $hostVersion ): self
+    {
+        return new self( $slug, $requiredVersion, $hostVersion );
+    }
+}

--- a/src/Modules/Plugins/Http/Controllers/PluginsController.php
+++ b/src/Modules/Plugins/Http/Controllers/PluginsController.php
@@ -4,6 +4,7 @@ declare( strict_types=1 );
 
 namespace ArtisanPackUI\CMSFramework\Modules\Plugins\Http\Controllers;
 
+use ArtisanPackUI\CMSFramework\Modules\Plugins\Exceptions\IncompatiblePluginException;
 use ArtisanPackUI\CMSFramework\Modules\Plugins\Managers\PluginManager;
 use ArtisanPackUI\CMSFramework\Modules\Plugins\Managers\UpdateManager;
 use Dedoc\Scramble\Attributes\Group;
@@ -90,6 +91,14 @@ class PluginsController extends Controller
             return response()->json( [
                 'message' => 'Plugin activated successfully',
             ] );
+        } catch ( IncompatiblePluginException $e ) {
+            return response()->json( [
+                'message'          => $e->getMessage(),
+                'code'             => 'plugin_incompatible',
+                'plugin'           => $e->pluginSlug,
+                'required_version' => $e->requiredVersion,
+                'host_version'     => $e->hostVersion,
+            ], 409 );
         } catch ( Exception $e ) {
             return response()->json( [
                 'message' => 'Activation failed: ' . $e->getMessage(),

--- a/src/Modules/Plugins/Managers/PluginManager.php
+++ b/src/Modules/Plugins/Managers/PluginManager.php
@@ -5,17 +5,20 @@ declare( strict_types=1 );
 namespace ArtisanPackUI\CMSFramework\Modules\Plugins\Managers;
 
 use ArtisanPackUI\CMSFramework\Modules\Core\Managers\Concerns\HasManifestParsing;
+use ArtisanPackUI\CMSFramework\Modules\Plugins\Exceptions\IncompatiblePluginException;
 use ArtisanPackUI\CMSFramework\Modules\Plugins\Exceptions\PluginInstallationException;
 use ArtisanPackUI\CMSFramework\Modules\Plugins\Exceptions\PluginNotFoundException;
 use ArtisanPackUI\CMSFramework\Modules\Plugins\Exceptions\PluginValidationException;
 use ArtisanPackUI\CMSFramework\Modules\Plugins\Models\Plugin;
 use Composer\Autoload\ClassLoader;
+use Composer\InstalledVersions;
 use Exception;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\File;
 use RuntimeException;
+use Throwable;
 use ZipArchive;
 
 class PluginManager
@@ -183,28 +186,51 @@ class PluginManager
             throw PluginNotFoundException::forSlug( $slug );
         }
 
+        // Host-version compatibility gate (#183). Runs before any state mutation.
+        $this->assertHostVersionCompatible( $plugin );
+
         doAction( 'plugin.activating', $slug );
 
-        DB::transaction( function () use ( $plugin ): void {
-            // Register autoloader
-            if ( isset( $plugin->meta['autoload'] ) ) {
-                $this->registerAutoloader( $plugin->slug, $plugin->meta['autoload'] );
-            }
+        $priorPsr4           = [];
+        $migrationsAttempted = false;
 
-            // Run migrations
-            if ( isset( $plugin->meta['migrations_path'] ) ) {
-                $this->runMigrations( $plugin->slug, $plugin->meta['migrations_path'] );
-            }
+        try {
+            DB::transaction( function () use ( $plugin, &$priorPsr4, &$migrationsAttempted ): void {
+                if ( isset( $plugin->meta['autoload'] ) ) {
+                    // Snapshot the PSR-4 map BEFORE adding, so rollback can
+                    // restore prior paths for shared namespaces instead of
+                    // wiping them with setPsr4($ns, []).
+                    $priorPsr4 = $this->snapshotPsr4( $plugin->meta['autoload']['psr-4'] ?? [] );
+                    $this->registerAutoloader( $plugin->slug, $plugin->meta['autoload'] );
+                }
 
-            // Register service provider
-            if ( $plugin->hasServiceProvider() ) {
-                app()->register( $plugin->service_provider );
-            }
+                if ( isset( $plugin->meta['migrations_path'] ) ) {
+                    // Flip BEFORE the Artisan call so a mid-migration failure
+                    // (DDL auto-commits in MySQL/MariaDB) still triggers a
+                    // rollback attempt in the catch block.
+                    $migrationsAttempted = true;
+                    $this->runMigrations( $plugin->slug, $plugin->meta['migrations_path'] );
+                }
 
-            // Mark as active
-            $plugin->is_active = true;
-            $plugin->save();
-        } );
+                if ( $plugin->hasServiceProvider() ) {
+                    app()->register( $plugin->service_provider );
+                }
+
+                $this->seedPermissions( $plugin );
+
+                $plugin->is_active = true;
+                $plugin->save();
+            } );
+        } catch ( Throwable $e ) {
+            // Roll back any partial activation state (#182).
+            $this->rollbackFailedActivation( $plugin, $priorPsr4, $migrationsAttempted );
+
+            throw $e;
+        }
+
+        if ( config( 'cms.plugins.autoClearFrameworkCaches', false ) ) {
+            $this->clearFrameworkCaches();
+        }
 
         $this->clearCaches();
 
@@ -241,6 +267,9 @@ class PluginManager
         $plugin->is_active = false;
         $plugin->save();
 
+        if ( config( 'cms.plugins.autoClearFrameworkCaches', false ) ) {
+            $this->clearFrameworkCaches();
+        }
         $this->clearCaches();
 
         doAction( 'plugin.deactivated', $slug );
@@ -280,6 +309,21 @@ class PluginManager
 
         doAction( 'plugin.deleting', $slug );
 
+        // Opt-in migration rollback (#182). Guarded by manifest flag so hosts don't
+        // accidentally drop plugin-owned data.
+        if ( $plugin->rollback_migrations_on_delete && isset( $plugin->meta['migrations_path'] ) ) {
+            try {
+                $this->rollbackMigrations( $plugin->slug, $plugin->meta['migrations_path'] );
+            } catch ( Throwable $e ) {
+                logger()->error( "Failed to rollback migrations for plugin: {$slug}", [
+                    'exception' => $e->getMessage(),
+                ] );
+            }
+        }
+
+        // Remove seeded permissions (#182).
+        $this->removeSeededPermissions( $plugin );
+
         // Remove from database
         $plugin->delete();
 
@@ -291,6 +335,9 @@ class PluginManager
             }
         }
 
+        if ( config( 'cms.plugins.autoClearFrameworkCaches', false ) ) {
+            $this->clearFrameworkCaches();
+        }
         $this->clearCaches();
 
         doAction( 'plugin.deleted', $slug );
@@ -336,17 +383,48 @@ class PluginManager
      */
     protected function runMigrations( string $slug, string $migrationsPath ): void
     {
-        $fullPath = $this->getPluginsPath() . '/' . $slug . '/' . $migrationsPath;
-
-        if ( ! File::isDirectory( $fullPath ) ) {
+        $safePath = $this->resolveSecureMigrationsPath( $slug, $migrationsPath );
+        if ( null === $safePath ) {
             return;
         }
 
         // Run migrations using Artisan
         Artisan::call( 'migrate', [
-            '--path'  => str_replace( base_path(), '', $fullPath ),
+            '--path'  => str_replace( base_path(), '', $safePath ),
             '--force' => true,
         ] );
+    }
+
+    /**
+     * Resolve a plugin-declared migrations path and confirm it lives inside the
+     * plugin's own directory. Defense-in-depth against a malicious manifest
+     * whose migrations_path escaped via ".." (the schema validator also
+     * rejects those, but that runs at install time only).
+     */
+    protected function resolveSecureMigrationsPath( string $slug, string $migrationsPath ): ?string
+    {
+        $pluginDir = $this->getPluginsPath() . '/' . $slug;
+        $fullPath  = $pluginDir . '/' . ltrim( $migrationsPath, '/' );
+
+        if ( ! File::isDirectory( $fullPath ) ) {
+            return null;
+        }
+
+        $realFull   = realpath( $fullPath );
+        $realPlugin = realpath( $pluginDir );
+
+        if ( false === $realFull || false === $realPlugin ) {
+            return null;
+        }
+
+        // The resolved path must sit inside the plugin's own directory.
+        if ( ! str_starts_with( $realFull . DIRECTORY_SEPARATOR, $realPlugin . DIRECTORY_SEPARATOR ) ) {
+            logger()->warning( "Plugin '{$slug}' migrations_path resolved outside plugin dir; refusing to touch: {$realFull}" );
+
+            return null;
+        }
+
+        return $realFull;
     }
 
     /**
@@ -401,6 +479,83 @@ class PluginManager
         // Anchored at end to prevent injection attempts like "1.0.0'; DROP TABLE"
         if ( ! preg_match( '/^\d+\.\d+\.\d+$/', $manifest['version'] ) ) {
             throw PluginValidationException::invalidManifest( 'Invalid version format. Use semantic versioning (e.g., 1.0.0).' );
+        }
+
+        $this->validateOptionalManifestFields( $manifest );
+    }
+
+    /**
+     * Validate optional manifest fields introduced in the v2.4 schema extension.
+     *
+     * @throws PluginValidationException If any optional field is malformed.
+     */
+    protected function validateOptionalManifestFields( array $manifest ): void
+    {
+        if ( isset( $manifest['min_host_version'] ) ) {
+            if ( ! is_string( $manifest['min_host_version'] )
+                || ! preg_match( '/^\d+\.\d+\.\d+$/', $manifest['min_host_version'] ) ) {
+                throw PluginValidationException::invalidManifest( 'Invalid min_host_version format. Use semantic versioning (e.g., 1.0.0).' );
+            }
+        }
+
+        if ( isset( $manifest['federated_module'] ) ) {
+            $federated = $manifest['federated_module'];
+            if ( ! is_array( $federated )
+                || empty( $federated['entry'] )
+                || ! is_string( $federated['entry'] ) ) {
+                throw PluginValidationException::invalidManifest( 'Invalid federated_module. Must be an object with a non-empty string "entry".' );
+            }
+            if ( isset( $federated['exposes'] ) && ! is_array( $federated['exposes'] ) ) {
+                throw PluginValidationException::invalidManifest( 'Invalid federated_module.exposes. Must be an array of module names.' );
+            }
+        }
+
+        if ( isset( $manifest['nav_entries'] ) ) {
+            if ( ! is_array( $manifest['nav_entries'] ) || false === array_is_list( $manifest['nav_entries'] ) ) {
+                throw PluginValidationException::invalidManifest( 'Invalid nav_entries. Must be a list of entry objects.' );
+            }
+            foreach ( $manifest['nav_entries'] as $index => $entry ) {
+                if ( ! is_array( $entry ) || empty( $entry['slug'] ) || empty( $entry['label'] ) ) {
+                    throw PluginValidationException::invalidManifest( "Invalid nav_entries[{$index}]. Each entry needs a slug and a label." );
+                }
+            }
+        }
+
+        if ( isset( $manifest['permissions'] ) ) {
+            if ( ! is_array( $manifest['permissions'] ) || false === array_is_list( $manifest['permissions'] ) ) {
+                throw PluginValidationException::invalidManifest( 'Invalid permissions. Must be a list of permission slugs.' );
+            }
+            // Enforce a plugin-slug namespace prefix so seed/remove can't touch
+            // framework-owned or other-plugin permissions. Prevents a manifest
+            // like `permissions: ["manage_users"]` from wiping core rows on
+            // uninstall.
+            $prefix = $manifest['slug'] . '.';
+            foreach ( $manifest['permissions'] as $index => $permission ) {
+                if ( ! is_string( $permission ) || '' === trim( $permission ) ) {
+                    throw PluginValidationException::invalidManifest( "Invalid permissions[{$index}]. Each permission must be a non-empty string." );
+                }
+                if ( ! str_starts_with( $permission, $prefix ) ) {
+                    throw PluginValidationException::invalidManifest(
+                        "Invalid permissions[{$index}]. Plugin permissions must be prefixed with '{$prefix}' (got '{$permission}').",
+                    );
+                }
+            }
+        }
+
+        if ( isset( $manifest['migrations_path'] ) ) {
+            $migrationsPath = $manifest['migrations_path'];
+            if ( ! is_string( $migrationsPath ) || '' === $migrationsPath ) {
+                throw PluginValidationException::invalidManifest( 'Invalid migrations_path. Must be a non-empty relative string.' );
+            }
+            // Reject any traversal or absolute-path attempts. runMigrations()
+            // resolves this against the plugin directory; a value like
+            // "../../database/migrations" would otherwise re-run/rollback
+            // framework migrations.
+            if ( str_starts_with( $migrationsPath, '/' )
+                || str_contains( $migrationsPath, '..' )
+                || 1 === preg_match( '/^[A-Za-z]:/', $migrationsPath ) ) {
+                throw PluginValidationException::invalidManifest( 'Invalid migrations_path. Must be a relative path inside the plugin directory (no "..", no absolute paths).' );
+            }
         }
     }
 
@@ -552,6 +707,276 @@ class PluginManager
     protected function clearCaches(): void
     {
         Cache::forget( config( 'cms.plugins.cacheKey' ) );
+    }
+
+    /**
+     * Clear Laravel's route/config/view caches so stale plugin registrations
+     * don't linger after activation state changes (#182).
+     */
+    protected function clearFrameworkCaches(): void
+    {
+        foreach ( ['route:clear', 'config:clear', 'view:clear'] as $command ) {
+            try {
+                Artisan::call( $command );
+            } catch ( Throwable $e ) {
+                logger()->warning( "Framework cache clear failed for {$command}", [
+                    'exception' => $e->getMessage(),
+                ] );
+            }
+        }
+    }
+
+    /**
+     * Assert that the framework version installed in the host satisfies the
+     * plugin's declared minimum host version (#183).
+     *
+     * @throws IncompatiblePluginException When the host is older than required.
+     */
+    protected function assertHostVersionCompatible( Plugin $plugin ): void
+    {
+        $required = $plugin->min_host_version;
+        if ( null === $required ) {
+            return;
+        }
+
+        $hostVersion = $this->resolveHostFrameworkVersion();
+        if ( null === $hostVersion ) {
+            // Unknown host version (e.g. path-repo dev checkout). Log so it's
+            // visible, then be permissive — the framework itself is running, so
+            // outright refusing every plugin here would be worse than
+            // best-effort activation.
+            logger()->warning( "Skipping min_host_version check for plugin '{$plugin->slug}': host framework version unresolved." );
+
+            return;
+        }
+
+        $normalizedHost = $this->normalizeSemver( $hostVersion );
+        if ( null === $normalizedHost ) {
+            // Same permissive policy for parseable-but-non-semver host versions
+            // (dev-main, 2.4.x-dev). Consistent with the null-host branch above.
+            logger()->warning( "Skipping min_host_version check for plugin '{$plugin->slug}': host version '{$hostVersion}' is not a comparable semver." );
+
+            return;
+        }
+
+        if ( version_compare( $normalizedHost, $required, '<' ) ) {
+            throw IncompatiblePluginException::forVersion( $plugin->slug, $required, $hostVersion );
+        }
+    }
+
+    /**
+     * Resolve the framework's installed package version.
+     *
+     * Prefers the framework's own composer.json when it declares a clean
+     * semver — that's the authoritative source and works uniformly for both
+     * real Composer installs and path-repo / symlinked dev checkouts (where
+     * InstalledVersions might report a non-comparable branch alias like
+     * `dev-release/2.4`). Falls back to Composer's InstalledVersions if
+     * composer.json is missing or lacks an explicit version field.
+     */
+    protected function resolveHostFrameworkVersion(): ?string
+    {
+        $composerVersion = $this->readFrameworkComposerVersion();
+        if ( null !== $composerVersion && 1 === preg_match( '/^\d+\.\d+\.\d+/', $composerVersion ) ) {
+            return $composerVersion;
+        }
+
+        try {
+            $version = InstalledVersions::getVersion( 'artisanpack-ui/cms-framework' );
+            if ( null !== $version && '' !== $version ) {
+                return $version;
+            }
+        } catch ( Throwable $e ) {
+            // Fall through.
+        }
+
+        return $composerVersion;
+    }
+
+    /**
+     * Read the framework's own composer.json (relative to this file) and
+     * return its declared `version` if present.
+     */
+    protected function readFrameworkComposerVersion(): ?string
+    {
+        $composerPath = __DIR__ . '/../../../../composer.json';
+        if ( ! File::exists( $composerPath ) ) {
+            return null;
+        }
+
+        $decoded = json_decode( ( string ) File::get( $composerPath ), true );
+        if ( ! is_array( $decoded ) || empty( $decoded['version'] ) || ! is_string( $decoded['version'] ) ) {
+            return null;
+        }
+
+        return $decoded['version'];
+    }
+
+    /**
+     * Strip Composer version suffixes (e.g. `v` prefix, `+metadata`) down to a
+     * comparable semver string. Returns null for anything that isn't parseable
+     * so the caller can apply a consistent unknown-version policy instead of
+     * silently coercing to 0.0.0 (which would false-fail every plugin against
+     * a dev-* checkout).
+     */
+    protected function normalizeSemver( string $version ): ?string
+    {
+        $stripped = ltrim( $version, 'v' );
+        $stripped = preg_replace( '/[-+].*$/', '', $stripped ) ?? $stripped;
+
+        if ( ! preg_match( '/^\d+\.\d+\.\d+$/', $stripped ) ) {
+            return null;
+        }
+
+        return $stripped;
+    }
+
+    /**
+     * Seed permission slugs declared by the plugin manifest.
+     *
+     * Uses artisanpack-ui/rbac's Permission model when available; falls back to
+     * a no-op so tests and hosts without RBAC installed still succeed.
+     */
+    protected function seedPermissions( Plugin $plugin ): void
+    {
+        $permissions = $plugin->declared_permissions;
+        if ( empty( $permissions ) ) {
+            return;
+        }
+
+        $model = $this->rbacPermissionModel();
+        if ( null === $model ) {
+            return;
+        }
+
+        foreach ( $permissions as $slug ) {
+            try {
+                $model::firstOrCreate( ['slug' => $slug], ['name' => $slug] );
+            } catch ( Throwable $e ) {
+                logger()->warning( "Failed seeding permission '{$slug}' for plugin {$plugin->slug}", [
+                    'exception' => $e->getMessage(),
+                ] );
+            }
+        }
+    }
+
+    /**
+     * Remove plugin-declared permissions on deletion.
+     */
+    protected function removeSeededPermissions( Plugin $plugin ): void
+    {
+        $permissions = $plugin->declared_permissions;
+        if ( empty( $permissions ) ) {
+            return;
+        }
+
+        $model = $this->rbacPermissionModel();
+        if ( null === $model ) {
+            return;
+        }
+
+        try {
+            $model::whereIn( 'slug', $permissions )->delete();
+        } catch ( Throwable $e ) {
+            logger()->warning( "Failed removing permissions for plugin {$plugin->slug}", [
+                'exception' => $e->getMessage(),
+            ] );
+        }
+    }
+
+    /**
+     * Best-effort locator for artisanpack-ui/rbac's Permission model.
+     *
+     * @return class-string|null
+     */
+    protected function rbacPermissionModel(): ?string
+    {
+        $candidate = 'ArtisanPackUI\\RBAC\\Models\\Permission';
+
+        return class_exists( $candidate ) ? $candidate : null;
+    }
+
+    /**
+     * Roll back a plugin's migrations. Used on deletion (#182) when the plugin
+     * has opted into `rollback_migrations_on_delete`.
+     */
+    protected function rollbackMigrations( string $slug, string $migrationsPath ): void
+    {
+        $safePath = $this->resolveSecureMigrationsPath( $slug, $migrationsPath );
+        if ( null === $safePath ) {
+            return;
+        }
+
+        Artisan::call( 'migrate:rollback', [
+            '--path'  => str_replace( base_path(), '', $safePath ),
+            '--force' => true,
+        ] );
+    }
+
+    /**
+     * Best-effort teardown when a partial activation blew up (#182).
+     *
+     * @param  array<string,array<int,string>>  $priorPsr4  Snapshot of the PSR-4
+     *                                                      map for the plugin's
+     *                                                      namespaces BEFORE
+     *                                                      registerAutoloader ran.
+     */
+    protected function rollbackFailedActivation( Plugin $plugin, array $priorPsr4, bool $migrationsAttempted ): void
+    {
+        if ( $migrationsAttempted && isset( $plugin->meta['migrations_path'] ) ) {
+            try {
+                $this->rollbackMigrations( $plugin->slug, $plugin->meta['migrations_path'] );
+            } catch ( Throwable $e ) {
+                logger()->warning( "Rollback of migrations after failed activation of {$plugin->slug}", [
+                    'exception' => $e->getMessage(),
+                ] );
+            }
+        }
+
+        if ( ! empty( $priorPsr4 ) ) {
+            // Restore the PSR-4 mapping snapshot rather than wiping shared
+            // namespaces to []. setPsr4 replaces (not appends) so restoring the
+            // prior path list preserves other plugins that shared the prefix.
+            foreach ( $priorPsr4 as $namespace => $paths ) {
+                try {
+                    $this->classLoader->setPsr4( $namespace, $paths );
+                } catch ( Throwable $e ) {
+                    logger()->warning( "Failed restoring prior PSR-4 mapping for '{$namespace}' after failed activation of {$plugin->slug}", [
+                        'exception' => $e->getMessage(),
+                    ] );
+                }
+            }
+        }
+
+        // Ensure the plugin isn't stuck marked active.
+        try {
+            $plugin->is_active = false;
+            $plugin->save();
+        } catch ( Throwable $e ) {
+            // Transaction was rolled back; nothing to persist.
+        }
+
+        $this->clearCaches();
+    }
+
+    /**
+     * Capture the current PSR-4 path list for each namespace the plugin
+     * declares, so a failed activation can restore prior mappings without
+     * blowing away paths owned by other plugins/packages that share a prefix.
+     *
+     * @param  array<string,string>  $psr4  namespace => relative path
+     *
+     * @return array<string,array<int,string>>
+     */
+    protected function snapshotPsr4( array $psr4 ): array
+    {
+        $prior       = [];
+        $currentMap  = $this->classLoader->getPrefixesPsr4();
+        foreach ( array_keys( $psr4 ) as $namespace ) {
+            $prior[ $namespace ] = $currentMap[ $namespace ] ?? [];
+        }
+
+        return $prior;
     }
 
     /**

--- a/src/Modules/Plugins/Managers/UpdateManager.php
+++ b/src/Modules/Plugins/Managers/UpdateManager.php
@@ -4,6 +4,7 @@ declare( strict_types=1 );
 
 namespace ArtisanPackUI\CMSFramework\Modules\Plugins\Managers;
 
+use ArtisanPackUI\CMSFramework\Modules\Plugins\Exceptions\IncompatiblePluginException;
 use ArtisanPackUI\CMSFramework\Modules\Plugins\Exceptions\PluginUpdateException;
 use ArtisanPackUI\CMSFramework\Modules\Plugins\Models\Plugin;
 use Exception;
@@ -104,8 +105,10 @@ class UpdateManager
             return false; // No update available
         }
 
-        $wasActive  = $plugin->is_active;
-        $oldVersion = $plugin->version;
+        $wasActive              = $plugin->is_active;
+        $oldVersion             = $plugin->version;
+        $oldMeta                = $plugin->meta;
+        $oldServiceProvider     = $plugin->service_provider;
 
         doAction( 'plugin.updating', $slug, $oldVersion, $updateInfo['version'] );
 
@@ -151,11 +154,42 @@ class UpdateManager
             doAction( 'plugin.updated', $slug, $updateInfo['version'] );
 
             return true;
+        } catch ( IncompatiblePluginException $e ) {
+            // The DB row was already updated with the new manifest at step 6,
+            // but the reactivate at step 7 rejected the new min_host_version.
+            // Restore files AND DB so the plugin isn't stranded pointing at a
+            // version whose files no longer exist.
+            $this->restoreFromBackup( $slug, $backupPath );
+            $this->revertPluginRow( $plugin, $oldVersion, $oldMeta, $oldServiceProvider );
+
+            throw $e;
         } catch ( Exception $e ) {
             // Restore from backup on failure
             $this->restoreFromBackup( $slug, $backupPath );
+            $this->revertPluginRow( $plugin, $oldVersion, $oldMeta, $oldServiceProvider );
 
             throw PluginUpdateException::downloadFailed( $slug );
+        }
+    }
+
+    /**
+     * Reset the DB row to the pre-update version/manifest/service_provider so
+     * a failed update doesn't leave the row pointing at a version whose files
+     * were rolled back.
+     *
+     * @param  array|null  $oldMeta  Prior manifest snapshot.
+     */
+    protected function revertPluginRow( Plugin $plugin, string $oldVersion, ?array $oldMeta, ?string $oldServiceProvider ): void
+    {
+        try {
+            $plugin->version          = $oldVersion;
+            $plugin->meta             = $oldMeta;
+            $plugin->service_provider = $oldServiceProvider;
+            $plugin->save();
+        } catch ( Exception $e ) {
+            logger()->error( "Failed reverting plugin row after failed update: {$plugin->slug}", [
+                'exception' => $e->getMessage(),
+            ] );
         }
     }
 

--- a/src/Modules/Plugins/Models/Plugin.php
+++ b/src/Modules/Plugins/Models/Plugin.php
@@ -58,4 +58,61 @@ class Plugin extends Model
     {
         return ! empty( $this->service_provider );
     }
+
+    /**
+     * Minimum framework version this plugin declares support for.
+     */
+    public function getMinHostVersionAttribute(): ?string
+    {
+        $value = $this->meta['min_host_version'] ?? null;
+
+        return is_string( $value ) ? $value : null;
+    }
+
+    /**
+     * Federated frontend module descriptor from the manifest.
+     *
+     * @return array{entry:string,exposes?:array<int,string>}|null
+     */
+    public function getFederatedModuleAttribute(): ?array
+    {
+        $module = $this->meta['federated_module'] ?? null;
+
+        return is_array( $module ) ? $module : null;
+    }
+
+    /**
+     * Nav entries pre-declared by the plugin manifest.
+     *
+     * @return array<int,array<string,mixed>>
+     */
+    public function getNavEntriesAttribute(): array
+    {
+        $entries = $this->meta['nav_entries'] ?? [];
+
+        return is_array( $entries ) ? array_values( $entries ) : [];
+    }
+
+    /**
+     * Permission slugs the plugin wants seeded on activation.
+     *
+     * @return array<int,string>
+     */
+    public function getDeclaredPermissionsAttribute(): array
+    {
+        $permissions = $this->meta['permissions'] ?? [];
+        if ( ! is_array( $permissions ) ) {
+            return [];
+        }
+
+        return array_values( array_filter( $permissions, 'is_string' ) );
+    }
+
+    /**
+     * Whether the plugin has opted into migration rollback on deletion.
+     */
+    public function getRollbackMigrationsOnDeleteAttribute(): bool
+    {
+        return ( bool ) ( $this->meta['rollback_migrations_on_delete'] ?? false );
+    }
 }

--- a/src/Modules/Plugins/Providers/PluginsServiceProvider.php
+++ b/src/Modules/Plugins/Providers/PluginsServiceProvider.php
@@ -6,6 +6,7 @@ namespace ArtisanPackUI\CMSFramework\Modules\Plugins\Providers;
 
 use ArtisanPackUI\CMSFramework\Modules\Plugins\Managers\PluginManager;
 use ArtisanPackUI\CMSFramework\Modules\Plugins\Managers\UpdateManager;
+use ArtisanPackUI\CMSFramework\Modules\Plugins\Support\PluginRegistry;
 use Exception;
 use Illuminate\Support\ServiceProvider;
 use Schema;
@@ -25,6 +26,12 @@ class PluginsServiceProvider extends ServiceProvider
                 $app->make( PluginManager::class ),
             );
         } );
+
+        // Shared registry for plugin-declared nav entries and federated
+        // modules; PluginServiceProvider writes into it, framework filters
+        // read from it. Container-keyed by slug/name so re-registration under
+        // Octane is idempotent.
+        $this->app->singleton( PluginRegistry::class );
 
         // Merge config
         $this->mergeConfigFrom(
@@ -46,6 +53,8 @@ class PluginsServiceProvider extends ServiceProvider
         // Load migrations
         $this->loadMigrationsFrom( __DIR__ . '/../../../database/migrations' );
 
+        $this->registerPluginRegistryFilters();
+
         // Load active plugins EARLY in boot cycle
         // Only attempt if the plugins table exists (to handle fresh installations)
         try {
@@ -57,5 +66,28 @@ class PluginsServiceProvider extends ServiceProvider
             // Silently fail during installation/migration
             logger()->debug( 'Plugin loading skipped: ' . $e->getMessage() );
         }
+    }
+
+    /**
+     * Wire ONE filter callback per hook that surfaces the PluginRegistry
+     * contents. Registering once at framework boot avoids the Octane
+     * accumulation pattern where per-plugin boot() calls would add a fresh
+     * closure to the filter chain on every request.
+     */
+    protected function registerPluginRegistryFilters(): void
+    {
+        $registry = $this->app->make( PluginRegistry::class );
+
+        addFilter( 'ap.admin.menu', function ( array $menu ) use ( $registry ): array {
+            foreach ( $registry->navEntries() as $slug => $entry ) {
+                $menu[ $slug ] = array_merge( $entry, $menu[ $slug ] ?? [] );
+            }
+
+            return $menu;
+        } );
+
+        addFilter( 'ap.plugins.federatedModules', function ( array $modules ) use ( $registry ): array {
+            return array_merge( $modules, $registry->federatedModules() );
+        } );
     }
 }

--- a/src/Modules/Plugins/Support/PluginRegistry.php
+++ b/src/Modules/Plugins/Support/PluginRegistry.php
@@ -1,0 +1,75 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Modules\Plugins\Support;
+
+/**
+ * Container-bound singleton that holds runtime registrations made by plugin
+ * service providers (nav entries and federated module descriptors).
+ *
+ * Plugin providers push into this registry from boot(); the framework wires a
+ * single `ap.admin.menu` filter callback in PluginsServiceProvider that reads
+ * from it. This avoids adding a fresh closure to the filter chain on every
+ * request under Octane / RoadRunner (where the container persists across
+ * requests but boot() re-runs).
+ *
+ * @since 2.4.0
+ */
+class PluginRegistry
+{
+    /**
+     * Nav entries keyed by slug so duplicate registrations idempotently
+     * overwrite instead of accumulating.
+     *
+     * @var array<string,array<string,mixed>>
+     */
+    protected array $navEntries = [];
+
+    /**
+     * Federated module descriptors keyed by name.
+     *
+     * @var array<string,array{entry:string,exposes?:array<int,string>}>
+     */
+    protected array $federatedModules = [];
+
+    /**
+     * Register (or overwrite) a nav entry by slug.
+     *
+     * @param  array<string,mixed>  $entry  A normalized nav entry row.
+     */
+    public function setNavEntry( string $slug, array $entry ): void
+    {
+        $this->navEntries[ $slug ] = $entry;
+    }
+
+    /**
+     * All registered nav entries.
+     *
+     * @return array<string,array<string,mixed>>
+     */
+    public function navEntries(): array
+    {
+        return $this->navEntries;
+    }
+
+    /**
+     * Register (or overwrite) a federated module descriptor by name.
+     *
+     * @param  array{entry:string,exposes?:array<int,string>}  $descriptor
+     */
+    public function setFederatedModule( string $name, array $descriptor ): void
+    {
+        $this->federatedModules[ $name ] = $descriptor;
+    }
+
+    /**
+     * All registered federated module descriptors.
+     *
+     * @return array<string,array{entry:string,exposes?:array<int,string>}>
+     */
+    public function federatedModules(): array
+    {
+        return $this->federatedModules;
+    }
+}

--- a/src/Modules/Plugins/Support/PluginServiceProvider.php
+++ b/src/Modules/Plugins/Support/PluginServiceProvider.php
@@ -1,0 +1,269 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Modules\Plugins\Support;
+
+use ArtisanPackUI\CMSFramework\Modules\Admin\Managers\AdminMenuManager;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\ServiceProvider;
+use ReflectionClass;
+use RuntimeException;
+
+/**
+ * Base service provider for cms-framework plugins.
+ *
+ * Extending this class gives plugin authors a consistent, opinionated API for
+ * the most common registration patterns: admin pages, nav entries, federated
+ * frontend modules, and manifest-aware path/config helpers.
+ *
+ * Extending is optional — plain Laravel ServiceProviders continue to work — but
+ * `PluginManager` uses the presence of this base to expose richer metadata to
+ * host apps.
+ *
+ * @since 2.4.0
+ */
+abstract class PluginServiceProvider extends ServiceProvider
+{
+    /**
+     * Parsed plugin.json contents for the plugin backing this provider.
+     *
+     * @var array<string,mixed>|null
+     */
+    protected ?array $manifest = null;
+
+    /**
+     * Register a Blade or Inertia admin page.
+     *
+     * @param  string  $slug  Route/URL slug for the admin page.
+     * @param  array{title?:string,section?:string,view?:string,component?:string,capability?:string,icon?:string,order?:int}  $config
+     */
+    protected function registerAdminPage( string $slug, array $config ): void
+    {
+        /** @var AdminMenuManager $menu */
+        $menu = $this->app->make( AdminMenuManager::class );
+
+        $title   = $config['title'] ?? ucfirst( $slug );
+        $section = $config['section'] ?? null;
+
+        $options = array_filter( [
+            'action'     => $config['view'] ?? $config['component'] ?? '',
+            'capability' => $config['capability'] ?? 'access_admin_dashboard',
+            'icon'       => $config['icon'] ?? 'fas.puzzle-piece',
+            'order'      => $config['order'] ?? 50,
+            'menuTitle'  => $config['menuTitle'] ?? $title,
+        ], fn ( $value ) => null !== $value );
+
+        $menu->addPage( $title, $slug, $section, $options );
+    }
+
+    /**
+     * Inject a nav entry into the admin menu.
+     *
+     * The entry is stored in the container-bound PluginRegistry so a single
+     * framework-owned filter callback surfaces all plugin nav entries in one
+     * place. Overwriting by slug is idempotent — repeated calls from the same
+     * plugin (e.g. under Octane) don't accumulate.
+     *
+     * @param  array{slug:string,label:string,url?:string,icon?:string,iconId?:string,permission?:string,order?:int,external?:bool,parent?:string}  $entry
+     */
+    protected function registerNavEntry( array $entry ): void
+    {
+        if ( empty( $entry['slug'] ) || empty( $entry['label'] ) ) {
+            throw new RuntimeException( 'registerNavEntry requires slug and label.' );
+        }
+
+        $slug = ( string ) $entry['slug'];
+        $url  = $this->normalizeNavUrl( $entry['url'] ?? '#' );
+
+        $normalized = [
+            'title'      => $entry['label'],
+            'slug'       => $slug,
+            'parent'     => $entry['parent'] ?? null,
+            'section'    => null,
+            'icon'       => $entry['icon'] ?? ( $entry['iconId'] ?? '' ),
+            'iconId'     => $entry['iconId'] ?? ( $entry['icon'] ?? '' ),
+            'capability' => $entry['permission'] ?? '',
+            'permission' => $entry['permission'] ?? '',
+            'order'      => ( int ) ( $entry['order'] ?? 50 ),
+            'route'      => $url,
+            'menuTitle'  => $entry['label'],
+            'label'      => $entry['label'],
+            'url'        => $url,
+            'external'   => ( bool ) ( $entry['external'] ?? false ),
+        ];
+
+        $this->pluginRegistry()->setNavEntry( $slug, $normalized );
+    }
+
+    /**
+     * Register a Module Federation entry so host apps that support runtime-loaded
+     * React pages can discover and mount plugin frontend modules.
+     *
+     * @param  array<int,string>  $exposes  Optional list of exposed module names.
+     */
+    protected function registerFederatedModule( string $name, string $entryPath, array $exposes = [] ): void
+    {
+        $descriptor = [
+            'entry' => $entryPath,
+        ];
+
+        if ( ! empty( $exposes ) ) {
+            $descriptor['exposes'] = array_values( $exposes );
+        }
+
+        $this->pluginRegistry()->setFederatedModule( $name, $descriptor );
+    }
+
+    /**
+     * Resolve a path relative to the plugin's installation directory.
+     */
+    protected function pluginPath( ?string $subpath = null ): string
+    {
+        $root = base_path( config( 'cms.plugins.directory', 'plugins' ) . '/' . $this->pluginSlug() );
+
+        if ( null === $subpath ) {
+            return $root;
+        }
+
+        return $root . '/' . ltrim( $subpath, '/' );
+    }
+
+    /**
+     * Read the plugin's manifest (or a specific key via dot notation).
+     */
+    protected function pluginConfig( ?string $key = null ): mixed
+    {
+        $manifest = $this->loadManifest();
+
+        if ( null === $key ) {
+            return $manifest;
+        }
+
+        $value = $manifest;
+        foreach ( explode( '.', $key ) as $segment ) {
+            if ( ! is_array( $value ) || ! array_key_exists( $segment, $value ) ) {
+                return null;
+            }
+            $value = $value[ $segment ];
+        }
+
+        return $value;
+    }
+
+    /**
+     * Slug used to locate the plugin directory. Defaults to the manifest's
+     * `slug`; plugins may override for edge cases (multi-plugin repos, etc).
+     */
+    protected function pluginSlug(): string
+    {
+        $manifest = $this->loadManifest();
+
+        if ( empty( $manifest['slug'] ) ) {
+            throw new RuntimeException( 'Unable to determine plugin slug: manifest is missing a slug.' );
+        }
+
+        return ( string ) $manifest['slug'];
+    }
+
+    /**
+     * Load and cache the plugin's manifest. Walks up from the provider file
+     * looking for a plugin.json — but ONLY accepts a match whose directory is
+     * a direct child of the configured plugins directory. This prevents a
+     * malicious plugin from adopting an unrelated manifest (host root, vendor
+     * subdir, or another plugin) by placing its provider deep in a vendor
+     * tree.
+     *
+     * @return array<string,mixed>
+     */
+    protected function loadManifest(): array
+    {
+        if ( null !== $this->manifest ) {
+            return $this->manifest;
+        }
+
+        $reflection    = new ReflectionClass( static::class );
+        $file          = ( string ) $reflection->getFileName();
+        $pluginsRoot   = realpath( base_path( config( 'cms.plugins.directory', 'plugins' ) ) );
+        $realProvider  = realpath( $file );
+
+        if ( false === $pluginsRoot || false === $realProvider ) {
+            return $this->manifest = [];
+        }
+
+        // Provider must live under the plugins directory. Reject anything else
+        // (host root, vendor, other packages) outright.
+        if ( ! str_starts_with( $realProvider . DIRECTORY_SEPARATOR, $pluginsRoot . DIRECTORY_SEPARATOR ) ) {
+            return $this->manifest = [];
+        }
+
+        // Walk from the provider's dir up to the plugins root (bounded by the
+        // real directory hierarchy, not a magic depth). The plugin's own root
+        // is a direct child of pluginsRoot — that's the ONLY manifest we
+        // trust.
+        $dir = dirname( $realProvider );
+        while ( $dir !== $pluginsRoot && str_starts_with( $dir . DIRECTORY_SEPARATOR, $pluginsRoot . DIRECTORY_SEPARATOR ) ) {
+            $parent = dirname( $dir );
+            if ( $parent === $pluginsRoot ) {
+                // $dir is the plugin's own root directory.
+                $candidate = $dir . '/plugin.json';
+                if ( File::exists( $candidate ) ) {
+                    $decoded = json_decode( ( string ) File::get( $candidate ), true );
+                    if ( is_array( $decoded ) ) {
+                        return $this->manifest = $decoded;
+                    }
+                }
+                break;
+            }
+            if ( $parent === $dir ) {
+                break;
+            }
+            $dir = $parent;
+        }
+
+        return $this->manifest = [];
+    }
+
+    /**
+     * Resolve the shared PluginRegistry singleton, binding a fresh one if the
+     * host container hasn't done so yet (defensive — the framework's
+     * PluginsServiceProvider is the canonical binder).
+     */
+    protected function pluginRegistry(): PluginRegistry
+    {
+        if ( ! $this->app->bound( PluginRegistry::class ) ) {
+            $this->app->singleton( PluginRegistry::class );
+        }
+
+        return $this->app->make( PluginRegistry::class );
+    }
+
+    /**
+     * Sanitize a plugin-supplied URL before it enters the nav registry.
+     * Rejects unsafe schemes; falls back to '#' for anything not obviously a
+     * navigation target. AdminMenuManager also sanitizes on render, but
+     * blocking at the ingress point keeps the registry itself clean.
+     */
+    protected function normalizeNavUrl( string $url ): string
+    {
+        $trimmed = trim( $url );
+        if ( '' === $trimmed ) {
+            return '#';
+        }
+
+        if ( str_starts_with( $trimmed, '/' ) || str_starts_with( $trimmed, '#' ) ) {
+            return $trimmed;
+        }
+
+        if ( 1 === preg_match( '#^([a-zA-Z][a-zA-Z0-9+.\-]*):#', $trimmed, $matches ) ) {
+            $scheme = strtolower( $matches[1] );
+            if ( in_array( $scheme, ['http', 'https', 'mailto', 'tel'], true ) ) {
+                return $trimmed;
+            }
+
+            return '#';
+        }
+
+        return $trimmed;
+    }
+}

--- a/src/Modules/Plugins/config/plugins.php
+++ b/src/Modules/Plugins/config/plugins.php
@@ -52,4 +52,20 @@ return [
     'updateCheckTimeout' => 10, // HTTP request timeout in seconds
     'updateCacheTtl'     => 43200, // 12 hours in seconds
     'backupPath'         => 'plugin-backups', // Relative to storage_path()
+
+    /*
+    |--------------------------------------------------------------------------
+    | Auto-clear Framework Caches on Lifecycle Events
+    |--------------------------------------------------------------------------
+    | If true, activate/deactivate/delete will run route:clear, config:clear
+    | and view:clear so newly (un)registered plugin routes/views take effect
+    | immediately. This is convenient in development but is a blunt hammer in
+    | production hosts that rely on `route:cache` / `config:cache` for
+    | performance — every toggle deletes the compiled cache files, causing a
+    | measurable latency regression until the next deploy rebuilds them.
+    |
+    | Default: false. Enable it explicitly in development, or when your
+    | deployment pipeline handles rebuilds on demand.
+    */
+    'autoClearFrameworkCaches' => env( 'PLUGINS_AUTO_CLEAR_FRAMEWORK_CACHES', false ),
 ];

--- a/tests/Feature/Plugins/HostVersionCompatibilityTest.php
+++ b/tests/Feature/Plugins/HostVersionCompatibilityTest.php
@@ -1,0 +1,72 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\CMSFramework\Modules\Plugins\Exceptions\IncompatiblePluginException;
+use ArtisanPackUI\CMSFramework\Modules\Plugins\Managers\PluginManager;
+use ArtisanPackUI\CMSFramework\Modules\Plugins\Models\Plugin;
+use ArtisanPackUI\CMSFramework\Tests\Support\TestUser;
+
+beforeEach( function (): void {
+    $this->manager = app( PluginManager::class );
+    $this->admin   = TestUser::factory()->create();
+} );
+
+it( 'refuses to activate a plugin requiring a newer host version', function (): void {
+    Plugin::create( [
+        'slug'      => 'future-plugin',
+        'name'      => 'Future Plugin',
+        'version'   => '1.0.0',
+        'is_active' => false,
+        'meta'      => [
+            'slug'             => 'future-plugin',
+            'name'             => 'Future Plugin',
+            'version'          => '1.0.0',
+            'min_host_version' => '999.0.0',
+        ],
+    ] );
+
+    try {
+        $this->manager->activate( 'future-plugin' );
+        $this->fail( 'Expected IncompatiblePluginException was not thrown.' );
+    } catch ( IncompatiblePluginException $e ) {
+        expect( $e->pluginSlug )->toBe( 'future-plugin' )
+            ->and( $e->requiredVersion )->toBe( '999.0.0' )
+            ->and( $e->hostVersion )->not->toBe( '' );
+    }
+
+    $plugin = Plugin::where( 'slug', 'future-plugin' )->first();
+    expect( $plugin->is_active )->toBeFalse();
+} );
+
+it( 'activates when no min_host_version is declared', function (): void {
+    Plugin::create( [
+        'slug'      => 'legacy-plugin',
+        'name'      => 'Legacy Plugin',
+        'version'   => '1.0.0',
+        'is_active' => false,
+        'meta'      => ['slug' => 'legacy-plugin'],
+    ] );
+
+    expect( $this->manager->activate( 'legacy-plugin' ) )->toBeTrue();
+} );
+
+it( 'returns a 409 with a structured payload when activation fails on incompatibility', function (): void {
+    Plugin::create( [
+        'slug'      => 'future-plugin',
+        'name'      => 'Future Plugin',
+        'version'   => '1.0.0',
+        'is_active' => false,
+        'meta'      => [
+            'slug'             => 'future-plugin',
+            'min_host_version' => '999.0.0',
+        ],
+    ] );
+
+    $response = $this->actingAs( $this->admin )->postJson( '/api/v1/plugins/future-plugin/activate' );
+
+    $response->assertStatus( 409 )
+        ->assertJsonPath( 'code', 'plugin_incompatible' )
+        ->assertJsonPath( 'plugin', 'future-plugin' )
+        ->assertJsonPath( 'required_version', '999.0.0' );
+} );

--- a/tests/Feature/Plugins/PluginLifecycleRollbackTest.php
+++ b/tests/Feature/Plugins/PluginLifecycleRollbackTest.php
@@ -1,0 +1,122 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\CMSFramework\Modules\Plugins\Managers\PluginManager;
+use ArtisanPackUI\CMSFramework\Modules\Plugins\Models\Plugin;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Schema;
+
+beforeEach( function (): void {
+    $this->manager         = app( PluginManager::class );
+    $this->testPluginsPath = __DIR__ . '/../../Support/Plugins';
+    $this->pluginsPath     = base_path( 'plugins' );
+    File::ensureDirectoryExists( $this->pluginsPath );
+} );
+
+afterEach( function (): void {
+    if ( File::exists( $this->pluginsPath . '/plugin-with-migrations' ) ) {
+        File::deleteDirectory( $this->pluginsPath . '/plugin-with-migrations' );
+    }
+    Schema::dropIfExists( 'plugin_test_table' );
+} );
+
+it( 'rolls back plugin state when activation raises mid-flight', function (): void {
+    Plugin::create( [
+        'slug'             => 'broken-plugin',
+        'name'             => 'Broken Plugin',
+        'version'          => '1.0.0',
+        'is_active'        => false,
+        'service_provider' => 'NonExistent\\ServiceProvider\\ThatDoesNotExist',
+        'meta'             => ['slug' => 'broken-plugin'],
+    ] );
+
+    try {
+        $this->manager->activate( 'broken-plugin' );
+    } catch ( Throwable $e ) {
+        // Expected — nonexistent provider blows up during registration.
+    }
+
+    $plugin = Plugin::where( 'slug', 'broken-plugin' )->first();
+
+    expect( $plugin->is_active )->toBeFalse();
+} );
+
+it( 'rolls back plugin migrations on delete when the manifest opts in', function (): void {
+    File::copyDirectory(
+        $this->testPluginsPath . '/plugin-with-migrations',
+        $this->pluginsPath . '/plugin-with-migrations',
+    );
+
+    $manifest                                  = json_decode( File::get( $this->pluginsPath . '/plugin-with-migrations/plugin.json' ), true );
+    $manifest['rollback_migrations_on_delete'] = true;
+
+    Plugin::create( [
+        'slug'      => $manifest['slug'],
+        'name'      => $manifest['name'],
+        'version'   => $manifest['version'],
+        'is_active' => false,
+        'meta'      => $manifest,
+    ] );
+
+    $this->manager->activate( 'plugin-with-migrations' );
+
+    expect( Schema::hasTable( 'plugin_test_table' ) )->toBeTrue();
+
+    $this->manager->delete( 'plugin-with-migrations' );
+
+    expect( Schema::hasTable( 'plugin_test_table' ) )->toBeFalse();
+} );
+
+it( 'refuses to touch a migrations_path that resolves outside the plugin directory', function (): void {
+    // Simulate a legacy plugin row that pre-dates the schema validator: meta
+    // has a traversal-y migrations_path. The runtime guard in
+    // resolveSecureMigrationsPath should reject it silently.
+    File::copyDirectory(
+        $this->testPluginsPath . '/valid-plugin',
+        $this->pluginsPath . '/valid-plugin',
+    );
+
+    Plugin::create( [
+        'slug'      => 'valid-plugin',
+        'name'      => 'Valid Plugin',
+        'version'   => '1.0.0',
+        'is_active' => false,
+        'meta'      => [
+            'slug'                          => 'valid-plugin',
+            'migrations_path'               => '../../database/migrations',
+            'rollback_migrations_on_delete' => true,
+        ],
+    ] );
+
+    // Snapshot: the framework's own plugins table exists.
+    expect( Schema::hasTable( 'plugins' ) )->toBeTrue();
+
+    $this->manager->delete( 'valid-plugin' );
+
+    // The framework schema must NOT have been rolled back.
+    expect( Schema::hasTable( 'plugins' ) )->toBeTrue();
+} );
+
+it( 'leaves plugin migrations in place when opt-in flag is absent', function (): void {
+    File::copyDirectory(
+        $this->testPluginsPath . '/plugin-with-migrations',
+        $this->pluginsPath . '/plugin-with-migrations',
+    );
+
+    $manifest = json_decode( File::get( $this->pluginsPath . '/plugin-with-migrations/plugin.json' ), true );
+
+    Plugin::create( [
+        'slug'      => $manifest['slug'],
+        'name'      => $manifest['name'],
+        'version'   => $manifest['version'],
+        'is_active' => false,
+        'meta'      => $manifest,
+    ] );
+
+    $this->manager->activate( 'plugin-with-migrations' );
+    $this->manager->delete( 'plugin-with-migrations' );
+
+    // Table persists because we did not opt in to rollback.
+    expect( Schema::hasTable( 'plugin_test_table' ) )->toBeTrue();
+} );

--- a/tests/Unit/Admin/AdminMenuManagerFilterTest.php
+++ b/tests/Unit/Admin/AdminMenuManagerFilterTest.php
@@ -1,0 +1,152 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\CMSFramework\Modules\Admin\Managers\AdminMenuManager;
+use Illuminate\Support\Facades\Gate;
+
+beforeEach( function (): void {
+    $this->manager = new AdminMenuManager;
+
+    // Allow everything EXCEPT the sentinel used by the Gate re-check test,
+    // so that test can prove enforceCapabilities strips filter-injected
+    // entries the current user isn't allowed to see.
+    Gate::before( fn ( ?Illuminate\Contracts\Auth\Authenticatable $user, string $ability ) => 'never_granted' === $ability ? null : true );
+
+    // Reset the hooks registry between tests so filter callbacks don't leak.
+    removeAllFilters( 'ap.admin.menu' );
+} );
+
+afterEach( function (): void {
+    removeAllFilters( 'ap.admin.menu' );
+} );
+
+describe( 'ap.admin.menu filter', function (): void {
+    it( 'fires when getAdminMenu is called', function (): void {
+        $called = false;
+        addFilter( 'ap.admin.menu', function ( array $menu ) use ( &$called ): array {
+            $called = true;
+
+            return $menu;
+        } );
+
+        $this->manager->getAdminMenu();
+
+        expect( $called )->toBeTrue();
+    } );
+
+    it( 'lets a subscriber inject a new top-level entry', function (): void {
+        addFilter( 'ap.admin.menu', function ( array $menu ): array {
+            $menu['plugin-entry'] = [
+                'title' => 'Plugin Entry',
+                'slug'  => 'plugin-entry',
+                'label' => 'Plugin Entry',
+                'url'   => '/admin/plugin-entry',
+                'order' => 10,
+            ];
+
+            return $menu;
+        } );
+
+        $menu = $this->manager->getAdminMenu();
+
+        expect( $menu )->toHaveKey( 'plugin-entry' )
+            ->and( $menu['plugin-entry']['label'] )->toBe( 'Plugin Entry' );
+    } );
+
+    it( 'lets a subscriber remove an entry', function (): void {
+        $this->manager->addPage( 'Dashboard', 'dashboard', null, ['icon' => 'x', 'capability' => ''] );
+
+        addFilter( 'ap.admin.menu', function ( array $menu ): array {
+            unset( $menu['dashboard'] );
+
+            return $menu;
+        } );
+
+        $menu = $this->manager->getAdminMenu();
+
+        expect( $menu )->not->toHaveKey( 'dashboard' );
+    } );
+} );
+
+describe( 'filter Gate re-check', function (): void {
+    it( 'drops filter-injected entries whose permission the user does not hold', function (): void {
+        // The beforeEach's allow-all returns null (falls through to defines)
+        // for the 'never_granted' sentinel, so Gate::allows resolves it to
+        // false — exactly the state an unauthorized user would hit.
+        addFilter( 'ap.admin.menu', function ( array $menu ): array {
+            $menu['gated'] = [
+                'title'      => 'Gated',
+                'slug'       => 'gated',
+                'label'      => 'Gated',
+                'url'        => '/gated',
+                'permission' => 'never_granted',
+                'external'   => false,
+            ];
+
+            return $menu;
+        } );
+
+        $menu = $this->manager->getAdminMenu();
+
+        expect( $menu )->not->toHaveKey( 'gated' );
+    } );
+} );
+
+describe( 'top-level slug with slashes', function (): void {
+    it( 'stores a route name with slashes replaced by dots', function (): void {
+        Gate::before( fn ( ?Illuminate\Contracts\Auth\Authenticatable $user, string $ability ) => true );
+
+        $this->manager->addPage( 'Reports', 'packages/reports', null, ['capability' => ''] );
+
+        $menu = $this->manager->getAdminMenu();
+
+        expect( $menu['packages/reports']['route'] )->toBe( 'admin.packages.reports' );
+    } );
+} );
+
+describe( 'extended menu row shape', function (): void {
+    it( 'adds label/iconId/permission/url/external to items', function (): void {
+        $this->manager->addPage( 'Dashboard', 'dashboard', null, [
+            'icon'       => 'fas.home',
+            'capability' => '',
+        ] );
+
+        $menu = $this->manager->getAdminMenu();
+
+        expect( $menu['dashboard'] )
+            ->toHaveKey( 'label' )
+            ->toHaveKey( 'iconId' )
+            ->toHaveKey( 'url' )
+            ->toHaveKey( 'external' );
+
+        expect( $menu['dashboard']['label'] )->toBe( 'Dashboard' )
+            ->and( $menu['dashboard']['iconId'] )->toBe( 'fas.home' )
+            ->and( $menu['dashboard']['external'] )->toBeFalse();
+    } );
+
+    it( 'includes the permission field when the item has a capability', function (): void {
+        Gate::define( 'view_admin_dashboard', fn ( $user = null ) => true );
+
+        $this->manager->addPage( 'Dashboard', 'dashboard', null, [
+            'icon'       => 'fas.home',
+            'capability' => 'view_admin_dashboard',
+        ] );
+
+        $menu = $this->manager->getAdminMenu();
+
+        expect( $menu['dashboard']['permission'] )->toBe( 'view_admin_dashboard' );
+    } );
+
+    it( 'keeps the pre-existing keys for Blade back-compat', function (): void {
+        $this->manager->addPage( 'Dashboard', 'dashboard', null, ['icon' => 'fas.home', 'capability' => ''] );
+
+        $menu = $this->manager->getAdminMenu();
+
+        expect( $menu['dashboard'] )
+            ->toHaveKey( 'title' )
+            ->toHaveKey( 'route' )
+            ->toHaveKey( 'icon' )
+            ->toHaveKey( 'capability' );
+    } );
+} );

--- a/tests/Unit/Plugins/ManifestSchemaExtensionTest.php
+++ b/tests/Unit/Plugins/ManifestSchemaExtensionTest.php
@@ -1,0 +1,177 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\CMSFramework\Modules\Plugins\Exceptions\PluginValidationException;
+use ArtisanPackUI\CMSFramework\Modules\Plugins\Managers\PluginManager;
+use ArtisanPackUI\CMSFramework\Modules\Plugins\Models\Plugin;
+
+beforeEach( function (): void {
+    $this->manager = new PluginManager;
+    $this->base    = [
+        'slug'    => 'test-plugin',
+        'name'    => 'Test Plugin',
+        'version' => '1.0.0',
+    ];
+} );
+
+describe( 'min_host_version', function (): void {
+    it( 'accepts a valid semver', function (): void {
+        $manifest = array_merge( $this->base, ['min_host_version' => '2.4.0'] );
+
+        expect( fn () => invokeMethod( $this->manager, 'validateManifest', [$manifest] ) )
+            ->not->toThrow( PluginValidationException::class );
+    } );
+
+    it( 'rejects a malformed version string', function (): void {
+        $manifest = array_merge( $this->base, ['min_host_version' => 'v2.4'] );
+
+        expect( fn () => invokeMethod( $this->manager, 'validateManifest', [$manifest] ) )
+            ->toThrow( PluginValidationException::class, 'Invalid min_host_version' );
+    } );
+} );
+
+describe( 'federated_module', function (): void {
+    it( 'accepts an entry-only descriptor', function (): void {
+        $manifest = array_merge( $this->base, [
+            'federated_module' => ['entry' => 'dist/remoteEntry.js'],
+        ] );
+
+        expect( fn () => invokeMethod( $this->manager, 'validateManifest', [$manifest] ) )
+            ->not->toThrow( PluginValidationException::class );
+    } );
+
+    it( 'rejects a missing entry', function (): void {
+        $manifest = array_merge( $this->base, ['federated_module' => ['exposes' => ['a']]] );
+
+        expect( fn () => invokeMethod( $this->manager, 'validateManifest', [$manifest] ) )
+            ->toThrow( PluginValidationException::class, 'Invalid federated_module' );
+    } );
+
+    it( 'rejects a non-array exposes', function (): void {
+        $manifest = array_merge( $this->base, [
+            'federated_module' => ['entry' => 'x.js', 'exposes' => 'oops'],
+        ] );
+
+        expect( fn () => invokeMethod( $this->manager, 'validateManifest', [$manifest] ) )
+            ->toThrow( PluginValidationException::class, 'exposes' );
+    } );
+} );
+
+describe( 'nav_entries', function (): void {
+    it( 'accepts a well-formed list', function (): void {
+        $manifest = array_merge( $this->base, [
+            'nav_entries' => [
+                ['slug' => 'reports', 'label' => 'Reports'],
+            ],
+        ] );
+
+        expect( fn () => invokeMethod( $this->manager, 'validateManifest', [$manifest] ) )
+            ->not->toThrow( PluginValidationException::class );
+    } );
+
+    it( 'rejects entries missing slug/label', function (): void {
+        $manifest = array_merge( $this->base, [
+            'nav_entries' => [
+                ['slug' => 'reports'],
+            ],
+        ] );
+
+        expect( fn () => invokeMethod( $this->manager, 'validateManifest', [$manifest] ) )
+            ->toThrow( PluginValidationException::class, 'nav_entries[0]' );
+    } );
+
+    it( 'rejects associative arrays', function (): void {
+        $manifest = array_merge( $this->base, [
+            'nav_entries' => ['not' => 'a list'],
+        ] );
+
+        expect( fn () => invokeMethod( $this->manager, 'validateManifest', [$manifest] ) )
+            ->toThrow( PluginValidationException::class );
+    } );
+} );
+
+describe( 'permissions', function (): void {
+    it( 'accepts a list of properly-namespaced slugs', function (): void {
+        $manifest = array_merge( $this->base, [
+            'permissions' => ['test-plugin.reports.view', 'test-plugin.reports.export'],
+        ] );
+
+        expect( fn () => invokeMethod( $this->manager, 'validateManifest', [$manifest] ) )
+            ->not->toThrow( PluginValidationException::class );
+    } );
+
+    it( 'rejects non-string entries', function (): void {
+        $manifest = array_merge( $this->base, ['permissions' => ['test-plugin.reports.view', 42]] );
+
+        expect( fn () => invokeMethod( $this->manager, 'validateManifest', [$manifest] ) )
+            ->toThrow( PluginValidationException::class );
+    } );
+
+    it( 'rejects permissions that are not prefixed with the plugin slug', function (): void {
+        // Without this rule a plugin could name framework-owned permissions
+        // ('manage_users') and delete them on uninstall.
+        $manifest = array_merge( $this->base, [
+            'permissions' => ['manage_users'],
+        ] );
+
+        expect( fn () => invokeMethod( $this->manager, 'validateManifest', [$manifest] ) )
+            ->toThrow( PluginValidationException::class, 'must be prefixed' );
+    } );
+} );
+
+describe( 'migrations_path', function (): void {
+    it( 'accepts a valid relative path', function (): void {
+        $manifest = array_merge( $this->base, ['migrations_path' => 'database/migrations'] );
+
+        expect( fn () => invokeMethod( $this->manager, 'validateManifest', [$manifest] ) )
+            ->not->toThrow( PluginValidationException::class );
+    } );
+
+    it( 'rejects a traversal attempt', function (): void {
+        $manifest = array_merge( $this->base, ['migrations_path' => '../../database/migrations'] );
+
+        expect( fn () => invokeMethod( $this->manager, 'validateManifest', [$manifest] ) )
+            ->toThrow( PluginValidationException::class, 'no ".."' );
+    } );
+
+    it( 'rejects an absolute path', function (): void {
+        $manifest = array_merge( $this->base, ['migrations_path' => '/etc/passwd'] );
+
+        expect( fn () => invokeMethod( $this->manager, 'validateManifest', [$manifest] ) )
+            ->toThrow( PluginValidationException::class );
+    } );
+} );
+
+describe( 'Plugin model accessors', function (): void {
+    it( 'exposes the new manifest fields ergonomically', function (): void {
+        $plugin = new Plugin( [
+            'slug'    => 'test-plugin',
+            'name'    => 'Test Plugin',
+            'version' => '1.0.0',
+            'meta'    => [
+                'min_host_version'              => '2.4.0',
+                'federated_module'              => ['entry' => 'dist/remoteEntry.js', 'exposes' => ['./App']],
+                'nav_entries'                   => [['slug' => 'x', 'label' => 'X']],
+                'permissions'                   => ['test-plugin.reports.view'],
+                'rollback_migrations_on_delete' => true,
+            ],
+        ] );
+
+        expect( $plugin->min_host_version )->toBe( '2.4.0' )
+            ->and( $plugin->federated_module )->toMatchArray( ['entry' => 'dist/remoteEntry.js'] )
+            ->and( $plugin->nav_entries )->toHaveCount( 1 )
+            ->and( $plugin->declared_permissions )->toBe( ['test-plugin.reports.view'] )
+            ->and( $plugin->rollback_migrations_on_delete )->toBeTrue();
+    } );
+
+    it( 'returns sensible defaults when manifest fields are absent', function (): void {
+        $plugin = new Plugin( ['slug' => 'x', 'name' => 'X', 'version' => '1.0.0', 'meta' => []] );
+
+        expect( $plugin->min_host_version )->toBeNull()
+            ->and( $plugin->federated_module )->toBeNull()
+            ->and( $plugin->nav_entries )->toBe( [] )
+            ->and( $plugin->declared_permissions )->toBe( [] )
+            ->and( $plugin->rollback_migrations_on_delete )->toBeFalse();
+    } );
+} );

--- a/tests/Unit/Plugins/PluginServiceProviderTest.php
+++ b/tests/Unit/Plugins/PluginServiceProviderTest.php
@@ -1,0 +1,200 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\CMSFramework\Modules\Admin\Managers\AdminMenuManager;
+use ArtisanPackUI\CMSFramework\Modules\Plugins\Support\PluginRegistry;
+use ArtisanPackUI\CMSFramework\Modules\Plugins\Support\PluginServiceProvider;
+use Illuminate\Support\Facades\Gate;
+
+beforeEach( function (): void {
+    Gate::before( fn ( ?Illuminate\Contracts\Auth\Authenticatable $user, string $ability ) => true );
+
+    removeAllFilters( 'ap.admin.menu' );
+    removeAllFilters( 'ap.plugins.federatedModules' );
+
+    $this->app->singleton( AdminMenuManager::class, fn () => new AdminMenuManager );
+    $this->app->singleton( PluginRegistry::class );
+
+    // Wire the same single-callback filter the framework's PluginsServiceProvider
+    // sets up, so registry contents surface in the admin menu.
+    $registry = app( PluginRegistry::class );
+    addFilter( 'ap.admin.menu', function ( array $menu ) use ( $registry ): array {
+        foreach ( $registry->navEntries() as $slug => $entry ) {
+            $menu[ $slug ] = array_merge( $entry, $menu[ $slug ] ?? [] );
+        }
+
+        return $menu;
+    } );
+    addFilter( 'ap.plugins.federatedModules', function ( array $modules ) use ( $registry ): array {
+        return array_merge( $modules, $registry->federatedModules() );
+    } );
+} );
+
+afterEach( function (): void {
+    removeAllFilters( 'ap.admin.menu' );
+    removeAllFilters( 'ap.plugins.federatedModules' );
+} );
+
+it( 'registers an admin page through the AdminMenuManager', function (): void {
+    $provider = new class( app() ) extends PluginServiceProvider {
+        public function boot(): void
+        {
+            $this->registerAdminPage( 'my-plugin', [
+                'title'      => 'My Plugin',
+                'icon'       => 'fas.star',
+                'capability' => '',
+            ] );
+        }
+
+        protected function loadManifest(): array
+        {
+            return $this->manifest = ['slug' => 'my-plugin'];
+        }
+    };
+
+    $provider->boot();
+
+    $menu = app( AdminMenuManager::class )->getAdminMenu();
+
+    expect( $menu )->toHaveKey( 'my-plugin' )
+        ->and( $menu['my-plugin']['label'] )->toBe( 'My Plugin' );
+} );
+
+it( 'injects a nav entry via the ap.admin.menu filter', function (): void {
+    $provider = new class( app() ) extends PluginServiceProvider {
+        public function boot(): void
+        {
+            $this->registerNavEntry( [
+                'slug'       => 'reports',
+                'label'      => 'Reports',
+                'url'        => '/admin/reports',
+                'icon'       => 'fas.chart-bar',
+                'permission' => 'reports.view',
+            ] );
+        }
+
+        protected function loadManifest(): array
+        {
+            return $this->manifest = ['slug' => 'reports-plugin'];
+        }
+    };
+
+    $provider->boot();
+
+    $menu = app( AdminMenuManager::class )->getAdminMenu();
+
+    expect( $menu )->toHaveKey( 'reports' )
+        ->and( $menu['reports']['url'] )->toBe( '/admin/reports' )
+        ->and( $menu['reports']['permission'] )->toBe( 'reports.view' )
+        ->and( $menu['reports']['external'] )->toBeFalse();
+} );
+
+it( 'sanitizes javascript: URLs in nav entries down to #', function (): void {
+    $provider = new class( app() ) extends PluginServiceProvider {
+        public function boot(): void
+        {
+            $this->registerNavEntry( [
+                'slug'  => 'evil',
+                'label' => 'Docs',
+                'url'   => 'javascript:alert(1)',
+            ] );
+        }
+
+        protected function loadManifest(): array
+        {
+            return $this->manifest = ['slug' => 'evil-plugin'];
+        }
+    };
+
+    $provider->boot();
+
+    $menu = app( AdminMenuManager::class )->getAdminMenu();
+
+    expect( $menu['evil']['url'] )->toBe( '#' );
+} );
+
+it( 'is idempotent when the same nav entry is registered twice', function (): void {
+    $provider = new class( app() ) extends PluginServiceProvider {
+        public function boot(): void
+        {
+            $this->registerNavEntry( [
+                'slug'  => 'reports',
+                'label' => 'Reports',
+                'url'   => '/admin/reports',
+            ] );
+            $this->registerNavEntry( [
+                'slug'  => 'reports',
+                'label' => 'Reports v2',
+                'url'   => '/admin/reports',
+            ] );
+        }
+
+        protected function loadManifest(): array
+        {
+            return $this->manifest = ['slug' => 'reports-plugin'];
+        }
+    };
+
+    $provider->boot();
+
+    $entries = app( PluginRegistry::class )->navEntries();
+
+    expect( $entries )->toHaveCount( 1 )
+        ->and( $entries['reports']['label'] )->toBe( 'Reports v2' );
+} );
+
+it( 'exposes federated modules via a filter', function (): void {
+    $provider = new class( app() ) extends PluginServiceProvider {
+        public function boot(): void
+        {
+            $this->registerFederatedModule( 'reports', 'dist/remoteEntry.js', ['./App'] );
+        }
+
+        protected function loadManifest(): array
+        {
+            return $this->manifest = ['slug' => 'reports-plugin'];
+        }
+    };
+
+    $provider->boot();
+
+    $modules = applyFilters( 'ap.plugins.federatedModules', [] );
+
+    expect( $modules )->toHaveKey( 'reports' )
+        ->and( $modules['reports']['entry'] )->toBe( 'dist/remoteEntry.js' )
+        ->and( $modules['reports']['exposes'] )->toBe( ['./App'] );
+} );
+
+it( 'resolves pluginPath and pluginConfig from the manifest', function (): void {
+    $provider = new class( app() ) extends PluginServiceProvider {
+        public function boot(): void
+        {
+        }
+
+        public function exposePluginPath( ?string $subpath = null ): string
+        {
+            return $this->pluginPath( $subpath );
+        }
+
+        public function exposePluginConfig( ?string $key = null ): mixed
+        {
+            return $this->pluginConfig( $key );
+        }
+
+        protected function loadManifest(): array
+        {
+            return $this->manifest = [
+                'slug'   => 'my-plugin',
+                'name'   => 'My Plugin',
+                'nested' => ['key' => 'value'],
+            ];
+        }
+    };
+
+    expect( $provider->exposePluginPath() )->toEndWith( '/plugins/my-plugin' )
+        ->and( $provider->exposePluginPath( 'resources/js' ) )->toEndWith( '/plugins/my-plugin/resources/js' )
+        ->and( $provider->exposePluginConfig( 'name' ) )->toBe( 'My Plugin' )
+        ->and( $provider->exposePluginConfig( 'nested.key' ) )->toBe( 'value' )
+        ->and( $provider->exposePluginConfig( 'missing' ) )->toBeNull();
+} );


### PR DESCRIPTION
## Description

Bundles the five v2.4 plugin-system enhancements that together unblock the Keystone CMS plugin UI initiative. See per-issue detail below.

**Closes:** #179, #180, #181, #182, #183

## Type of Change

- [x] New feature (adds new functionality)
- [x] Enhancement (improves existing functionality)
- [x] Security fix

## Related Issue

- #179 — Add `ap.admin.menu` filter to AdminMenuManager
- #180 — Provide a base `PluginServiceProvider` class for plugin authors
- #181 — Extend `plugin.json` manifest schema
- #182 — Complete the plugin lifecycle hooks
- #183 — Add plugin host-version compatibility check on activation

## Motivation and Context

Keystone CMS (the downstream host) needs a way for plugins to inject admin nav entries, declare host-version compatibility, register frontend modules, and rely on real lifecycle guarantees. The framework's existing filter API had a conspicuous gap at the admin menu, no base service provider for plugin authors, no host-version gate, and lifecycle hooks that were only stubbed.

## Changes Made

**Manifest schema (#181):**
- New optional fields: `min_host_version`, `federated_module`, `nav_entries`, `permissions`, `migrations_path`, `rollback_migrations_on_delete`
- Per-field validation with clear error messages
- Model accessors: `$plugin->min_host_version`, `->federated_module`, `->nav_entries`, `->declared_permissions`, `->rollback_migrations_on_delete`

**Admin menu filter (#179):**
- `AdminMenuManager::getAdminMenu()` wraps output in `applyFilters('ap.admin.menu', $menu)`
- Rows decorated with React/Inertia-friendly `url`, `label`, `iconId`, `permission`, `external` while keeping the pre-existing Blade keys
- Post-filter `enforceCapabilities()` re-runs the Gate check on plugin-injected entries so filter subscribers can't bypass authorization

**PluginServiceProvider base (#180):**
- New abstract class in `src/Modules/Plugins/Support/PluginServiceProvider.php`
- Helpers: `registerAdminPage`, `registerNavEntry`, `registerFederatedModule`, `pluginPath`, `pluginConfig`
- Backed by a container-bound `PluginRegistry` singleton keyed by slug/name — `PluginsServiceProvider` wires a single filter callback that reads from it, avoiding closure accumulation under Octane
- Manifest loader constrained to direct children of the plugins directory (blocks identity theft from vendor subdirs)

**Host-version compat (#183):**
- New `IncompatiblePluginException` (readonly-promoted props, matching-shape factory)
- `PluginManager::activate()` calls `assertHostVersionCompatible()` before any state mutation
- Version resolution prefers `composer.json` declared version (clean semver), falls back to `Composer\InstalledVersions`; unparseable/unknown versions log a warning and skip permissively (consistent policy)
- `PluginsController::activate()` returns structured HTTP 409 with `code: plugin_incompatible`, `plugin`, `required_version`, `host_version`

**Lifecycle rewrite (#182):**
- Transactional `activate()` with rollback on failure: PSR-4 snapshot + restore (preserves shared-namespace paths), migrations rolled back (flag set before the Artisan call so mid-migration DDL still triggers), `is_active` reset
- `deactivate()` and `delete()` optionally clear route/config/view caches gated by `cms.plugins.autoClearFrameworkCaches` (default false — enabled explicitly in dev, avoided in production `route:cache` deployments)
- `delete()` honors `rollback_migrations_on_delete` manifest flag and removes seeded RBAC permissions
- Permission seed/unseed scoped by plugin-slug namespace (validator enforces prefix) so cross-plugin/framework wipeouts are impossible by construction

**Security hardening (local review pass before this PR opened):**
- Manifest `migrations_path` traversal rejection (schema + runtime realpath check) — closes CRITICAL: malicious plugin could otherwise drop framework tables on delete
- Permission namespace enforcement — closes CRITICAL: plugin could otherwise name core slugs and wipe them on uninstall
- URL scheme allow-list (`http/https/mailto/tel`, `/` paths, `#` fragments) in `registerNavEntry` + `resolveRouteUrl` — closes HIGH: `javascript:` URLs would otherwise reach the admin sidebar's `<a href>`
- `enforceCapabilities` after filter — closes HIGH: filter-injected entries would otherwise bypass Gate
- Constrained `PluginServiceProvider::loadManifest()` walk — closes MEDIUM: cross-plugin identity theft
- `UpdateManager` catches `IncompatiblePluginException` and reverts DB row — closes HIGH: DB-vs-disk desync after failed update
- Fixed `addPage()` route-name slash/dot mismatch — closes HIGH: `url` field was falling back to `#` for every multi-segment slug

## How Has This Been Tested?

**Testing Environment:**
- PHP: 8.4
- Project Version: 2.4 branch (targets `release/2.4`)

**Tests Performed:**
1. `./vendor/bin/pest tests/Feature/Plugins tests/Unit/Plugins tests/Unit/Admin` — 134 tests pass
2. `php -d memory_limit=1G ./vendor/bin/pest` (full suite) — 1088 pass, 7 skipped (pre-existing)
3. `./vendor/bin/php-cs-fixer fix` — code formatted per ArtisanPack UI standards

## Accessibility Tests Run

- [x] N/A — backend/framework change; no UI surface introduced

## Tests Added

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] All tests passing

**Test details:**
- `ManifestSchemaExtensionTest` — each new field: valid + malformed variants; permission namespace prefix enforcement; `migrations_path` traversal / absolute-path rejection; model accessors
- `AdminMenuManagerFilterTest` — filter fires, subscribers add/remove entries; post-filter Gate re-check strips unauthorized rows; sub-page slug slash/dot handling; extended row shape
- `PluginServiceProviderTest` — registerAdminPage, registerNavEntry (idempotence under repeat calls), javascript: URL sanitization, registerFederatedModule, pluginPath/pluginConfig
- `HostVersionCompatibilityTest` — rejects newer-required, allows when no min set, controller returns 409
- `PluginLifecycleRollbackTest` — activation rollback on failure, opt-in migration rollback on delete, refuses traversal-y migrations_path even for legacy rows

## Documentation

- [x] Inline PHPDoc added on all new methods and classes
- [ ] README not yet updated — worth a follow-up PR summarizing the new hooks and manifest fields in the Hook Reference / Plugin System sections (kept out of this PR to keep review focused)

## Pre-Submission Checklist

- [x] Followed contributing guidelines
- [x] Code passes all tests (1088 / 1088)
- [x] Code has been linted (`php-cs-fixer fix` clean)
- [x] Code follows project style guide
- [x] Self-review completed (plus multi-agent code-review pass with security focus)
- [x] Comments added for complex code
- [x] No new warnings generated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added plugin host-version compatibility checks with clear activation error details.
  * Added support for plugin-provided admin navigation and federated frontend modules.
  * Added safer plugin manifest options for navigation, permissions, migrations, and compatibility.
* **Bug Fixes**
  * Failed plugin activations and updates now restore previous state more reliably.
  * Admin navigation now applies permissions consistently and blocks unsafe external URLs.
  * Plugin migration paths are validated to prevent access outside the plugin.
* **Tests**
  * Expanded coverage for plugin compatibility, lifecycle recovery, manifest validation, and admin navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->