### PR TITLE
feat(plugins): complete plugin extensibility (#184, #185, #186, #187, #188)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ A comprehensive Laravel package that provides back-end support for building a CM
 - **Visual Editor Integration** *(new in 2.0.0)*: Opt-in bridge to the optional `artisanpack-ui/visual-editor` package
 - **Blog Comments** *(new in 2.1.0)*: Threaded post comments with public read / guest submit, rate-limited public submission, and auth-gated moderation
 - **Themes**: Discovery, activation, ZIP upload, and lifecycle hooks
-- **Plugins**: Plugin system ⚠️ **Experimental**
+- **Plugins**: Plugin system with lifecycle management, hooks, custom field types, admin pages, and Module Federation support — see the [Plugin Author Guide](./docs/plugin-authoring.md)
 - **Core Updates**: Automatic update checking and management with rollback support
 - **PWA Support**: Progressive Web App features
 - **Audit Logging**: Track changes and user actions
@@ -270,27 +270,19 @@ composer require artisanpack-ui/ai:^1.0
 
 Without it, the agents, the Livewire component, and the REST endpoints stay unregistered — the framework boots normally.
 
+## Plugin System
+
+Plugins extend the framework with new admin pages, nav entries, hook
+subscriptions, custom field types, edit-screen panels, and — in hosts that
+ship a Module Federation runtime — React admin components.
+
+- Start with the [Plugin Author Guide](./docs/plugin-authoring.md).
+- Copy the [`examples/hello-world-plugin/`](./examples/hello-world-plugin/) skeleton for a working reference.
+
 ## Experimental Features
 
-The following features are **experimental** in the 1.0.0 release and should be used with caution in production environments:
-
-### Plugin System
-
-The plugin system provides a foundation for extending the CMS with custom functionality.
-
-**What Works:**
-- Plugin model with activation/deactivation tracking
-- Plugin manager for lifecycle management
-- Plugin installation and validation
-- Plugin update manager integration
-
-**Known Limitations:**
-- Plugin lifecycle hooks not fully implemented
-- No plugin dependency management
-- Limited plugin configuration API
-- No plugin marketplace integration
-
-**Recommendation:** Use for testing and development. Not recommended for production until full lifecycle support is added in a future release.
+The following features are **experimental** and should be used with caution in
+production environments:
 
 ### Theme System
 

--- a/docs/plugin-authoring.md
+++ b/docs/plugin-authoring.md
@@ -1,0 +1,351 @@
+# Plugin Author Guide
+
+Plugins extend the CMS Framework with new content types, custom fields, admin
+pages, nav entries, hooks, and — in hosts that ship a Module Federation runtime
+— React admin components. This guide walks through every piece a plugin author
+needs and points at the reference example under
+[`examples/hello-world-plugin/`](../examples/hello-world-plugin/).
+
+- [Plugin lifecycle](#plugin-lifecycle)
+- [`plugin.json` manifest schema](#pluginjson-manifest-schema)
+- [Base `PluginServiceProvider`](#base-pluginserviceprovider)
+- [Registering an admin page](#registering-an-admin-page)
+- [Registering nav entries](#registering-nav-entries)
+- [Migrations](#migrations)
+- [Hook subscriptions](#hook-subscriptions)
+- [Registering custom field types](#registering-custom-field-types)
+- [Injecting edit-screen panels & tabs](#injecting-edit-screen-panels--tabs)
+- [Federated React modules](#federated-react-modules)
+- [Versioning & host compatibility](#versioning--host-compatibility)
+- [Testing your plugin](#testing-your-plugin)
+
+## Plugin lifecycle
+
+1. **Discovery** — The framework scans `base_path(config('cms.plugins.directory'))`
+   ( default `plugins/` ) for directories containing a `plugin.json` manifest.
+2. **Install** — When a plugin is uploaded, `PluginManager::install()` validates
+   the manifest and inserts a row in the `plugins` table.
+3. **Activate** — On activation, the plugin's `service_provider` ( from
+   `plugin.json` ) is registered with the container. This runs your
+   `register()` and `boot()` methods, and any manifest-declared migrations.
+4. **Deactivate** — The plugin row is marked inactive. The service provider is
+   unregistered on the next request boot.
+5. **Delete** — The plugin's directory and DB record are removed.
+
+## `plugin.json` manifest schema
+
+A plugin's root directory MUST contain a `plugin.json` file:
+
+```json
+{
+  "$schema": "https://artisanpack-ui.dev/schemas/plugin.json",
+  "slug": "hello-world",
+  "name": "Hello World",
+  "version": "1.0.0",
+  "description": "Reference plugin demonstrating the framework's plugin API.",
+  "author": {
+    "name": "Jacob Martella",
+    "email": "me@jacobmartella.com",
+    "url": "https://jacobmartella.com"
+  },
+  "homepage": "https://example.com/hello-world",
+  "license": "MIT",
+  "service_provider": "HelloWorld\\HelloWorldServiceProvider",
+  "requires": {
+    "cms-framework": "^2.4",
+    "php": "^8.2"
+  },
+  "autoload": {
+    "psr-4": {
+      "HelloWorld\\": "src/"
+    }
+  },
+  "migrations": "database/migrations",
+  "federated_modules": [
+    {
+      "name": "helloWorldAdmin",
+      "entry": "dist/remoteEntry.js",
+      "exposes": ["./HelloWorldPanel"]
+    }
+  ]
+}
+```
+
+### Required fields
+
+| Field              | Type   | Notes |
+| ------------------ | ------ | ----- |
+| `slug`             | string | Lowercase, dashes; matches directory name. |
+| `name`             | string | Human-readable name for the admin UI. |
+| `version`          | string | Semver. Used for host-compatibility checks and update flows. |
+| `service_provider` | string | Fully-qualified Laravel service provider class ( see below ). |
+
+### Optional fields
+
+| Field               | Type            | Notes |
+| ------------------- | --------------- | ----- |
+| `description`       | string          | Shown in the admin plugin list. |
+| `author`            | object          | `{ name, email?, url? }`. |
+| `homepage`          | string ( URL )  | Documentation or marketing URL. |
+| `license`           | string          | SPDX identifier ( `MIT`, `Apache-2.0`, etc. ). |
+| `requires`          | object          | Semver constraints: `{ "cms-framework": "^2.4", "php": "^8.2" }`. Enforced on activation. |
+| `autoload`          | object          | PSR-4 map. The framework hands this to Composer's runtime `ClassLoader`. |
+| `migrations`        | string ( path ) | Relative path to your migrations directory. Auto-run on activate. |
+| `federated_modules` | array           | See [Federated React modules](#federated-react-modules). |
+| `nav`               | array           | Static nav entries; equivalent to calling `registerNavEntry()` from your provider. |
+
+## Base `PluginServiceProvider`
+
+Extend
+`ArtisanPackUI\CMSFramework\Modules\Plugins\Support\PluginServiceProvider`
+for opinionated helpers:
+
+```php
+<?php
+
+namespace HelloWorld;
+
+use ArtisanPackUI\CMSFramework\Modules\Plugins\Support\PluginServiceProvider;
+
+final class HelloWorldServiceProvider extends PluginServiceProvider
+{
+    public function register(): void
+    {
+        // Bind services here.
+    }
+
+    public function boot(): void
+    {
+        $this->registerAdminPage( 'hello-world', [
+            'title'      => __( 'Hello World' ),
+            'section'    => 'tools',
+            'view'       => 'hello-world::admin.index',
+            'capability' => 'access_admin_dashboard',
+            'icon'       => 'fas.puzzle-piece',
+            'order'      => 60,
+        ] );
+
+        $this->registerNavEntry( [
+            'slug'       => 'hello-world',
+            'label'      => __( 'Hello World' ),
+            'url'        => '/admin/hello-world',
+            'icon'       => 'fas.puzzle-piece',
+            'permission' => 'access_admin_dashboard',
+            'order'      => 60,
+        ] );
+
+        $this->loadViewsFrom( $this->pluginPath( 'resources/views' ), 'hello-world' );
+    }
+}
+```
+
+Available helpers:
+
+- `registerAdminPage( string $slug, array $config )` — attach an admin page to the shared `AdminMenuManager`. `view` for Blade, `component` for federated React.
+- `registerNavEntry( array $entry )` — add an idempotent nav entry to the container-bound `PluginRegistry`.
+- `registerFederatedModule( string $name, string $entryPath, array $exposes = [] )` — declare a Module Federation entry hosts can consume.
+- `pluginPath( ?string $subpath = null )` — resolve a path within your plugin directory.
+- `pluginConfig( ?string $key = null )` — read the plugin's `plugin.json`; dot-notation supported.
+- `pluginSlug()` — resolves from your manifest.
+
+## Registering an admin page
+
+Blade version:
+
+```php
+$this->registerAdminPage( 'hello-world', [
+    'title'      => __( 'Hello World' ),
+    'section'    => 'tools',
+    'view'       => 'hello-world::admin.index',
+    'capability' => 'access_admin_dashboard',
+] );
+```
+
+The `view` value is a namespaced Blade view; register it with `loadViewsFrom(
+$this->pluginPath('resources/views'), 'hello-world' )` in `boot()`.
+
+Federated ( React ) version — same helper, use `component` instead of `view`:
+
+```php
+$this->registerAdminPage( 'hello-world', [
+    'title'     => __( 'Hello World' ),
+    'section'   => 'tools',
+    'component' => 'helloWorldAdmin/HelloWorldPanel',
+] );
+```
+
+Host apps map the `component` identifier to a real React component through
+their Module Federation loader.
+
+## Registering nav entries
+
+`registerNavEntry()` writes an entry to the framework's `PluginRegistry`; the
+host's admin shell reads it via the `ap.admin.menu` filter. Entries are
+identified by `slug` and are idempotent — repeated registrations from the same
+plugin ( e.g. under Octane workers ) overwrite instead of accumulating.
+
+You may alternatively pre-declare nav entries in `plugin.json` under `nav`.
+Programmatic registration is preferred when nav visibility depends on
+per-request state ( feature flags, tenant configuration, etc. ).
+
+## Migrations
+
+Set `"migrations": "database/migrations"` in your manifest to have the
+framework load your migrations on activation. Prefer schema-only changes;
+data seeding belongs in a separate seeder invoked via an install hook.
+
+```php
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create( 'hello_world_greetings', function ( Blueprint $table ): void {
+            $table->id();
+            $table->string( 'message' );
+            $table->timestamps();
+        } );
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists( 'hello_world_greetings' );
+    }
+};
+```
+
+## Hook subscriptions
+
+The framework's action / filter system ( `artisanpack-ui/hooks` ) is the
+primary extension seam. Register callbacks in `boot()`:
+
+```php
+addAction( 'ap.contentTypes.created', function ( $contentType ) {
+    logger()->info( 'A content type was created: ' . $contentType->slug );
+} );
+
+addFilter( 'ap.admin.contentEdit.saveData', function ( array $data, array $context ): array {
+    if ( 'post' === $context['contentType'] ) {
+        $data['metadata']['reviewed_at'] = now()->toIso8601String();
+    }
+
+    return $data;
+} );
+```
+
+Full hook reference: [`docs/Hooks-and-Events.md`](./Hooks-and-Events.md).
+
+## Registering custom field types
+
+Plugins can extend the closed `FieldType` enum through the
+`CustomFieldTypeRegistry`. Registered types become available in the admin
+custom-field-type dropdown and validate on save.
+
+```php
+apRegisterFieldType( 'map_picker', [
+    'label'              => __( 'Map Picker' ),
+    'column_type'        => 'string',
+    'validation_rules'   => ['string', 'regex:/^-?\d+\.\d+,-?\d+\.\d+$/'],
+    'editor_component'   => 'helloWorldAdmin/MapPickerEditor',
+    'renderer_component' => 'helloWorldAdmin/MapPickerRenderer',
+    'meta'               => ['icon' => 'fas.map'],
+] );
+```
+
+Filter-registered fields do not materialize a physical DB column. Their values
+live in the content record's `metadata` JSON column — the framework's
+`HasCustomFields` trait knows how to read and write them there.
+
+## Injecting edit-screen panels & tabs
+
+Host apps that build a post/page edit screen ( such as Keystone CMS ) consult
+the `ContentEditExtensions` manager to render plugin-supplied panels and tabs.
+Register from your provider's `boot()`:
+
+```php
+addFilter( 'ap.admin.contentEdit.panels', function ( array $panels ): array {
+    $panels[] = [
+        'slug'         => 'hello-world.seo',
+        'title'        => __( 'SEO' ),
+        'component'    => 'helloWorldAdmin/SeoPanel',
+        'contentTypes' => ['post', 'page'],
+        'order'        => 20,
+    ];
+
+    return $panels;
+} );
+```
+
+Filters:
+
+- `ap.admin.contentEdit.panels` — sidebar/right-column panels
+- `ap.admin.contentEdit.tabs` — tabs above the main editor
+- `ap.admin.contentEdit.beforeEditor` / `afterEditor` — blocks above/below the editor
+- `ap.admin.contentEdit.saveData` — pre-persistence transform of the save payload
+
+Entry shape: `{ slug, title, component, order?, contentTypes?, capability? }`.
+`contentTypes` accepts `['*']` for "all" or an explicit list.
+
+## Federated React modules
+
+The framework does not own the frontend, and does not ship a Module Federation
+runtime. Host apps ( e.g. Keystone CMS ) that support runtime-loaded React
+plugins consume federated modules the plugin has declared through:
+
+- **Manifest** — `federated_modules` array in `plugin.json`.
+- **Programmatic** — `$this->registerFederatedModule( $name, $entry, $exposes )` in `boot()`.
+
+An example Module Federation config, Vite build, and remoteEntry contract live
+in the Keystone CMS docs. See
+[`examples/hello-world-plugin/`](../examples/hello-world-plugin/) for a stub
+that pairs a Blade admin page with a `federated_modules` declaration that
+Keystone can consume.
+
+## Versioning & host compatibility
+
+Semver your plugin. Declare host-compatibility in `plugin.json`:
+
+```json
+"requires": {
+    "cms-framework": "^2.4",
+    "php": "^8.2"
+}
+```
+
+`PluginManager::install()` refuses installation when the running framework
+version does not satisfy the `cms-framework` constraint.
+
+## Testing your plugin
+
+Plugins ship their own Pest / PHPUnit test suites. A minimal `TestCase`
+extending Orchestra Testbench boots the framework in a testing container:
+
+```php
+use ArtisanPackUI\CMSFramework\CMSFrameworkServiceProvider;
+use HelloWorld\HelloWorldServiceProvider;
+use Orchestra\Testbench\TestCase as BaseTestCase;
+
+abstract class TestCase extends BaseTestCase
+{
+    protected function getPackageProviders( $app ): array
+    {
+        return [
+            CMSFrameworkServiceProvider::class,
+            HelloWorldServiceProvider::class,
+        ];
+    }
+}
+```
+
+Test what matters: your admin page renders, your migrations run, your hook
+subscriptions fire, and any custom field types round-trip through
+`HasCustomFields`.
+
+---
+
+Reference plugin: [`examples/hello-world-plugin/`](../examples/hello-world-plugin/).

--- a/examples/hello-world-plugin/README.md
+++ b/examples/hello-world-plugin/README.md
@@ -1,0 +1,77 @@
+# Hello World Plugin
+
+Reference plugin for the ArtisanPack UI CMS Framework. It exists to give plugin
+authors a canonical example of every extension point the framework exposes.
+
+**This is a documentation-only skeleton.** It is not installed by the framework
+and is not a Composer package. Copy the tree into your host application's
+`plugins/hello-world/` directory to explore it interactively.
+
+## What it demonstrates
+
+| Piece | File |
+| ----- | ---- |
+| Manifest schema, including `requires`, `autoload`, `nav`, `federated_modules` | [`plugin.json`](./plugin.json) |
+| Base `PluginServiceProvider` usage, admin page, nav entry, federated module | [`src/HelloWorldServiceProvider.php`](./src/HelloWorldServiceProvider.php) |
+| Custom field type registration ( `map_picker` ) via `apRegisterFieldType()` | [`src/HelloWorldServiceProvider.php`](./src/HelloWorldServiceProvider.php) |
+| Edit-screen panel registration via `ap.admin.contentEdit.panels` | [`src/HelloWorldServiceProvider.php`](./src/HelloWorldServiceProvider.php) |
+| Action-hook subscription ( `ap.contentTypes.created` ) | [`src/HelloWorldServiceProvider.php`](./src/HelloWorldServiceProvider.php) |
+| Migration path — plugin ships its own schema | [`database/migrations/`](./database/migrations/) |
+| Blade admin page | [`resources/views/admin/index.blade.php`](./resources/views/admin/index.blade.php) |
+
+## Two admin-page flavors, one plugin
+
+`plugin.json` declares BOTH a Blade admin view and a federated module the host
+can consume. The framework itself is view-layer agnostic — it hands the
+declarations to `AdminMenuManager` and `PluginRegistry`, and each host renders
+whichever flavor fits its stack.
+
+- **Blade flavor** — `registerAdminPage()` with a `view` key. Works in any
+  Laravel host today. See `resources/views/admin/index.blade.php`.
+- **Federated React flavor** — `registerFederatedModule()` +
+  `registerAdminPage()` with a `component` key. Requires a host that ships a
+  Module Federation runtime — for example, the Keystone CMS. The
+  `dist/remoteEntry.js` path referenced in `plugin.json` is intentionally
+  omitted here; Keystone's docs cover the full federated-plugin build
+  ( Vite / Module Federation config, remote-entry contract, host loader ).
+
+## Trying it in a host app
+
+1. Copy this directory into your host's `plugins/` folder ( default:
+   `base_path('plugins/hello-world')` ).
+2. Upload / activate via the admin plugin list, or seed a row into the
+   `plugins` table with `is_active = 1`.
+3. Navigate to `/admin/hello-world`. The Blade page renders.
+4. In a Module Federation host: swap the admin page's `view` for a
+   `component`, build a federated module from the `helloWorldAdmin` entry, and
+   the host loads the React panel instead.
+
+## Local testing
+
+Plugin authors typically ship their own test suite. A minimal `TestCase` looks
+like:
+
+```php
+use ArtisanPackUI\CMSFramework\CMSFrameworkServiceProvider;
+use HelloWorld\HelloWorldServiceProvider;
+use Orchestra\Testbench\TestCase as BaseTestCase;
+
+abstract class TestCase extends BaseTestCase
+{
+    protected function getPackageProviders( $app ): array
+    {
+        return [
+            CMSFrameworkServiceProvider::class,
+            HelloWorldServiceProvider::class,
+        ];
+    }
+}
+```
+
+Then write feature tests that exercise your admin page, hook subscriptions,
+and any custom field types.
+
+## Further reading
+
+- [Plugin author guide](../../docs/plugin-authoring.md)
+- [Hooks & events](../../docs/Hooks-and-Events.md)

--- a/examples/hello-world-plugin/database/migrations/2026_07_16_000000_create_hello_world_greetings_table.php
+++ b/examples/hello-world-plugin/database/migrations/2026_07_16_000000_create_hello_world_greetings_table.php
@@ -1,0 +1,24 @@
+<?php
+
+declare( strict_types=1 );
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create( 'hello_world_greetings', function ( Blueprint $table ): void {
+            $table->id();
+            $table->string( 'message' );
+            $table->timestamps();
+        } );
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists( 'hello_world_greetings' );
+    }
+};

--- a/examples/hello-world-plugin/plugin.json
+++ b/examples/hello-world-plugin/plugin.json
@@ -1,0 +1,45 @@
+{
+    "$schema": "https://artisanpack-ui.dev/schemas/plugin.json",
+    "slug": "hello-world",
+    "name": "Hello World",
+    "version": "1.0.0",
+    "description": "Reference plugin that demonstrates every extension point in the CMS Framework plugin API — admin page, nav entry, migration, custom field type, hook subscriptions, and a federated-module stub.",
+    "author": {
+        "name": "ArtisanPack UI",
+        "email": "me@jacobmartella.com",
+        "url": "https://artisanpack-ui.dev"
+    },
+    "homepage": "https://artisanpack-ui.dev/docs/plugins/hello-world",
+    "license": "MIT",
+    "service_provider": "HelloWorld\\HelloWorldServiceProvider",
+    "requires": {
+        "cms-framework": "^2.4",
+        "php": "^8.2"
+    },
+    "autoload": {
+        "psr-4": {
+            "HelloWorld\\": "src/"
+        }
+    },
+    "migrations": "database/migrations",
+    "nav": [
+        {
+            "slug": "hello-world-manifest-nav",
+            "label": "Hello (from manifest)",
+            "url": "/admin/hello-world",
+            "icon": "fas.puzzle-piece",
+            "permission": "access_admin_dashboard",
+            "order": 61
+        }
+    ],
+    "federated_modules": [
+        {
+            "name": "helloWorldAdmin",
+            "entry": "dist/remoteEntry.js",
+            "exposes": [
+                "./HelloWorldPanel",
+                "./MapPickerEditor"
+            ]
+        }
+    ]
+}

--- a/examples/hello-world-plugin/resources/views/admin/index.blade.php
+++ b/examples/hello-world-plugin/resources/views/admin/index.blade.php
@@ -1,0 +1,17 @@
+@extends('cms::admin.layouts.app')
+
+@section('title', __('Hello World'))
+
+@section('content')
+    <div class="hello-world">
+        <h1>{{ __('Hello World') }}</h1>
+
+        <p>
+            {{ __('This admin page is registered by the hello-world plugin. It uses the framework\'s Blade admin-page path.') }}
+        </p>
+
+        <p>
+            {{ __('The plugin also declares a federated_modules entry for hosts that support runtime-loaded React admin pages (see plugin.json). Blade and federated flavors coexist — the host chooses which to render based on its own capabilities.') }}
+        </p>
+    </div>
+@endsection

--- a/examples/hello-world-plugin/src/HelloWorldServiceProvider.php
+++ b/examples/hello-world-plugin/src/HelloWorldServiceProvider.php
@@ -1,0 +1,105 @@
+<?php
+
+declare( strict_types=1 );
+
+/**
+ * Hello World Plugin Service Provider.
+ *
+ * Reference implementation showing how to extend the framework's base
+ * `PluginServiceProvider` and register admin pages, nav entries, hook
+ * subscriptions, a custom field type, and an edit-screen panel.
+ *
+ * @since 1.0.0
+ */
+
+namespace HelloWorld;
+
+use ArtisanPackUI\CMSFramework\Modules\Plugins\Support\PluginServiceProvider;
+
+final class HelloWorldServiceProvider extends PluginServiceProvider
+{
+    public function register(): void
+    {
+        // Bind plugin services on the container. Nothing to bind for the
+        // reference plugin; keep the method as an anchor for real plugins.
+    }
+
+    public function boot(): void
+    {
+        $this->loadViewsFrom( $this->pluginPath( 'resources/views' ), 'hello-world' );
+
+        $this->registerAdminPage( 'hello-world', [
+            'title'      => __( 'Hello World' ),
+            'section'    => 'tools',
+            'view'       => 'hello-world::admin.index',
+            'capability' => 'access_admin_dashboard',
+            'icon'       => 'fas.puzzle-piece',
+            'order'      => 60,
+        ] );
+
+        $this->registerNavEntry( [
+            'slug'       => 'hello-world',
+            'label'      => __( 'Hello World' ),
+            'url'        => '/admin/hello-world',
+            'icon'       => 'fas.puzzle-piece',
+            'permission' => 'access_admin_dashboard',
+            'order'      => 60,
+        ] );
+
+        $this->registerFederatedModule(
+            'helloWorldAdmin',
+            $this->pluginPath( 'dist/remoteEntry.js' ),
+            ['./HelloWorldPanel', './MapPickerEditor'],
+        );
+
+        $this->registerFieldTypes();
+        $this->registerEditPanels();
+        $this->registerHookSubscriptions();
+    }
+
+    /**
+     * Add a `map_picker` field type that stores its value as a lat/lng string
+     * on the record's `metadata` JSON column.
+     */
+    protected function registerFieldTypes(): void
+    {
+        apRegisterFieldType( 'map_picker', [
+            'label'              => __( 'Map Picker' ),
+            'column_type'        => 'string',
+            'validation_rules'   => ['string', 'regex:/^-?\d+\.\d+,-?\d+\.\d+$/'],
+            'editor_component'   => 'helloWorldAdmin/MapPickerEditor',
+            'renderer_component' => 'helloWorldAdmin/MapPickerRenderer',
+            'meta'               => ['icon' => 'fas.map', 'category' => 'location'],
+        ] );
+    }
+
+    /**
+     * Add a sidebar panel to every post/page edit screen.
+     */
+    protected function registerEditPanels(): void
+    {
+        addFilter( 'ap.admin.contentEdit.panels', function ( array $panels ): array {
+            $panels[] = [
+                'slug'         => 'hello-world.notes',
+                'title'        => __( 'Hello World Notes' ),
+                'component'    => 'helloWorldAdmin/HelloWorldPanel',
+                'contentTypes' => ['post', 'page'],
+                'order'        => 45,
+                'capability'   => 'access_admin_dashboard',
+            ];
+
+            return $panels;
+        } );
+    }
+
+    /**
+     * Log a friendly greeting whenever a content type is created — the smallest
+     * possible demonstration of a plugin subscribing to a framework hook.
+     */
+    protected function registerHookSubscriptions(): void
+    {
+        addAction( 'ap.contentTypes.created', static function ( $contentType ): void {
+            logger()->info( 'Hello World says hi to a new content type: ' . $contentType->slug );
+        } );
+    }
+}

--- a/src/Modules/ContentTypes/Http/Requests/CustomFieldRequest.php
+++ b/src/Modules/ContentTypes/Http/Requests/CustomFieldRequest.php
@@ -14,7 +14,7 @@ declare( strict_types=1 );
 namespace ArtisanPackUI\CMSFramework\Modules\ContentTypes\Http\Requests;
 
 use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Enums\ColumnType;
-use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Enums\FieldType;
+use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Registries\CustomFieldTypeRegistry;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
 
@@ -68,7 +68,7 @@ class CustomFieldRequest extends FormRequest
             'type' => [
                 'required',
                 'string',
-                FieldType::validationRule(),
+                Rule::in( app( CustomFieldTypeRegistry::class )->slugs() ),
             ],
             'column_type' => [
                 'required',

--- a/src/Modules/ContentTypes/Managers/ContentEditExtensions.php
+++ b/src/Modules/ContentTypes/Managers/ContentEditExtensions.php
@@ -1,0 +1,182 @@
+<?php
+
+declare( strict_types=1 );
+
+/**
+ * ContentEditExtensions Manager.
+ *
+ * Extensibility seam around the post/page edit render pipeline. Host apps
+ * consume the merged data structures returned from these methods to render
+ * plugin-supplied panels, tabs, before/after-editor content, and to intercept
+ * save payloads before persistence.
+ *
+ * The framework does not render any of these itself — it only fires the
+ * filters and normalizes the shapes so hosts and plugins agree on the contract.
+ *
+ * @since 2.4.0
+ */
+
+namespace ArtisanPackUI\CMSFramework\Modules\ContentTypes\Managers;
+
+/**
+ * Aggregates plugin-registered edit-screen extensions.
+ *
+ * @since 2.4.0
+ */
+class ContentEditExtensions
+{
+    /**
+     * Return sidebar/right-column panel definitions applicable to the given
+     * content type. Plugins add panels by returning an array of shapes from the
+     * `ap.admin.contentEdit.panels` filter.
+     *
+     * Each panel: `slug`, `title`, `component`, optional `position`
+     * ( `top`/`bottom`/`default` ), optional `order`, optional
+     * `contentTypes` ( array of slugs — `['*']` for all, defaults to `['*']` ),
+     * optional `capability` ( permission gate applied by the host ).
+     *
+     * @since 2.4.0
+     *
+     * @param  array<string,mixed>  $context  Context passed through to filters.
+     *
+     * @return array<int,array<string,mixed>>
+     */
+    public function panels( array $context ): array
+    {
+        return $this->collect( 'ap.admin.contentEdit.panels', $context );
+    }
+
+    /**
+     * Return tab definitions rendered above the main editor column.
+     *
+     * Each tab: `slug`, `title`, `component`, optional `order`, optional
+     * `contentTypes`, optional `capability`.
+     *
+     * @since 2.4.0
+     *
+     * @param  array<string,mixed>  $context
+     *
+     * @return array<int,array<string,mixed>>
+     */
+    public function tabs( array $context ): array
+    {
+        return $this->collect( 'ap.admin.contentEdit.tabs', $context );
+    }
+
+    /**
+     * Return content-block definitions rendered above the main editor column.
+     *
+     * @since 2.4.0
+     *
+     * @param  array<string,mixed>  $context
+     *
+     * @return array<int,array<string,mixed>>
+     */
+    public function beforeEditor( array $context ): array
+    {
+        return $this->collect( 'ap.admin.contentEdit.beforeEditor', $context );
+    }
+
+    /**
+     * Return content-block definitions rendered below the main editor column.
+     *
+     * @since 2.4.0
+     *
+     * @param  array<string,mixed>  $context
+     *
+     * @return array<int,array<string,mixed>>
+     */
+    public function afterEditor( array $context ): array
+    {
+        return $this->collect( 'ap.admin.contentEdit.afterEditor', $context );
+    }
+
+    /**
+     * Filter incoming save data before the host persists it. Plugins can wash,
+     * validate, or annotate the payload. The return value replaces `$data`.
+     *
+     * @since 2.4.0
+     *
+     * @param  array<string,mixed>  $data
+     * @param  array<string,mixed>  $context
+     *
+     * @return array<string,mixed>
+     */
+    public function saveData( array $data, array $context ): array
+    {
+        $filtered = applyFilters( 'ap.admin.contentEdit.saveData', $data, $context );
+
+        return is_array( $filtered ) ? $filtered : $data;
+    }
+
+    /**
+     * Fetch, normalize, filter by content type, and order a list of items from
+     * one of the panel/tab/block filters.
+     *
+     * @since 2.4.0
+     *
+     * @param  array<string,mixed>  $context
+     *
+     * @return array<int,array<string,mixed>>
+     */
+    protected function collect( string $hook, array $context ): array
+    {
+        $raw = applyFilters( $hook, [], $context );
+
+        if ( ! is_array( $raw ) ) {
+            return [];
+        }
+
+        $contentType = isset( $context['contentType'] ) ? ( string ) $context['contentType'] : null;
+        $out         = [];
+
+        foreach ( $raw as $entry ) {
+            if ( ! is_array( $entry ) ) {
+                continue;
+            }
+            if ( ! isset( $entry['slug'], $entry['component'] ) ) {
+                continue;
+            }
+            if ( ! $this->matchesContentType( $entry, $contentType ) ) {
+                continue;
+            }
+
+            $entry['order'] = ( int ) ( $entry['order'] ?? 50 );
+            $out[]          = $entry;
+        }
+
+        usort( $out, static fn ( array $a, array $b ): int => $a['order'] <=> $b['order'] );
+
+        return $out;
+    }
+
+    /**
+     * Whether an entry's `contentTypes` restriction admits the requested
+     * content type. Missing key or a `'*'` wildcard means "always applies".
+     *
+     * @since 2.4.0
+     *
+     * @param  array<string,mixed>  $entry
+     */
+    protected function matchesContentType( array $entry, ?string $contentType ): bool
+    {
+        if ( ! isset( $entry['contentTypes'] ) ) {
+            return true;
+        }
+
+        $allowed = $entry['contentTypes'];
+        if ( ! is_array( $allowed ) || [] === $allowed ) {
+            return true;
+        }
+
+        if ( in_array( '*', $allowed, true ) ) {
+            return true;
+        }
+
+        if ( null === $contentType ) {
+            return false;
+        }
+
+        return in_array( $contentType, $allowed, true );
+    }
+}

--- a/src/Modules/ContentTypes/Managers/ContentTypeManager.php
+++ b/src/Modules/ContentTypes/Managers/ContentTypeManager.php
@@ -22,6 +22,23 @@ use Exception;
  */
 class ContentTypeManager
 {
+
+    /**
+     * Persistence-critical keys a plugin must never be able to seed via the
+     * `ap.contentTypes.registeredContentTypes` filter. Blocking them at
+     * hydration time keeps a filter payload from carrying primary keys or
+     * soft-delete timestamps that would collide with real DB rows or steer
+     * downstream persistence.
+     *
+     * @var array<int,string>
+     */
+    protected const FILTER_HYDRATION_BLOCKLIST = [
+        'id',
+        'created_at',
+        'updated_at',
+        'deleted_at',
+    ];
+
     /**
      * Register a content type programmatically.
      *
@@ -82,11 +99,40 @@ class ContentTypeManager
     /**
      * Get a specific content type by slug.
      *
+     * Checks the database first; falls back to filter-registered content types,
+     * hydrated into an unpersisted `ContentType` model so callers can treat both
+     * sources uniformly. Filter-only entries have no primary key — callers that
+     * need to persist them should re-create via `createContentType()`.
+     *
      * @since 1.0.0
      *
      * @param  string  $slug  Content type slug.
      */
     public function getContentType( string $slug ): ?ContentType
+    {
+        $slug = sanitizeText( $slug );
+
+        $contentType = ContentType::where( 'slug', $slug )->first();
+        if ( $contentType ) {
+            return $contentType;
+        }
+
+        return $this->hydrateFilterContentType( $slug );
+    }
+
+    /**
+     * Get a specific content type by slug, restricted to database-persisted
+     * rows. Never returns a filter-hydrated model.
+     *
+     * Use this instead of `getContentType()` in privileged paths that trust
+     * the returned model's `table_name` — schema mutations, migration
+     * generation, or anything that writes to the database on behalf of the
+     * content type. Filter-registered content types can carry plugin-supplied
+     * `table_name` values and must not steer such operations.
+     *
+     * @since 2.4.0
+     */
+    public function getPersistedContentType( string $slug ): ?ContentType
     {
         return ContentType::where( 'slug', sanitizeText( $slug ) )->first();
     }
@@ -126,7 +172,10 @@ class ContentTypeManager
      */
     public function updateContentType( string $slug, array $data ): ContentType
     {
-        $contentType = $this->getContentType( $slug );
+        // Persisted-only lookup — filter-registered content types have no DB
+        // row and would silently INSERT a phantom row on `update()` because
+        // Eloquent runs performInsert() when `exists === false`.
+        $contentType = $this->getPersistedContentType( $slug );
 
         if ( ! $contentType ) {
             throw new Exception( "Content type {$slug} not found." );
@@ -157,7 +206,11 @@ class ContentTypeManager
      */
     public function deleteContentType( string $slug ): bool
     {
-        $contentType = $this->getContentType( $slug );
+        // Persisted-only lookup — Eloquent `delete()` on an `exists=false`
+        // model is a no-op, so passing a filter-only slug here would return
+        // false but skip firing the `ap.contentTypes.deleted` hook. Keep the
+        // legacy "false == not found" contract by refusing the call outright.
+        $contentType = $this->getPersistedContentType( $slug );
 
         if ( ! $contentType ) {
             return false;
@@ -201,6 +254,38 @@ class ContentTypeManager
      */
     public function contentTypeExists( string $slug ): bool
     {
-        return ContentType::where( 'slug', sanitizeText( $slug ) )->exists();
+        $slug = sanitizeText( $slug );
+
+        if ( ContentType::where( 'slug', $slug )->exists() ) {
+            return true;
+        }
+
+        return null !== $this->hydrateFilterContentType( $slug );
+    }
+
+    /**
+     * Look up a filter-registered content type by slug and hydrate it into an
+     * unpersisted `ContentType` model. Returns null if no filter entry matches.
+     *
+     * @since 2.4.0
+     */
+    protected function hydrateFilterContentType( string $slug ): ?ContentType
+    {
+        $filtered = applyFilters( 'ap.contentTypes.registeredContentTypes', [] );
+
+        if ( ! is_array( $filtered ) || ! isset( $filtered[ $slug ] ) || ! is_array( $filtered[ $slug ] ) ) {
+            return null;
+        }
+
+        $args = array_diff_key( $filtered[ $slug ], array_flip( self::FILTER_HYDRATION_BLOCKLIST ) );
+        if ( ! isset( $args['slug'] ) ) {
+            $args['slug'] = $slug;
+        }
+
+        $model = new ContentType;
+        $model->forceFill( $args );
+        $model->exists = false;
+
+        return $model;
     }
 }

--- a/src/Modules/ContentTypes/Managers/CustomFieldManager.php
+++ b/src/Modules/ContentTypes/Managers/CustomFieldManager.php
@@ -64,9 +64,17 @@ class CustomFieldManager
      */
     public function getFieldsForContentType( string $contentType ): Collection
     {
-        return CustomField::whereJsonContains( 'content_types', $contentType )
+        $dbFields = CustomField::whereJsonContains( 'content_types', $contentType )
             ->orderBy( 'order' )
             ->get();
+
+        $filterFields = $this->filterFieldsForContentType( $contentType, $dbFields->pluck( 'key' )->all() );
+
+        if ( $filterFields->isEmpty() ) {
+            return $dbFields;
+        }
+
+        return $dbFields->concat( $filterFields )->values();
     }
 
     /**
@@ -81,9 +89,11 @@ class CustomFieldManager
         $field = DB::transaction( function () use ( $data ) {
             $field = CustomField::create( $data );
 
-            // Add columns to content type tables
+            // Add columns to content type tables. Restricted to DB-persisted
+            // content types so a plugin's filter-registered `table_name` can
+            // never steer Schema::table at an arbitrary host table.
             foreach ( $field->content_types as $contentTypeSlug ) {
-                $contentType = app( ContentTypeManager::class )->getContentType( $contentTypeSlug );
+                $contentType = app( ContentTypeManager::class )->getPersistedContentType( $contentTypeSlug );
                 if ( $contentType ) {
                     $this->addColumnToTable( $field, $contentType->table_name );
                 }
@@ -128,17 +138,19 @@ class CustomFieldManager
                 $addedTypes      = array_diff( $newContentTypes, $oldContentTypes );
                 $removedTypes    = array_diff( $oldContentTypes, $newContentTypes );
 
-                // Add columns to new content types
+                // Add columns to new content types. Restricted to DB-persisted
+                // content types ( see createField() ) to prevent plugin-supplied
+                // `table_name` values from steering Schema::table.
                 foreach ( $addedTypes as $contentTypeSlug ) {
-                    $contentType = app( ContentTypeManager::class )->getContentType( $contentTypeSlug );
+                    $contentType = app( ContentTypeManager::class )->getPersistedContentType( $contentTypeSlug );
                     if ( $contentType ) {
                         $this->addColumnToTable( $field, $contentType->table_name );
                     }
                 }
 
-                // Remove columns from removed content types
+                // Remove columns from removed content types.
                 foreach ( $removedTypes as $contentTypeSlug ) {
-                    $contentType = app( ContentTypeManager::class )->getContentType( $contentTypeSlug );
+                    $contentType = app( ContentTypeManager::class )->getPersistedContentType( $contentTypeSlug );
                     if ( $contentType ) {
                         $this->removeColumnFromTable( $field, $contentType->table_name );
                     }
@@ -188,9 +200,11 @@ class CustomFieldManager
             $deleted = $field->delete();
 
             if ( $deleted ) {
-                // Remove columns from content type tables
+                // Remove columns from content type tables. DB-only lookup
+                // matches the createField() / updateField() paths so we
+                // never dropColumn against a plugin-supplied `table_name`.
                 foreach ( $field->content_types as $contentTypeSlug ) {
-                    $contentType = app( ContentTypeManager::class )->getContentType( $contentTypeSlug );
+                    $contentType = app( ContentTypeManager::class )->getPersistedContentType( $contentTypeSlug );
                     if ( $contentType ) {
                         $this->removeColumnFromTable( $field, $contentType->table_name );
                     }
@@ -316,6 +330,64 @@ class CustomFieldManager
     }
 
     /**
+     * Hydrate filter-registered custom fields into unpersisted `CustomField`
+     * models for the given content type. DB rows always win on key collisions.
+     *
+     * Filter-registered fields carry the `storage = 'metadata'` flag so
+     * `HasCustomFields` knows to read/write through the model's `metadata`
+     * JSON column rather than a physical column that doesn't exist.
+     *
+     * @since 2.4.0
+     *
+     * @param  array<int,string>  $excludeKeys
+     */
+    protected function filterFieldsForContentType( string $contentType, array $excludeKeys ): Collection
+    {
+        $filtered = applyFilters( 'ap.contentTypes.registeredCustomFields', [] );
+        $out      = collect();
+
+        if ( ! is_array( $filtered ) ) {
+            return $out;
+        }
+
+        foreach ( $filtered as $key => $args ) {
+            if ( ! is_array( $args ) ) {
+                continue;
+            }
+            $resolvedKey = ( string ) ( $args['key'] ?? $key );
+
+            if ( in_array( $resolvedKey, $excludeKeys, true ) ) {
+                continue;
+            }
+
+            $contentTypes = ( array ) ( $args['content_types'] ?? [] );
+            if ( ! in_array( $contentType, $contentTypes, true ) ) {
+                continue;
+            }
+
+            $args['key']     = $resolvedKey;
+            $args['storage'] = $args['storage'] ?? 'metadata';
+
+            // Strip persistence-critical keys so a plugin cannot seed `id`
+            // or timestamps onto the hydrated CustomField model.
+            $args = array_diff_key( $args, array_flip( [
+                'id',
+                'created_at',
+                'updated_at',
+                'deleted_at',
+            ] ) );
+
+            $field         = new CustomField;
+            $field->forceFill( $args );
+            $field->exists = false;
+
+            $out->push( $field );
+        }
+
+        return $out->sortBy( fn ( CustomField $field ) => $field->order ?? 0 )->values();
+    }
+
+    /**
      * Get the migration stub content.
      *
      * @since 1.0.0
@@ -326,9 +398,12 @@ class CustomFieldManager
      */
     protected function getMigrationStub( CustomField $field, string $action, string $className ): string
     {
+        // DB-only lookup: the generated migration writes literal `table_name`
+        // values into a Schema::table() call, so we must never emit a
+        // plugin-supplied table name from a filter registration.
         $tables = [];
         foreach ( $field->content_types as $contentTypeSlug ) {
-            $contentType = app( ContentTypeManager::class )->getContentType( $contentTypeSlug );
+            $contentType = app( ContentTypeManager::class )->getPersistedContentType( $contentTypeSlug );
             if ( $contentType ) {
                 $tables[] = $contentType->table_name;
             }

--- a/src/Modules/ContentTypes/Managers/TaxonomyManager.php
+++ b/src/Modules/ContentTypes/Managers/TaxonomyManager.php
@@ -89,7 +89,34 @@ class TaxonomyManager
      */
     public function getTaxonomiesForContentType( string $contentTypeSlug ): Collection
     {
-        return Taxonomy::where( 'content_type_slug', sanitizeText( $contentTypeSlug ) )->get();
+        $contentTypeSlug = sanitizeText( $contentTypeSlug );
+
+        $dbTaxonomies = Taxonomy::where( 'content_type_slug', $contentTypeSlug )->get();
+
+        $filtered = applyFilters( 'ap.taxonomies.registeredTaxonomies', [] );
+        if ( ! is_array( $filtered ) ) {
+            return $dbTaxonomies;
+        }
+
+        $existingSlugs = $dbTaxonomies->pluck( 'slug' )->all();
+
+        foreach ( $filtered as $slug => $args ) {
+            if ( ! is_array( $args ) ) {
+                continue;
+            }
+            if ( ! isset( $args['content_type_slug'] ) || $args['content_type_slug'] !== $contentTypeSlug ) {
+                continue;
+            }
+            $resolvedSlug = ( string ) ( $args['slug'] ?? $slug );
+            if ( in_array( $resolvedSlug, $existingSlugs, true ) ) {
+                continue;
+            }
+
+            $args['slug'] = $resolvedSlug;
+            $dbTaxonomies->push( $this->hydrateTaxonomyFromArgs( $args ) );
+        }
+
+        return $dbTaxonomies;
     }
 
     /**
@@ -101,17 +128,48 @@ class TaxonomyManager
      */
     public function taxonomyExists( string $slug ): bool
     {
-        return Taxonomy::where( 'slug', sanitizeText( $slug ) )->exists();
+        $slug = sanitizeText( $slug );
+
+        if ( Taxonomy::where( 'slug', $slug )->exists() ) {
+            return true;
+        }
+
+        return null !== $this->hydrateFilterTaxonomy( $slug );
     }
 
     /**
      * Get a specific taxonomy by slug.
+     *
+     * Checks the database first; falls back to filter-registered taxonomies,
+     * hydrated into an unpersisted `Taxonomy` model so callers can treat both
+     * sources uniformly.
      *
      * @since 1.0.0
      *
      * @param  string  $slug  Taxonomy slug.
      */
     public function getTaxonomy( string $slug ): ?Taxonomy
+    {
+        $slug = sanitizeText( $slug );
+
+        $taxonomy = Taxonomy::where( 'slug', $slug )->first();
+        if ( $taxonomy ) {
+            return $taxonomy;
+        }
+
+        return $this->hydrateFilterTaxonomy( $slug );
+    }
+
+    /**
+     * Get a specific taxonomy by slug, restricted to database-persisted rows.
+     * Never returns a filter-hydrated model.
+     *
+     * Use this in privileged paths (update, delete, migration generation)
+     * where the returned model must correspond to a real DB row.
+     *
+     * @since 2.4.0
+     */
+    public function getPersistedTaxonomy( string $slug ): ?Taxonomy
     {
         return Taxonomy::where( 'slug', sanitizeText( $slug ) )->first();
     }
@@ -151,7 +209,10 @@ class TaxonomyManager
      */
     public function updateTaxonomy( string $slug, array $data ): Taxonomy
     {
-        $taxonomy = $this->getTaxonomy( $slug );
+        // Persisted-only lookup — a filter-registered taxonomy would silently
+        // INSERT a phantom row on `update()` because Eloquent runs
+        // performInsert() when `exists === false`.
+        $taxonomy = $this->getPersistedTaxonomy( $slug );
 
         if ( ! $taxonomy ) {
             throw new Exception( "Taxonomy {$slug} not found." );
@@ -182,7 +243,11 @@ class TaxonomyManager
      */
     public function deleteTaxonomy( string $slug ): bool
     {
-        $taxonomy = $this->getTaxonomy( $slug );
+        // Persisted-only lookup so we never no-op `delete()` on an
+        // `exists=false` filter-hydrated model ( which would return false
+        // AND skip firing the `ap.taxonomies.deleted` hook, breaking the
+        // legacy "false == not found" contract ).
+        $taxonomy = $this->getPersistedTaxonomy( $slug );
 
         if ( ! $taxonomy ) {
             return false;
@@ -215,5 +280,54 @@ class TaxonomyManager
         }
 
         return $deleted;
+    }
+
+    /**
+     * Look up a filter-registered taxonomy by slug and hydrate it into an
+     * unpersisted `Taxonomy` model. Returns null if no filter entry matches.
+     *
+     * @since 2.4.0
+     */
+    protected function hydrateFilterTaxonomy( string $slug ): ?Taxonomy
+    {
+        $filtered = applyFilters( 'ap.taxonomies.registeredTaxonomies', [] );
+
+        if ( ! is_array( $filtered ) || ! isset( $filtered[ $slug ] ) || ! is_array( $filtered[ $slug ] ) ) {
+            return null;
+        }
+
+        $args = $filtered[ $slug ];
+        if ( ! isset( $args['slug'] ) ) {
+            $args['slug'] = $slug;
+        }
+
+        return $this->hydrateTaxonomyFromArgs( $args );
+    }
+
+    /**
+     * Hydrate an unpersisted `Taxonomy` model from a raw args array.
+     *
+     * Strips persistence-critical keys before `forceFill()` so a plugin can
+     * never seed `id`, `created_at`, `updated_at`, or `deleted_at` via the
+     * `ap.taxonomies.registeredTaxonomies` filter.
+     *
+     * @since 2.4.0
+     *
+     * @param  array<string,mixed>  $args
+     */
+    protected function hydrateTaxonomyFromArgs( array $args ): Taxonomy
+    {
+        $args = array_diff_key( $args, array_flip( [
+            'id',
+            'created_at',
+            'updated_at',
+            'deleted_at',
+        ] ) );
+
+        $model = new Taxonomy;
+        $model->forceFill( $args );
+        $model->exists = false;
+
+        return $model;
     }
 }

--- a/src/Modules/ContentTypes/Models/Concerns/HasCustomFields.php
+++ b/src/Modules/ContentTypes/Models/Concerns/HasCustomFields.php
@@ -13,16 +13,44 @@ declare( strict_types=1 );
 namespace ArtisanPackUI\CMSFramework\Modules\ContentTypes\Models\Concerns;
 
 use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Managers\CustomFieldManager;
-use Exception;
+use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Models\CustomField;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Schema;
+use RuntimeException;
+use Throwable;
 
 /**
  * Trait for adding custom fields support to models.
+ *
+ * DB-registered fields ( storage = `column` ) resolve through the model's
+ * physical column. Filter-registered fields ( storage = `metadata` ) resolve
+ * through the model's `metadata` JSON column, falling back to `default_value`.
+ *
+ * Models using filter-registered custom fields must expose a `metadata` JSON
+ * attribute cast to `array` — Post, Page, and any host content type intending
+ * to accept plugin-registered custom fields should follow that convention.
  *
  * @since 1.0.0
  */
 trait HasCustomFields
 {
+    /**
+     * Per-model-class cache of the real DB columns for the model's table.
+     * Populated on first read so we never mistake a real column for a
+     * plugin-registered custom-field key.
+     *
+     * @var array<class-string,array<int,string>>
+     */
+    protected static array $customFieldsRealColumnsCache = [];
+
+    /**
+     * Per-instance cache of the custom-field collection for this model's
+     * content type. Cleared implicitly when the instance is destroyed.
+     *
+     * @var Collection<int,CustomField>|null
+     */
+    protected ?Collection $customFieldsCache = null;
+
     /**
      * Magic getter for custom field values.
      *
@@ -34,22 +62,21 @@ trait HasCustomFields
      */
     public function __get( $key )
     {
-        // First try to get the attribute from the parent
-        try {
-            return parent::__get( $key );
-        } catch ( Exception $e ) {
-            // If it doesn't exist, check if it's a custom field
-            $customFields = $this->getCustomFieldsForType();
+        $field = $this->findCustomFieldByKey( $key );
 
-            foreach ( $customFields as $field ) {
-                if ( $field->key === $key ) {
-                    return $this->attributes[ $key ] ?? $field->default_value;
-                }
-            }
+        if ( null !== $field && 'metadata' === $field->storageMode() ) {
+            $metadata = ( array ) ( $this->getAttribute( 'metadata' ) ?? [] );
 
-            // If not a custom field, throw the original exception
-            throw $e;
+            return array_key_exists( $key, $metadata ) ? $metadata[ $key ] : $field->default_value;
         }
+
+        $value = parent::__get( $key );
+
+        if ( null === $value && null !== $field && 'column' === $field->storageMode() ) {
+            return $field->default_value;
+        }
+
+        return $value;
     }
 
     /**
@@ -62,33 +89,168 @@ trait HasCustomFields
      */
     public function __set( $key, $value ): void
     {
-        // Check if it's a custom field
-        $customFields  = $this->getCustomFieldsForType();
-        $isCustomField = false;
+        $field = $this->findCustomFieldByKey( $key );
 
-        foreach ( $customFields as $field ) {
-            if ( $field->key === $key ) {
-                $isCustomField = true;
-                break;
-            }
+        if ( null !== $field && 'metadata' === $field->storageMode() ) {
+            $this->assertMetadataColumnAvailable( $key );
+
+            $metadata         = ( array ) ( $this->getAttribute( 'metadata' ) ?? [] );
+            $metadata[ $key ] = $value;
+            $this->setAttribute( 'metadata', $metadata );
+
+            return;
         }
 
-        if ( $isCustomField ) {
-            $this->attributes[ $key ] = $value;
-        } else {
-            parent::__set( $key, $value );
-        }
+        parent::__set( $key, $value );
     }
 
     /**
-     * Get the custom fields for the content type.
+     * Get the custom fields for the content type. Memoized per instance so a
+     * single Blade render / JSON serialization doesn't re-run the DB query on
+     * every unknown attribute access.
      *
      * @since 1.0.0
      */
     public function getCustomFieldsForType(): Collection
     {
-        $contentType = $this->getTable();
+        if ( null !== $this->customFieldsCache ) {
+            return $this->customFieldsCache;
+        }
 
-        return app( CustomFieldManager::class )->getFieldsForContentType( $contentType );
+        return $this->customFieldsCache = app( CustomFieldManager::class )
+            ->getFieldsForContentType( $this->getTable() );
+    }
+
+    /**
+     * Clear the per-instance memoized custom-field list. Called automatically
+     * on save/delete via Eloquent's model events; hosts can call it manually
+     * after registering a new filter-scoped field mid-request.
+     *
+     * @since 2.4.0
+     */
+    public function flushCustomFieldsCache(): void
+    {
+        $this->customFieldsCache = null;
+    }
+
+    /**
+     * Wire up Eloquent model events so the memoized custom-field list is
+     * flushed at the right lifecycle points.
+     *
+     * @since 2.4.0
+     */
+    protected static function bootHasCustomFields(): void
+    {
+        static::saved( fn ( $model ) => $model->flushCustomFieldsCache() );
+        static::deleted( fn ( $model ) => $model->flushCustomFieldsCache() );
+    }
+
+    /**
+     * Locate a custom field for this model by key. Returns null when the key
+     * is not a registered custom field so callers can fall back to the normal
+     * attribute pipeline.
+     *
+     * The lookup order is defensive: keys that name a real DB column, cast,
+     * mutator, accessor, or relation short-circuit before we ever consult
+     * the custom-field registry. This blocks a plugin from shadowing host
+     * attributes ( e.g. `password`, `is_admin`, or the model's own `metadata`
+     * column ) by registering a filter-scoped field with a colliding key.
+     *
+     * @since 2.4.0
+     */
+    protected function findCustomFieldByKey( string $key ): ?CustomField
+    {
+        if ( array_key_exists( $key, $this->attributes ) ) {
+            return null;
+        }
+        if ( array_key_exists( $key, $this->getCasts() ) ) {
+            return null;
+        }
+        if ( $this->isRealDatabaseColumn( $key ) ) {
+            return null;
+        }
+        if ( method_exists( $this, $key ) ) {
+            return null;
+        }
+        if ( method_exists( $this, 'hasGetMutator' ) && $this->hasGetMutator( $key ) ) {
+            return null;
+        }
+        if ( method_exists( $this, 'hasSetMutator' ) && $this->hasSetMutator( $key ) ) {
+            return null;
+        }
+        if ( method_exists( $this, 'hasAttributeMutator' ) && $this->hasAttributeMutator( $key ) ) {
+            return null;
+        }
+        if ( method_exists( $this, 'hasAttributeGetMutator' ) && $this->hasAttributeGetMutator( $key ) ) {
+            return null;
+        }
+        if ( method_exists( $this, 'hasAttributeSetMutator' ) && $this->hasAttributeSetMutator( $key ) ) {
+            return null;
+        }
+        if ( method_exists( $this, 'isRelation' ) && $this->isRelation( $key ) ) {
+            return null;
+        }
+
+        foreach ( $this->getCustomFieldsForType() as $field ) {
+            if ( $field->key === $key ) {
+                return $field;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Whether the given key is a real column on this model's table. Cached
+     * per model class so we don't hit `information_schema` on every read.
+     *
+     * @since 2.4.0
+     */
+    protected function isRealDatabaseColumn( string $key ): bool
+    {
+        $class = static::class;
+
+        if ( ! isset( self::$customFieldsRealColumnsCache[ $class ] ) ) {
+            $table = $this->getTable();
+            try {
+                self::$customFieldsRealColumnsCache[ $class ] = Schema::getColumnListing( $table );
+            } catch ( Throwable ) {
+                // Schema introspection can fail during boot or with drivers
+                // that don't support column listing — fall back to an empty
+                // listing so we don't cache a false negative permanently.
+                return false;
+            }
+        }
+
+        return in_array( $key, self::$customFieldsRealColumnsCache[ $class ], true );
+    }
+
+    /**
+     * Ensure the host model actually exposes a `metadata` JSON attribute
+     * before we try to write into it. Fail loud rather than silently drop
+     * writes on models that opt into `HasCustomFields` but never added the
+     * `metadata` column.
+     *
+     * @since 2.4.0
+     */
+    protected function assertMetadataColumnAvailable( string $key ): void
+    {
+        $casts = $this->getCasts();
+
+        // `metadata` must be either an array-cast attribute or a real column.
+        if ( isset( $casts['metadata'] ) ) {
+            return;
+        }
+
+        if ( $this->isRealDatabaseColumn( 'metadata' ) ) {
+            return;
+        }
+
+        throw new RuntimeException( sprintf(
+            'Cannot write custom field "%s" via HasCustomFields on %s: the model has no `metadata` JSON column. '
+            . 'Add a `metadata` JSON column ( cast to `array` ) or register the field as `storage = column` instead.',
+            $key,
+            static::class,
+        ) );
     }
 }

--- a/src/Modules/ContentTypes/Models/CustomField.php
+++ b/src/Modules/ContentTypes/Models/CustomField.php
@@ -14,6 +14,8 @@ namespace ArtisanPackUI\CMSFramework\Modules\ContentTypes\Models;
 
 use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Enums\ColumnType;
 use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Enums\FieldType;
+use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Registries\CustomFieldTypeRegistry;
+use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Support\FieldTypeDefinition;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Collection;
@@ -24,7 +26,7 @@ use Illuminate\Support\Collection;
  * @property int $id
  * @property string $name
  * @property string $key
- * @property FieldType $type
+ * @property string $type
  * @property ColumnType $column_type
  * @property string|null $description
  * @property array $content_types
@@ -97,6 +99,55 @@ class CustomField extends Model
     }
 
     /**
+     * Resolve the `FieldType` enum case for this field's type, if the type
+     * corresponds to one of the framework's built-in cases. Returns null for
+     * plugin-registered types that live outside the enum.
+     *
+     * @since 2.4.0
+     */
+    public function fieldTypeEnum(): ?FieldType
+    {
+        return FieldType::tryFrom( $this->type );
+    }
+
+    /**
+     * Resolve the `FieldTypeDefinition` for this field's type from the
+     * `CustomFieldTypeRegistry`. Covers both built-in and plugin-registered types.
+     * Returns null when the type is unregistered.
+     *
+     * @since 2.4.0
+     */
+    public function fieldTypeDefinition(): ?FieldTypeDefinition
+    {
+        return app( CustomFieldTypeRegistry::class )->get( $this->type );
+    }
+
+    /**
+     * Where this field's values are stored on a content record.
+     *
+     * - `column`  → a physical column materialized on the content type's table
+     *   ( the DB-registered path used by `CustomFieldManager::createField()` ).
+     * - `metadata` → the value lives in the model's `metadata` JSON column;
+     *   used by filter-registered fields ( plugins ) that never get a physical
+     *   column.
+     *
+     * @since 2.4.0
+     *
+     * @return 'column'|'metadata'
+     */
+    public function storageMode(): string
+    {
+        $explicit = $this->getAttribute( 'storage' );
+
+        if ( 'metadata' === $explicit || 'column' === $explicit ) {
+            return $explicit;
+        }
+
+        // Persisted DB rows always materialize a physical column.
+        return $this->exists ? 'column' : 'metadata';
+    }
+
+    /**
      * Get the attributes that should be cast.
      *
      * @since 1.0.0
@@ -106,7 +157,7 @@ class CustomField extends Model
     protected function casts(): array
     {
         return [
-            'type'          => FieldType::class,
+            'type'          => 'string',
             'column_type'   => ColumnType::class,
             'content_types' => 'array',
             'options'       => 'array',

--- a/src/Modules/ContentTypes/Providers/ContentTypesServiceProvider.php
+++ b/src/Modules/ContentTypes/Providers/ContentTypesServiceProvider.php
@@ -12,6 +12,7 @@ declare( strict_types=1 );
 
 namespace ArtisanPackUI\CMSFramework\Modules\ContentTypes\Providers;
 
+use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Managers\ContentEditExtensions;
 use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Managers\ContentTypeManager;
 use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Managers\CustomFieldManager;
 use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Managers\TaxonomyManager;
@@ -21,6 +22,7 @@ use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Models\Taxonomy;
 use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Policies\ContentTypePolicy;
 use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Policies\CustomFieldPolicy;
 use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Policies\TaxonomyPolicy;
+use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Registries\CustomFieldTypeRegistry;
 use Illuminate\Routing\Router;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Facades\Route;
@@ -48,6 +50,12 @@ class ContentTypesServiceProvider extends ServiceProvider
 
         // Register TaxonomyManager as singleton
         $this->app->singleton( TaxonomyManager::class, fn () => new TaxonomyManager );
+
+        // Register CustomFieldTypeRegistry as singleton
+        $this->app->singleton( CustomFieldTypeRegistry::class, fn () => new CustomFieldTypeRegistry );
+
+        // Register ContentEditExtensions manager as singleton
+        $this->app->singleton( ContentEditExtensions::class, fn () => new ContentEditExtensions );
 
         // Load helpers
         $this->loadHelpers();

--- a/src/Modules/ContentTypes/Registries/CustomFieldTypeRegistry.php
+++ b/src/Modules/ContentTypes/Registries/CustomFieldTypeRegistry.php
@@ -1,0 +1,229 @@
+<?php
+
+declare( strict_types=1 );
+
+/**
+ * CustomFieldTypeRegistry.
+ *
+ * Registry for custom-field types. Ships with the framework's 16 built-in
+ * `FieldType` enum cases pre-registered and merges plugin-registered types
+ * from the `ap.contentTypes.registeredFieldTypes` filter on every read.
+ *
+ * The closed `FieldType` enum remains supported for backwards compatibility;
+ * new code should register plugin field types through this registry so the
+ * admin UI, validation, and `HasCustomFields` runtime all recognize them.
+ *
+ * @since 2.4.0
+ */
+
+namespace ArtisanPackUI\CMSFramework\Modules\ContentTypes\Registries;
+
+use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Enums\FieldType;
+use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Support\FieldTypeDefinition;
+use Throwable;
+
+/**
+ * In-memory registry keyed by field-type slug.
+ *
+ * @since 2.4.0
+ */
+class CustomFieldTypeRegistry
+{
+    /**
+     * Column-type mapping for the built-in enum cases, keeping DB-materialized
+     * fields storage-shape consistent with the legacy behavior.
+     *
+     * @var array<string,string>
+     */
+    protected const BUILTIN_COLUMN_TYPES = [
+        'text'     => 'string',
+        'textarea' => 'text',
+        'number'   => 'integer',
+        'select'   => 'string',
+        'checkbox' => 'boolean',
+        'radio'    => 'string',
+        'boolean'  => 'boolean',
+        'date'     => 'date',
+        'datetime' => 'datetime',
+        'time'     => 'time',
+        'email'    => 'string',
+        'url'      => 'string',
+        'tel'      => 'string',
+        'color'    => 'string',
+        'file'     => 'string',
+        'image'    => 'string',
+    ];
+
+    /**
+     * Locally registered ( non-filter ) field types keyed by slug.
+     *
+     * @var array<string,FieldTypeDefinition>
+     */
+    protected array $types = [];
+
+    public function __construct()
+    {
+        $this->registerBuiltins();
+    }
+
+    /**
+     * Register a field type. Overwrites any prior registration with the same slug.
+     *
+     * @since 2.4.0
+     */
+    public function register( FieldTypeDefinition $definition ): void
+    {
+        $this->types[ $definition->slug ] = $definition;
+    }
+
+    /**
+     * Fetch a single field-type definition by slug, merging local registrations
+     * and filter-registered plugin types. Returns null when nothing matches.
+     *
+     * @since 2.4.0
+     */
+    public function get( string $slug ): ?FieldTypeDefinition
+    {
+        return $this->all()[ $slug ] ?? null;
+    }
+
+    /**
+     * Return every known field-type definition keyed by slug. Locally
+     * registered entries take precedence over filter-registered ones.
+     *
+     * @since 2.4.0
+     *
+     * @return array<string,FieldTypeDefinition>
+     */
+    public function all(): array
+    {
+        $filtered = applyFilters( 'ap.contentTypes.registeredFieldTypes', [] );
+
+        $out = [];
+        if ( is_array( $filtered ) ) {
+            foreach ( $filtered as $key => $entry ) {
+                $definition = $this->normalizeFilterEntry( $key, $entry );
+                if ( null !== $definition ) {
+                    $out[ $definition->slug ] = $definition;
+                }
+            }
+        }
+
+        // Locally registered types overwrite filter entries with matching slugs.
+        foreach ( $this->types as $slug => $definition ) {
+            $out[ $slug ] = $definition;
+        }
+
+        return $out;
+    }
+
+    /**
+     * Whether the registry knows about the given field-type slug.
+     *
+     * @since 2.4.0
+     */
+    public function has( string $slug ): bool
+    {
+        return null !== $this->get( $slug );
+    }
+
+    /**
+     * Convenience: list every known slug ( e.g. for `Rule::in(...)` validation ).
+     *
+     * @since 2.4.0
+     *
+     * @return array<int,string>
+     */
+    public function slugs(): array
+    {
+        return array_values( array_keys( $this->all() ) );
+    }
+
+    /**
+     * Pre-register every built-in `FieldType` enum case so consumers of the
+     * registry ( admin field-type dropdown, validation, HasCustomFields ) always
+     * see the framework defaults even before any plugin has loaded.
+     *
+     * @since 2.4.0
+     */
+    protected function registerBuiltins(): void
+    {
+        foreach ( FieldType::cases() as $case ) {
+            $slug = $case->value;
+
+            $this->register( new FieldTypeDefinition(
+                slug       : $slug,
+                label      : $case->label(),
+                columnType : self::BUILTIN_COLUMN_TYPES[ $slug ] ?? 'string',
+                meta       : ['builtin' => true],
+            ) );
+        }
+    }
+
+    /**
+     * Coerce a raw filter entry into a `FieldTypeDefinition`. Accepts either
+     * a `FieldTypeDefinition` instance or an array literal. Skips malformed
+     * entries silently rather than crashing the registry.
+     *
+     * @since 2.4.0
+     *
+     * @param  int|string  $key
+     */
+    protected function normalizeFilterEntry( int|string $key, mixed $entry ): ?FieldTypeDefinition
+    {
+        if ( $entry instanceof FieldTypeDefinition ) {
+            return $entry;
+        }
+
+        if ( ! is_array( $entry ) ) {
+            return null;
+        }
+
+        if ( ! isset( $entry['slug'] ) ) {
+            if ( ! is_string( $key ) || '' === $key ) {
+                return null;
+            }
+            $entry['slug'] = $key;
+        }
+
+        // Reject malformed plugin payloads before they reach FieldTypeDefinition
+        // — a single non-scalar slug would otherwise fatal via `(string)` cast
+        // and take down every consumer of the registry.
+        if ( ! $this->hasScalarString( $entry, 'slug' ) ) {
+            return null;
+        }
+        if ( '' === trim( ( string ) $entry['slug'] ) ) {
+            return null;
+        }
+        foreach ( ['label', 'column_type', 'columnType', 'editor_component', 'editorComponent', 'renderer_component', 'rendererComponent'] as $optionalString ) {
+            if ( isset( $entry[ $optionalString ] ) && ! $this->hasScalarString( $entry, $optionalString ) ) {
+                return null;
+            }
+        }
+
+        try {
+            return FieldTypeDefinition::fromArray( $entry );
+        } catch ( Throwable ) {
+            return null;
+        }
+    }
+
+    /**
+     * Whether `$entry[$key]` is present and scalar-string-safe.
+     *
+     * @since 2.4.0
+     *
+     * @param  array<string,mixed>  $entry
+     */
+    protected function hasScalarString( array $entry, string $key ): bool
+    {
+        if ( ! isset( $entry[ $key ] ) ) {
+            return false;
+        }
+
+        $value = $entry[ $key ];
+
+        return is_string( $value ) || is_int( $value ) || is_float( $value )
+            || ( is_object( $value ) && method_exists( $value, '__toString' ) );
+    }
+}

--- a/src/Modules/ContentTypes/Support/FieldTypeDefinition.php
+++ b/src/Modules/ContentTypes/Support/FieldTypeDefinition.php
@@ -1,0 +1,84 @@
+<?php
+
+declare( strict_types=1 );
+
+/**
+ * FieldTypeDefinition Value Object.
+ *
+ * Describes a custom-field type registered with the framework's CustomFieldTypeRegistry.
+ * Both built-in types (mirrored from the `FieldType` enum) and plugin-registered
+ * types hydrate into this shape so consumers can treat them uniformly.
+ *
+ * @since 2.4.0
+ */
+
+namespace ArtisanPackUI\CMSFramework\Modules\ContentTypes\Support;
+
+/**
+ * Immutable descriptor for a registered field type.
+ *
+ * @since 2.4.0
+ */
+final class FieldTypeDefinition
+{
+    /**
+     * @param  string  $slug  Machine key ( e.g. `text`, `map_picker` ).
+     * @param  string  $label  Human-readable label ( already translated when possible ).
+     * @param  string  $columnType  Laravel Schema column-method slug for DB-materialized fields ( e.g. `string`, `text`, `integer` ). Plugin types that store via `metadata` may still declare a column type for documentation purposes; it is only used by `CustomFieldManager::createField()` on the DB-materialized path.
+     * @param  array<int,object|string>  $validationRules  Laravel validation rules applied to values of this type.
+     * @param  string|null  $editorComponent  Frontend admin-editor component identifier ( host-resolved ).
+     * @param  string|null  $rendererComponent  Frontend public-renderer component identifier ( host-resolved ).
+     * @param  array<string,mixed>  $meta  Freeform metadata a host or plugin can attach ( icon slug, category, etc. ).
+     */
+    public function __construct(
+        public readonly string $slug,
+        public readonly string $label,
+        public readonly string $columnType = 'string',
+        public readonly array $validationRules = [],
+        public readonly ?string $editorComponent = null,
+        public readonly ?string $rendererComponent = null,
+        public readonly array $meta = [],
+    ) {
+    }
+
+    /**
+     * Convenience factory for array-shaped registrations coming from plugin
+     * manifests or the `ap.contentTypes.registeredFieldTypes` filter.
+     *
+     * @since 2.4.0
+     *
+     * @param  array{slug:string,label?:string,column_type?:string,columnType?:string,validation_rules?:array,validationRules?:array,editor_component?:string|null,editorComponent?:string|null,renderer_component?:string|null,rendererComponent?:string|null,meta?:array<string,mixed>}  $args
+     */
+    public static function fromArray( array $args ): self
+    {
+        return new self(
+            slug              : ( string ) $args['slug'],
+            label             : ( string ) ( $args['label'] ?? ucfirst( $args['slug'] ) ),
+            columnType        : ( string ) ( $args['column_type'] ?? $args['columnType'] ?? 'string' ),
+            validationRules   : ( array ) ( $args['validation_rules'] ?? $args['validationRules'] ?? [] ),
+            editorComponent   : $args['editor_component'] ?? $args['editorComponent'] ?? null,
+            rendererComponent : $args['renderer_component'] ?? $args['rendererComponent'] ?? null,
+            meta              : ( array ) ( $args['meta'] ?? [] ),
+        );
+    }
+
+    /**
+     * Array-shape representation for JSON APIs and Blade templates.
+     *
+     * @since 2.4.0
+     *
+     * @return array<string,mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'slug'               => $this->slug,
+            'label'              => $this->label,
+            'column_type'        => $this->columnType,
+            'validation_rules'   => $this->validationRules,
+            'editor_component'   => $this->editorComponent,
+            'renderer_component' => $this->rendererComponent,
+            'meta'               => $this->meta,
+        ];
+    }
+}

--- a/src/Modules/ContentTypes/helpers.php
+++ b/src/Modules/ContentTypes/helpers.php
@@ -12,6 +12,8 @@ declare( strict_types=1 );
 
 use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Managers\ContentTypeManager;
 use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Models\ContentType;
+use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Registries\CustomFieldTypeRegistry;
+use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Support\FieldTypeDefinition;
 
 if ( ! function_exists( 'getContentType' ) ) {
     /**
@@ -42,5 +44,65 @@ if ( ! function_exists( 'contentTypeExists' ) ) {
     function contentTypeExists( string $slug ): bool
     {
         return app( ContentTypeManager::class )->contentTypeExists( $slug );
+    }
+}
+
+if ( ! function_exists( 'apRegisterFieldType' ) ) {
+    /**
+     * Register a custom-field type with the framework's CustomFieldTypeRegistry.
+     *
+     * Signature matches sibling `apRegister*` helpers ( slug first, definition
+     * second ). Accepts either an array of arguments understood by
+     * `FieldTypeDefinition::fromArray()` or a fully-constructed
+     * `FieldTypeDefinition`. The `$slug` always wins over any `slug` key
+     * inside the definition payload.
+     *
+     * @since 2.4.0
+     *
+     * @param  array<string,mixed>|FieldTypeDefinition  $definition
+     */
+    function apRegisterFieldType( string $slug, FieldTypeDefinition|array $definition ): FieldTypeDefinition
+    {
+        if ( is_array( $definition ) ) {
+            $definition['slug'] = $slug;
+            $definition         = FieldTypeDefinition::fromArray( $definition );
+        } elseif ( $definition->slug !== $slug ) {
+            // A pre-built definition with a mismatched slug — re-hydrate so the
+            // registry stays keyed by the caller's slug.
+            $definition = FieldTypeDefinition::fromArray( array_merge(
+                $definition->toArray(),
+                ['slug' => $slug],
+            ) );
+        }
+
+        app( CustomFieldTypeRegistry::class )->register( $definition );
+
+        return $definition;
+    }
+}
+
+if ( ! function_exists( 'apGetFieldType' ) ) {
+    /**
+     * Fetch a registered field-type definition by slug, or null if unknown.
+     *
+     * @since 2.4.0
+     */
+    function apGetFieldType( string $slug ): ?FieldTypeDefinition
+    {
+        return app( CustomFieldTypeRegistry::class )->get( $slug );
+    }
+}
+
+if ( ! function_exists( 'apRegisteredFieldTypes' ) ) {
+    /**
+     * Return every registered field-type definition keyed by slug.
+     *
+     * @since 2.4.0
+     *
+     * @return array<string,FieldTypeDefinition>
+     */
+    function apRegisteredFieldTypes(): array
+    {
+        return app( CustomFieldTypeRegistry::class )->all();
     }
 }

--- a/tests/Unit/ContentTypes/ContentEditExtensionsTest.php
+++ b/tests/Unit/ContentTypes/ContentEditExtensionsTest.php
@@ -1,0 +1,94 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Managers\ContentEditExtensions;
+
+test( 'panels() returns filter-registered panels ordered by order', function (): void {
+    $manager = new ContentEditExtensions;
+
+    addFilter( 'ap.admin.contentEdit.panels', function ( array $panels ): array {
+        $panels[] = ['slug' => 'seo', 'title' => 'SEO', 'component' => 'SeoPanel', 'order' => 20];
+        $panels[] = ['slug' => 'schedule', 'title' => 'Schedule', 'component' => 'SchedulePanel', 'order' => 5];
+
+        return $panels;
+    } );
+
+    $panels = $manager->panels( ['contentType' => 'post', 'recordId' => 42] );
+
+    expect( $panels )->toHaveCount( 2 );
+    expect( $panels[0]['slug'] )->toBe( 'schedule' );
+    expect( $panels[1]['slug'] )->toBe( 'seo' );
+} );
+
+test( 'panels() filters by contentTypes restriction', function (): void {
+    $manager = new ContentEditExtensions;
+
+    addFilter( 'ap.admin.contentEdit.panels', function ( array $panels ): array {
+        $panels[] = ['slug' => 'gallery', 'title' => 'Gallery', 'component' => 'GalleryPanel', 'contentTypes' => ['portfolio']];
+        $panels[] = ['slug' => 'universal', 'title' => 'Universal', 'component' => 'AllPanel', 'contentTypes' => ['*']];
+        $panels[] = ['slug' => 'no-restriction', 'title' => 'Any', 'component' => 'AnyPanel'];
+
+        return $panels;
+    } );
+
+    $portfolioPanels = $manager->panels( ['contentType' => 'portfolio'] );
+    $postPanels      = $manager->panels( ['contentType' => 'post'] );
+
+    expect( array_column( $portfolioPanels, 'slug' ) )->toBe( ['gallery', 'universal', 'no-restriction'] );
+    expect( array_column( $postPanels, 'slug' ) )->toBe( ['universal', 'no-restriction'] );
+} );
+
+test( 'panels() rejects entries missing slug or component', function (): void {
+    $manager = new ContentEditExtensions;
+
+    addFilter( 'ap.admin.contentEdit.panels', function ( array $panels ): array {
+        $panels[] = ['title' => 'No slug', 'component' => 'X'];
+        $panels[] = ['slug' => 'no-component', 'title' => 'Bad'];
+        $panels[] = ['slug' => 'ok', 'title' => 'Good', 'component' => 'OkPanel'];
+
+        return $panels;
+    } );
+
+    $panels = $manager->panels( [] );
+
+    expect( array_column( $panels, 'slug' ) )->toBe( ['ok'] );
+} );
+
+test( 'tabs() and beforeEditor()/afterEditor() honor the same filter contract', function (): void {
+    $manager = new ContentEditExtensions;
+
+    addFilter( 'ap.admin.contentEdit.tabs', function ( array $items ): array {
+        $items[] = ['slug' => 'reviews', 'title' => 'Reviews', 'component' => 'ReviewsTab'];
+
+        return $items;
+    } );
+    addFilter( 'ap.admin.contentEdit.beforeEditor', function ( array $items ): array {
+        $items[] = ['slug' => 'banner', 'title' => 'Banner', 'component' => 'BannerBlock'];
+
+        return $items;
+    } );
+    addFilter( 'ap.admin.contentEdit.afterEditor', function ( array $items ): array {
+        $items[] = ['slug' => 'footer', 'title' => 'Footer', 'component' => 'FooterBlock'];
+
+        return $items;
+    } );
+
+    expect( $manager->tabs( ['contentType' => 'post'] )[0]['slug'] )->toBe( 'reviews' );
+    expect( $manager->beforeEditor( ['contentType' => 'post'] )[0]['slug'] )->toBe( 'banner' );
+    expect( $manager->afterEditor( ['contentType' => 'post'] )[0]['slug'] )->toBe( 'footer' );
+} );
+
+test( 'saveData() runs the payload through the filter and preserves fallback', function (): void {
+    $manager = new ContentEditExtensions;
+
+    addFilter( 'ap.admin.contentEdit.saveData', function ( array $data ): array {
+        $data['title'] = strtoupper( $data['title'] );
+
+        return $data;
+    } );
+
+    $result = $manager->saveData( ['title' => 'hello'], ['contentType' => 'post'] );
+
+    expect( $result['title'] )->toBe( 'HELLO' );
+} );

--- a/tests/Unit/ContentTypes/ContentTypeManagerTest.php
+++ b/tests/Unit/ContentTypes/ContentTypeManagerTest.php
@@ -234,3 +234,124 @@ test( 'registered content types merges database and filtered content types', fun
     expect( $registeredTypes )->toHaveKey( 'posts' );
     expect( $registeredTypes )->toHaveKey( 'custom' );
 } );
+
+test( 'get content type returns filter-registered content type as unpersisted model', function (): void {
+    $manager = new ContentTypeManager;
+
+    $manager->register( [
+        'name'        => 'Filter Only',
+        'slug'        => 'filter-only',
+        'table_name'  => 'filter_only',
+        'model_class' => 'App\\Models\\FilterOnly',
+        'supports'    => ['title'],
+    ] );
+
+    $contentType = $manager->getContentType( 'filter-only' );
+
+    expect( $contentType )->not->toBeNull();
+    expect( $contentType )->toBeInstanceOf( ContentType::class );
+    expect( $contentType->slug )->toBe( 'filter-only' );
+    expect( $contentType->name )->toBe( 'Filter Only' );
+    expect( $contentType->exists )->toBeFalse();
+    expect( $contentType->supportsFeature( 'title' ) )->toBeTrue();
+} );
+
+test( 'get content type prefers database entry over filter entry for the same slug', function (): void {
+    $manager = new ContentTypeManager;
+
+    ContentType::create( [
+        'name'          => 'DB Version',
+        'slug'          => 'shared',
+        'table_name'    => 'shared',
+        'model_class'   => 'App\\Models\\Shared',
+        'public'        => true,
+        'show_in_admin' => true,
+    ] );
+
+    $manager->register( [
+        'name'        => 'Filter Version',
+        'slug'        => 'shared',
+        'table_name'  => 'shared',
+        'model_class' => 'App\\Models\\SharedFilter',
+    ] );
+
+    $contentType = $manager->getContentType( 'shared' );
+
+    expect( $contentType->name )->toBe( 'DB Version' );
+    expect( $contentType->exists )->toBeTrue();
+} );
+
+test( 'updateContentType refuses filter-only slugs (no phantom INSERT)', function (): void {
+    $manager = new ContentTypeManager;
+
+    $manager->register( [
+        'name'        => 'Filter Only',
+        'slug'        => 'filter-only-update',
+        'table_name'  => 'filter_only_update',
+        'model_class' => 'App\\Models\\FilterOnly',
+    ] );
+
+    expect( fn () => $manager->updateContentType( 'filter-only-update', ['name' => 'Renamed'] ) )
+        ->toThrow( Exception::class, 'not found' );
+
+    expect( ContentType::where( 'slug', 'filter-only-update' )->exists() )->toBeFalse();
+} );
+
+test( 'deleteContentType returns false for filter-only slugs and never no-op-deletes', function (): void {
+    $manager = new ContentTypeManager;
+
+    $manager->register( [
+        'name'        => 'Filter Only',
+        'slug'        => 'filter-only-delete',
+        'table_name'  => 'filter_only_delete',
+        'model_class' => 'App\\Models\\FilterOnly',
+    ] );
+
+    expect( $manager->deleteContentType( 'filter-only-delete' ) )->toBeFalse();
+} );
+
+test( 'filter-hydrated content type strips persistence-critical keys', function (): void {
+    $manager = new ContentTypeManager;
+
+    $manager->register( [
+        'id'          => 999,
+        'created_at'  => '2020-01-01 00:00:00',
+        'name'        => 'Sneaky',
+        'slug'        => 'sneaky',
+        'table_name'  => 'sneaky',
+        'model_class' => 'App\\Models\\Sneaky',
+    ] );
+
+    $contentType = $manager->getContentType( 'sneaky' );
+
+    expect( $contentType->id )->toBeNull();
+    expect( $contentType->created_at )->toBeNull();
+    expect( $contentType->slug )->toBe( 'sneaky' );
+} );
+
+test( 'getPersistedContentType never returns filter-hydrated entries', function (): void {
+    $manager = new ContentTypeManager;
+
+    $manager->register( [
+        'name'        => 'Filter Only',
+        'slug'        => 'persist-check',
+        'table_name'  => 'persist_check',
+        'model_class' => 'App\\Models\\PersistCheck',
+    ] );
+
+    expect( $manager->getPersistedContentType( 'persist-check' ) )->toBeNull();
+} );
+
+test( 'content type exists returns true for filter-registered content types', function (): void {
+    $manager = new ContentTypeManager;
+
+    $manager->register( [
+        'name'        => 'Filter Only',
+        'slug'        => 'filter-existence',
+        'table_name'  => 'filter_existence',
+        'model_class' => 'App\\Models\\FilterExistence',
+    ] );
+
+    expect( $manager->contentTypeExists( 'filter-existence' ) )->toBeTrue();
+    expect( $manager->contentTypeExists( 'nonexistent' ) )->toBeFalse();
+} );

--- a/tests/Unit/ContentTypes/CustomFieldManagerTest.php
+++ b/tests/Unit/ContentTypes/CustomFieldManagerTest.php
@@ -2,6 +2,7 @@
 
 declare( strict_types=1 );
 
+use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Managers\ContentTypeManager;
 use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Managers\CustomFieldManager;
 use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Models\ContentType;
 use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Models\CustomField;
@@ -425,5 +426,149 @@ test( 'update field handles content type changes', function (): void {
     expect( Schema::hasColumn( 'test_pages_ct', 'custom_field' ) )->toBeTrue();
 
     Schema::dropIfExists( 'test_posts_ct' );
-    Schema::dropIfExists( 'test_pages_ct');
-});
+    Schema::dropIfExists( 'test_pages_ct' );
+} );
+
+test( 'get fields for content type merges DB and filter-registered fields', function (): void {
+    $manager = new CustomFieldManager;
+
+    CustomField::create( [
+        'name'          => 'DB Field',
+        'key'           => 'db_field',
+        'type'          => 'text',
+        'column_type'   => 'string',
+        'content_types' => ['posts'],
+        'order'         => 1,
+        'required'      => false,
+    ] );
+
+    $manager->registerField( [
+        'name'          => 'Plugin Field',
+        'key'           => 'plugin_field',
+        'type'          => 'text',
+        'column_type'   => 'string',
+        'content_types' => ['posts'],
+        'order'         => 2,
+        'required'      => false,
+    ] );
+
+    $manager->registerField( [
+        'name'          => 'Other Content Type Field',
+        'key'           => 'wrong_ct',
+        'type'          => 'text',
+        'column_type'   => 'string',
+        'content_types' => ['pages'],
+    ] );
+
+    $fields = $manager->getFieldsForContentType( 'posts' );
+    $keys   = $fields->pluck( 'key' )->all();
+
+    expect( $keys )->toContain( 'db_field' );
+    expect( $keys )->toContain( 'plugin_field' );
+    expect( $keys )->not->toContain( 'wrong_ct' );
+} );
+
+test( 'filter-registered fields are marked as metadata storage', function (): void {
+    $manager = new CustomFieldManager;
+
+    $manager->registerField( [
+        'name'          => 'Plugin Field',
+        'key'           => 'plugin_stored_field',
+        'type'          => 'text',
+        'column_type'   => 'string',
+        'content_types' => ['posts'],
+    ] );
+
+    $fields = $manager->getFieldsForContentType( 'posts' );
+    $plugin = $fields->firstWhere( 'key', 'plugin_stored_field' );
+
+    expect( $plugin )->not->toBeNull();
+    expect( $plugin->exists )->toBeFalse();
+    expect( $plugin->storageMode() )->toBe( 'metadata' );
+} );
+
+test( 'createField refuses to run Schema::table against a filter-only content type', function (): void {
+    // A plugin registers a content type with table_name pointing at a real
+    // host table. An admin creating a custom field must NOT trigger a schema
+    // mutation on that table.
+    $manager    = new CustomFieldManager;
+    $ctManager  = app( ContentTypeManager::class );
+
+    Schema::create( 'attacker_target', function ( $table ): void {
+        $table->id();
+        $table->string( 'legit_column' );
+        $table->timestamps();
+    } );
+
+    $ctManager->register( [
+        'name'        => 'Attacker CT',
+        'slug'        => 'attacker-ct',
+        'table_name'  => 'attacker_target', // Plugin picks a real host table.
+        'model_class' => 'App\\Models\\Attacker',
+    ] );
+
+    $field = $manager->createField( [
+        'name'          => 'Injected',
+        'key'           => 'injected_col',
+        'type'          => 'text',
+        'column_type'   => 'string',
+        'content_types' => ['attacker-ct'],
+        'order'         => 1,
+        'required'      => false,
+    ] );
+
+    expect( $field )->toBeInstanceOf( CustomField::class );
+    expect( Schema::hasColumn( 'attacker_target', 'injected_col' ) )->toBeFalse();
+
+    Schema::dropIfExists( 'attacker_target' );
+} );
+
+test( 'filter-registered custom fields strip persistence-critical keys on hydration', function (): void {
+    $manager = new CustomFieldManager;
+
+    $manager->registerField( [
+        'id'            => 999,
+        'created_at'    => '2020-01-01 00:00:00',
+        'name'          => 'Sneaky Field',
+        'key'           => 'sneaky',
+        'type'          => 'text',
+        'column_type'   => 'string',
+        'content_types' => ['posts'],
+    ] );
+
+    $field = $manager->getFieldsForContentType( 'posts' )->firstWhere( 'key', 'sneaky' );
+
+    expect( $field )->not->toBeNull();
+    expect( $field->id )->toBeNull();
+    expect( $field->created_at )->toBeNull();
+    expect( $field->exists )->toBeFalse();
+} );
+
+test( 'DB entry wins over filter entry when keys collide', function (): void {
+    $manager = new CustomFieldManager;
+
+    CustomField::create( [
+        'name'          => 'DB Version',
+        'key'           => 'shared_key',
+        'type'          => 'text',
+        'column_type'   => 'string',
+        'content_types' => ['posts'],
+        'order'         => 1,
+        'required'      => false,
+    ] );
+
+    $manager->registerField( [
+        'name'          => 'Filter Version',
+        'key'           => 'shared_key',
+        'type'          => 'text',
+        'column_type'   => 'string',
+        'content_types' => ['posts'],
+    ] );
+
+    $fields  = $manager->getFieldsForContentType( 'posts' );
+    $matches = $fields->where( 'key', 'shared_key' );
+
+    expect( $matches )->toHaveCount( 1 );
+    expect( $matches->first()->name )->toBe( 'DB Version' );
+    expect( $matches->first()->exists )->toBeTrue();
+} );

--- a/tests/Unit/ContentTypes/CustomFieldTypeRegistryTest.php
+++ b/tests/Unit/ContentTypes/CustomFieldTypeRegistryTest.php
@@ -1,0 +1,117 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Enums\FieldType;
+use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Registries\CustomFieldTypeRegistry;
+use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Support\FieldTypeDefinition;
+
+test( 'registry pre-registers every built-in FieldType enum case', function (): void {
+    $registry = new CustomFieldTypeRegistry;
+
+    $slugs = $registry->slugs();
+
+    foreach ( FieldType::cases() as $case ) {
+        expect( $slugs )->toContain( $case->value );
+        expect( $registry->get( $case->value ) )->toBeInstanceOf( FieldTypeDefinition::class );
+    }
+} );
+
+test( 'registry allows registering new plugin field types via register()', function (): void {
+    $registry = new CustomFieldTypeRegistry;
+
+    $registry->register( new FieldTypeDefinition(
+        slug       : 'map_picker',
+        label      : 'Map Picker',
+        columnType : 'string',
+    ) );
+
+    expect( $registry->has( 'map_picker' ) )->toBeTrue();
+    expect( $registry->get( 'map_picker' )->label )->toBe( 'Map Picker' );
+} );
+
+test( 'registry surfaces filter-registered field types via all()', function (): void {
+    $registry = new CustomFieldTypeRegistry;
+
+    addFilter( 'ap.contentTypes.registeredFieldTypes', function ( array $types ): array {
+        $types['image_gallery'] = [
+            'slug'        => 'image_gallery',
+            'label'       => 'Image Gallery',
+            'column_type' => 'text',
+        ];
+
+        return $types;
+    } );
+
+    expect( $registry->has( 'image_gallery' ) )->toBeTrue();
+    expect( $registry->get( 'image_gallery' )->columnType )->toBe( 'text' );
+} );
+
+test( 'registry accepts FieldTypeDefinition instances from filter', function (): void {
+    $registry = new CustomFieldTypeRegistry;
+
+    addFilter( 'ap.contentTypes.registeredFieldTypes', function ( array $types ): array {
+        $types['color_picker'] = new FieldTypeDefinition(
+            slug       : 'color_picker',
+            label      : 'Color Picker',
+            columnType : 'string',
+        );
+
+        return $types;
+    } );
+
+    expect( $registry->get( 'color_picker' ) )->not->toBeNull();
+    expect( $registry->get( 'color_picker' )->label )->toBe( 'Color Picker' );
+} );
+
+test( 'apRegisterFieldType helper registers on the shared singleton', function (): void {
+    $definition = apRegisterFieldType( 'phone_verified', [
+        'label'       => 'Verified Phone',
+        'column_type' => 'string',
+    ] );
+
+    expect( $definition )->toBeInstanceOf( FieldTypeDefinition::class );
+    expect( $definition->slug )->toBe( 'phone_verified' );
+    expect( apGetFieldType( 'phone_verified' ) )->not->toBeNull();
+    expect( apRegisteredFieldTypes() )->toHaveKey( 'phone_verified' );
+} );
+
+test( 'registry silently drops filter entries with non-scalar slug or label', function (): void {
+    $registry = new CustomFieldTypeRegistry;
+
+    addFilter( 'ap.contentTypes.registeredFieldTypes', function ( array $types ): array {
+        $types['bad_slug']   = ['slug' => ['nested', 'array'], 'label' => 'Bad'];
+        $types['bad_label']  = ['slug' => 'bad_label', 'label' => (object) ['ha' => 'ha']];
+        $types['empty_slug'] = ['slug' => '   ', 'label' => 'Blank'];
+        $types['good_one']   = ['slug' => 'good_one', 'label' => 'Good'];
+
+        return $types;
+    } );
+
+    $slugs = $registry->slugs();
+
+    expect( $slugs )->toContain( 'good_one' );
+    expect( $slugs )->not->toContain( 'bad_slug' );
+    expect( $slugs )->not->toContain( 'bad_label' );
+    expect( $slugs )->not->toContain( '' );
+    expect( $slugs )->not->toContain( '   ' );
+} );
+
+test( 'FieldTypeDefinition fromArray maps camelCase and snake_case keys', function (): void {
+    $definition = FieldTypeDefinition::fromArray( [
+        'slug'              => 'rating_stars',
+        'label'             => 'Rating',
+        'columnType'        => 'integer',
+        'validationRules'   => ['integer', 'between:1,5'],
+        'editorComponent'   => 'RatingEditor',
+        'rendererComponent' => 'RatingRenderer',
+        'meta'              => ['icon' => 'star'],
+    ] );
+
+    expect( $definition->slug )->toBe( 'rating_stars' );
+    expect( $definition->columnType )->toBe( 'integer' );
+    expect( $definition->validationRules )->toBe( ['integer', 'between:1,5'] );
+    expect( $definition->editorComponent )->toBe( 'RatingEditor' );
+    expect( $definition->rendererComponent )->toBe( 'RatingRenderer' );
+    expect( $definition->meta )->toBe( ['icon' => 'star'] );
+} );

--- a/tests/Unit/ContentTypes/HasCustomFieldsTest.php
+++ b/tests/Unit/ContentTypes/HasCustomFieldsTest.php
@@ -1,0 +1,227 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Managers\CustomFieldManager;
+use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Models\Concerns\HasCustomFields;
+use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Models\CustomField;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Test-only content-type model with a `metadata` JSON column, exercising
+ * the HasCustomFields metadata-storage code path for filter-registered
+ * fields.
+ */
+class TestHasCustomFieldsPost extends Model
+{
+    use HasCustomFields;
+
+    protected $table = 'test_hcf_posts';
+
+    protected $guarded = [];
+
+    protected $casts = [
+        'metadata' => 'array',
+    ];
+}
+
+beforeEach( function (): void {
+    $this->artisan( 'migrate', ['--database' => 'testing'] );
+
+    Schema::dropIfExists( 'test_hcf_posts' );
+    Schema::create( 'test_hcf_posts', function ( $table ): void {
+        $table->id();
+        $table->string( 'title' );
+        $table->json( 'metadata' )->nullable();
+        $table->timestamps();
+    } );
+} );
+
+afterEach( function (): void {
+    Schema::dropIfExists( 'test_hcf_posts' );
+} );
+
+test( 'reads filter-registered field value from metadata', function (): void {
+    app( CustomFieldManager::class )->registerField( [
+        'name'          => 'Plugin Field',
+        'key'           => 'plugin_note',
+        'type'          => 'text',
+        'column_type'   => 'string',
+        'content_types' => ['test_hcf_posts'],
+        'default_value' => 'unset',
+    ] );
+
+    $post           = new TestHasCustomFieldsPost;
+    $post->title    = 'Hello';
+    $post->metadata = ['plugin_note' => 'stored via metadata'];
+    $post->save();
+
+    $reloaded = TestHasCustomFieldsPost::find( $post->id );
+
+    expect( $reloaded->plugin_note )->toBe( 'stored via metadata' );
+} );
+
+test( 'writes filter-registered field value into metadata', function (): void {
+    app( CustomFieldManager::class )->registerField( [
+        'name'          => 'Plugin Field',
+        'key'           => 'plugin_bio',
+        'type'          => 'text',
+        'column_type'   => 'string',
+        'content_types' => ['test_hcf_posts'],
+    ] );
+
+    $post             = new TestHasCustomFieldsPost;
+    $post->title      = 'Bio Post';
+    $post->plugin_bio = 'A short bio.';
+    $post->save();
+
+    $reloaded = TestHasCustomFieldsPost::find( $post->id );
+
+    expect( $reloaded->metadata )->toHaveKey( 'plugin_bio' );
+    expect( $reloaded->metadata['plugin_bio'] )->toBe( 'A short bio.' );
+    expect( $reloaded->plugin_bio )->toBe( 'A short bio.' );
+} );
+
+test( 'reads default_value when metadata is missing the key', function (): void {
+    app( CustomFieldManager::class )->registerField( [
+        'name'          => 'Plugin Field',
+        'key'           => 'plugin_default',
+        'type'          => 'text',
+        'column_type'   => 'string',
+        'content_types' => ['test_hcf_posts'],
+        'default_value' => 'default from field',
+    ] );
+
+    $post        = new TestHasCustomFieldsPost;
+    $post->title = 'No plugin data yet';
+    $post->save();
+
+    expect( $post->plugin_default )->toBe( 'default from field' );
+} );
+
+test( 'plugin custom field key colliding with a real column does NOT hijack the column', function (): void {
+    // Ensures a rogue plugin cannot shadow a host attribute by registering
+    // a filter-scoped custom field whose key matches a real DB column.
+    app( CustomFieldManager::class )->registerField( [
+        'name'          => 'Hijack Attempt',
+        'key'           => 'title', // Real column on `test_hcf_posts`.
+        'type'          => 'text',
+        'column_type'   => 'string',
+        'content_types' => ['test_hcf_posts'],
+    ] );
+
+    $post        = new TestHasCustomFieldsPost;
+    $post->title = 'Legit Title';
+    $post->save();
+
+    $reloaded = TestHasCustomFieldsPost::find( $post->id );
+
+    expect( $reloaded->title )->toBe( 'Legit Title' );
+    expect( $reloaded->metadata )->toBeNull();
+} );
+
+test( 'plugin custom field key colliding with a cast attribute does NOT hijack it', function (): void {
+    // Casts declared via `casts()` method (per Laravel 12 convention) must
+    // still short-circuit — the trait consults `getCasts()`, not `$casts`.
+    app( CustomFieldManager::class )->registerField( [
+        'name'          => 'Hijack Attempt',
+        'key'           => 'metadata', // The cast attribute itself.
+        'type'          => 'text',
+        'column_type'   => 'string',
+        'content_types' => ['test_hcf_posts'],
+    ] );
+
+    $post           = new TestHasCustomFieldsPost;
+    $post->title    = 'Post';
+    $post->metadata = ['user_supplied' => 'ok'];
+    $post->save();
+
+    $reloaded = TestHasCustomFieldsPost::find( $post->id );
+
+    expect( $reloaded->metadata )->toBe( ['user_supplied' => 'ok'] );
+} );
+
+test( 'plugin custom field write on a model without metadata column fails loud', function (): void {
+    // A HasCustomFields model that has no metadata column must not silently
+    // drop plugin writes — throw so the plugin author sees the misuse.
+    Schema::dropIfExists( 'test_no_meta_hcf' );
+    Schema::create( 'test_no_meta_hcf', function ( $table ): void {
+        $table->id();
+        $table->string( 'title' );
+        $table->timestamps();
+    } );
+
+    $model = new class extends Model {
+        use HasCustomFields;
+
+        protected $table = 'test_no_meta_hcf';
+
+        protected $guarded = [];
+    };
+
+    app( CustomFieldManager::class )->registerField( [
+        'name'          => 'Plugin Field',
+        'key'           => 'plugin_only',
+        'type'          => 'text',
+        'column_type'   => 'string',
+        'content_types' => ['test_no_meta_hcf'],
+    ] );
+
+    expect( fn () => $model->plugin_only = 'boom' )
+        ->toThrow( RuntimeException::class, 'no `metadata` JSON column' );
+
+    Schema::dropIfExists( 'test_no_meta_hcf' );
+} );
+
+test( 'getCustomFieldsForType is memoized per instance', function (): void {
+    app( CustomFieldManager::class )->registerField( [
+        'name'          => 'Plugin Field',
+        'key'           => 'memoized_field',
+        'type'          => 'text',
+        'column_type'   => 'string',
+        'content_types' => ['test_hcf_posts'],
+    ] );
+
+    $post        = new TestHasCustomFieldsPost;
+    $post->title = 'x';
+    $post->save();
+
+    Illuminate\Support\Facades\DB::enableQueryLog();
+    Illuminate\Support\Facades\DB::flushQueryLog();
+
+    // First lookup populates the cache; subsequent lookups must not requery.
+    $post->getCustomFieldsForType();
+    $post->getCustomFieldsForType();
+    $post->getCustomFieldsForType();
+
+    expect( Illuminate\Support\Facades\DB::getQueryLog() )->toHaveCount( 1 );
+
+    Illuminate\Support\Facades\DB::disableQueryLog();
+} );
+
+test( 'DB-registered field values still flow through physical columns', function (): void {
+    Schema::table( 'test_hcf_posts', function ( $table ): void {
+        $table->string( 'db_field' )->nullable();
+    } );
+
+    CustomField::create( [
+        'name'          => 'DB Field',
+        'key'           => 'db_field',
+        'type'          => 'text',
+        'column_type'   => 'string',
+        'content_types' => ['test_hcf_posts'],
+        'order'         => 1,
+        'required'      => false,
+    ] );
+
+    $post           = new TestHasCustomFieldsPost;
+    $post->title    = 'DB Post';
+    $post->db_field = 'column value';
+    $post->save();
+
+    $reloaded = TestHasCustomFieldsPost::find( $post->id );
+
+    expect( $reloaded->db_field )->toBe( 'column value' );
+    expect( $reloaded->metadata )->toBeNull();
+} );

--- a/tests/Unit/ContentTypes/TaxonomyManagerTest.php
+++ b/tests/Unit/ContentTypes/TaxonomyManagerTest.php
@@ -1,0 +1,179 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Managers\TaxonomyManager;
+use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Models\Taxonomy;
+
+beforeEach( function (): void {
+    $this->artisan( 'migrate', ['--database' => 'testing'] );
+} );
+
+test( 'get taxonomy returns filter-registered taxonomy as unpersisted model', function (): void {
+    $manager = new TaxonomyManager;
+
+    $manager->registerTaxonomy( [
+        'name'              => 'Filter Category',
+        'slug'              => 'filter-category',
+        'content_type_slug' => 'posts',
+        'hierarchical'      => true,
+        'show_in_admin'     => true,
+    ] );
+
+    $taxonomy = $manager->getTaxonomy( 'filter-category' );
+
+    expect( $taxonomy )->not->toBeNull();
+    expect( $taxonomy )->toBeInstanceOf( Taxonomy::class );
+    expect( $taxonomy->slug )->toBe( 'filter-category' );
+    expect( $taxonomy->name )->toBe( 'Filter Category' );
+    expect( $taxonomy->content_type_slug )->toBe( 'posts' );
+    expect( $taxonomy->exists )->toBeFalse();
+} );
+
+test( 'get taxonomy prefers database entry over filter entry', function (): void {
+    $manager = new TaxonomyManager;
+
+    Taxonomy::create( [
+        'name'              => 'DB Tag',
+        'slug'              => 'shared-tag',
+        'content_type_slug' => 'posts',
+        'hierarchical'      => false,
+        'show_in_admin'     => true,
+    ] );
+
+    $manager->registerTaxonomy( [
+        'name'              => 'Filter Tag',
+        'slug'              => 'shared-tag',
+        'content_type_slug' => 'posts',
+    ] );
+
+    $taxonomy = $manager->getTaxonomy( 'shared-tag' );
+
+    expect( $taxonomy->name )->toBe( 'DB Tag' );
+    expect( $taxonomy->exists )->toBeTrue();
+} );
+
+test( 'taxonomy exists returns true for filter-registered taxonomies', function (): void {
+    $manager = new TaxonomyManager;
+
+    $manager->registerTaxonomy( [
+        'name'              => 'Filter Series',
+        'slug'              => 'filter-series',
+        'content_type_slug' => 'posts',
+    ] );
+
+    expect( $manager->taxonomyExists( 'filter-series' ) )->toBeTrue();
+    expect( $manager->taxonomyExists( 'nonexistent-taxonomy' ) )->toBeFalse();
+} );
+
+test( 'get taxonomies for content type merges DB and filter entries', function (): void {
+    $manager = new TaxonomyManager;
+
+    Taxonomy::create( [
+        'name'              => 'DB Category',
+        'slug'              => 'db-category',
+        'content_type_slug' => 'posts',
+        'hierarchical'      => true,
+        'show_in_admin'     => true,
+    ] );
+
+    $manager->registerTaxonomy( [
+        'name'              => 'Filter Category',
+        'slug'              => 'filter-category',
+        'content_type_slug' => 'posts',
+    ] );
+
+    $manager->registerTaxonomy( [
+        'name'              => 'Wrong Content Type',
+        'slug'              => 'other',
+        'content_type_slug' => 'pages',
+    ] );
+
+    $taxonomies = $manager->getTaxonomiesForContentType( 'posts' );
+
+    $slugs = $taxonomies->pluck( 'slug' )->all();
+    expect( $slugs )->toContain( 'db-category' );
+    expect( $slugs )->toContain( 'filter-category' );
+    expect( $slugs )->not->toContain( 'other' );
+} );
+
+test( 'get taxonomies for content type prefers DB entry when slugs collide', function (): void {
+    $manager = new TaxonomyManager;
+
+    Taxonomy::create( [
+        'name'              => 'DB Version',
+        'slug'              => 'collision',
+        'content_type_slug' => 'posts',
+        'hierarchical'      => true,
+        'show_in_admin'     => true,
+    ] );
+
+    $manager->registerTaxonomy( [
+        'name'              => 'Filter Version',
+        'slug'              => 'collision',
+        'content_type_slug' => 'posts',
+    ] );
+
+    $taxonomies = $manager->getTaxonomiesForContentType( 'posts' );
+
+    $collision = $taxonomies->firstWhere( 'slug', 'collision' );
+    expect( $collision )->not->toBeNull();
+    expect( $collision->name )->toBe( 'DB Version' );
+    expect( $collision->exists )->toBeTrue();
+} );
+
+test( 'updateTaxonomy refuses filter-only slugs (no phantom INSERT)', function (): void {
+    $manager = new TaxonomyManager;
+
+    $manager->registerTaxonomy( [
+        'name'              => 'Filter Only',
+        'slug'              => 'filter-only-tag',
+        'content_type_slug' => 'posts',
+    ] );
+
+    expect( fn () => $manager->updateTaxonomy( 'filter-only-tag', ['name' => 'Renamed'] ) )
+        ->toThrow( Exception::class, 'not found' );
+
+    expect( Taxonomy::where( 'slug', 'filter-only-tag' )->exists() )->toBeFalse();
+} );
+
+test( 'deleteTaxonomy returns false for filter-only slugs', function (): void {
+    $manager = new TaxonomyManager;
+
+    $manager->registerTaxonomy( [
+        'name'              => 'Filter Only',
+        'slug'              => 'filter-only-delete',
+        'content_type_slug' => 'posts',
+    ] );
+
+    expect( $manager->deleteTaxonomy( 'filter-only-delete' ) )->toBeFalse();
+} );
+
+test( 'filter-hydrated taxonomy strips persistence-critical keys', function (): void {
+    $manager = new TaxonomyManager;
+
+    $manager->registerTaxonomy( [
+        'id'                => 999,
+        'created_at'        => '2020-01-01 00:00:00',
+        'name'              => 'Sneaky',
+        'slug'              => 'sneaky-tag',
+        'content_type_slug' => 'posts',
+    ] );
+
+    $taxonomy = $manager->getTaxonomy( 'sneaky-tag' );
+
+    expect( $taxonomy->id )->toBeNull();
+    expect( $taxonomy->created_at )->toBeNull();
+} );
+
+test( 'getPersistedTaxonomy never returns filter-hydrated entries', function (): void {
+    $manager = new TaxonomyManager;
+
+    $manager->registerTaxonomy( [
+        'name'              => 'Filter Only',
+        'slug'              => 'persist-tag',
+        'content_type_slug' => 'posts',
+    ] );
+
+    expect( $manager->getPersistedTaxonomy( 'persist-tag' ) )->toBeNull();
+} );


### PR DESCRIPTION
## Description

Ships five interrelated plugin-system issues in one branch so third-party plugins can extend the framework end-to-end: filter-hydrated content-type / taxonomy singular getters, a new `CustomFieldTypeRegistry` replacing the closed `FieldType` enum, filter-registered custom fields stored in a `metadata` JSON column, a `ContentEditExtensions` manager exposing edit-screen hook seams, and a full plugin author guide with a working example plugin skeleton.

**Closes:** #184, #185, #186, #187, #188

## Type of Change

- [x] New feature (adds new functionality)
- [x] Enhancement (improves existing functionality)
- [x] Documentation update
- [x] Security fix

## Related Issues

- **#184** — Write plugin author guide and ship example plugin skeleton
- **#185** — Fix CustomFieldManager code-registered path (filter output never consumed)
- **#186** — Reconcile singular getters in ContentTypeManager and TaxonomyManager to honor filter
- **#187** — Make FieldType extensible: replace closed enum with a registry
- **#188** — Add metabox/panel filter hooks around post/page edit render pipeline

## Motivation and Context

The framework's plugin system had extensibility gaps that made third-party development impractical:

- Plugins could register content types / taxonomies via filter, but the singular getters and existence checks only looked at the DB.
- `CustomFieldManager::registerField()` wrote to a filter no reader consumed — dead code.
- `FieldType` was a closed enum with 16 hard-coded cases, blocking plugin-shipped field types entirely.
- No hook seam existed anywhere in the post/page edit render pipeline for panels, tabs, or save-time transforms.
- No plugin author documentation and no example plugin.

This PR closes all of the above and, after a `/code-review` pass, hardens the surface so a third-party plugin cannot shadow host attributes or steer schema mutations at arbitrary host tables.

## Changes Made

**#186 — Singular getters (Option B, backwards compatible)**
- `ContentTypeManager::{getContentType, contentTypeExists}` and `TaxonomyManager::{getTaxonomy, taxonomyExists, getTaxonomiesForContentType}` now hydrate filter-registered entries as unpersisted models via `forceFill` + `exists=false`.
- New `getPersistedContentType()` / `getPersistedTaxonomy()` for privileged callers that must never trust plugin-supplied `table_name`.

**#187 — `CustomFieldTypeRegistry` + `FieldTypeDefinition`**
- New registry under `src/Modules/ContentTypes/Registries/`, pre-registers all 16 built-in `FieldType` cases on boot.
- Filter-extensible via `ap.contentTypes.registeredFieldTypes`.
- Helpers: `apRegisterFieldType(string $slug, array|FieldTypeDefinition $def)`, `apGetFieldType()`, `apRegisteredFieldTypes()` — signature matches sibling `apRegister*` helpers.
- `CustomField.type` cast changed from `FieldType::class` → `string`; `fieldTypeEnum()`, `fieldTypeDefinition()`, `storageMode()` accessors added.
- `CustomFieldRequest` validates against `Rule::in($registry->slugs())`.

**#185 — CustomFieldManager filter path**
- `getFieldsForContentType()` merges DB + filter; filter fields carry `storage=metadata`.
- `HasCustomFields` trait rewritten: routes filter-registered fields through the model's `metadata` JSON column while DB fields keep their physical columns.
- Schema mutations restricted to DB-persisted content types via `getPersistedContentType()` in `createField`, `updateField`, `deleteField`, and `generateMigration`.

**#188 — `ContentEditExtensions`**
- New manager exposing `panels()`, `tabs()`, `beforeEditor()`, `afterEditor()`, `saveData()` over `ap.admin.contentEdit.{panels,tabs,beforeEditor,afterEditor,saveData}` filters.
- Respects `contentTypes` restriction (`['*']` wildcard or explicit slug list) and `order` field.

**#184 — Docs and example plugin**
- `docs/plugin-authoring.md` covers lifecycle, `plugin.json` schema, base `PluginServiceProvider`, admin pages (both Blade and Module Federation), nav entries, migrations, hooks, custom field types, edit-screen panels, versioning, and testing.
- `examples/hello-world-plugin/` skeleton with `plugin.json`, `HelloWorldServiceProvider`, migration, Blade admin view, and README (React MF flavor stubbed with pointer to Keystone).
- README plugin-system section rewritten; "experimental" wording removed.

**Security hardening (10 findings surfaced by `/code-review high`, all addressed):**
- `HasCustomFields::findCustomFieldByKey` consults `getCasts()` (not the empty `$this->casts` property) and a per-class cached `Schema::getColumnListing()` so a plugin cannot shadow a host attribute (`password`, `is_admin`, `metadata`, etc.) by registering a filter-scoped field with a colliding key.
- `__set` on filter-registered fields throws `RuntimeException` when the host model has no `metadata` column instead of silently dropping writes.
- `update{Content,Type}` / `delete{Content,Type}` and Taxonomy siblings refuse filter-only slugs — previously they silently INSERTed phantom rows because Eloquent `update()` on `exists=false` runs `performInsert()`.
- `hydrateFilterContentType`, `hydrateTaxonomyFromArgs`, and `filterFieldsForContentType` strip `id`, `created_at`, `updated_at`, `deleted_at` before `forceFill`.
- `CustomFieldTypeRegistry` rejects malformed filter entries (non-scalar slug/label, empty slug) — one bad plugin no longer DoSes the registry.
- `getCustomFieldsForType` memoized per instance and auto-flushed on `saved`/`deleted` events.

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS Sequoia (Darwin 25.5.0)
- PHP Version: 8.4.3 (runtime), package supports 8.2+
- Project Version: 2.3.0 → 2.4.x

**Tests Performed:**
1. `php -d memory_limit=2G ./vendor/bin/pest --compact` — full suite
2. Manual tinker verification of `apRegisterFieldType()`, `getContentType()` filter path, `ContentEditExtensions::panels()`
3. `./vendor/bin/php-cs-fixer fix` — Pint clean

## Accessibility Tests Run

Not applicable to this PR — the framework is backend-only. The Blade admin view in the example plugin extends the host's admin layout; accessibility is the host's responsibility.

## Tests Added

- [x] Unit tests added/updated
- [x] All tests passing

**Test details:** 1129 passing, 7 skipped, 0 failing. New coverage:
- Filter-registered content-type / taxonomy getters return unpersisted models with DB precedence on collision.
- `CustomFieldTypeRegistry` built-ins, plugin registration, filter merge, malformed-entry rejection.
- `HasCustomFields` metadata read/write, column shadow attack blocked, cast collision blocked, missing-metadata-column failure mode, per-instance memoization (1 query for 3 lookups).
- `ContentEditExtensions` filter dispatch, ordering, `contentTypes` restriction, entry shape validation.
- `updateContentType`/`updateTaxonomy` phantom-INSERT blocking, `deleteContentType`/`deleteTaxonomy` no-op return.
- `forceFill` allow-list on all three managers.
- `CustomFieldManager::createField` refuses to run `Schema::table` on a filter-registered content type.

## Documentation

- [x] Inline code documentation added
- [x] README updated
- [ ] Wiki updated
- [ ] API documentation updated

**Documentation details:**
- `docs/plugin-authoring.md` (new, ~350 lines) — full plugin author guide.
- `examples/hello-world-plugin/README.md` — walks through every extension point demonstrated by the example.
- README plugin-system section rewritten and linked to the guide.

## Pre-Submission Checklist

- [x] Followed contributing guidelines
- [x] Checked for other open PRs for same update
- [x] Code passes all tests (1129 passing)
- [x] Code has been linted (php-cs-fixer clean)
- [x] Code follows project style guide (WordPress-style spacing, Yoda conditions, aligned operators)
- [x] Self-review completed via `/code-review high` — 10 findings surfaced and all addressed before this PR was opened
- [x] Comments added for complex code
- [x] No new warnings generated

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a comprehensive plugin author guide and reference Hello World plugin example.
  * Expanded plugin capabilities for custom field types, admin pages, navigation, migrations, hooks, and edit-screen panels.
  * Added support for plugin-registered content types, taxonomies, and custom fields.
  * Added metadata-backed custom fields with defaults and validation support.

* **Bug Fixes**
  * Improved separation between registered definitions and persisted records, preventing unintended database updates, deletions, or schema changes.
  * Improved custom-field handling to avoid conflicts with existing model attributes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->