### PR TITLE
Release v2.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,41 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+## [2.4.0] - 2026-07-16
+
+### Added
+
+- **Dynamic content system** ([#178](https://github.com/ArtisanPack-UI/cms-framework/issues/178)) — Site-wide dynamic content module at `src/Modules/DynamicContent/`. Site owners define a piece of content once and reference it anywhere via `{{source.field|mod:arg}}` merge tokens; edits propagate everywhere the token is used. Ships four migrations (`dynamic_content_types`, `_fields`, `_records`, `_record_values`); an in-memory registry that merges admin-created (DB) and code-registered types with slug-conflict warnings; 11 built-in field types (text, rich_text, url, email, phone, image, date, datetime, number, address, select) with HTML-safe rendering (text-shaped types escape at render time, rich text stays raw by design); 7 built-in modifiers (default, upper, lower, truncate, date, time, nl2br — `nl2br` escapes input before inserting `<br>` and returns `HtmlString`); a `DynamicContentResolver` with a 65KB `/resolve` cap plus throttle; the `apRenderContent()` helper and `@dynamicContent` Blade directive; a `DynamicContentCast` Eloquent cast (documented as a public content pipeline — do NOT store secrets in dynamic content records); filter-driven authz (`manage_dynamic_content` capability with per-type policy scoping via `viewAnyForType` / `createForType`); per-request memoization on the accessor to eliminate collection-token N+1s; a resolver signature cache invalidated on record save/delete; REST endpoints under `/api/v1/dynamic-content/*` with types bound by slug; a Livewire admin surface (type list, field builder, singleton editor, collection editor); and wiring into `HasRenderedBlockContent::renderContent()` so Blog Post, Pages, and any content type using the trait auto-resolve tokens.
+
+- **Plugin system v2.4 — schema, filter, base provider, compat, lifecycle** ([#179](https://github.com/ArtisanPack-UI/cms-framework/issues/179), [#180](https://github.com/ArtisanPack-UI/cms-framework/issues/180), [#181](https://github.com/ArtisanPack-UI/cms-framework/issues/181), [#182](https://github.com/ArtisanPack-UI/cms-framework/issues/182), [#183](https://github.com/ArtisanPack-UI/cms-framework/issues/183), [#190](https://github.com/ArtisanPack-UI/cms-framework/pull/190)) — Five interrelated enhancements for the Keystone CMS plugin UI initiative:
+  - `plugin.json` schema extended with `min_host_version`, `federated_module`, `nav_entries`, `permissions` (plugin-slug-namespaced), `migrations_path` (traversal-guarded), and `rollback_migrations_on_delete`.
+  - New `ap.admin.menu` filter with a React/Inertia-friendly row shape (`url` / `label` / `iconId` / `permission` / `external`); post-filter capability re-check gates plugin-injected entries.
+  - New `PluginServiceProvider` base class with `registerAdminPage` / `registerNavEntry` / `registerFederatedModule` / `pluginPath` / `pluginConfig` helpers, backed by a container-bound `PluginRegistry` singleton (Octane-safe).
+  - Plugin `min_host_version` enforced at activation via `IncompatiblePluginException` with `composer.json` + `InstalledVersions` resolution; controller surfaces a structured 409 response.
+  - Complete plugin lifecycle: transactional activation with PSR-4 snapshot/restore rollback, opt-in migration rollback on delete, namespace-scoped permission seed/unseed, and optional framework cache clears (`cms.plugins.autoClearFrameworkCaches`, default `false`).
+
+- **Complete plugin extensibility** ([#184](https://github.com/ArtisanPack-UI/cms-framework/issues/184), [#185](https://github.com/ArtisanPack-UI/cms-framework/issues/185), [#186](https://github.com/ArtisanPack-UI/cms-framework/issues/186), [#187](https://github.com/ArtisanPack-UI/cms-framework/issues/187), [#188](https://github.com/ArtisanPack-UI/cms-framework/issues/188), [#191](https://github.com/ArtisanPack-UI/cms-framework/pull/191)) — Ships the remaining plugin-system issues so third-party plugins can extend the framework end-to-end:
+  - `ContentTypeManager` / `TaxonomyManager` singular getters (`getContentType`, `contentTypeExists`, `getTaxonomy`, `taxonomyExists`, `getTaxonomiesForContentType`) now hydrate filter-registered entries as unpersisted models (backwards compatible via Option B); added `getPersistedContentType` / `getPersistedTaxonomy` for privileged callers that must never trust plugin-supplied `table_name`.
+  - New `CustomFieldTypeRegistry` + `FieldTypeDefinition` value object under `src/Modules/ContentTypes/`. All 16 built-in `FieldType` enum cases are pre-registered. New `apRegisterFieldType(string $slug, array|FieldTypeDefinition $definition)` helper matches the sibling `apRegister*` signature convention. `CustomField.type` cast changed from `FieldType::class` to `string`; new `fieldTypeEnum()`, `fieldTypeDefinition()`, `storageMode()` accessors. `CustomFieldRequest` now validates against `Rule::in(registry->slugs())`.
+  - `CustomFieldManager::getFieldsForContentType()` merges DB + filter fields. Filter fields carry `storage = metadata`. The `HasCustomFields` trait was rewritten to route metadata-storage fields to the model's `metadata` JSON column. Schema mutations (`createField`, `updateField`, `deleteField`, `generateMigration`) are now restricted to DB-persisted content types so a plugin's filter-registered `table_name` can never steer `Schema::table` at a host table.
+  - New `ContentEditExtensions` manager exposing `panels()`, `tabs()`, `beforeEditor()`, `afterEditor()`, `saveData()` over `ap.admin.contentEdit.{panels,tabs,beforeEditor,afterEditor,saveData}`. Respects `contentTypes` restriction and `order`.
+  - Plugin authoring guide (`docs/plugin-authoring.md`) and `examples/hello-world-plugin/` skeleton with `plugin.json`, base `PluginServiceProvider` usage, migration, and Blade admin view. Federated React flavor stubbed with pointer to Keystone. `README` plugin-system section rewritten; "experimental" wording removed.
+
+### Security
+
+- **Plugin system hardening** ([#190](https://github.com/ArtisanPack-UI/cms-framework/pull/190), [#191](https://github.com/ArtisanPack-UI/cms-framework/pull/191)) — surfaced by local `/code-review` passes:
+  - Reject manifest `migrations_path` traversal (schema + runtime `realpath` check).
+  - Namespace-prefix permission slugs so seed/unseed cannot touch core or other plugin rows.
+  - Re-apply `Gate::allows` after the `ap.admin.menu` filter runs.
+  - Allow-list URL schemes in `registerNavEntry` and `resolveRouteUrl`.
+  - Constrain `PluginServiceProvider` manifest walk to direct children of the plugins root.
+  - `HasCustomFields` short-circuits via `getCasts()` + real `Schema` column listing so a plugin cannot shadow a host attribute (`password`, `is_admin`, `metadata`) by registering a filter-scoped field with a colliding key.
+  - `__set` on filter-registered fields throws `RuntimeException` when the host model has no `metadata` column instead of silently dropping writes.
+  - `update/deleteContentType` and `update/deleteTaxonomy` refuse filter-only slugs (previously silently `INSERT`ed phantom rows via Eloquent `update()` on `exists = false`).
+  - `forceFill` payloads strip `id` / `created_at` / `updated_at` / `deleted_at` so plugins cannot seed persistence-critical keys.
+  - `CustomFieldTypeRegistry` rejects malformed filter entries (non-scalar `slug` or `label`, empty `slug`) — one bad plugin no longer DoSes the registry.
+  - `getCustomFieldsForType` is memoized per instance and auto-flushed on `saved` / `deleted`.
+
 ## [2.3.0] - 2026-07-09
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ A comprehensive Laravel package that provides back-end support for building a CM
 - **Visual Editor Integration** *(new in 2.0.0)*: Opt-in bridge to the optional `artisanpack-ui/visual-editor` package
 - **Blog Comments** *(new in 2.1.0)*: Threaded post comments with public read / guest submit, rate-limited public submission, and auth-gated moderation
 - **Themes**: Discovery, activation, ZIP upload, and lifecycle hooks
-- **Plugins**: Plugin system ⚠️ **Experimental**
+- **Plugins**: Plugin system with lifecycle management, hooks, custom field types, admin pages, and Module Federation support — see the [Plugin Author Guide](./docs/plugin-authoring.md)
 - **Core Updates**: Automatic update checking and management with rollback support
 - **PWA Support**: Progressive Web App features
 - **Audit Logging**: Track changes and user actions
@@ -270,27 +270,19 @@ composer require artisanpack-ui/ai:^1.0
 
 Without it, the agents, the Livewire component, and the REST endpoints stay unregistered — the framework boots normally.
 
+## Plugin System
+
+Plugins extend the framework with new admin pages, nav entries, hook
+subscriptions, custom field types, edit-screen panels, and — in hosts that
+ship a Module Federation runtime — React admin components.
+
+- Start with the [Plugin Author Guide](./docs/plugin-authoring.md).
+- Copy the [`examples/hello-world-plugin/`](./examples/hello-world-plugin/) skeleton for a working reference.
+
 ## Experimental Features
 
-The following features are **experimental** in the 1.0.0 release and should be used with caution in production environments:
-
-### Plugin System
-
-The plugin system provides a foundation for extending the CMS with custom functionality.
-
-**What Works:**
-- Plugin model with activation/deactivation tracking
-- Plugin manager for lifecycle management
-- Plugin installation and validation
-- Plugin update manager integration
-
-**Known Limitations:**
-- Plugin lifecycle hooks not fully implemented
-- No plugin dependency management
-- Limited plugin configuration API
-- No plugin marketplace integration
-
-**Recommendation:** Use for testing and development. Not recommended for production until full lifecycle support is added in a future release.
+The following features are **experimental** and should be used with caution in
+production environments:
 
 ### Theme System
 

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "description": "Adds in the back end support for building a CMS with any front end framework.",
   "type": "library",
   "license": "MIT",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "autoload": {
     "psr-4": {
       "ArtisanPackUI\\CMSFramework\\": "src/",

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
       "src/Modules/Users/helpers.php",
       "src/Modules/Admin/helpers.php",
       "src/Modules/Core/helpers.php",
-      "src/Modules/Settings/helpers.php"
+      "src/Modules/Settings/helpers.php",
+      "src/Modules/DynamicContent/helpers.php"
     ]
   },
   "autoload-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b016a26ece3cf19d5daefc11acdb90f8",
+    "content-hash": "ecb43e7d608057f16bb6b552e8059ccb",
     "packages": [
         {
             "name": "artisanpack-ui/accessibility",

--- a/config/cms-framework.php
+++ b/config/cms-framework.php
@@ -32,7 +32,7 @@ return [
 
         'info' => [
             'title'       => 'ArtisanPack CMS Framework API',
-            'version'     => '2.3.0',
+            'version'     => '2.4.0',
             'description' => 'RESTful API for the ArtisanPack CMS Framework. Provides endpoints for managing posts, pages, content types, users, roles, permissions, settings, notifications, plugins, and themes.',
         ],
 

--- a/docs/plugin-authoring.md
+++ b/docs/plugin-authoring.md
@@ -1,0 +1,351 @@
+# Plugin Author Guide
+
+Plugins extend the CMS Framework with new content types, custom fields, admin
+pages, nav entries, hooks, and — in hosts that ship a Module Federation runtime
+— React admin components. This guide walks through every piece a plugin author
+needs and points at the reference example under
+[`examples/hello-world-plugin/`](../examples/hello-world-plugin/).
+
+- [Plugin lifecycle](#plugin-lifecycle)
+- [`plugin.json` manifest schema](#pluginjson-manifest-schema)
+- [Base `PluginServiceProvider`](#base-pluginserviceprovider)
+- [Registering an admin page](#registering-an-admin-page)
+- [Registering nav entries](#registering-nav-entries)
+- [Migrations](#migrations)
+- [Hook subscriptions](#hook-subscriptions)
+- [Registering custom field types](#registering-custom-field-types)
+- [Injecting edit-screen panels & tabs](#injecting-edit-screen-panels--tabs)
+- [Federated React modules](#federated-react-modules)
+- [Versioning & host compatibility](#versioning--host-compatibility)
+- [Testing your plugin](#testing-your-plugin)
+
+## Plugin lifecycle
+
+1. **Discovery** — The framework scans `base_path(config('cms.plugins.directory'))`
+   ( default `plugins/` ) for directories containing a `plugin.json` manifest.
+2. **Install** — When a plugin is uploaded, `PluginManager::install()` validates
+   the manifest and inserts a row in the `plugins` table.
+3. **Activate** — On activation, the plugin's `service_provider` ( from
+   `plugin.json` ) is registered with the container. This runs your
+   `register()` and `boot()` methods, and any manifest-declared migrations.
+4. **Deactivate** — The plugin row is marked inactive. The service provider is
+   unregistered on the next request boot.
+5. **Delete** — The plugin's directory and DB record are removed.
+
+## `plugin.json` manifest schema
+
+A plugin's root directory MUST contain a `plugin.json` file:
+
+```json
+{
+  "$schema": "https://artisanpack-ui.dev/schemas/plugin.json",
+  "slug": "hello-world",
+  "name": "Hello World",
+  "version": "1.0.0",
+  "description": "Reference plugin demonstrating the framework's plugin API.",
+  "author": {
+    "name": "Jacob Martella",
+    "email": "me@jacobmartella.com",
+    "url": "https://jacobmartella.com"
+  },
+  "homepage": "https://example.com/hello-world",
+  "license": "MIT",
+  "service_provider": "HelloWorld\\HelloWorldServiceProvider",
+  "requires": {
+    "cms-framework": "^2.4",
+    "php": "^8.2"
+  },
+  "autoload": {
+    "psr-4": {
+      "HelloWorld\\": "src/"
+    }
+  },
+  "migrations": "database/migrations",
+  "federated_modules": [
+    {
+      "name": "helloWorldAdmin",
+      "entry": "dist/remoteEntry.js",
+      "exposes": ["./HelloWorldPanel"]
+    }
+  ]
+}
+```
+
+### Required fields
+
+| Field              | Type   | Notes |
+| ------------------ | ------ | ----- |
+| `slug`             | string | Lowercase, dashes; matches directory name. |
+| `name`             | string | Human-readable name for the admin UI. |
+| `version`          | string | Semver. Used for host-compatibility checks and update flows. |
+| `service_provider` | string | Fully-qualified Laravel service provider class ( see below ). |
+
+### Optional fields
+
+| Field               | Type            | Notes |
+| ------------------- | --------------- | ----- |
+| `description`       | string          | Shown in the admin plugin list. |
+| `author`            | object          | `{ name, email?, url? }`. |
+| `homepage`          | string ( URL )  | Documentation or marketing URL. |
+| `license`           | string          | SPDX identifier ( `MIT`, `Apache-2.0`, etc. ). |
+| `requires`          | object          | Semver constraints: `{ "cms-framework": "^2.4", "php": "^8.2" }`. Enforced on activation. |
+| `autoload`          | object          | PSR-4 map. The framework hands this to Composer's runtime `ClassLoader`. |
+| `migrations`        | string ( path ) | Relative path to your migrations directory. Auto-run on activate. |
+| `federated_modules` | array           | See [Federated React modules](#federated-react-modules). |
+| `nav`               | array           | Static nav entries; equivalent to calling `registerNavEntry()` from your provider. |
+
+## Base `PluginServiceProvider`
+
+Extend
+`ArtisanPackUI\CMSFramework\Modules\Plugins\Support\PluginServiceProvider`
+for opinionated helpers:
+
+```php
+<?php
+
+namespace HelloWorld;
+
+use ArtisanPackUI\CMSFramework\Modules\Plugins\Support\PluginServiceProvider;
+
+final class HelloWorldServiceProvider extends PluginServiceProvider
+{
+    public function register(): void
+    {
+        // Bind services here.
+    }
+
+    public function boot(): void
+    {
+        $this->registerAdminPage( 'hello-world', [
+            'title'      => __( 'Hello World' ),
+            'section'    => 'tools',
+            'view'       => 'hello-world::admin.index',
+            'capability' => 'access_admin_dashboard',
+            'icon'       => 'fas.puzzle-piece',
+            'order'      => 60,
+        ] );
+
+        $this->registerNavEntry( [
+            'slug'       => 'hello-world',
+            'label'      => __( 'Hello World' ),
+            'url'        => '/admin/hello-world',
+            'icon'       => 'fas.puzzle-piece',
+            'permission' => 'access_admin_dashboard',
+            'order'      => 60,
+        ] );
+
+        $this->loadViewsFrom( $this->pluginPath( 'resources/views' ), 'hello-world' );
+    }
+}
+```
+
+Available helpers:
+
+- `registerAdminPage( string $slug, array $config )` — attach an admin page to the shared `AdminMenuManager`. `view` for Blade, `component` for federated React.
+- `registerNavEntry( array $entry )` — add an idempotent nav entry to the container-bound `PluginRegistry`.
+- `registerFederatedModule( string $name, string $entryPath, array $exposes = [] )` — declare a Module Federation entry hosts can consume.
+- `pluginPath( ?string $subpath = null )` — resolve a path within your plugin directory.
+- `pluginConfig( ?string $key = null )` — read the plugin's `plugin.json`; dot-notation supported.
+- `pluginSlug()` — resolves from your manifest.
+
+## Registering an admin page
+
+Blade version:
+
+```php
+$this->registerAdminPage( 'hello-world', [
+    'title'      => __( 'Hello World' ),
+    'section'    => 'tools',
+    'view'       => 'hello-world::admin.index',
+    'capability' => 'access_admin_dashboard',
+] );
+```
+
+The `view` value is a namespaced Blade view; register it with `loadViewsFrom(
+$this->pluginPath('resources/views'), 'hello-world' )` in `boot()`.
+
+Federated ( React ) version — same helper, use `component` instead of `view`:
+
+```php
+$this->registerAdminPage( 'hello-world', [
+    'title'     => __( 'Hello World' ),
+    'section'   => 'tools',
+    'component' => 'helloWorldAdmin/HelloWorldPanel',
+] );
+```
+
+Host apps map the `component` identifier to a real React component through
+their Module Federation loader.
+
+## Registering nav entries
+
+`registerNavEntry()` writes an entry to the framework's `PluginRegistry`; the
+host's admin shell reads it via the `ap.admin.menu` filter. Entries are
+identified by `slug` and are idempotent — repeated registrations from the same
+plugin ( e.g. under Octane workers ) overwrite instead of accumulating.
+
+You may alternatively pre-declare nav entries in `plugin.json` under `nav`.
+Programmatic registration is preferred when nav visibility depends on
+per-request state ( feature flags, tenant configuration, etc. ).
+
+## Migrations
+
+Set `"migrations": "database/migrations"` in your manifest to have the
+framework load your migrations on activation. Prefer schema-only changes;
+data seeding belongs in a separate seeder invoked via an install hook.
+
+```php
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create( 'hello_world_greetings', function ( Blueprint $table ): void {
+            $table->id();
+            $table->string( 'message' );
+            $table->timestamps();
+        } );
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists( 'hello_world_greetings' );
+    }
+};
+```
+
+## Hook subscriptions
+
+The framework's action / filter system ( `artisanpack-ui/hooks` ) is the
+primary extension seam. Register callbacks in `boot()`:
+
+```php
+addAction( 'ap.contentTypes.created', function ( $contentType ) {
+    logger()->info( 'A content type was created: ' . $contentType->slug );
+} );
+
+addFilter( 'ap.admin.contentEdit.saveData', function ( array $data, array $context ): array {
+    if ( 'post' === $context['contentType'] ) {
+        $data['metadata']['reviewed_at'] = now()->toIso8601String();
+    }
+
+    return $data;
+} );
+```
+
+Full hook reference: [`docs/Hooks-and-Events.md`](./Hooks-and-Events.md).
+
+## Registering custom field types
+
+Plugins can extend the closed `FieldType` enum through the
+`CustomFieldTypeRegistry`. Registered types become available in the admin
+custom-field-type dropdown and validate on save.
+
+```php
+apRegisterFieldType( 'map_picker', [
+    'label'              => __( 'Map Picker' ),
+    'column_type'        => 'string',
+    'validation_rules'   => ['string', 'regex:/^-?\d+\.\d+,-?\d+\.\d+$/'],
+    'editor_component'   => 'helloWorldAdmin/MapPickerEditor',
+    'renderer_component' => 'helloWorldAdmin/MapPickerRenderer',
+    'meta'               => ['icon' => 'fas.map'],
+] );
+```
+
+Filter-registered fields do not materialize a physical DB column. Their values
+live in the content record's `metadata` JSON column — the framework's
+`HasCustomFields` trait knows how to read and write them there.
+
+## Injecting edit-screen panels & tabs
+
+Host apps that build a post/page edit screen ( such as Keystone CMS ) consult
+the `ContentEditExtensions` manager to render plugin-supplied panels and tabs.
+Register from your provider's `boot()`:
+
+```php
+addFilter( 'ap.admin.contentEdit.panels', function ( array $panels ): array {
+    $panels[] = [
+        'slug'         => 'hello-world.seo',
+        'title'        => __( 'SEO' ),
+        'component'    => 'helloWorldAdmin/SeoPanel',
+        'contentTypes' => ['post', 'page'],
+        'order'        => 20,
+    ];
+
+    return $panels;
+} );
+```
+
+Filters:
+
+- `ap.admin.contentEdit.panels` — sidebar/right-column panels
+- `ap.admin.contentEdit.tabs` — tabs above the main editor
+- `ap.admin.contentEdit.beforeEditor` / `afterEditor` — blocks above/below the editor
+- `ap.admin.contentEdit.saveData` — pre-persistence transform of the save payload
+
+Entry shape: `{ slug, title, component, order?, contentTypes?, capability? }`.
+`contentTypes` accepts `['*']` for "all" or an explicit list.
+
+## Federated React modules
+
+The framework does not own the frontend, and does not ship a Module Federation
+runtime. Host apps ( e.g. Keystone CMS ) that support runtime-loaded React
+plugins consume federated modules the plugin has declared through:
+
+- **Manifest** — `federated_modules` array in `plugin.json`.
+- **Programmatic** — `$this->registerFederatedModule( $name, $entry, $exposes )` in `boot()`.
+
+An example Module Federation config, Vite build, and remoteEntry contract live
+in the Keystone CMS docs. See
+[`examples/hello-world-plugin/`](../examples/hello-world-plugin/) for a stub
+that pairs a Blade admin page with a `federated_modules` declaration that
+Keystone can consume.
+
+## Versioning & host compatibility
+
+Semver your plugin. Declare host-compatibility in `plugin.json`:
+
+```json
+"requires": {
+    "cms-framework": "^2.4",
+    "php": "^8.2"
+}
+```
+
+`PluginManager::install()` refuses installation when the running framework
+version does not satisfy the `cms-framework` constraint.
+
+## Testing your plugin
+
+Plugins ship their own Pest / PHPUnit test suites. A minimal `TestCase`
+extending Orchestra Testbench boots the framework in a testing container:
+
+```php
+use ArtisanPackUI\CMSFramework\CMSFrameworkServiceProvider;
+use HelloWorld\HelloWorldServiceProvider;
+use Orchestra\Testbench\TestCase as BaseTestCase;
+
+abstract class TestCase extends BaseTestCase
+{
+    protected function getPackageProviders( $app ): array
+    {
+        return [
+            CMSFrameworkServiceProvider::class,
+            HelloWorldServiceProvider::class,
+        ];
+    }
+}
+```
+
+Test what matters: your admin page renders, your migrations run, your hook
+subscriptions fire, and any custom field types round-trip through
+`HasCustomFields`.
+
+---
+
+Reference plugin: [`examples/hello-world-plugin/`](../examples/hello-world-plugin/).

--- a/examples/hello-world-plugin/README.md
+++ b/examples/hello-world-plugin/README.md
@@ -1,0 +1,77 @@
+# Hello World Plugin
+
+Reference plugin for the ArtisanPack UI CMS Framework. It exists to give plugin
+authors a canonical example of every extension point the framework exposes.
+
+**This is a documentation-only skeleton.** It is not installed by the framework
+and is not a Composer package. Copy the tree into your host application's
+`plugins/hello-world/` directory to explore it interactively.
+
+## What it demonstrates
+
+| Piece | File |
+| ----- | ---- |
+| Manifest schema, including `requires`, `autoload`, `nav`, `federated_modules` | [`plugin.json`](./plugin.json) |
+| Base `PluginServiceProvider` usage, admin page, nav entry, federated module | [`src/HelloWorldServiceProvider.php`](./src/HelloWorldServiceProvider.php) |
+| Custom field type registration ( `map_picker` ) via `apRegisterFieldType()` | [`src/HelloWorldServiceProvider.php`](./src/HelloWorldServiceProvider.php) |
+| Edit-screen panel registration via `ap.admin.contentEdit.panels` | [`src/HelloWorldServiceProvider.php`](./src/HelloWorldServiceProvider.php) |
+| Action-hook subscription ( `ap.contentTypes.created` ) | [`src/HelloWorldServiceProvider.php`](./src/HelloWorldServiceProvider.php) |
+| Migration path — plugin ships its own schema | [`database/migrations/`](./database/migrations/) |
+| Blade admin page | [`resources/views/admin/index.blade.php`](./resources/views/admin/index.blade.php) |
+
+## Two admin-page flavors, one plugin
+
+`plugin.json` declares BOTH a Blade admin view and a federated module the host
+can consume. The framework itself is view-layer agnostic — it hands the
+declarations to `AdminMenuManager` and `PluginRegistry`, and each host renders
+whichever flavor fits its stack.
+
+- **Blade flavor** — `registerAdminPage()` with a `view` key. Works in any
+  Laravel host today. See `resources/views/admin/index.blade.php`.
+- **Federated React flavor** — `registerFederatedModule()` +
+  `registerAdminPage()` with a `component` key. Requires a host that ships a
+  Module Federation runtime — for example, the Keystone CMS. The
+  `dist/remoteEntry.js` path referenced in `plugin.json` is intentionally
+  omitted here; Keystone's docs cover the full federated-plugin build
+  ( Vite / Module Federation config, remote-entry contract, host loader ).
+
+## Trying it in a host app
+
+1. Copy this directory into your host's `plugins/` folder ( default:
+   `base_path('plugins/hello-world')` ).
+2. Upload / activate via the admin plugin list, or seed a row into the
+   `plugins` table with `is_active = 1`.
+3. Navigate to `/admin/hello-world`. The Blade page renders.
+4. In a Module Federation host: swap the admin page's `view` for a
+   `component`, build a federated module from the `helloWorldAdmin` entry, and
+   the host loads the React panel instead.
+
+## Local testing
+
+Plugin authors typically ship their own test suite. A minimal `TestCase` looks
+like:
+
+```php
+use ArtisanPackUI\CMSFramework\CMSFrameworkServiceProvider;
+use HelloWorld\HelloWorldServiceProvider;
+use Orchestra\Testbench\TestCase as BaseTestCase;
+
+abstract class TestCase extends BaseTestCase
+{
+    protected function getPackageProviders( $app ): array
+    {
+        return [
+            CMSFrameworkServiceProvider::class,
+            HelloWorldServiceProvider::class,
+        ];
+    }
+}
+```
+
+Then write feature tests that exercise your admin page, hook subscriptions,
+and any custom field types.
+
+## Further reading
+
+- [Plugin author guide](../../docs/plugin-authoring.md)
+- [Hooks & events](../../docs/Hooks-and-Events.md)

--- a/examples/hello-world-plugin/database/migrations/2026_07_16_000000_create_hello_world_greetings_table.php
+++ b/examples/hello-world-plugin/database/migrations/2026_07_16_000000_create_hello_world_greetings_table.php
@@ -1,0 +1,24 @@
+<?php
+
+declare( strict_types=1 );
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create( 'hello_world_greetings', function ( Blueprint $table ): void {
+            $table->id();
+            $table->string( 'message' );
+            $table->timestamps();
+        } );
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists( 'hello_world_greetings' );
+    }
+};

--- a/examples/hello-world-plugin/plugin.json
+++ b/examples/hello-world-plugin/plugin.json
@@ -1,0 +1,45 @@
+{
+    "$schema": "https://artisanpack-ui.dev/schemas/plugin.json",
+    "slug": "hello-world",
+    "name": "Hello World",
+    "version": "1.0.0",
+    "description": "Reference plugin that demonstrates every extension point in the CMS Framework plugin API — admin page, nav entry, migration, custom field type, hook subscriptions, and a federated-module stub.",
+    "author": {
+        "name": "ArtisanPack UI",
+        "email": "me@jacobmartella.com",
+        "url": "https://artisanpack-ui.dev"
+    },
+    "homepage": "https://artisanpack-ui.dev/docs/plugins/hello-world",
+    "license": "MIT",
+    "service_provider": "HelloWorld\\HelloWorldServiceProvider",
+    "requires": {
+        "cms-framework": "^2.4",
+        "php": "^8.2"
+    },
+    "autoload": {
+        "psr-4": {
+            "HelloWorld\\": "src/"
+        }
+    },
+    "migrations": "database/migrations",
+    "nav": [
+        {
+            "slug": "hello-world-manifest-nav",
+            "label": "Hello (from manifest)",
+            "url": "/admin/hello-world",
+            "icon": "fas.puzzle-piece",
+            "permission": "access_admin_dashboard",
+            "order": 61
+        }
+    ],
+    "federated_modules": [
+        {
+            "name": "helloWorldAdmin",
+            "entry": "dist/remoteEntry.js",
+            "exposes": [
+                "./HelloWorldPanel",
+                "./MapPickerEditor"
+            ]
+        }
+    ]
+}

--- a/examples/hello-world-plugin/resources/views/admin/index.blade.php
+++ b/examples/hello-world-plugin/resources/views/admin/index.blade.php
@@ -1,0 +1,17 @@
+@extends('cms::admin.layouts.app')
+
+@section('title', __('Hello World'))
+
+@section('content')
+    <div class="hello-world">
+        <h1>{{ __('Hello World') }}</h1>
+
+        <p>
+            {{ __('This admin page is registered by the hello-world plugin. It uses the framework\'s Blade admin-page path.') }}
+        </p>
+
+        <p>
+            {{ __('The plugin also declares a federated_modules entry for hosts that support runtime-loaded React admin pages (see plugin.json). Blade and federated flavors coexist — the host chooses which to render based on its own capabilities.') }}
+        </p>
+    </div>
+@endsection

--- a/examples/hello-world-plugin/src/HelloWorldServiceProvider.php
+++ b/examples/hello-world-plugin/src/HelloWorldServiceProvider.php
@@ -1,0 +1,105 @@
+<?php
+
+declare( strict_types=1 );
+
+/**
+ * Hello World Plugin Service Provider.
+ *
+ * Reference implementation showing how to extend the framework's base
+ * `PluginServiceProvider` and register admin pages, nav entries, hook
+ * subscriptions, a custom field type, and an edit-screen panel.
+ *
+ * @since 1.0.0
+ */
+
+namespace HelloWorld;
+
+use ArtisanPackUI\CMSFramework\Modules\Plugins\Support\PluginServiceProvider;
+
+final class HelloWorldServiceProvider extends PluginServiceProvider
+{
+    public function register(): void
+    {
+        // Bind plugin services on the container. Nothing to bind for the
+        // reference plugin; keep the method as an anchor for real plugins.
+    }
+
+    public function boot(): void
+    {
+        $this->loadViewsFrom( $this->pluginPath( 'resources/views' ), 'hello-world' );
+
+        $this->registerAdminPage( 'hello-world', [
+            'title'      => __( 'Hello World' ),
+            'section'    => 'tools',
+            'view'       => 'hello-world::admin.index',
+            'capability' => 'access_admin_dashboard',
+            'icon'       => 'fas.puzzle-piece',
+            'order'      => 60,
+        ] );
+
+        $this->registerNavEntry( [
+            'slug'       => 'hello-world',
+            'label'      => __( 'Hello World' ),
+            'url'        => '/admin/hello-world',
+            'icon'       => 'fas.puzzle-piece',
+            'permission' => 'access_admin_dashboard',
+            'order'      => 60,
+        ] );
+
+        $this->registerFederatedModule(
+            'helloWorldAdmin',
+            $this->pluginPath( 'dist/remoteEntry.js' ),
+            ['./HelloWorldPanel', './MapPickerEditor'],
+        );
+
+        $this->registerFieldTypes();
+        $this->registerEditPanels();
+        $this->registerHookSubscriptions();
+    }
+
+    /**
+     * Add a `map_picker` field type that stores its value as a lat/lng string
+     * on the record's `metadata` JSON column.
+     */
+    protected function registerFieldTypes(): void
+    {
+        apRegisterFieldType( 'map_picker', [
+            'label'              => __( 'Map Picker' ),
+            'column_type'        => 'string',
+            'validation_rules'   => ['string', 'regex:/^-?\d+\.\d+,-?\d+\.\d+$/'],
+            'editor_component'   => 'helloWorldAdmin/MapPickerEditor',
+            'renderer_component' => 'helloWorldAdmin/MapPickerRenderer',
+            'meta'               => ['icon' => 'fas.map', 'category' => 'location'],
+        ] );
+    }
+
+    /**
+     * Add a sidebar panel to every post/page edit screen.
+     */
+    protected function registerEditPanels(): void
+    {
+        addFilter( 'ap.admin.contentEdit.panels', function ( array $panels ): array {
+            $panels[] = [
+                'slug'         => 'hello-world.notes',
+                'title'        => __( 'Hello World Notes' ),
+                'component'    => 'helloWorldAdmin/HelloWorldPanel',
+                'contentTypes' => ['post', 'page'],
+                'order'        => 45,
+                'capability'   => 'access_admin_dashboard',
+            ];
+
+            return $panels;
+        } );
+    }
+
+    /**
+     * Log a friendly greeting whenever a content type is created — the smallest
+     * possible demonstration of a plugin subscribing to a framework hook.
+     */
+    protected function registerHookSubscriptions(): void
+    {
+        addAction( 'ap.contentTypes.created', static function ( $contentType ): void {
+            logger()->info( 'Hello World says hi to a new content type: ' . $contentType->slug );
+        } );
+    }
+}

--- a/src/CMSFrameworkServiceProvider.php
+++ b/src/CMSFrameworkServiceProvider.php
@@ -28,6 +28,7 @@ use ArtisanPackUI\CMSFramework\Modules\Blog\Providers\BlogServiceProvider;
 use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Managers\ContentTypeManager;
 use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Providers\ContentTypesServiceProvider;
 use ArtisanPackUI\CMSFramework\Modules\Core\Providers\CoreServiceProvider;
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Providers\DynamicContentServiceProvider;
 use ArtisanPackUI\CMSFramework\Modules\Notifications\Providers\NotificationServiceProvider;
 use ArtisanPackUI\CMSFramework\Modules\OpenApi\Providers\OpenApiServiceProvider;
 use ArtisanPackUI\CMSFramework\Modules\Pages\Models\Page;
@@ -236,6 +237,7 @@ class CMSFrameworkServiceProvider extends ServiceProvider
         $this->app->register( SettingsServiceProvider::class );
         $this->app->register( NotificationServiceProvider::class );
         $this->app->register( ContentTypesServiceProvider::class );
+        $this->app->register( DynamicContentServiceProvider::class );
         $this->app->register( BlogServiceProvider::class );
         $this->app->register( PagesServiceProvider::class );
         $this->app->register( ThemesServiceProvider::class );

--- a/src/Modules/Admin/Managers/AdminMenuManager.php
+++ b/src/Modules/Admin/Managers/AdminMenuManager.php
@@ -11,6 +11,8 @@ declare( strict_types=1 );
 namespace ArtisanPackUI\CMSFramework\Modules\Admin\Managers;
 
 use Illuminate\Support\Facades\Gate;
+use Illuminate\Support\Facades\Route;
+use Throwable;
 
 /**
  * Manages the registration and structure of the admin navigation menu.
@@ -83,7 +85,12 @@ class AdminMenuManager
             'icon'       => $options['icon'],
             'capability' => $options['capability'],
             'order'      => $options['order'],
-            'route'      => 'admin.' . $slug,
+            // Route names replace slashes with dots to match what
+            // AdminPageManager::registerRoutes actually names the Laravel
+            // route, so Route::has() lookups (and the decorated `url` field)
+            // resolve correctly for multi-segment slugs like
+            // `packages/visual-editor`.
+            'route'      => 'admin.' . str_replace( '/', '.', $slug ),
             'menuTitle'  => $options['menuTitle'],
         ];
 
@@ -189,8 +196,18 @@ class AdminMenuManager
                 uasort( $item['subItems'], fn ( $a, $b ) => $a['order'] <=> $b['order'] );
             }
         }
+        unset( $item );
 
-        return array_merge( $topLevelItems, $menu );
+        $menu = $this->decorateMenuForConsumers( array_merge( $topLevelItems, $menu ) );
+
+        $menu = applyFilters( 'ap.admin.menu', $menu );
+
+        // Defense-in-depth: re-apply capability filtering AFTER the filter
+        // runs so plugin-injected entries can't bypass the Gate check that
+        // native items go through above. Filter subscribers can push in new
+        // rows freely, but any row declaring a `permission`/`capability` gets
+        // hidden from users who lack it.
+        return $this->enforceCapabilities( $menu );
     }
 
     /**
@@ -205,5 +222,171 @@ class AdminMenuManager
     public function getPageBySlug( string $slug ): ?array
     {
         return $this->items[ $slug ] ?? null;
+    }
+
+    /**
+     * Recursively drop any menu node whose `permission` (or legacy
+     * `capability`) the current user does not hold. Applied after the
+     * `ap.admin.menu` filter so filter-injected entries are gated too.
+     *
+     * @param  array  $menu  The (already-decorated) menu.
+     *
+     * @return array The gated menu.
+     */
+    protected function enforceCapabilities( array $menu ): array
+    {
+        $allowed = [];
+        foreach ( $menu as $key => $node ) {
+            $ability = $node['permission'] ?? ( $node['capability'] ?? null );
+            if ( ! empty( $ability ) && ! Gate::allows( $ability ) ) {
+                continue;
+            }
+
+            if ( isset( $node['items'] ) && is_array( $node['items'] ) ) {
+                $node['items'] = $this->enforceCapabilities( $node['items'] );
+                // Drop sections that end up empty after filtering.
+                if ( empty( $node['items'] ) ) {
+                    continue;
+                }
+            }
+            if ( isset( $node['subItems'] ) && is_array( $node['subItems'] ) ) {
+                $node['subItems'] = $this->enforceCapabilities( $node['subItems'] );
+            }
+
+            $allowed[ $key ] = $node;
+        }
+
+        return $allowed;
+    }
+
+    /**
+     * Add React/Inertia-friendly fields (url, label, iconId, permission, external)
+     * to each menu row while keeping the existing keys for Blade hosts.
+     *
+     * @param  array  $menu  The structured menu.
+     *
+     * @return array The decorated menu.
+     */
+    protected function decorateMenuForConsumers( array $menu ): array
+    {
+        foreach ( $menu as $key => &$node ) {
+            if ( isset( $node['items'] ) && is_array( $node['items'] ) ) {
+                $node['items'] = $this->decorateMenuForConsumers( $node['items'] );
+                continue;
+            }
+
+            $node = $this->decorateItem( $node );
+
+            if ( ! empty( $node['subItems'] ) ) {
+                $node['subItems'] = $this->decorateMenuForConsumers( $node['subItems'] );
+            }
+        }
+
+        return $menu;
+    }
+
+    /**
+     * Resolve consumer-friendly fields for a single menu item.
+     *
+     * @param  array  $item  The menu item as stored in $this->items.
+     *
+     * @return array The item enriched with url/label/iconId/permission/external.
+     */
+    protected function decorateItem( array $item ): array
+    {
+        if ( ! isset( $item['route'] ) ) {
+            return $item;
+        }
+
+        if ( ! isset( $item['url'] ) ) {
+            $item['url'] = $this->resolveRouteUrl( $item['route'], $item['external'] ?? null );
+        } elseif ( is_string( $item['url'] ) ) {
+            // A filter subscriber (e.g. registerNavEntry) may pre-set `url`.
+            // Sanitize regardless so `javascript:` URIs never reach the nav
+            // renderer.
+            $item['url'] = $this->sanitizeExternalUrl( $item['url'] );
+        }
+
+        if ( ! isset( $item['label'] ) ) {
+            $item['label'] = $item['menuTitle'] ?? $item['title'] ?? '';
+        }
+
+        if ( ! isset( $item['iconId'] ) && isset( $item['icon'] ) ) {
+            $item['iconId'] = $item['icon'];
+        }
+
+        if ( ! isset( $item['permission'] ) && ! empty( $item['capability'] ) ) {
+            $item['permission'] = $item['capability'];
+        }
+
+        if ( ! array_key_exists( 'external', $item ) ) {
+            $item['external'] = false;
+        }
+
+        return $item;
+    }
+
+    /**
+     * Resolve a route name to a URL. Falls back to '#' when the route is not
+     * registered (common in test contexts or before admin routes are booted).
+     *
+     * External URLs are only trusted when their scheme is safe — any plugin
+     * or filter subscriber setting a `javascript:` / `data:` / `vbscript:`
+     * URL would otherwise reach the admin nav's `<a href>` and execute in
+     * the authenticated admin session.
+     */
+    protected function resolveRouteUrl( string $routeName, ?bool $external = null ): string
+    {
+        if ( true === $external ) {
+            return $this->sanitizeExternalUrl( $routeName );
+        }
+
+        try {
+            if ( Route::has( $routeName ) ) {
+                return route( $routeName );
+            }
+        } catch ( Throwable $e ) {
+            // Fall through to the safe default below.
+        }
+
+        return '#';
+    }
+
+    /**
+     * Allow only navigation-safe URL forms:
+     *   - Absolute http(s) URLs
+     *   - Same-origin relative URLs (starting with '/')
+     *   - Hash fragments (starting with '#')
+     *
+     * Anything else (javascript:, data:, vbscript:, file:, etc.) collapses to
+     * '#'. Prevents plugin authors from injecting XSS vectors into the admin
+     * sidebar via `registerNavEntry(['external' => true, 'url' => ...])`.
+     */
+    protected function sanitizeExternalUrl( string $url ): string
+    {
+        $trimmed = trim( $url );
+        if ( '' === $trimmed ) {
+            return '#';
+        }
+
+        if ( str_starts_with( $trimmed, '/' ) || str_starts_with( $trimmed, '#' ) ) {
+            return $trimmed;
+        }
+
+        // Match absolute URLs with an explicit scheme.
+        if ( 1 === preg_match( '#^([a-zA-Z][a-zA-Z0-9+.\-]*):#', $trimmed, $matches ) ) {
+            $scheme = strtolower( $matches[1] );
+            if ( in_array( $scheme, ['http', 'https', 'mailto', 'tel'], true ) ) {
+                return $trimmed;
+            }
+
+            logger()->warning( "AdminMenuManager: refused unsafe URL scheme '{$scheme}' in nav entry." );
+
+            return '#';
+        }
+
+        // Scheme-less values that aren't obviously a path — treat as safe
+        // relative reference (e.g., 'docs/index.html').
+        return $trimmed;
     }
 }

--- a/src/Modules/ContentTypes/Http/Requests/CustomFieldRequest.php
+++ b/src/Modules/ContentTypes/Http/Requests/CustomFieldRequest.php
@@ -14,7 +14,7 @@ declare( strict_types=1 );
 namespace ArtisanPackUI\CMSFramework\Modules\ContentTypes\Http\Requests;
 
 use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Enums\ColumnType;
-use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Enums\FieldType;
+use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Registries\CustomFieldTypeRegistry;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
 
@@ -68,7 +68,7 @@ class CustomFieldRequest extends FormRequest
             'type' => [
                 'required',
                 'string',
-                FieldType::validationRule(),
+                Rule::in( app( CustomFieldTypeRegistry::class )->slugs() ),
             ],
             'column_type' => [
                 'required',

--- a/src/Modules/ContentTypes/Managers/ContentEditExtensions.php
+++ b/src/Modules/ContentTypes/Managers/ContentEditExtensions.php
@@ -1,0 +1,182 @@
+<?php
+
+declare( strict_types=1 );
+
+/**
+ * ContentEditExtensions Manager.
+ *
+ * Extensibility seam around the post/page edit render pipeline. Host apps
+ * consume the merged data structures returned from these methods to render
+ * plugin-supplied panels, tabs, before/after-editor content, and to intercept
+ * save payloads before persistence.
+ *
+ * The framework does not render any of these itself — it only fires the
+ * filters and normalizes the shapes so hosts and plugins agree on the contract.
+ *
+ * @since 2.4.0
+ */
+
+namespace ArtisanPackUI\CMSFramework\Modules\ContentTypes\Managers;
+
+/**
+ * Aggregates plugin-registered edit-screen extensions.
+ *
+ * @since 2.4.0
+ */
+class ContentEditExtensions
+{
+    /**
+     * Return sidebar/right-column panel definitions applicable to the given
+     * content type. Plugins add panels by returning an array of shapes from the
+     * `ap.admin.contentEdit.panels` filter.
+     *
+     * Each panel: `slug`, `title`, `component`, optional `position`
+     * ( `top`/`bottom`/`default` ), optional `order`, optional
+     * `contentTypes` ( array of slugs — `['*']` for all, defaults to `['*']` ),
+     * optional `capability` ( permission gate applied by the host ).
+     *
+     * @since 2.4.0
+     *
+     * @param  array<string,mixed>  $context  Context passed through to filters.
+     *
+     * @return array<int,array<string,mixed>>
+     */
+    public function panels( array $context ): array
+    {
+        return $this->collect( 'ap.admin.contentEdit.panels', $context );
+    }
+
+    /**
+     * Return tab definitions rendered above the main editor column.
+     *
+     * Each tab: `slug`, `title`, `component`, optional `order`, optional
+     * `contentTypes`, optional `capability`.
+     *
+     * @since 2.4.0
+     *
+     * @param  array<string,mixed>  $context
+     *
+     * @return array<int,array<string,mixed>>
+     */
+    public function tabs( array $context ): array
+    {
+        return $this->collect( 'ap.admin.contentEdit.tabs', $context );
+    }
+
+    /**
+     * Return content-block definitions rendered above the main editor column.
+     *
+     * @since 2.4.0
+     *
+     * @param  array<string,mixed>  $context
+     *
+     * @return array<int,array<string,mixed>>
+     */
+    public function beforeEditor( array $context ): array
+    {
+        return $this->collect( 'ap.admin.contentEdit.beforeEditor', $context );
+    }
+
+    /**
+     * Return content-block definitions rendered below the main editor column.
+     *
+     * @since 2.4.0
+     *
+     * @param  array<string,mixed>  $context
+     *
+     * @return array<int,array<string,mixed>>
+     */
+    public function afterEditor( array $context ): array
+    {
+        return $this->collect( 'ap.admin.contentEdit.afterEditor', $context );
+    }
+
+    /**
+     * Filter incoming save data before the host persists it. Plugins can wash,
+     * validate, or annotate the payload. The return value replaces `$data`.
+     *
+     * @since 2.4.0
+     *
+     * @param  array<string,mixed>  $data
+     * @param  array<string,mixed>  $context
+     *
+     * @return array<string,mixed>
+     */
+    public function saveData( array $data, array $context ): array
+    {
+        $filtered = applyFilters( 'ap.admin.contentEdit.saveData', $data, $context );
+
+        return is_array( $filtered ) ? $filtered : $data;
+    }
+
+    /**
+     * Fetch, normalize, filter by content type, and order a list of items from
+     * one of the panel/tab/block filters.
+     *
+     * @since 2.4.0
+     *
+     * @param  array<string,mixed>  $context
+     *
+     * @return array<int,array<string,mixed>>
+     */
+    protected function collect( string $hook, array $context ): array
+    {
+        $raw = applyFilters( $hook, [], $context );
+
+        if ( ! is_array( $raw ) ) {
+            return [];
+        }
+
+        $contentType = isset( $context['contentType'] ) ? ( string ) $context['contentType'] : null;
+        $out         = [];
+
+        foreach ( $raw as $entry ) {
+            if ( ! is_array( $entry ) ) {
+                continue;
+            }
+            if ( ! isset( $entry['slug'], $entry['component'] ) ) {
+                continue;
+            }
+            if ( ! $this->matchesContentType( $entry, $contentType ) ) {
+                continue;
+            }
+
+            $entry['order'] = ( int ) ( $entry['order'] ?? 50 );
+            $out[]          = $entry;
+        }
+
+        usort( $out, static fn ( array $a, array $b ): int => $a['order'] <=> $b['order'] );
+
+        return $out;
+    }
+
+    /**
+     * Whether an entry's `contentTypes` restriction admits the requested
+     * content type. Missing key or a `'*'` wildcard means "always applies".
+     *
+     * @since 2.4.0
+     *
+     * @param  array<string,mixed>  $entry
+     */
+    protected function matchesContentType( array $entry, ?string $contentType ): bool
+    {
+        if ( ! isset( $entry['contentTypes'] ) ) {
+            return true;
+        }
+
+        $allowed = $entry['contentTypes'];
+        if ( ! is_array( $allowed ) || [] === $allowed ) {
+            return true;
+        }
+
+        if ( in_array( '*', $allowed, true ) ) {
+            return true;
+        }
+
+        if ( null === $contentType ) {
+            return false;
+        }
+
+        return in_array( $contentType, $allowed, true );
+    }
+}

--- a/src/Modules/ContentTypes/Managers/ContentTypeManager.php
+++ b/src/Modules/ContentTypes/Managers/ContentTypeManager.php
@@ -22,6 +22,23 @@ use Exception;
  */
 class ContentTypeManager
 {
+
+    /**
+     * Persistence-critical keys a plugin must never be able to seed via the
+     * `ap.contentTypes.registeredContentTypes` filter. Blocking them at
+     * hydration time keeps a filter payload from carrying primary keys or
+     * soft-delete timestamps that would collide with real DB rows or steer
+     * downstream persistence.
+     *
+     * @var array<int,string>
+     */
+    protected const FILTER_HYDRATION_BLOCKLIST = [
+        'id',
+        'created_at',
+        'updated_at',
+        'deleted_at',
+    ];
+
     /**
      * Register a content type programmatically.
      *
@@ -82,11 +99,40 @@ class ContentTypeManager
     /**
      * Get a specific content type by slug.
      *
+     * Checks the database first; falls back to filter-registered content types,
+     * hydrated into an unpersisted `ContentType` model so callers can treat both
+     * sources uniformly. Filter-only entries have no primary key — callers that
+     * need to persist them should re-create via `createContentType()`.
+     *
      * @since 1.0.0
      *
      * @param  string  $slug  Content type slug.
      */
     public function getContentType( string $slug ): ?ContentType
+    {
+        $slug = sanitizeText( $slug );
+
+        $contentType = ContentType::where( 'slug', $slug )->first();
+        if ( $contentType ) {
+            return $contentType;
+        }
+
+        return $this->hydrateFilterContentType( $slug );
+    }
+
+    /**
+     * Get a specific content type by slug, restricted to database-persisted
+     * rows. Never returns a filter-hydrated model.
+     *
+     * Use this instead of `getContentType()` in privileged paths that trust
+     * the returned model's `table_name` — schema mutations, migration
+     * generation, or anything that writes to the database on behalf of the
+     * content type. Filter-registered content types can carry plugin-supplied
+     * `table_name` values and must not steer such operations.
+     *
+     * @since 2.4.0
+     */
+    public function getPersistedContentType( string $slug ): ?ContentType
     {
         return ContentType::where( 'slug', sanitizeText( $slug ) )->first();
     }
@@ -126,7 +172,10 @@ class ContentTypeManager
      */
     public function updateContentType( string $slug, array $data ): ContentType
     {
-        $contentType = $this->getContentType( $slug );
+        // Persisted-only lookup — filter-registered content types have no DB
+        // row and would silently INSERT a phantom row on `update()` because
+        // Eloquent runs performInsert() when `exists === false`.
+        $contentType = $this->getPersistedContentType( $slug );
 
         if ( ! $contentType ) {
             throw new Exception( "Content type {$slug} not found." );
@@ -157,7 +206,11 @@ class ContentTypeManager
      */
     public function deleteContentType( string $slug ): bool
     {
-        $contentType = $this->getContentType( $slug );
+        // Persisted-only lookup — Eloquent `delete()` on an `exists=false`
+        // model is a no-op, so passing a filter-only slug here would return
+        // false but skip firing the `ap.contentTypes.deleted` hook. Keep the
+        // legacy "false == not found" contract by refusing the call outright.
+        $contentType = $this->getPersistedContentType( $slug );
 
         if ( ! $contentType ) {
             return false;
@@ -201,6 +254,38 @@ class ContentTypeManager
      */
     public function contentTypeExists( string $slug ): bool
     {
-        return ContentType::where( 'slug', sanitizeText( $slug ) )->exists();
+        $slug = sanitizeText( $slug );
+
+        if ( ContentType::where( 'slug', $slug )->exists() ) {
+            return true;
+        }
+
+        return null !== $this->hydrateFilterContentType( $slug );
+    }
+
+    /**
+     * Look up a filter-registered content type by slug and hydrate it into an
+     * unpersisted `ContentType` model. Returns null if no filter entry matches.
+     *
+     * @since 2.4.0
+     */
+    protected function hydrateFilterContentType( string $slug ): ?ContentType
+    {
+        $filtered = applyFilters( 'ap.contentTypes.registeredContentTypes', [] );
+
+        if ( ! is_array( $filtered ) || ! isset( $filtered[ $slug ] ) || ! is_array( $filtered[ $slug ] ) ) {
+            return null;
+        }
+
+        $args = array_diff_key( $filtered[ $slug ], array_flip( self::FILTER_HYDRATION_BLOCKLIST ) );
+        if ( ! isset( $args['slug'] ) ) {
+            $args['slug'] = $slug;
+        }
+
+        $model = new ContentType;
+        $model->forceFill( $args );
+        $model->exists = false;
+
+        return $model;
     }
 }

--- a/src/Modules/ContentTypes/Managers/CustomFieldManager.php
+++ b/src/Modules/ContentTypes/Managers/CustomFieldManager.php
@@ -64,9 +64,17 @@ class CustomFieldManager
      */
     public function getFieldsForContentType( string $contentType ): Collection
     {
-        return CustomField::whereJsonContains( 'content_types', $contentType )
+        $dbFields = CustomField::whereJsonContains( 'content_types', $contentType )
             ->orderBy( 'order' )
             ->get();
+
+        $filterFields = $this->filterFieldsForContentType( $contentType, $dbFields->pluck( 'key' )->all() );
+
+        if ( $filterFields->isEmpty() ) {
+            return $dbFields;
+        }
+
+        return $dbFields->concat( $filterFields )->values();
     }
 
     /**
@@ -81,9 +89,11 @@ class CustomFieldManager
         $field = DB::transaction( function () use ( $data ) {
             $field = CustomField::create( $data );
 
-            // Add columns to content type tables
+            // Add columns to content type tables. Restricted to DB-persisted
+            // content types so a plugin's filter-registered `table_name` can
+            // never steer Schema::table at an arbitrary host table.
             foreach ( $field->content_types as $contentTypeSlug ) {
-                $contentType = app( ContentTypeManager::class )->getContentType( $contentTypeSlug );
+                $contentType = app( ContentTypeManager::class )->getPersistedContentType( $contentTypeSlug );
                 if ( $contentType ) {
                     $this->addColumnToTable( $field, $contentType->table_name );
                 }
@@ -128,17 +138,19 @@ class CustomFieldManager
                 $addedTypes      = array_diff( $newContentTypes, $oldContentTypes );
                 $removedTypes    = array_diff( $oldContentTypes, $newContentTypes );
 
-                // Add columns to new content types
+                // Add columns to new content types. Restricted to DB-persisted
+                // content types ( see createField() ) to prevent plugin-supplied
+                // `table_name` values from steering Schema::table.
                 foreach ( $addedTypes as $contentTypeSlug ) {
-                    $contentType = app( ContentTypeManager::class )->getContentType( $contentTypeSlug );
+                    $contentType = app( ContentTypeManager::class )->getPersistedContentType( $contentTypeSlug );
                     if ( $contentType ) {
                         $this->addColumnToTable( $field, $contentType->table_name );
                     }
                 }
 
-                // Remove columns from removed content types
+                // Remove columns from removed content types.
                 foreach ( $removedTypes as $contentTypeSlug ) {
-                    $contentType = app( ContentTypeManager::class )->getContentType( $contentTypeSlug );
+                    $contentType = app( ContentTypeManager::class )->getPersistedContentType( $contentTypeSlug );
                     if ( $contentType ) {
                         $this->removeColumnFromTable( $field, $contentType->table_name );
                     }
@@ -188,9 +200,11 @@ class CustomFieldManager
             $deleted = $field->delete();
 
             if ( $deleted ) {
-                // Remove columns from content type tables
+                // Remove columns from content type tables. DB-only lookup
+                // matches the createField() / updateField() paths so we
+                // never dropColumn against a plugin-supplied `table_name`.
                 foreach ( $field->content_types as $contentTypeSlug ) {
-                    $contentType = app( ContentTypeManager::class )->getContentType( $contentTypeSlug );
+                    $contentType = app( ContentTypeManager::class )->getPersistedContentType( $contentTypeSlug );
                     if ( $contentType ) {
                         $this->removeColumnFromTable( $field, $contentType->table_name );
                     }
@@ -316,6 +330,64 @@ class CustomFieldManager
     }
 
     /**
+     * Hydrate filter-registered custom fields into unpersisted `CustomField`
+     * models for the given content type. DB rows always win on key collisions.
+     *
+     * Filter-registered fields carry the `storage = 'metadata'` flag so
+     * `HasCustomFields` knows to read/write through the model's `metadata`
+     * JSON column rather than a physical column that doesn't exist.
+     *
+     * @since 2.4.0
+     *
+     * @param  array<int,string>  $excludeKeys
+     */
+    protected function filterFieldsForContentType( string $contentType, array $excludeKeys ): Collection
+    {
+        $filtered = applyFilters( 'ap.contentTypes.registeredCustomFields', [] );
+        $out      = collect();
+
+        if ( ! is_array( $filtered ) ) {
+            return $out;
+        }
+
+        foreach ( $filtered as $key => $args ) {
+            if ( ! is_array( $args ) ) {
+                continue;
+            }
+            $resolvedKey = ( string ) ( $args['key'] ?? $key );
+
+            if ( in_array( $resolvedKey, $excludeKeys, true ) ) {
+                continue;
+            }
+
+            $contentTypes = ( array ) ( $args['content_types'] ?? [] );
+            if ( ! in_array( $contentType, $contentTypes, true ) ) {
+                continue;
+            }
+
+            $args['key']     = $resolvedKey;
+            $args['storage'] = $args['storage'] ?? 'metadata';
+
+            // Strip persistence-critical keys so a plugin cannot seed `id`
+            // or timestamps onto the hydrated CustomField model.
+            $args = array_diff_key( $args, array_flip( [
+                'id',
+                'created_at',
+                'updated_at',
+                'deleted_at',
+            ] ) );
+
+            $field         = new CustomField;
+            $field->forceFill( $args );
+            $field->exists = false;
+
+            $out->push( $field );
+        }
+
+        return $out->sortBy( fn ( CustomField $field ) => $field->order ?? 0 )->values();
+    }
+
+    /**
      * Get the migration stub content.
      *
      * @since 1.0.0
@@ -326,9 +398,12 @@ class CustomFieldManager
      */
     protected function getMigrationStub( CustomField $field, string $action, string $className ): string
     {
+        // DB-only lookup: the generated migration writes literal `table_name`
+        // values into a Schema::table() call, so we must never emit a
+        // plugin-supplied table name from a filter registration.
         $tables = [];
         foreach ( $field->content_types as $contentTypeSlug ) {
-            $contentType = app( ContentTypeManager::class )->getContentType( $contentTypeSlug );
+            $contentType = app( ContentTypeManager::class )->getPersistedContentType( $contentTypeSlug );
             if ( $contentType ) {
                 $tables[] = $contentType->table_name;
             }

--- a/src/Modules/ContentTypes/Managers/TaxonomyManager.php
+++ b/src/Modules/ContentTypes/Managers/TaxonomyManager.php
@@ -89,7 +89,34 @@ class TaxonomyManager
      */
     public function getTaxonomiesForContentType( string $contentTypeSlug ): Collection
     {
-        return Taxonomy::where( 'content_type_slug', sanitizeText( $contentTypeSlug ) )->get();
+        $contentTypeSlug = sanitizeText( $contentTypeSlug );
+
+        $dbTaxonomies = Taxonomy::where( 'content_type_slug', $contentTypeSlug )->get();
+
+        $filtered = applyFilters( 'ap.taxonomies.registeredTaxonomies', [] );
+        if ( ! is_array( $filtered ) ) {
+            return $dbTaxonomies;
+        }
+
+        $existingSlugs = $dbTaxonomies->pluck( 'slug' )->all();
+
+        foreach ( $filtered as $slug => $args ) {
+            if ( ! is_array( $args ) ) {
+                continue;
+            }
+            if ( ! isset( $args['content_type_slug'] ) || $args['content_type_slug'] !== $contentTypeSlug ) {
+                continue;
+            }
+            $resolvedSlug = ( string ) ( $args['slug'] ?? $slug );
+            if ( in_array( $resolvedSlug, $existingSlugs, true ) ) {
+                continue;
+            }
+
+            $args['slug'] = $resolvedSlug;
+            $dbTaxonomies->push( $this->hydrateTaxonomyFromArgs( $args ) );
+        }
+
+        return $dbTaxonomies;
     }
 
     /**
@@ -101,17 +128,48 @@ class TaxonomyManager
      */
     public function taxonomyExists( string $slug ): bool
     {
-        return Taxonomy::where( 'slug', sanitizeText( $slug ) )->exists();
+        $slug = sanitizeText( $slug );
+
+        if ( Taxonomy::where( 'slug', $slug )->exists() ) {
+            return true;
+        }
+
+        return null !== $this->hydrateFilterTaxonomy( $slug );
     }
 
     /**
      * Get a specific taxonomy by slug.
+     *
+     * Checks the database first; falls back to filter-registered taxonomies,
+     * hydrated into an unpersisted `Taxonomy` model so callers can treat both
+     * sources uniformly.
      *
      * @since 1.0.0
      *
      * @param  string  $slug  Taxonomy slug.
      */
     public function getTaxonomy( string $slug ): ?Taxonomy
+    {
+        $slug = sanitizeText( $slug );
+
+        $taxonomy = Taxonomy::where( 'slug', $slug )->first();
+        if ( $taxonomy ) {
+            return $taxonomy;
+        }
+
+        return $this->hydrateFilterTaxonomy( $slug );
+    }
+
+    /**
+     * Get a specific taxonomy by slug, restricted to database-persisted rows.
+     * Never returns a filter-hydrated model.
+     *
+     * Use this in privileged paths (update, delete, migration generation)
+     * where the returned model must correspond to a real DB row.
+     *
+     * @since 2.4.0
+     */
+    public function getPersistedTaxonomy( string $slug ): ?Taxonomy
     {
         return Taxonomy::where( 'slug', sanitizeText( $slug ) )->first();
     }
@@ -151,7 +209,10 @@ class TaxonomyManager
      */
     public function updateTaxonomy( string $slug, array $data ): Taxonomy
     {
-        $taxonomy = $this->getTaxonomy( $slug );
+        // Persisted-only lookup — a filter-registered taxonomy would silently
+        // INSERT a phantom row on `update()` because Eloquent runs
+        // performInsert() when `exists === false`.
+        $taxonomy = $this->getPersistedTaxonomy( $slug );
 
         if ( ! $taxonomy ) {
             throw new Exception( "Taxonomy {$slug} not found." );
@@ -182,7 +243,11 @@ class TaxonomyManager
      */
     public function deleteTaxonomy( string $slug ): bool
     {
-        $taxonomy = $this->getTaxonomy( $slug );
+        // Persisted-only lookup so we never no-op `delete()` on an
+        // `exists=false` filter-hydrated model ( which would return false
+        // AND skip firing the `ap.taxonomies.deleted` hook, breaking the
+        // legacy "false == not found" contract ).
+        $taxonomy = $this->getPersistedTaxonomy( $slug );
 
         if ( ! $taxonomy ) {
             return false;
@@ -215,5 +280,54 @@ class TaxonomyManager
         }
 
         return $deleted;
+    }
+
+    /**
+     * Look up a filter-registered taxonomy by slug and hydrate it into an
+     * unpersisted `Taxonomy` model. Returns null if no filter entry matches.
+     *
+     * @since 2.4.0
+     */
+    protected function hydrateFilterTaxonomy( string $slug ): ?Taxonomy
+    {
+        $filtered = applyFilters( 'ap.taxonomies.registeredTaxonomies', [] );
+
+        if ( ! is_array( $filtered ) || ! isset( $filtered[ $slug ] ) || ! is_array( $filtered[ $slug ] ) ) {
+            return null;
+        }
+
+        $args = $filtered[ $slug ];
+        if ( ! isset( $args['slug'] ) ) {
+            $args['slug'] = $slug;
+        }
+
+        return $this->hydrateTaxonomyFromArgs( $args );
+    }
+
+    /**
+     * Hydrate an unpersisted `Taxonomy` model from a raw args array.
+     *
+     * Strips persistence-critical keys before `forceFill()` so a plugin can
+     * never seed `id`, `created_at`, `updated_at`, or `deleted_at` via the
+     * `ap.taxonomies.registeredTaxonomies` filter.
+     *
+     * @since 2.4.0
+     *
+     * @param  array<string,mixed>  $args
+     */
+    protected function hydrateTaxonomyFromArgs( array $args ): Taxonomy
+    {
+        $args = array_diff_key( $args, array_flip( [
+            'id',
+            'created_at',
+            'updated_at',
+            'deleted_at',
+        ] ) );
+
+        $model = new Taxonomy;
+        $model->forceFill( $args );
+        $model->exists = false;
+
+        return $model;
     }
 }

--- a/src/Modules/ContentTypes/Models/Concerns/HasCustomFields.php
+++ b/src/Modules/ContentTypes/Models/Concerns/HasCustomFields.php
@@ -13,16 +13,44 @@ declare( strict_types=1 );
 namespace ArtisanPackUI\CMSFramework\Modules\ContentTypes\Models\Concerns;
 
 use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Managers\CustomFieldManager;
-use Exception;
+use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Models\CustomField;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Schema;
+use RuntimeException;
+use Throwable;
 
 /**
  * Trait for adding custom fields support to models.
+ *
+ * DB-registered fields ( storage = `column` ) resolve through the model's
+ * physical column. Filter-registered fields ( storage = `metadata` ) resolve
+ * through the model's `metadata` JSON column, falling back to `default_value`.
+ *
+ * Models using filter-registered custom fields must expose a `metadata` JSON
+ * attribute cast to `array` — Post, Page, and any host content type intending
+ * to accept plugin-registered custom fields should follow that convention.
  *
  * @since 1.0.0
  */
 trait HasCustomFields
 {
+    /**
+     * Per-model-class cache of the real DB columns for the model's table.
+     * Populated on first read so we never mistake a real column for a
+     * plugin-registered custom-field key.
+     *
+     * @var array<class-string,array<int,string>>
+     */
+    protected static array $customFieldsRealColumnsCache = [];
+
+    /**
+     * Per-instance cache of the custom-field collection for this model's
+     * content type. Cleared implicitly when the instance is destroyed.
+     *
+     * @var Collection<int,CustomField>|null
+     */
+    protected ?Collection $customFieldsCache = null;
+
     /**
      * Magic getter for custom field values.
      *
@@ -34,22 +62,21 @@ trait HasCustomFields
      */
     public function __get( $key )
     {
-        // First try to get the attribute from the parent
-        try {
-            return parent::__get( $key );
-        } catch ( Exception $e ) {
-            // If it doesn't exist, check if it's a custom field
-            $customFields = $this->getCustomFieldsForType();
+        $field = $this->findCustomFieldByKey( $key );
 
-            foreach ( $customFields as $field ) {
-                if ( $field->key === $key ) {
-                    return $this->attributes[ $key ] ?? $field->default_value;
-                }
-            }
+        if ( null !== $field && 'metadata' === $field->storageMode() ) {
+            $metadata = ( array ) ( $this->getAttribute( 'metadata' ) ?? [] );
 
-            // If not a custom field, throw the original exception
-            throw $e;
+            return array_key_exists( $key, $metadata ) ? $metadata[ $key ] : $field->default_value;
         }
+
+        $value = parent::__get( $key );
+
+        if ( null === $value && null !== $field && 'column' === $field->storageMode() ) {
+            return $field->default_value;
+        }
+
+        return $value;
     }
 
     /**
@@ -62,33 +89,168 @@ trait HasCustomFields
      */
     public function __set( $key, $value ): void
     {
-        // Check if it's a custom field
-        $customFields  = $this->getCustomFieldsForType();
-        $isCustomField = false;
+        $field = $this->findCustomFieldByKey( $key );
 
-        foreach ( $customFields as $field ) {
-            if ( $field->key === $key ) {
-                $isCustomField = true;
-                break;
-            }
+        if ( null !== $field && 'metadata' === $field->storageMode() ) {
+            $this->assertMetadataColumnAvailable( $key );
+
+            $metadata         = ( array ) ( $this->getAttribute( 'metadata' ) ?? [] );
+            $metadata[ $key ] = $value;
+            $this->setAttribute( 'metadata', $metadata );
+
+            return;
         }
 
-        if ( $isCustomField ) {
-            $this->attributes[ $key ] = $value;
-        } else {
-            parent::__set( $key, $value );
-        }
+        parent::__set( $key, $value );
     }
 
     /**
-     * Get the custom fields for the content type.
+     * Get the custom fields for the content type. Memoized per instance so a
+     * single Blade render / JSON serialization doesn't re-run the DB query on
+     * every unknown attribute access.
      *
      * @since 1.0.0
      */
     public function getCustomFieldsForType(): Collection
     {
-        $contentType = $this->getTable();
+        if ( null !== $this->customFieldsCache ) {
+            return $this->customFieldsCache;
+        }
 
-        return app( CustomFieldManager::class )->getFieldsForContentType( $contentType );
+        return $this->customFieldsCache = app( CustomFieldManager::class )
+            ->getFieldsForContentType( $this->getTable() );
+    }
+
+    /**
+     * Clear the per-instance memoized custom-field list. Called automatically
+     * on save/delete via Eloquent's model events; hosts can call it manually
+     * after registering a new filter-scoped field mid-request.
+     *
+     * @since 2.4.0
+     */
+    public function flushCustomFieldsCache(): void
+    {
+        $this->customFieldsCache = null;
+    }
+
+    /**
+     * Wire up Eloquent model events so the memoized custom-field list is
+     * flushed at the right lifecycle points.
+     *
+     * @since 2.4.0
+     */
+    protected static function bootHasCustomFields(): void
+    {
+        static::saved( fn ( $model ) => $model->flushCustomFieldsCache() );
+        static::deleted( fn ( $model ) => $model->flushCustomFieldsCache() );
+    }
+
+    /**
+     * Locate a custom field for this model by key. Returns null when the key
+     * is not a registered custom field so callers can fall back to the normal
+     * attribute pipeline.
+     *
+     * The lookup order is defensive: keys that name a real DB column, cast,
+     * mutator, accessor, or relation short-circuit before we ever consult
+     * the custom-field registry. This blocks a plugin from shadowing host
+     * attributes ( e.g. `password`, `is_admin`, or the model's own `metadata`
+     * column ) by registering a filter-scoped field with a colliding key.
+     *
+     * @since 2.4.0
+     */
+    protected function findCustomFieldByKey( string $key ): ?CustomField
+    {
+        if ( array_key_exists( $key, $this->attributes ) ) {
+            return null;
+        }
+        if ( array_key_exists( $key, $this->getCasts() ) ) {
+            return null;
+        }
+        if ( $this->isRealDatabaseColumn( $key ) ) {
+            return null;
+        }
+        if ( method_exists( $this, $key ) ) {
+            return null;
+        }
+        if ( method_exists( $this, 'hasGetMutator' ) && $this->hasGetMutator( $key ) ) {
+            return null;
+        }
+        if ( method_exists( $this, 'hasSetMutator' ) && $this->hasSetMutator( $key ) ) {
+            return null;
+        }
+        if ( method_exists( $this, 'hasAttributeMutator' ) && $this->hasAttributeMutator( $key ) ) {
+            return null;
+        }
+        if ( method_exists( $this, 'hasAttributeGetMutator' ) && $this->hasAttributeGetMutator( $key ) ) {
+            return null;
+        }
+        if ( method_exists( $this, 'hasAttributeSetMutator' ) && $this->hasAttributeSetMutator( $key ) ) {
+            return null;
+        }
+        if ( method_exists( $this, 'isRelation' ) && $this->isRelation( $key ) ) {
+            return null;
+        }
+
+        foreach ( $this->getCustomFieldsForType() as $field ) {
+            if ( $field->key === $key ) {
+                return $field;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Whether the given key is a real column on this model's table. Cached
+     * per model class so we don't hit `information_schema` on every read.
+     *
+     * @since 2.4.0
+     */
+    protected function isRealDatabaseColumn( string $key ): bool
+    {
+        $class = static::class;
+
+        if ( ! isset( self::$customFieldsRealColumnsCache[ $class ] ) ) {
+            $table = $this->getTable();
+            try {
+                self::$customFieldsRealColumnsCache[ $class ] = Schema::getColumnListing( $table );
+            } catch ( Throwable ) {
+                // Schema introspection can fail during boot or with drivers
+                // that don't support column listing — fall back to an empty
+                // listing so we don't cache a false negative permanently.
+                return false;
+            }
+        }
+
+        return in_array( $key, self::$customFieldsRealColumnsCache[ $class ], true );
+    }
+
+    /**
+     * Ensure the host model actually exposes a `metadata` JSON attribute
+     * before we try to write into it. Fail loud rather than silently drop
+     * writes on models that opt into `HasCustomFields` but never added the
+     * `metadata` column.
+     *
+     * @since 2.4.0
+     */
+    protected function assertMetadataColumnAvailable( string $key ): void
+    {
+        $casts = $this->getCasts();
+
+        // `metadata` must be either an array-cast attribute or a real column.
+        if ( isset( $casts['metadata'] ) ) {
+            return;
+        }
+
+        if ( $this->isRealDatabaseColumn( 'metadata' ) ) {
+            return;
+        }
+
+        throw new RuntimeException( sprintf(
+            'Cannot write custom field "%s" via HasCustomFields on %s: the model has no `metadata` JSON column. '
+            . 'Add a `metadata` JSON column ( cast to `array` ) or register the field as `storage = column` instead.',
+            $key,
+            static::class,
+        ) );
     }
 }

--- a/src/Modules/ContentTypes/Models/Concerns/HasRenderedBlockContent.php
+++ b/src/Modules/ContentTypes/Models/Concerns/HasRenderedBlockContent.php
@@ -117,6 +117,32 @@ trait HasRenderedBlockContent
             }
         }
 
-        return is_string( $content ) ? $content : '';
+        $rendered = is_string( $content ) ? $content : '';
+
+        return $this->resolveDynamicContentTokens( $rendered );
+    }
+
+    /**
+     * Pass rendered content through the dynamic-content resolver when the
+     * DynamicContent module is loaded. Kept as a soft integration so this
+     * trait doesn't hard-depend on the DynamicContent module.
+     *
+     * @since 2.4.0
+     */
+    protected function resolveDynamicContentTokens( string $rendered ): string
+    {
+        if ( '' === $rendered || ! function_exists( 'apRenderContent' ) ) {
+            return $rendered;
+        }
+
+        try {
+            return apRenderContent( $rendered, [
+                'model'    => static::class,
+                'model_id' => $this->getKey(),
+            ] );
+        } catch ( Throwable ) {
+            // Never let a resolver failure hide the underlying content.
+            return $rendered;
+        }
     }
 }

--- a/src/Modules/ContentTypes/Models/CustomField.php
+++ b/src/Modules/ContentTypes/Models/CustomField.php
@@ -14,6 +14,8 @@ namespace ArtisanPackUI\CMSFramework\Modules\ContentTypes\Models;
 
 use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Enums\ColumnType;
 use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Enums\FieldType;
+use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Registries\CustomFieldTypeRegistry;
+use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Support\FieldTypeDefinition;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Collection;
@@ -24,7 +26,7 @@ use Illuminate\Support\Collection;
  * @property int $id
  * @property string $name
  * @property string $key
- * @property FieldType $type
+ * @property string $type
  * @property ColumnType $column_type
  * @property string|null $description
  * @property array $content_types
@@ -97,6 +99,55 @@ class CustomField extends Model
     }
 
     /**
+     * Resolve the `FieldType` enum case for this field's type, if the type
+     * corresponds to one of the framework's built-in cases. Returns null for
+     * plugin-registered types that live outside the enum.
+     *
+     * @since 2.4.0
+     */
+    public function fieldTypeEnum(): ?FieldType
+    {
+        return FieldType::tryFrom( $this->type );
+    }
+
+    /**
+     * Resolve the `FieldTypeDefinition` for this field's type from the
+     * `CustomFieldTypeRegistry`. Covers both built-in and plugin-registered types.
+     * Returns null when the type is unregistered.
+     *
+     * @since 2.4.0
+     */
+    public function fieldTypeDefinition(): ?FieldTypeDefinition
+    {
+        return app( CustomFieldTypeRegistry::class )->get( $this->type );
+    }
+
+    /**
+     * Where this field's values are stored on a content record.
+     *
+     * - `column`  → a physical column materialized on the content type's table
+     *   ( the DB-registered path used by `CustomFieldManager::createField()` ).
+     * - `metadata` → the value lives in the model's `metadata` JSON column;
+     *   used by filter-registered fields ( plugins ) that never get a physical
+     *   column.
+     *
+     * @since 2.4.0
+     *
+     * @return 'column'|'metadata'
+     */
+    public function storageMode(): string
+    {
+        $explicit = $this->getAttribute( 'storage' );
+
+        if ( 'metadata' === $explicit || 'column' === $explicit ) {
+            return $explicit;
+        }
+
+        // Persisted DB rows always materialize a physical column.
+        return $this->exists ? 'column' : 'metadata';
+    }
+
+    /**
      * Get the attributes that should be cast.
      *
      * @since 1.0.0
@@ -106,7 +157,7 @@ class CustomField extends Model
     protected function casts(): array
     {
         return [
-            'type'          => FieldType::class,
+            'type'          => 'string',
             'column_type'   => ColumnType::class,
             'content_types' => 'array',
             'options'       => 'array',

--- a/src/Modules/ContentTypes/Providers/ContentTypesServiceProvider.php
+++ b/src/Modules/ContentTypes/Providers/ContentTypesServiceProvider.php
@@ -12,6 +12,7 @@ declare( strict_types=1 );
 
 namespace ArtisanPackUI\CMSFramework\Modules\ContentTypes\Providers;
 
+use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Managers\ContentEditExtensions;
 use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Managers\ContentTypeManager;
 use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Managers\CustomFieldManager;
 use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Managers\TaxonomyManager;
@@ -21,6 +22,7 @@ use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Models\Taxonomy;
 use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Policies\ContentTypePolicy;
 use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Policies\CustomFieldPolicy;
 use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Policies\TaxonomyPolicy;
+use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Registries\CustomFieldTypeRegistry;
 use Illuminate\Routing\Router;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Facades\Route;
@@ -48,6 +50,12 @@ class ContentTypesServiceProvider extends ServiceProvider
 
         // Register TaxonomyManager as singleton
         $this->app->singleton( TaxonomyManager::class, fn () => new TaxonomyManager );
+
+        // Register CustomFieldTypeRegistry as singleton
+        $this->app->singleton( CustomFieldTypeRegistry::class, fn () => new CustomFieldTypeRegistry );
+
+        // Register ContentEditExtensions manager as singleton
+        $this->app->singleton( ContentEditExtensions::class, fn () => new ContentEditExtensions );
 
         // Load helpers
         $this->loadHelpers();

--- a/src/Modules/ContentTypes/Registries/CustomFieldTypeRegistry.php
+++ b/src/Modules/ContentTypes/Registries/CustomFieldTypeRegistry.php
@@ -1,0 +1,229 @@
+<?php
+
+declare( strict_types=1 );
+
+/**
+ * CustomFieldTypeRegistry.
+ *
+ * Registry for custom-field types. Ships with the framework's 16 built-in
+ * `FieldType` enum cases pre-registered and merges plugin-registered types
+ * from the `ap.contentTypes.registeredFieldTypes` filter on every read.
+ *
+ * The closed `FieldType` enum remains supported for backwards compatibility;
+ * new code should register plugin field types through this registry so the
+ * admin UI, validation, and `HasCustomFields` runtime all recognize them.
+ *
+ * @since 2.4.0
+ */
+
+namespace ArtisanPackUI\CMSFramework\Modules\ContentTypes\Registries;
+
+use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Enums\FieldType;
+use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Support\FieldTypeDefinition;
+use Throwable;
+
+/**
+ * In-memory registry keyed by field-type slug.
+ *
+ * @since 2.4.0
+ */
+class CustomFieldTypeRegistry
+{
+    /**
+     * Column-type mapping for the built-in enum cases, keeping DB-materialized
+     * fields storage-shape consistent with the legacy behavior.
+     *
+     * @var array<string,string>
+     */
+    protected const BUILTIN_COLUMN_TYPES = [
+        'text'     => 'string',
+        'textarea' => 'text',
+        'number'   => 'integer',
+        'select'   => 'string',
+        'checkbox' => 'boolean',
+        'radio'    => 'string',
+        'boolean'  => 'boolean',
+        'date'     => 'date',
+        'datetime' => 'datetime',
+        'time'     => 'time',
+        'email'    => 'string',
+        'url'      => 'string',
+        'tel'      => 'string',
+        'color'    => 'string',
+        'file'     => 'string',
+        'image'    => 'string',
+    ];
+
+    /**
+     * Locally registered ( non-filter ) field types keyed by slug.
+     *
+     * @var array<string,FieldTypeDefinition>
+     */
+    protected array $types = [];
+
+    public function __construct()
+    {
+        $this->registerBuiltins();
+    }
+
+    /**
+     * Register a field type. Overwrites any prior registration with the same slug.
+     *
+     * @since 2.4.0
+     */
+    public function register( FieldTypeDefinition $definition ): void
+    {
+        $this->types[ $definition->slug ] = $definition;
+    }
+
+    /**
+     * Fetch a single field-type definition by slug, merging local registrations
+     * and filter-registered plugin types. Returns null when nothing matches.
+     *
+     * @since 2.4.0
+     */
+    public function get( string $slug ): ?FieldTypeDefinition
+    {
+        return $this->all()[ $slug ] ?? null;
+    }
+
+    /**
+     * Return every known field-type definition keyed by slug. Locally
+     * registered entries take precedence over filter-registered ones.
+     *
+     * @since 2.4.0
+     *
+     * @return array<string,FieldTypeDefinition>
+     */
+    public function all(): array
+    {
+        $filtered = applyFilters( 'ap.contentTypes.registeredFieldTypes', [] );
+
+        $out = [];
+        if ( is_array( $filtered ) ) {
+            foreach ( $filtered as $key => $entry ) {
+                $definition = $this->normalizeFilterEntry( $key, $entry );
+                if ( null !== $definition ) {
+                    $out[ $definition->slug ] = $definition;
+                }
+            }
+        }
+
+        // Locally registered types overwrite filter entries with matching slugs.
+        foreach ( $this->types as $slug => $definition ) {
+            $out[ $slug ] = $definition;
+        }
+
+        return $out;
+    }
+
+    /**
+     * Whether the registry knows about the given field-type slug.
+     *
+     * @since 2.4.0
+     */
+    public function has( string $slug ): bool
+    {
+        return null !== $this->get( $slug );
+    }
+
+    /**
+     * Convenience: list every known slug ( e.g. for `Rule::in(...)` validation ).
+     *
+     * @since 2.4.0
+     *
+     * @return array<int,string>
+     */
+    public function slugs(): array
+    {
+        return array_values( array_keys( $this->all() ) );
+    }
+
+    /**
+     * Pre-register every built-in `FieldType` enum case so consumers of the
+     * registry ( admin field-type dropdown, validation, HasCustomFields ) always
+     * see the framework defaults even before any plugin has loaded.
+     *
+     * @since 2.4.0
+     */
+    protected function registerBuiltins(): void
+    {
+        foreach ( FieldType::cases() as $case ) {
+            $slug = $case->value;
+
+            $this->register( new FieldTypeDefinition(
+                slug       : $slug,
+                label      : $case->label(),
+                columnType : self::BUILTIN_COLUMN_TYPES[ $slug ] ?? 'string',
+                meta       : ['builtin' => true],
+            ) );
+        }
+    }
+
+    /**
+     * Coerce a raw filter entry into a `FieldTypeDefinition`. Accepts either
+     * a `FieldTypeDefinition` instance or an array literal. Skips malformed
+     * entries silently rather than crashing the registry.
+     *
+     * @since 2.4.0
+     *
+     * @param  int|string  $key
+     */
+    protected function normalizeFilterEntry( int|string $key, mixed $entry ): ?FieldTypeDefinition
+    {
+        if ( $entry instanceof FieldTypeDefinition ) {
+            return $entry;
+        }
+
+        if ( ! is_array( $entry ) ) {
+            return null;
+        }
+
+        if ( ! isset( $entry['slug'] ) ) {
+            if ( ! is_string( $key ) || '' === $key ) {
+                return null;
+            }
+            $entry['slug'] = $key;
+        }
+
+        // Reject malformed plugin payloads before they reach FieldTypeDefinition
+        // — a single non-scalar slug would otherwise fatal via `(string)` cast
+        // and take down every consumer of the registry.
+        if ( ! $this->hasScalarString( $entry, 'slug' ) ) {
+            return null;
+        }
+        if ( '' === trim( ( string ) $entry['slug'] ) ) {
+            return null;
+        }
+        foreach ( ['label', 'column_type', 'columnType', 'editor_component', 'editorComponent', 'renderer_component', 'rendererComponent'] as $optionalString ) {
+            if ( isset( $entry[ $optionalString ] ) && ! $this->hasScalarString( $entry, $optionalString ) ) {
+                return null;
+            }
+        }
+
+        try {
+            return FieldTypeDefinition::fromArray( $entry );
+        } catch ( Throwable ) {
+            return null;
+        }
+    }
+
+    /**
+     * Whether `$entry[$key]` is present and scalar-string-safe.
+     *
+     * @since 2.4.0
+     *
+     * @param  array<string,mixed>  $entry
+     */
+    protected function hasScalarString( array $entry, string $key ): bool
+    {
+        if ( ! isset( $entry[ $key ] ) ) {
+            return false;
+        }
+
+        $value = $entry[ $key ];
+
+        return is_string( $value ) || is_int( $value ) || is_float( $value )
+            || ( is_object( $value ) && method_exists( $value, '__toString' ) );
+    }
+}

--- a/src/Modules/ContentTypes/Support/FieldTypeDefinition.php
+++ b/src/Modules/ContentTypes/Support/FieldTypeDefinition.php
@@ -1,0 +1,84 @@
+<?php
+
+declare( strict_types=1 );
+
+/**
+ * FieldTypeDefinition Value Object.
+ *
+ * Describes a custom-field type registered with the framework's CustomFieldTypeRegistry.
+ * Both built-in types (mirrored from the `FieldType` enum) and plugin-registered
+ * types hydrate into this shape so consumers can treat them uniformly.
+ *
+ * @since 2.4.0
+ */
+
+namespace ArtisanPackUI\CMSFramework\Modules\ContentTypes\Support;
+
+/**
+ * Immutable descriptor for a registered field type.
+ *
+ * @since 2.4.0
+ */
+final class FieldTypeDefinition
+{
+    /**
+     * @param  string  $slug  Machine key ( e.g. `text`, `map_picker` ).
+     * @param  string  $label  Human-readable label ( already translated when possible ).
+     * @param  string  $columnType  Laravel Schema column-method slug for DB-materialized fields ( e.g. `string`, `text`, `integer` ). Plugin types that store via `metadata` may still declare a column type for documentation purposes; it is only used by `CustomFieldManager::createField()` on the DB-materialized path.
+     * @param  array<int,object|string>  $validationRules  Laravel validation rules applied to values of this type.
+     * @param  string|null  $editorComponent  Frontend admin-editor component identifier ( host-resolved ).
+     * @param  string|null  $rendererComponent  Frontend public-renderer component identifier ( host-resolved ).
+     * @param  array<string,mixed>  $meta  Freeform metadata a host or plugin can attach ( icon slug, category, etc. ).
+     */
+    public function __construct(
+        public readonly string $slug,
+        public readonly string $label,
+        public readonly string $columnType = 'string',
+        public readonly array $validationRules = [],
+        public readonly ?string $editorComponent = null,
+        public readonly ?string $rendererComponent = null,
+        public readonly array $meta = [],
+    ) {
+    }
+
+    /**
+     * Convenience factory for array-shaped registrations coming from plugin
+     * manifests or the `ap.contentTypes.registeredFieldTypes` filter.
+     *
+     * @since 2.4.0
+     *
+     * @param  array{slug:string,label?:string,column_type?:string,columnType?:string,validation_rules?:array,validationRules?:array,editor_component?:string|null,editorComponent?:string|null,renderer_component?:string|null,rendererComponent?:string|null,meta?:array<string,mixed>}  $args
+     */
+    public static function fromArray( array $args ): self
+    {
+        return new self(
+            slug              : ( string ) $args['slug'],
+            label             : ( string ) ( $args['label'] ?? ucfirst( $args['slug'] ) ),
+            columnType        : ( string ) ( $args['column_type'] ?? $args['columnType'] ?? 'string' ),
+            validationRules   : ( array ) ( $args['validation_rules'] ?? $args['validationRules'] ?? [] ),
+            editorComponent   : $args['editor_component'] ?? $args['editorComponent'] ?? null,
+            rendererComponent : $args['renderer_component'] ?? $args['rendererComponent'] ?? null,
+            meta              : ( array ) ( $args['meta'] ?? [] ),
+        );
+    }
+
+    /**
+     * Array-shape representation for JSON APIs and Blade templates.
+     *
+     * @since 2.4.0
+     *
+     * @return array<string,mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'slug'               => $this->slug,
+            'label'              => $this->label,
+            'column_type'        => $this->columnType,
+            'validation_rules'   => $this->validationRules,
+            'editor_component'   => $this->editorComponent,
+            'renderer_component' => $this->rendererComponent,
+            'meta'               => $this->meta,
+        ];
+    }
+}

--- a/src/Modules/ContentTypes/helpers.php
+++ b/src/Modules/ContentTypes/helpers.php
@@ -12,6 +12,8 @@ declare( strict_types=1 );
 
 use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Managers\ContentTypeManager;
 use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Models\ContentType;
+use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Registries\CustomFieldTypeRegistry;
+use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Support\FieldTypeDefinition;
 
 if ( ! function_exists( 'getContentType' ) ) {
     /**
@@ -42,5 +44,65 @@ if ( ! function_exists( 'contentTypeExists' ) ) {
     function contentTypeExists( string $slug ): bool
     {
         return app( ContentTypeManager::class )->contentTypeExists( $slug );
+    }
+}
+
+if ( ! function_exists( 'apRegisterFieldType' ) ) {
+    /**
+     * Register a custom-field type with the framework's CustomFieldTypeRegistry.
+     *
+     * Signature matches sibling `apRegister*` helpers ( slug first, definition
+     * second ). Accepts either an array of arguments understood by
+     * `FieldTypeDefinition::fromArray()` or a fully-constructed
+     * `FieldTypeDefinition`. The `$slug` always wins over any `slug` key
+     * inside the definition payload.
+     *
+     * @since 2.4.0
+     *
+     * @param  array<string,mixed>|FieldTypeDefinition  $definition
+     */
+    function apRegisterFieldType( string $slug, FieldTypeDefinition|array $definition ): FieldTypeDefinition
+    {
+        if ( is_array( $definition ) ) {
+            $definition['slug'] = $slug;
+            $definition         = FieldTypeDefinition::fromArray( $definition );
+        } elseif ( $definition->slug !== $slug ) {
+            // A pre-built definition with a mismatched slug — re-hydrate so the
+            // registry stays keyed by the caller's slug.
+            $definition = FieldTypeDefinition::fromArray( array_merge(
+                $definition->toArray(),
+                ['slug' => $slug],
+            ) );
+        }
+
+        app( CustomFieldTypeRegistry::class )->register( $definition );
+
+        return $definition;
+    }
+}
+
+if ( ! function_exists( 'apGetFieldType' ) ) {
+    /**
+     * Fetch a registered field-type definition by slug, or null if unknown.
+     *
+     * @since 2.4.0
+     */
+    function apGetFieldType( string $slug ): ?FieldTypeDefinition
+    {
+        return app( CustomFieldTypeRegistry::class )->get( $slug );
+    }
+}
+
+if ( ! function_exists( 'apRegisteredFieldTypes' ) ) {
+    /**
+     * Return every registered field-type definition keyed by slug.
+     *
+     * @since 2.4.0
+     *
+     * @return array<string,FieldTypeDefinition>
+     */
+    function apRegisteredFieldTypes(): array
+    {
+        return app( CustomFieldTypeRegistry::class )->all();
     }
 }

--- a/src/Modules/DynamicContent/Casts/DynamicContentCast.php
+++ b/src/Modules/DynamicContent/Casts/DynamicContentCast.php
@@ -1,0 +1,62 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Modules\DynamicContent\Casts;
+
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Services\DynamicContentResolver;
+use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * Eloquent cast that auto-resolves dynamic-content tokens on attribute access.
+ *
+ * Usage in a model:
+ *   protected function casts(): array {
+ *       return [ 'body' => DynamicContentCast::class ];
+ *   }
+ *
+ * SECURITY: dynamic content is a **public content pipeline** by design —
+ * every record and every field is readable by anyone who can write a
+ * token to a casted attribute. Do NOT store secrets (API keys, credentials,
+ * private user data) in dynamic content records. If a low-trust author can
+ * write to a casted attribute, they can render any dynamic-content field
+ * into the resolved output. Restrict `manage_dynamic_content` accordingly
+ * and keep sensitive configuration in {@see \ArtisanPackUI\CMSFramework\Modules\Settings\Models\Setting}
+ * or environment variables instead.
+ *
+ * The resolver escapes text-shaped field values at render time (see
+ * {@see \ArtisanPackUI\CMSFramework\Modules\DynamicContent\FieldTypes\AbstractFieldType})
+ * — rich-text fields are NOT escaped because that's their point. Hosts
+ * accepting untrusted rich-text authors must sanitize at save time
+ * (e.g. via `artisanpack-ui/security`'s `kses()` helper).
+ *
+ * @implements CastsAttributes<string, string>
+ *
+ * @since 2.4.0
+ */
+class DynamicContentCast implements CastsAttributes
+{
+    /**
+     * @param  array<string, mixed>  $attributes
+     */
+    public function get( Model $model, string $key, mixed $value, array $attributes ): ?string
+    {
+        if ( null === $value ) {
+            return null;
+        }
+
+        return app( DynamicContentResolver::class )->render(
+            (string) $value,
+            [ 'model' => $model::class, 'model_id' => $model->getKey(), 'attribute' => $key ],
+        );
+    }
+
+    /**
+     * @param  array<string, mixed>  $attributes
+     */
+    public function set( Model $model, string $key, mixed $value, array $attributes ): mixed
+    {
+        return $value;
+    }
+}

--- a/src/Modules/DynamicContent/Casts/RecordValueCast.php
+++ b/src/Modules/DynamicContent/Casts/RecordValueCast.php
@@ -1,0 +1,49 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Modules\DynamicContent\Casts;
+
+use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * Cast for {@see \ArtisanPackUI\CMSFramework\Modules\DynamicContent\Models\DynamicContentRecordValue}
+ * that transparently round-trips scalars, arrays, and null through the JSON
+ * column without a sentinel wrapper.
+ *
+ * Storage rules:
+ *   - null                        → SQL NULL
+ *   - scalar (string|int|float|bool) → its JSON-encoded literal (`"foo"`, `42`, `true`)
+ *   - array                       → its JSON-encoded object/array
+ *
+ * @implements CastsAttributes<mixed, mixed>
+ *
+ * @since 2.4.0
+ */
+class RecordValueCast implements CastsAttributes
+{
+    public function get( Model $model, string $key, mixed $value, array $attributes ): mixed
+    {
+        if ( null === $value ) {
+            return null;
+        }
+
+        if ( ! is_string( $value ) ) {
+            return $value;
+        }
+
+        $decoded = json_decode( $value, true );
+
+        return JSON_ERROR_NONE === json_last_error() ? $decoded : $value;
+    }
+
+    public function set( Model $model, string $key, mixed $value, array $attributes ): mixed
+    {
+        if ( null === $value ) {
+            return null;
+        }
+
+        return json_encode( $value );
+    }
+}

--- a/src/Modules/DynamicContent/Contracts/FieldType.php
+++ b/src/Modules/DynamicContent/Contracts/FieldType.php
@@ -1,0 +1,40 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Modules\DynamicContent\Contracts;
+
+use Illuminate\Support\HtmlString;
+
+/**
+ * Contract for a dynamic-content field type.
+ *
+ * @since 2.4.0
+ */
+interface FieldType
+{
+    /**
+     * The type slug (e.g. "text", "email", "image").
+     */
+    public function slug(): string;
+
+    /**
+     * The human label used in the admin UI.
+     */
+    public function label(): string;
+
+    /**
+     * Cast a raw stored value into its runtime representation.
+     */
+    public function cast( mixed $value, array $options = [] ): mixed;
+
+    /**
+     * Render the value as HTML-safe output.
+     *
+     * Implementations MUST return output that is safe to echo into an HTML
+     * context — either intentionally-authored HTML (rich text) or escaped
+     * plain text. Callers echo the result raw via `@dynamicContent`, so
+     * anything unsafe returned here is a stored-XSS sink.
+     */
+    public function render( mixed $value, array $options = [] ): HtmlString;
+}

--- a/src/Modules/DynamicContent/Contracts/Modifier.php
+++ b/src/Modules/DynamicContent/Contracts/Modifier.php
@@ -1,0 +1,22 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Modules\DynamicContent\Contracts;
+
+/**
+ * Contract for a token modifier (e.g. `|upper`, `|truncate:100`).
+ *
+ * @since 2.4.0
+ */
+interface Modifier
+{
+    public function slug(): string;
+
+    /**
+     * Apply the modifier to a value.
+     *
+     * @param  array<int, string>  $args
+     */
+    public function apply( mixed $value, array $args ): mixed;
+}

--- a/src/Modules/DynamicContent/Enums/Cardinality.php
+++ b/src/Modules/DynamicContent/Enums/Cardinality.php
@@ -1,0 +1,16 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Modules\DynamicContent\Enums;
+
+/**
+ * Cardinality of a dynamic content type.
+ *
+ * @since 2.4.0
+ */
+enum Cardinality: string
+{
+    case Singleton  = 'singleton';
+    case Collection = 'collection';
+}

--- a/src/Modules/DynamicContent/Enums/Source.php
+++ b/src/Modules/DynamicContent/Enums/Source.php
@@ -1,0 +1,16 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Modules\DynamicContent\Enums;
+
+/**
+ * Source of a dynamic content type registration.
+ *
+ * @since 2.4.0
+ */
+enum Source: string
+{
+    case Db   = 'db';
+    case Code = 'code';
+}

--- a/src/Modules/DynamicContent/FieldTypes/AbstractFieldType.php
+++ b/src/Modules/DynamicContent/FieldTypes/AbstractFieldType.php
@@ -1,0 +1,46 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Modules\DynamicContent\FieldTypes;
+
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Contracts\FieldType;
+use Illuminate\Support\HtmlString;
+
+/**
+ * Shared behavior for built-in text-shaped field types.
+ *
+ * Renders scalar values as HTML-escaped strings so the resolver's raw
+ * output path can't leak stored XSS. Field types that emit intentional
+ * HTML (rich text) or safe URLs override `render()`.
+ *
+ * @since 2.4.0
+ */
+abstract class AbstractFieldType implements FieldType
+{
+    public function cast( mixed $value, array $options = [] ): mixed
+    {
+        return $value;
+    }
+
+    public function render( mixed $value, array $options = [] ): HtmlString
+    {
+        if ( $value instanceof HtmlString ) {
+            return $value;
+        }
+
+        if ( null === $value ) {
+            return new HtmlString( '' );
+        }
+
+        if ( is_bool( $value ) ) {
+            return new HtmlString( $value ? '1' : '0' );
+        }
+
+        if ( is_scalar( $value ) ) {
+            return new HtmlString( e( (string) $value ) );
+        }
+
+        return new HtmlString( '' );
+    }
+}

--- a/src/Modules/DynamicContent/FieldTypes/AddressFieldType.php
+++ b/src/Modules/DynamicContent/FieldTypes/AddressFieldType.php
@@ -1,0 +1,44 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Modules\DynamicContent\FieldTypes;
+
+use Illuminate\Support\HtmlString;
+
+/**
+ * Compound address field.
+ *
+ * Value shape:
+ *   [ 'line1' => ..., 'line2' => ..., 'city' => ..., 'region' => ..., 'postal_code' => ..., 'country' => ... ]
+ *
+ * @since 2.4.0
+ */
+class AddressFieldType extends AbstractFieldType
+{
+    public function slug(): string
+    {
+        return 'address';
+    }
+
+    public function label(): string
+    {
+        return __( 'Address' );
+    }
+
+    public function render( mixed $value, array $options = [] ): HtmlString
+    {
+        if ( ! is_array( $value ) ) {
+            return new HtmlString( '' );
+        }
+
+        $parts = array_filter( [
+            $value['line1'] ?? null,
+            $value['line2'] ?? null,
+            trim( ( $value['city'] ?? '' ) . ', ' . ( $value['region'] ?? '' ) . ' ' . ( $value['postal_code'] ?? '' ) ),
+            $value['country'] ?? null,
+        ], fn ( $part ) => null !== $part && '' !== trim( (string) $part, ', ' ) );
+
+        return new HtmlString( e( implode( ', ', $parts ) ) );
+    }
+}

--- a/src/Modules/DynamicContent/FieldTypes/ImageFieldType.php
+++ b/src/Modules/DynamicContent/FieldTypes/ImageFieldType.php
@@ -1,0 +1,58 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Modules\DynamicContent\FieldTypes;
+
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\HtmlString;
+
+/**
+ * Image field: value is a media library id.
+ *
+ * When rendered as a token, resolves to the media URL (default size),
+ * HTML-escaped so it's safe in an attribute context.
+ * Block-binding integrations consume the raw media id directly.
+ *
+ * @since 2.4.0
+ */
+class ImageFieldType extends AbstractFieldType
+{
+    public function slug(): string
+    {
+        return 'image';
+    }
+
+    public function label(): string
+    {
+        return __( 'Image' );
+    }
+
+    public function render( mixed $value, array $options = [] ): HtmlString
+    {
+        if ( null === $value || '' === $value ) {
+            return new HtmlString( '' );
+        }
+
+        $mediaId = is_numeric( $value ) ? (int) $value : null;
+
+        if ( null === $mediaId ) {
+            return new HtmlString( '' );
+        }
+
+        if ( ! function_exists( 'apGetMediaUrl' ) ) {
+            Log::channel(
+                config( 'logging.channels.dynamic-content' ) ? 'dynamic-content' : 'stack',
+            )->warning(
+                'Dynamic content: image field rendered but apGetMediaUrl() is unavailable — media-library package likely missing',
+                [ 'media_id' => $mediaId ],
+            );
+
+            return new HtmlString( '' );
+        }
+
+        $url = apGetMediaUrl( $mediaId, $options['size'] ?? 'full' );
+
+        return new HtmlString( null === $url ? '' : e( (string) $url ) );
+    }
+}

--- a/src/Modules/DynamicContent/FieldTypes/NumberFieldType.php
+++ b/src/Modules/DynamicContent/FieldTypes/NumberFieldType.php
@@ -1,0 +1,27 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Modules\DynamicContent\FieldTypes;
+
+class NumberFieldType extends AbstractFieldType
+{
+    public function slug(): string
+    {
+        return 'number';
+    }
+
+    public function label(): string
+    {
+        return __( 'Number' );
+    }
+
+    public function cast( mixed $value, array $options = [] ): mixed
+    {
+        if ( null === $value || '' === $value ) {
+            return null;
+        }
+
+        return is_numeric( $value ) ? $value + 0 : null;
+    }
+}

--- a/src/Modules/DynamicContent/FieldTypes/RichTextFieldType.php
+++ b/src/Modules/DynamicContent/FieldTypes/RichTextFieldType.php
@@ -1,0 +1,43 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Modules\DynamicContent\FieldTypes;
+
+use Illuminate\Support\HtmlString;
+
+/**
+ * Rich-text field: content is author-supplied HTML. Not escaped on render.
+ *
+ * If a host application accepts untrusted authors for this field type, it
+ * must sanitize the input at save time (e.g. via `artisanpack-ui/security`'s
+ * `kses()` helper) before it reaches the resolver — see the security note
+ * on {@see \ArtisanPackUI\CMSFramework\Modules\DynamicContent\Casts\DynamicContentCast}.
+ *
+ * @since 2.4.0
+ */
+class RichTextFieldType extends AbstractFieldType
+{
+    public function slug(): string
+    {
+        return 'rich_text';
+    }
+
+    public function label(): string
+    {
+        return __( 'Rich Text' );
+    }
+
+    public function render( mixed $value, array $options = [] ): HtmlString
+    {
+        if ( $value instanceof HtmlString ) {
+            return $value;
+        }
+
+        if ( null === $value || ! is_scalar( $value ) ) {
+            return new HtmlString( '' );
+        }
+
+        return new HtmlString( (string) $value );
+    }
+}

--- a/src/Modules/DynamicContent/FieldTypes/ScalarFieldType.php
+++ b/src/Modules/DynamicContent/FieldTypes/ScalarFieldType.php
@@ -1,0 +1,33 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Modules\DynamicContent\FieldTypes;
+
+/**
+ * Data-driven field type for plain scalar values.
+ *
+ * Text, email, phone, URL, date, datetime, and select all share the same
+ * "cast raw, render escaped" behavior — this class holds them so we don't
+ * ship seven byte-identical shells.
+ *
+ * @since 2.4.0
+ */
+class ScalarFieldType extends AbstractFieldType
+{
+    public function __construct(
+        protected string $slug,
+        protected string $translationKey,
+    ) {
+    }
+
+    public function slug(): string
+    {
+        return $this->slug;
+    }
+
+    public function label(): string
+    {
+        return __( $this->translationKey );
+    }
+}

--- a/src/Modules/DynamicContent/Http/Controllers/DynamicContentRecordController.php
+++ b/src/Modules/DynamicContent/Http/Controllers/DynamicContentRecordController.php
@@ -1,0 +1,72 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Modules\DynamicContent\Http\Controllers;
+
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Http\Requests\DynamicContentRecordRequest;
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Http\Resources\DynamicContentRecordResource;
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Managers\DynamicContentRecordManager;
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Models\DynamicContentRecord;
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Models\DynamicContentType;
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
+use Illuminate\Http\Response;
+use Illuminate\Routing\Controller;
+
+class DynamicContentRecordController extends Controller
+{
+    use AuthorizesRequests;
+
+    public function __construct( protected DynamicContentRecordManager $manager )
+    {
+    }
+
+    public function index( DynamicContentType $type ): AnonymousResourceCollection
+    {
+        $this->authorize( 'viewAnyForType', [ DynamicContentRecord::class, $type ] );
+
+        $records = $type->records()->with( 'values.field', 'type.fields' )->get();
+
+        return DynamicContentRecordResource::collection( $records );
+    }
+
+    public function store( DynamicContentRecordRequest $request, DynamicContentType $type ): DynamicContentRecordResource
+    {
+        $this->authorize( 'createForType', [ DynamicContentRecord::class, $type ] );
+
+        return new DynamicContentRecordResource( $this->manager->create( $type, $request->validated() ) );
+    }
+
+    public function show( DynamicContentType $type, DynamicContentRecord $record ): DynamicContentRecordResource
+    {
+        $this->authorize( 'view', $record );
+
+        abort_unless( $record->dynamic_content_type_id === $type->id, 404 );
+
+        return new DynamicContentRecordResource( $record->load( 'values.field', 'type.fields' ) );
+    }
+
+    public function update(
+        DynamicContentRecordRequest $request,
+        DynamicContentType $type,
+        DynamicContentRecord $record,
+    ): DynamicContentRecordResource {
+        $this->authorize( 'update', $record );
+
+        abort_unless( $record->dynamic_content_type_id === $type->id, 404 );
+
+        return new DynamicContentRecordResource( $this->manager->update( $record, $request->validated() ) );
+    }
+
+    public function destroy( DynamicContentType $type, DynamicContentRecord $record ): Response
+    {
+        $this->authorize( 'delete', $record );
+
+        abort_unless( $record->dynamic_content_type_id === $type->id, 404 );
+
+        $this->manager->delete( $record );
+
+        return response()->noContent();
+    }
+}

--- a/src/Modules/DynamicContent/Http/Controllers/DynamicContentResolverController.php
+++ b/src/Modules/DynamicContent/Http/Controllers/DynamicContentResolverController.php
@@ -1,0 +1,46 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Modules\DynamicContent\Http\Controllers;
+
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Models\DynamicContentType;
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Services\DynamicContentResolver;
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Routing\Controller;
+
+class DynamicContentResolverController extends Controller
+{
+    use AuthorizesRequests;
+
+    /**
+     * Cap on the size of a single preview payload.
+     *
+     * 65 KB is generous for post bodies + templates but short-circuits
+     * any megabyte-scale token-bomb payload before the resolver's
+     * `preg_replace_callback` gets to iterate.
+     */
+    public const MAX_CONTENT_LENGTH = 65_535;
+
+    public function __construct( protected DynamicContentResolver $resolver )
+    {
+    }
+
+    public function resolve( Request $request ): JsonResponse
+    {
+        $this->authorize( 'viewAny', DynamicContentType::class );
+
+        $validated = $request->validate( [
+            'content' => [ 'required', 'string', 'max:' . self::MAX_CONTENT_LENGTH ],
+        ] );
+
+        return response()->json( [
+            'data' => [
+                'rendered'  => $this->resolver->render( $validated['content'] ),
+                'signature' => $this->resolver->signatureFor( $validated['content'] ),
+            ],
+        ] );
+    }
+}

--- a/src/Modules/DynamicContent/Http/Controllers/DynamicContentTypeController.php
+++ b/src/Modules/DynamicContent/Http/Controllers/DynamicContentTypeController.php
@@ -1,0 +1,91 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Modules\DynamicContent\Http\Controllers;
+
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Http\Requests\DynamicContentTypeRequest;
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Http\Resources\DynamicContentTypeResource;
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Managers\DynamicContentTypeManager;
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Managers\DynamicContentTypeRegistry;
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Models\DynamicContentType;
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
+use Illuminate\Http\Response;
+use Illuminate\Routing\Controller;
+
+class DynamicContentTypeController extends Controller
+{
+    use AuthorizesRequests;
+
+    public function __construct(
+        protected DynamicContentTypeManager $manager,
+        protected DynamicContentTypeRegistry $registry,
+    ) {
+    }
+
+    public function index(): AnonymousResourceCollection|JsonResponse
+    {
+        $this->authorize( 'viewAny', DynamicContentType::class );
+
+        return DynamicContentTypeResource::collection(
+            DynamicContentType::with( 'fields' )->orderBy( 'name' )->get(),
+        );
+    }
+
+    public function registered(): JsonResponse
+    {
+        $this->authorize( 'viewAny', DynamicContentType::class );
+
+        $types = [];
+
+        foreach ( $this->registry->all() as $slug => $type ) {
+            $types[] = [
+                'slug'        => $slug,
+                'name'        => $type['name'],
+                'cardinality' => $type['cardinality']->value,
+                'source'      => $type['source']->value,
+                'fields'      => array_map( fn ( $f ) => [
+                    'slug'  => $f['slug'],
+                    'label' => $f['label'],
+                    'type'  => $f['type'],
+                ], $type['fields'] ),
+            ];
+        }
+
+        return response()->json( [ 'data' => $types ] );
+    }
+
+    public function store( DynamicContentTypeRequest $request ): DynamicContentTypeResource
+    {
+        $this->authorize( 'create', DynamicContentType::class );
+
+        $type = $this->manager->create( $request->validated() );
+
+        return new DynamicContentTypeResource( $type );
+    }
+
+    public function show( DynamicContentType $type ): DynamicContentTypeResource
+    {
+        $this->authorize( 'view', $type );
+
+        return new DynamicContentTypeResource( $type->load( 'fields' ) );
+    }
+
+    public function update( DynamicContentTypeRequest $request, DynamicContentType $type ): DynamicContentTypeResource
+    {
+        $this->authorize( 'update', $type );
+
+        return new DynamicContentTypeResource( $this->manager->update( $type, $request->validated() ) );
+    }
+
+    public function destroy( DynamicContentType $type ): Response
+    {
+        $this->authorize( 'delete', $type );
+
+        $this->manager->delete( $type );
+
+        return response()->noContent();
+    }
+}

--- a/src/Modules/DynamicContent/Http/Requests/DynamicContentRecordRequest.php
+++ b/src/Modules/DynamicContent/Http/Requests/DynamicContentRecordRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Modules\DynamicContent\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class DynamicContentRecordRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'label'    => [ 'nullable', 'string', 'max:255' ],
+            'order'    => [ 'nullable', 'integer' ],
+            'values'   => [ 'array' ],
+            'values.*' => [ 'nullable' ],
+        ];
+    }
+}

--- a/src/Modules/DynamicContent/Http/Requests/DynamicContentTypeRequest.php
+++ b/src/Modules/DynamicContent/Http/Requests/DynamicContentTypeRequest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Modules\DynamicContent\Http\Requests;
+
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Enums\Cardinality;
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Managers\FieldTypeRegistry;
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Models\DynamicContentType;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class DynamicContentTypeRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        $existing = $this->route( 'type' );
+        $isUpdate = $existing instanceof DynamicContentType;
+
+        $fieldTypeSlugs = array_keys( app( FieldTypeRegistry::class )->all() );
+
+        $slugRules = [ 'required', 'string', 'max:64', 'regex:/^[a-z][a-z0-9_]*$/' ];
+
+        if ( $isUpdate ) {
+            // Slug is immutable post-create: changing it would silently break every
+            // persisted `{{oldslug.field}}` token across the site.
+            $slugRules[] = Rule::in( [ $existing->slug ] );
+        } else {
+            $slugRules[] = Rule::unique( 'dynamic_content_types', 'slug' );
+        }
+
+        return [
+            'slug'              => $slugRules,
+            'name'              => [ 'required', 'string', 'max:255' ],
+            'cardinality'       => [ 'required', Rule::in( array_column( Cardinality::cases(), 'value' ) ) ],
+            'description'       => [ 'nullable', 'string' ],
+            'icon'              => [ 'nullable', 'string', 'max:64' ],
+            'fields'            => [ 'array' ],
+            'fields.*.slug'     => [ 'required', 'string', 'max:64', 'regex:/^[a-z][a-z0-9_]*$/' ],
+            'fields.*.label'    => [ 'required', 'string', 'max:255' ],
+            'fields.*.type'     => [ 'required', 'string', Rule::in( $fieldTypeSlugs ) ],
+            'fields.*.options'  => [ 'nullable', 'array' ],
+            'fields.*.default'  => [ 'nullable' ],
+            'fields.*.required' => [ 'nullable', 'boolean' ],
+        ];
+    }
+
+    public function messages(): array
+    {
+        return [
+            'slug.in'          => __( 'Type slug is immutable; changing it would break existing tokens.' ),
+            'fields.*.type.in' => __( 'The field type is not registered.' ),
+        ];
+    }
+}

--- a/src/Modules/DynamicContent/Http/Resources/DynamicContentRecordResource.php
+++ b/src/Modules/DynamicContent/Http/Resources/DynamicContentRecordResource.php
@@ -1,0 +1,28 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Modules\DynamicContent\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * @property-read \ArtisanPackUI\CMSFramework\Modules\DynamicContent\Models\DynamicContentRecord $resource
+ */
+class DynamicContentRecordResource extends JsonResource
+{
+    public function toArray( Request $request ): array
+    {
+        return [
+            'id'     => $this->resource->id,
+            'label'  => $this->resource->label,
+            'order'  => $this->resource->order,
+            'values' => $this->resource->fieldValues(),
+            'type'   => [
+                'slug' => $this->resource->type?->slug,
+                'name' => $this->resource->type?->name,
+            ],
+        ];
+    }
+}

--- a/src/Modules/DynamicContent/Http/Resources/DynamicContentTypeResource.php
+++ b/src/Modules/DynamicContent/Http/Resources/DynamicContentTypeResource.php
@@ -1,0 +1,39 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Modules\DynamicContent\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * @property-read \ArtisanPackUI\CMSFramework\Modules\DynamicContent\Models\DynamicContentType $resource
+ */
+class DynamicContentTypeResource extends JsonResource
+{
+    public function toArray( Request $request ): array
+    {
+        return [
+            'id'          => $this->resource->id,
+            'slug'        => $this->resource->slug,
+            'name'        => $this->resource->name,
+            'cardinality' => $this->resource->cardinality->value,
+            'source'      => $this->resource->source->value,
+            'description' => $this->resource->description,
+            'icon'        => $this->resource->icon,
+            'fields'      => $this->whenLoaded( 'fields', function () {
+                return $this->resource->fields->map( fn ( $f ) => [
+                    'id'       => $f->id,
+                    'slug'     => $f->slug,
+                    'label'    => $f->label,
+                    'type'     => $f->type,
+                    'options'  => $f->options ?? [],
+                    'default'  => $f->default_value,
+                    'required' => $f->required,
+                    'order'    => $f->order,
+                ] )->all();
+            } ),
+        ];
+    }
+}

--- a/src/Modules/DynamicContent/Livewire/CollectionEditor.php
+++ b/src/Modules/DynamicContent/Livewire/CollectionEditor.php
@@ -1,0 +1,117 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Modules\DynamicContent\Livewire;
+
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Managers\DynamicContentRecordManager;
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Models\DynamicContentRecord;
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Models\DynamicContentType;
+use Illuminate\Contracts\View\View;
+use Illuminate\Support\Facades\Gate;
+use Livewire\Component;
+use Livewire\WithPagination;
+
+/**
+ * Edits records of a collection type: paginated list + inline editor.
+ *
+ * @since 2.4.0
+ */
+class CollectionEditor extends Component
+{
+    use WithPagination;
+
+    public int $typeId;
+
+    public ?int $editingRecordId = null;
+
+    public ?string $editingLabel = null;
+
+    /**
+     * @var array<string, mixed>
+     */
+    public array $editingValues = [];
+
+    public function mount( int $typeId ): void
+    {
+        $this->typeId = $typeId;
+
+        $type = DynamicContentType::findOrFail( $typeId );
+
+        abort_unless( $type->isCollection(), 404 );
+        Gate::authorize( 'update', $type );
+    }
+
+    public function edit( int $recordId ): void
+    {
+        $record = DynamicContentRecord::with( 'values.field', 'type.fields' )->findOrFail( $recordId );
+
+        abort_unless( $record->dynamic_content_type_id === $this->typeId, 404 );
+        Gate::authorize( 'update', $record );
+
+        $this->editingRecordId = $recordId;
+        $this->editingLabel    = $record->label;
+        $this->editingValues   = $record->fieldValues();
+    }
+
+    public function create(): void
+    {
+        $type = DynamicContentType::with( 'fields' )->findOrFail( $this->typeId );
+
+        Gate::authorize( 'create', DynamicContentRecord::class );
+
+        $this->editingRecordId = null;
+        $this->editingLabel    = null;
+        $this->editingValues   = [];
+
+        foreach ( $type->fields as $field ) {
+            $this->editingValues[ $field->slug ] = $field->default_value;
+        }
+    }
+
+    public function save(): void
+    {
+        $type    = DynamicContentType::with( 'fields' )->findOrFail( $this->typeId );
+        $manager = app( DynamicContentRecordManager::class );
+
+        $data = [ 'label' => $this->editingLabel, 'values' => $this->editingValues ];
+
+        if ( null === $this->editingRecordId ) {
+            Gate::authorize( 'create', DynamicContentRecord::class );
+            $manager->create( $type, $data );
+        } else {
+            $record = DynamicContentRecord::findOrFail( $this->editingRecordId );
+            Gate::authorize( 'update', $record );
+            $manager->update( $record, $data );
+        }
+
+        $this->editingRecordId = null;
+        $this->editingLabel    = null;
+        $this->editingValues   = [];
+        $this->dispatch( 'dynamic-content-record-saved' );
+    }
+
+    public function delete( int $recordId ): void
+    {
+        $record = DynamicContentRecord::findOrFail( $recordId );
+
+        abort_unless( $record->dynamic_content_type_id === $this->typeId, 404 );
+        Gate::authorize( 'delete', $record );
+
+        $record->delete();
+    }
+
+    public function render(): View
+    {
+        $type = DynamicContentType::with( 'fields' )->findOrFail( $this->typeId );
+
+        $records = $type->records()
+            ->with( 'values.field' )
+            ->paginate( 20 );
+
+        return view( 'ap-cms-dynamic-content::livewire.collection-editor', [
+            'type'    => $type,
+            'records' => $records,
+        ] );
+    }
+}

--- a/src/Modules/DynamicContent/Livewire/FieldBuilder.php
+++ b/src/Modules/DynamicContent/Livewire/FieldBuilder.php
@@ -1,0 +1,134 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Modules\DynamicContent\Livewire;
+
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Managers\DynamicContentTypeManager;
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Managers\FieldTypeRegistry;
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Models\DynamicContentType;
+use Illuminate\Contracts\View\View;
+use Illuminate\Support\Facades\Gate;
+use Livewire\Attributes\Validate;
+use Livewire\Component;
+
+/**
+ * Type + field builder — drag-to-order fields, per-type-field option panel.
+ *
+ * @since 2.4.0
+ */
+class FieldBuilder extends Component
+{
+    public ?int $typeId = null;
+
+    #[Validate( 'required|string|max:64|regex:/^[a-z][a-z0-9_]*$/' )]
+    public string $slug = '';
+
+    #[Validate( 'required|string|max:255' )]
+    public string $name = '';
+
+    #[Validate( 'required|in:singleton,collection' )]
+    public string $cardinality = 'singleton';
+
+    public ?string $description = null;
+
+    /**
+     * @var array<int, array{slug:string, label:string, type:string, required:bool, default:?string, options:array}>
+     */
+    public array $fields = [];
+
+    public function mount( ?int $typeId = null ): void
+    {
+        $this->typeId = $typeId;
+
+        if ( null !== $typeId ) {
+            $type = DynamicContentType::with( 'fields' )->findOrFail( $typeId );
+
+            Gate::authorize( 'update', $type );
+
+            $this->slug        = $type->slug;
+            $this->name        = $type->name;
+            $this->cardinality = $type->cardinality->value;
+            $this->description = $type->description;
+            $this->fields      = $type->fields->map( fn ( $f ) => [
+                'slug'     => $f->slug,
+                'label'    => $f->label,
+                'type'     => $f->type,
+                'required' => $f->required,
+                'default'  => $f->default_value,
+                'options'  => $f->options ?? [],
+            ] )->all();
+        } else {
+            Gate::authorize( 'create', DynamicContentType::class );
+        }
+    }
+
+    public function addField(): void
+    {
+        $this->fields[] = [
+            'slug'     => '',
+            'label'    => '',
+            'type'     => 'text',
+            'required' => false,
+            'default'  => null,
+            'options'  => [],
+        ];
+    }
+
+    public function removeField( int $index ): void
+    {
+        unset( $this->fields[ $index ] );
+        $this->fields = array_values( $this->fields );
+    }
+
+    public function moveUp( int $index ): void
+    {
+        if ( $index <= 0 || ! isset( $this->fields[ $index ] ) ) {
+            return;
+        }
+
+        [ $this->fields[ $index - 1 ], $this->fields[ $index ] ] = [ $this->fields[ $index ], $this->fields[ $index - 1 ] ];
+    }
+
+    public function moveDown( int $index ): void
+    {
+        if ( ! isset( $this->fields[ $index + 1 ] ) ) {
+            return;
+        }
+
+        [ $this->fields[ $index ], $this->fields[ $index + 1 ] ] = [ $this->fields[ $index + 1 ], $this->fields[ $index ] ];
+    }
+
+    public function save(): void
+    {
+        $this->validate();
+
+        $data = [
+            'slug'        => $this->slug,
+            'name'        => $this->name,
+            'cardinality' => $this->cardinality,
+            'description' => $this->description,
+            'fields'      => $this->fields,
+        ];
+
+        $manager = app( DynamicContentTypeManager::class );
+
+        if ( null === $this->typeId ) {
+            $type         = $manager->create( $data );
+            $this->typeId = $type->id;
+        } else {
+            $type = DynamicContentType::findOrFail( $this->typeId );
+            Gate::authorize( 'update', $type );
+            $manager->update( $type, $data );
+        }
+
+        $this->dispatch( 'dynamic-content-type-saved', typeId: $this->typeId );
+    }
+
+    public function render(): View
+    {
+        return view( 'ap-cms-dynamic-content::livewire.field-builder', [
+            'fieldTypes' => app( FieldTypeRegistry::class )->all(),
+        ] );
+    }
+}

--- a/src/Modules/DynamicContent/Livewire/SingletonEditor.php
+++ b/src/Modules/DynamicContent/Livewire/SingletonEditor.php
@@ -1,0 +1,73 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Modules\DynamicContent\Livewire;
+
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Managers\DynamicContentRecordManager;
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Models\DynamicContentType;
+use Illuminate\Contracts\View\View;
+use Illuminate\Support\Facades\Gate;
+use Livewire\Component;
+
+/**
+ * Edits the single record of a singleton type.
+ *
+ * @since 2.4.0
+ */
+class SingletonEditor extends Component
+{
+    public int $typeId;
+
+    /**
+     * @var array<string, mixed>
+     */
+    public array $values = [];
+
+    public function mount( int $typeId ): void
+    {
+        $this->typeId = $typeId;
+
+        $type = DynamicContentType::with( 'fields', 'records.values.field' )->findOrFail( $typeId );
+
+        abort_unless( $type->isSingleton(), 404 );
+        Gate::authorize( 'update', $type );
+
+        $record = $type->records->first();
+
+        if ( null !== $record ) {
+            $this->values = $record->fieldValues();
+        } else {
+            foreach ( $type->fields as $field ) {
+                $this->values[ $field->slug ] = $field->default_value;
+            }
+        }
+    }
+
+    public function save(): void
+    {
+        $type = DynamicContentType::with( 'fields', 'records' )->findOrFail( $this->typeId );
+
+        Gate::authorize( 'update', $type );
+
+        $manager = app( DynamicContentRecordManager::class );
+        $record  = $type->records->first();
+
+        if ( null === $record ) {
+            $manager->create( $type, [ 'values' => $this->values ] );
+        } else {
+            $manager->update( $record, [ 'values' => $this->values ] );
+        }
+
+        $this->dispatch( 'dynamic-content-record-saved' );
+    }
+
+    public function render(): View
+    {
+        $type = DynamicContentType::with( 'fields' )->findOrFail( $this->typeId );
+
+        return view( 'ap-cms-dynamic-content::livewire.singleton-editor', [
+            'type' => $type,
+        ] );
+    }
+}

--- a/src/Modules/DynamicContent/Livewire/TypeList.php
+++ b/src/Modules/DynamicContent/Livewire/TypeList.php
@@ -1,0 +1,38 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Modules\DynamicContent\Livewire;
+
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Managers\DynamicContentTypeManager;
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Managers\DynamicContentTypeRegistry;
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Models\DynamicContentType;
+use Illuminate\Contracts\View\View;
+use Illuminate\Support\Facades\Gate;
+use Livewire\Component;
+
+/**
+ * Admin type list — shows admin-created + code-registered types.
+ *
+ * @since 2.4.0
+ */
+class TypeList extends Component
+{
+    public function delete( int $typeId ): void
+    {
+        $type = DynamicContentType::findOrFail( $typeId );
+
+        Gate::authorize( 'delete', $type );
+
+        app( DynamicContentTypeManager::class )->delete( $type );
+    }
+
+    public function render(): View
+    {
+        Gate::authorize( 'viewAny', DynamicContentType::class );
+
+        return view( 'ap-cms-dynamic-content::livewire.type-list', [
+            'types' => app( DynamicContentTypeRegistry::class )->all(),
+        ] );
+    }
+}

--- a/src/Modules/DynamicContent/Managers/DynamicContentRecordManager.php
+++ b/src/Modules/DynamicContent/Managers/DynamicContentRecordManager.php
@@ -1,0 +1,77 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Modules\DynamicContent\Managers;
+
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Models\DynamicContentRecord;
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Models\DynamicContentType;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Writes / reads dynamic content records.
+ *
+ * @since 2.4.0
+ */
+class DynamicContentRecordManager
+{
+    /**
+     * @param  array{label?:?string, order?:int, values?:array<string,mixed>}  $data
+     */
+    public function create( DynamicContentType $type, array $data ): DynamicContentRecord
+    {
+        return DB::transaction( function () use ( $type, $data ): DynamicContentRecord {
+            $record = $type->records()->create( [
+                'label' => $data['label'] ?? null,
+                'order' => $data['order'] ?? 0,
+            ] );
+
+            $this->syncValues( $record, $type, $data['values'] ?? [] );
+
+            return $record->fresh( 'values.field' );
+        } );
+    }
+
+    /**
+     * @param  array{label?:?string, order?:int, values?:array<string,mixed>}  $data
+     */
+    public function update( DynamicContentRecord $record, array $data ): DynamicContentRecord
+    {
+        return DB::transaction( function () use ( $record, $data ): DynamicContentRecord {
+            $record->update( [
+                'label' => $data['label'] ?? $record->label,
+                'order' => $data['order'] ?? $record->order,
+            ] );
+
+            if ( array_key_exists( 'values', $data ) ) {
+                $this->syncValues( $record, $record->type, $data['values'] );
+            }
+
+            return $record->fresh( 'values.field' );
+        } );
+    }
+
+    public function delete( DynamicContentRecord $record ): void
+    {
+        $record->delete();
+    }
+
+    /**
+     * @param  array<string, mixed>  $values  Values keyed by field slug.
+     */
+    protected function syncValues( DynamicContentRecord $record, DynamicContentType $type, array $values ): void
+    {
+        $type->loadMissing( 'fields' );
+
+        foreach ( $type->fields as $field ) {
+            if ( ! array_key_exists( $field->slug, $values ) ) {
+                continue;
+            }
+
+            $record->values()->updateOrCreate(
+                [ 'dynamic_content_field_id' => $field->id ],
+                [ 'value' => $values[ $field->slug ] ],
+            );
+        }
+    }
+}

--- a/src/Modules/DynamicContent/Managers/DynamicContentTypeManager.php
+++ b/src/Modules/DynamicContent/Managers/DynamicContentTypeManager.php
@@ -1,0 +1,113 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Modules\DynamicContent\Managers;
+
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Enums\Source;
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Models\DynamicContentField;
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Models\DynamicContentType;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Writes / reads DB-backed dynamic content types.
+ *
+ * @since 2.4.0
+ */
+class DynamicContentTypeManager
+{
+    public function __construct( protected DynamicContentTypeRegistry $registry )
+    {
+    }
+
+    /**
+     * Create a type from validated input.
+     *
+     * @param  array<string, mixed>  $data
+     */
+    public function create( array $data ): DynamicContentType
+    {
+        return DB::transaction( function () use ( $data ): DynamicContentType {
+            $type = DynamicContentType::create( [
+                'slug'        => $data['slug'],
+                'name'        => $data['name'],
+                'cardinality' => $data['cardinality'],
+                'source'      => Source::Db->value,
+                'description' => $data['description'] ?? null,
+                'icon'        => $data['icon'] ?? null,
+            ] );
+
+            $this->syncFields( $type, $data['fields'] ?? [] );
+
+            $this->registry->forget();
+
+            return $type->fresh( 'fields' );
+        } );
+    }
+
+    /**
+     * Update an existing type.
+     *
+     * @param  array<string, mixed>  $data
+     */
+    public function update( DynamicContentType $type, array $data ): DynamicContentType
+    {
+        return DB::transaction( function () use ( $type, $data ): DynamicContentType {
+            // Slug is intentionally not updated: mutating it would silently
+            // break every persisted `{{oldslug.field}}` token across the site.
+            $type->update( [
+                'name'        => $data['name'] ?? $type->name,
+                'cardinality' => $data['cardinality'] ?? $type->cardinality->value,
+                'description' => $data['description'] ?? $type->description,
+                'icon'        => $data['icon'] ?? $type->icon,
+            ] );
+
+            if ( array_key_exists( 'fields', $data ) ) {
+                $this->syncFields( $type, $data['fields'] );
+            }
+
+            $this->registry->forget();
+
+            return $type->fresh( 'fields' );
+        } );
+    }
+
+    public function delete( DynamicContentType $type ): void
+    {
+        DB::transaction( function () use ( $type ): void {
+            $type->delete();
+            $this->registry->forget();
+        } );
+    }
+
+    /**
+     * Replace the type's fields with the given definition.
+     *
+     * @param  array<int, array<string, mixed>>  $fields
+     */
+    protected function syncFields( DynamicContentType $type, array $fields ): void
+    {
+        $seen = [];
+
+        foreach ( $fields as $order => $field ) {
+            $model = $type->fields()->updateOrCreate(
+                [ 'slug' => $field['slug'] ],
+                [
+                    'label'         => $field['label'],
+                    'type'          => $field['type'],
+                    'options'       => $field['options'] ?? null,
+                    'default_value' => $field['default'] ?? null,
+                    'required'      => (bool) ( $field['required'] ?? false ),
+                    'order'         => (int) ( $field['order'] ?? $order ),
+                ],
+            );
+
+            $seen[] = $model->id;
+        }
+
+        DynamicContentField::query()
+            ->where( 'dynamic_content_type_id', $type->id )
+            ->whereNotIn( 'id', $seen )
+            ->delete();
+    }
+}

--- a/src/Modules/DynamicContent/Managers/DynamicContentTypeRegistry.php
+++ b/src/Modules/DynamicContent/Managers/DynamicContentTypeRegistry.php
@@ -1,0 +1,190 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Modules\DynamicContent\Managers;
+
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Enums\Cardinality;
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Enums\Source;
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Models\DynamicContentType;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Schema;
+use Throwable;
+
+/**
+ * In-memory registry of dynamic content types.
+ *
+ * Merges admin-created types (from the DB) with code-registered types.
+ * Code-registered types win on slug conflict; a warning is logged.
+ *
+ * @since 2.4.0
+ */
+class DynamicContentTypeRegistry
+{
+    /**
+     * Code-registered type definitions keyed by slug.
+     *
+     * Each definition is an array:
+     *   [
+     *     'slug' => string,
+     *     'name' => string,
+     *     'cardinality' => Cardinality,
+     *     'description' => ?string,
+     *     'icon' => ?string,
+     *     'fields' => list<array{slug:string, label:string, type:string, options?:array, default?:mixed, required?:bool}>,
+     *     'records' => callable():iterable<array<string,mixed>>|iterable<array<string,mixed>>|null,
+     *   ]
+     *
+     * @var array<string, array<string, mixed>>
+     */
+    protected array $codeTypes = [];
+
+    protected ?array $mergedCache = null;
+
+    /**
+     * Register a type in code.
+     *
+     * @param  array<string, mixed>  $definition
+     */
+    public function registerCodeType( string $slug, array $definition ): void
+    {
+        $definition['slug']        = $slug;
+        $definition['source']      = Source::Code;
+        $definition['cardinality'] = $definition['cardinality'] ?? Cardinality::Singleton;
+
+        $this->codeTypes[ $slug ] = $definition;
+        $this->mergedCache        = null;
+    }
+
+    /**
+     * All registered types keyed by slug.
+     *
+     * @return array<string, array<string, mixed>>
+     */
+    public function all(): array
+    {
+        if ( null !== $this->mergedCache ) {
+            return $this->mergedCache;
+        }
+
+        $out = [];
+
+        // Pull DB types only if the table exists (guards early-boot / migrations).
+        if ( Schema::hasTable( 'dynamic_content_types' ) ) {
+            foreach ( DynamicContentType::with( 'fields' )->get() as $dbType ) {
+                $out[ $dbType->slug ] = $this->normalizeDbType( $dbType );
+            }
+        }
+
+        // Merge in code-registered — invoke filter first so packages can contribute.
+        $codeTypes = $this->codeTypes;
+
+        if ( function_exists( 'applyFilters' ) ) {
+            try {
+                $filtered = applyFilters( 'ap.dynamic_content.register-types', $codeTypes );
+
+                if ( is_array( $filtered ) ) {
+                    $codeTypes = $filtered;
+                }
+            } catch ( Throwable $e ) {
+                // A third-party filter callback threw. Fall back to the pre-filter
+                // set so one buggy plugin can't take down every token resolution.
+                Log::channel( $this->logChannel() )->warning(
+                    'Dynamic content: register-types filter threw; falling back to unfiltered set',
+                    [ 'exception' => $e->getMessage() ],
+                );
+            }
+        }
+
+        foreach ( $codeTypes as $slug => $definition ) {
+            if ( isset( $out[ $slug ] ) ) {
+                Log::channel( $this->logChannel() )->warning(
+                    'Dynamic content: code-registered type shadows admin-created type',
+                    [ 'slug' => $slug ],
+                );
+            }
+
+            $out[ $slug ] = $this->normalizeCodeType( $slug, $definition );
+        }
+
+        return $this->mergedCache = $out;
+    }
+
+    public function get( string $slug ): ?array
+    {
+        return $this->all()[ $slug ] ?? null;
+    }
+
+    public function forget(): void
+    {
+        $this->mergedCache = null;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    protected function normalizeDbType( DynamicContentType $type ): array
+    {
+        return [
+            'slug'        => $type->slug,
+            'name'        => $type->name,
+            'cardinality' => $type->cardinality,
+            'source'      => Source::Db,
+            'description' => $type->description,
+            'icon'        => $type->icon,
+            'fields'      => $type->fields->map( fn ( $f ) => [
+                'slug'     => $f->slug,
+                'label'    => $f->label,
+                'type'     => $f->type,
+                'options'  => $f->options ?? [],
+                'default'  => $f->default_value,
+                'required' => $f->required,
+            ] )->all(),
+            'db_id'   => $type->id,
+            'records' => null,
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $definition
+     *
+     * @return array<string, mixed>
+     */
+    protected function normalizeCodeType( string $slug, array $definition ): array
+    {
+        $cardinality = $definition['cardinality'] ?? Cardinality::Singleton;
+
+        if ( is_string( $cardinality ) ) {
+            $cardinality = Cardinality::from( $cardinality );
+        }
+
+        $fields = [];
+
+        foreach ( $definition['fields'] ?? [] as $field ) {
+            $fields[] = [
+                'slug'     => $field['slug'],
+                'label'    => $field['label'] ?? $field['slug'],
+                'type'     => $field['type'] ?? 'text',
+                'options'  => $field['options'] ?? [],
+                'default'  => $field['default'] ?? null,
+                'required' => (bool) ( $field['required'] ?? false ),
+            ];
+        }
+
+        return [
+            'slug'        => $slug,
+            'name'        => $definition['name'] ?? $slug,
+            'cardinality' => $cardinality,
+            'source'      => Source::Code,
+            'description' => $definition['description'] ?? null,
+            'icon'        => $definition['icon'] ?? null,
+            'fields'      => $fields,
+            'records'     => $definition['records'] ?? null,
+        ];
+    }
+
+    protected function logChannel(): string
+    {
+        return config( 'logging.channels.dynamic-content' ) ? 'dynamic-content' : 'stack';
+    }
+}

--- a/src/Modules/DynamicContent/Managers/FieldTypeRegistry.php
+++ b/src/Modules/DynamicContent/Managers/FieldTypeRegistry.php
@@ -1,0 +1,62 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Modules\DynamicContent\Managers;
+
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Contracts\FieldType;
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\FieldTypes\AddressFieldType;
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\FieldTypes\ImageFieldType;
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\FieldTypes\NumberFieldType;
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\FieldTypes\RichTextFieldType;
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\FieldTypes\ScalarFieldType;
+
+/**
+ * Registry of available field-type classes keyed by slug.
+ *
+ * @since 2.4.0
+ */
+class FieldTypeRegistry
+{
+    /**
+     * @var array<string, FieldType>
+     */
+    protected array $types = [];
+
+    public function __construct()
+    {
+        foreach ( [
+            new ScalarFieldType( 'text', 'Text' ),
+            new ScalarFieldType( 'url', 'URL' ),
+            new ScalarFieldType( 'email', 'Email' ),
+            new ScalarFieldType( 'phone', 'Phone' ),
+            new ScalarFieldType( 'date', 'Date' ),
+            new ScalarFieldType( 'datetime', 'Date & Time' ),
+            new ScalarFieldType( 'select', 'Select' ),
+            new RichTextFieldType(),
+            new ImageFieldType(),
+            new NumberFieldType(),
+            new AddressFieldType(),
+        ] as $type ) {
+            $this->register( $type );
+        }
+    }
+
+    public function register( FieldType $type ): void
+    {
+        $this->types[ $type->slug() ] = $type;
+    }
+
+    public function get( string $slug ): ?FieldType
+    {
+        return $this->types[ $slug ] ?? null;
+    }
+
+    /**
+     * @return array<string, FieldType>
+     */
+    public function all(): array
+    {
+        return $this->types;
+    }
+}

--- a/src/Modules/DynamicContent/Managers/ModifierRegistry.php
+++ b/src/Modules/DynamicContent/Managers/ModifierRegistry.php
@@ -1,0 +1,57 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Modules\DynamicContent\Managers;
+
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Contracts\Modifier;
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Modifiers\DateModifier;
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Modifiers\DefaultModifier;
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Modifiers\LowerModifier;
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Modifiers\Nl2brModifier;
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Modifiers\TimeModifier;
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Modifiers\TruncateModifier;
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Modifiers\UpperModifier;
+
+/**
+ * Registry of built-in token modifiers.
+ *
+ * Sealed to public API in v1: only the built-in modifiers are exposed.
+ *
+ * @since 2.4.0
+ */
+class ModifierRegistry
+{
+    /**
+     * @var array<string, Modifier>
+     */
+    protected array $modifiers = [];
+
+    public function __construct()
+    {
+        foreach ( [
+            new DefaultModifier(),
+            new UpperModifier(),
+            new LowerModifier(),
+            new TruncateModifier(),
+            new DateModifier(),
+            new TimeModifier(),
+            new Nl2brModifier(),
+        ] as $modifier ) {
+            $this->modifiers[ $modifier->slug() ] = $modifier;
+        }
+    }
+
+    public function get( string $slug ): ?Modifier
+    {
+        return $this->modifiers[ $slug ] ?? null;
+    }
+
+    /**
+     * @return array<string, Modifier>
+     */
+    public function all(): array
+    {
+        return $this->modifiers;
+    }
+}

--- a/src/Modules/DynamicContent/Models/DynamicContentField.php
+++ b/src/Modules/DynamicContent/Models/DynamicContentField.php
@@ -1,0 +1,54 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Modules\DynamicContent\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * @property int $id
+ * @property int $dynamic_content_type_id
+ * @property string $slug
+ * @property string $label
+ * @property string $type
+ * @property array|null $options
+ * @property string|null $default_value
+ * @property bool $required
+ * @property int $order
+ *
+ * @since 2.4.0
+ */
+class DynamicContentField extends Model
+{
+    use HasFactory;
+
+    protected $table = 'dynamic_content_fields';
+
+    protected $fillable = [
+        'dynamic_content_type_id',
+        'slug',
+        'label',
+        'type',
+        'options',
+        'default_value',
+        'required',
+        'order',
+    ];
+
+    public function type(): BelongsTo
+    {
+        return $this->belongsTo( DynamicContentType::class, 'dynamic_content_type_id' );
+    }
+
+    protected function casts(): array
+    {
+        return [
+            'options'  => 'array',
+            'required' => 'boolean',
+            'order'    => 'integer',
+        ];
+    }
+}

--- a/src/Modules/DynamicContent/Models/DynamicContentRecord.php
+++ b/src/Modules/DynamicContent/Models/DynamicContentRecord.php
@@ -1,0 +1,74 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Modules\DynamicContent\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+/**
+ * @property int $id
+ * @property int $dynamic_content_type_id
+ * @property string|null $label
+ * @property int $order
+ * @property \Illuminate\Support\Carbon $created_at
+ * @property \Illuminate\Support\Carbon $updated_at
+ *
+ * @since 2.4.0
+ */
+class DynamicContentRecord extends Model
+{
+    use HasFactory;
+
+    protected $table = 'dynamic_content_records';
+
+    protected $fillable = [
+        'dynamic_content_type_id',
+        'label',
+        'order',
+    ];
+
+    public function type(): BelongsTo
+    {
+        return $this->belongsTo( DynamicContentType::class, 'dynamic_content_type_id' );
+    }
+
+    public function values(): HasMany
+    {
+        return $this->hasMany( DynamicContentRecordValue::class, 'dynamic_content_record_id' );
+    }
+
+    /**
+     * Return the record's values keyed by field slug.
+     *
+     * @return array<string, mixed>
+     */
+    public function fieldValues(): array
+    {
+        $this->loadMissing( 'values.field', 'type.fields' );
+
+        $out = [];
+
+        foreach ( $this->type->fields as $field ) {
+            $out[ $field->slug ] = $field->default_value;
+        }
+
+        foreach ( $this->values as $value ) {
+            if ( null !== $value->field ) {
+                $out[ $value->field->slug ] = $value->value;
+            }
+        }
+
+        return $out;
+    }
+
+    protected function casts(): array
+    {
+        return [
+            'order' => 'integer',
+        ];
+    }
+}

--- a/src/Modules/DynamicContent/Models/DynamicContentRecordValue.php
+++ b/src/Modules/DynamicContent/Models/DynamicContentRecordValue.php
@@ -1,0 +1,48 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Modules\DynamicContent\Models;
+
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Casts\RecordValueCast;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * @property int $id
+ * @property int $dynamic_content_record_id
+ * @property int $dynamic_content_field_id
+ * @property mixed $value
+ *
+ * @since 2.4.0
+ */
+class DynamicContentRecordValue extends Model
+{
+    use HasFactory;
+
+    protected $table = 'dynamic_content_record_values';
+
+    protected $fillable = [
+        'dynamic_content_record_id',
+        'dynamic_content_field_id',
+        'value',
+    ];
+
+    public function record(): BelongsTo
+    {
+        return $this->belongsTo( DynamicContentRecord::class, 'dynamic_content_record_id' );
+    }
+
+    public function field(): BelongsTo
+    {
+        return $this->belongsTo( DynamicContentField::class, 'dynamic_content_field_id' );
+    }
+
+    protected function casts(): array
+    {
+        return [
+            'value' => RecordValueCast::class,
+        ];
+    }
+}

--- a/src/Modules/DynamicContent/Models/DynamicContentType.php
+++ b/src/Modules/DynamicContent/Models/DynamicContentType.php
@@ -1,0 +1,73 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Modules\DynamicContent\Models;
+
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Enums\Cardinality;
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Enums\Source;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+/**
+ * @property int $id
+ * @property string $slug
+ * @property string $name
+ * @property Cardinality $cardinality
+ * @property Source $source
+ * @property string|null $description
+ * @property string|null $icon
+ * @property \Illuminate\Support\Carbon $created_at
+ * @property \Illuminate\Support\Carbon $updated_at
+ *
+ * @since 2.4.0
+ */
+class DynamicContentType extends Model
+{
+    use HasFactory;
+
+    protected $table = 'dynamic_content_types';
+
+    protected $fillable = [
+        'slug',
+        'name',
+        'cardinality',
+        'source',
+        'description',
+        'icon',
+    ];
+
+    public function fields(): HasMany
+    {
+        return $this->hasMany( DynamicContentField::class, 'dynamic_content_type_id' )->orderBy( 'order' );
+    }
+
+    public function records(): HasMany
+    {
+        return $this->hasMany( DynamicContentRecord::class, 'dynamic_content_type_id' )->orderBy( 'order' );
+    }
+
+    public function getRouteKeyName(): string
+    {
+        return 'slug';
+    }
+
+    public function isSingleton(): bool
+    {
+        return Cardinality::Singleton === $this->cardinality;
+    }
+
+    public function isCollection(): bool
+    {
+        return Cardinality::Collection === $this->cardinality;
+    }
+
+    protected function casts(): array
+    {
+        return [
+            'cardinality' => Cardinality::class,
+            'source'      => Source::class,
+        ];
+    }
+}

--- a/src/Modules/DynamicContent/Modifiers/DateModifier.php
+++ b/src/Modules/DynamicContent/Modifiers/DateModifier.php
@@ -1,0 +1,34 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Modules\DynamicContent\Modifiers;
+
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Contracts\Modifier;
+use Illuminate\Support\Carbon;
+use Throwable;
+
+class DateModifier implements Modifier
+{
+    public function slug(): string
+    {
+        return 'date';
+    }
+
+    public function apply( mixed $value, array $args ): mixed
+    {
+        if ( null === $value || '' === $value ) {
+            return '';
+        }
+
+        // Args arrive already split on ":" by the tokenizer, so rejoin them to
+        // reconstruct multi-part format strings like "g:i a".
+        $format = empty( $args ) ? 'Y-m-d' : implode( ':', $args );
+
+        try {
+            return Carbon::parse( $value )->format( $format );
+        } catch ( Throwable ) {
+            return $value;
+        }
+    }
+}

--- a/src/Modules/DynamicContent/Modifiers/DefaultModifier.php
+++ b/src/Modules/DynamicContent/Modifiers/DefaultModifier.php
@@ -1,0 +1,24 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Modules\DynamicContent\Modifiers;
+
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Contracts\Modifier;
+
+class DefaultModifier implements Modifier
+{
+    public function slug(): string
+    {
+        return 'default';
+    }
+
+    public function apply( mixed $value, array $args ): mixed
+    {
+        if ( null === $value || '' === $value ) {
+            return $args[0] ?? '';
+        }
+
+        return $value;
+    }
+}

--- a/src/Modules/DynamicContent/Modifiers/LowerModifier.php
+++ b/src/Modules/DynamicContent/Modifiers/LowerModifier.php
@@ -1,0 +1,20 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Modules\DynamicContent\Modifiers;
+
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Contracts\Modifier;
+
+class LowerModifier implements Modifier
+{
+    public function slug(): string
+    {
+        return 'lower';
+    }
+
+    public function apply( mixed $value, array $args ): mixed
+    {
+        return is_string( $value ) ? mb_strtolower( $value ) : $value;
+    }
+}

--- a/src/Modules/DynamicContent/Modifiers/Nl2brModifier.php
+++ b/src/Modules/DynamicContent/Modifiers/Nl2brModifier.php
@@ -1,0 +1,37 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Modules\DynamicContent\Modifiers;
+
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Contracts\Modifier;
+use Illuminate\Support\HtmlString;
+
+/**
+ * Converts newlines to `<br>` tags after HTML-escaping the input.
+ *
+ * Returns an {@see HtmlString} so downstream field-type rendering
+ * doesn't double-escape the inserted `<br>` markup.
+ *
+ * @since 2.4.0
+ */
+class Nl2brModifier implements Modifier
+{
+    public function slug(): string
+    {
+        return 'nl2br';
+    }
+
+    public function apply( mixed $value, array $args ): mixed
+    {
+        if ( $value instanceof HtmlString ) {
+            $value = (string) $value;
+        }
+
+        if ( ! is_string( $value ) ) {
+            return $value;
+        }
+
+        return new HtmlString( nl2br( e( $value ), false ) );
+    }
+}

--- a/src/Modules/DynamicContent/Modifiers/TimeModifier.php
+++ b/src/Modules/DynamicContent/Modifiers/TimeModifier.php
@@ -1,0 +1,34 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Modules\DynamicContent\Modifiers;
+
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Contracts\Modifier;
+use Illuminate\Support\Carbon;
+use Throwable;
+
+class TimeModifier implements Modifier
+{
+    public function slug(): string
+    {
+        return 'time';
+    }
+
+    public function apply( mixed $value, array $args ): mixed
+    {
+        if ( null === $value || '' === $value ) {
+            return '';
+        }
+
+        // Args arrive already split on ":" by the tokenizer, so rejoin them to
+        // reconstruct multi-part format strings like "g:i a".
+        $format = empty( $args ) ? 'H:i' : implode( ':', $args );
+
+        try {
+            return Carbon::parse( $value )->format( $format );
+        } catch ( Throwable ) {
+            return $value;
+        }
+    }
+}

--- a/src/Modules/DynamicContent/Modifiers/TruncateModifier.php
+++ b/src/Modules/DynamicContent/Modifiers/TruncateModifier.php
@@ -1,0 +1,30 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Modules\DynamicContent\Modifiers;
+
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Contracts\Modifier;
+
+class TruncateModifier implements Modifier
+{
+    public function slug(): string
+    {
+        return 'truncate';
+    }
+
+    public function apply( mixed $value, array $args ): mixed
+    {
+        if ( ! is_string( $value ) ) {
+            return $value;
+        }
+
+        $length = isset( $args[0] ) ? (int) $args[0] : 100;
+
+        if ( mb_strlen( $value ) <= $length ) {
+            return $value;
+        }
+
+        return mb_substr( $value, 0, $length ) . '…';
+    }
+}

--- a/src/Modules/DynamicContent/Modifiers/UpperModifier.php
+++ b/src/Modules/DynamicContent/Modifiers/UpperModifier.php
@@ -1,0 +1,20 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Modules\DynamicContent\Modifiers;
+
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Contracts\Modifier;
+
+class UpperModifier implements Modifier
+{
+    public function slug(): string
+    {
+        return 'upper';
+    }
+
+    public function apply( mixed $value, array $args ): mixed
+    {
+        return is_string( $value ) ? mb_strtoupper( $value ) : $value;
+    }
+}

--- a/src/Modules/DynamicContent/Policies/DynamicContentRecordPolicy.php
+++ b/src/Modules/DynamicContent/Policies/DynamicContentRecordPolicy.php
@@ -1,0 +1,68 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Modules\DynamicContent\Policies;
+
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Models\DynamicContentRecord;
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Models\DynamicContentType;
+use Illuminate\Contracts\Auth\Authenticatable;
+
+/**
+ * Policy for DynamicContentRecord.
+ *
+ * All checks default to the global `manage_dynamic_content` capability,
+ * but each check invokes an `applyFilters()` hook that receives the
+ * capability slug AND the target {@see DynamicContentType} (when known)
+ * so hosts can gate per-type — e.g. return a type-scoped capability like
+ * `manage_dynamic_content_records.integrations` to keep credential
+ * records off-limits to marketing editors.
+ *
+ * @since 2.4.0
+ */
+class DynamicContentRecordPolicy
+{
+    /**
+     * Type-aware viewAny check. Callers with a known type should invoke
+     * this via `Gate::check('viewAnyForType', $type)` rather than the
+     * type-less {@see viewAny()} — the type-less variant can't be scoped.
+     */
+    public function viewAnyForType( Authenticatable $user, DynamicContentType $type ): bool
+    {
+        return $user->can( applyFilters( 'dynamicContent.record.viewAny', 'manage_dynamic_content', $type ) );
+    }
+
+    public function viewAny( Authenticatable $user ): bool
+    {
+        return $user->can( applyFilters( 'dynamicContent.record.viewAny', 'manage_dynamic_content', null ) );
+    }
+
+    public function view( Authenticatable $user, DynamicContentRecord $record ): bool
+    {
+        return $user->can( applyFilters( 'dynamicContent.record.view', 'manage_dynamic_content', $record->type ) );
+    }
+
+    /**
+     * Type-aware create check. Callers with a known type should invoke
+     * this via `Gate::check('createForType', $type)`.
+     */
+    public function createForType( Authenticatable $user, DynamicContentType $type ): bool
+    {
+        return $user->can( applyFilters( 'dynamicContent.record.create', 'manage_dynamic_content', $type ) );
+    }
+
+    public function create( Authenticatable $user ): bool
+    {
+        return $user->can( applyFilters( 'dynamicContent.record.create', 'manage_dynamic_content', null ) );
+    }
+
+    public function update( Authenticatable $user, DynamicContentRecord $record ): bool
+    {
+        return $user->can( applyFilters( 'dynamicContent.record.update', 'manage_dynamic_content', $record->type ) );
+    }
+
+    public function delete( Authenticatable $user, DynamicContentRecord $record ): bool
+    {
+        return $user->can( applyFilters( 'dynamicContent.record.delete', 'manage_dynamic_content', $record->type ) );
+    }
+}

--- a/src/Modules/DynamicContent/Policies/DynamicContentTypePolicy.php
+++ b/src/Modules/DynamicContent/Policies/DynamicContentTypePolicy.php
@@ -1,0 +1,43 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Modules\DynamicContent\Policies;
+
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Models\DynamicContentType;
+use Illuminate\Contracts\Auth\Authenticatable;
+
+/**
+ * Policy for DynamicContentType.
+ *
+ * All checks gate on the `manage_dynamic_content` capability.
+ *
+ * @since 2.4.0
+ */
+class DynamicContentTypePolicy
+{
+    public function viewAny( Authenticatable $user ): bool
+    {
+        return $user->can( applyFilters( 'dynamicContent.viewAny', 'manage_dynamic_content' ) );
+    }
+
+    public function view( Authenticatable $user, DynamicContentType $type ): bool
+    {
+        return $user->can( applyFilters( 'dynamicContent.view', 'manage_dynamic_content', $type ) );
+    }
+
+    public function create( Authenticatable $user ): bool
+    {
+        return $user->can( applyFilters( 'dynamicContent.create', 'manage_dynamic_content' ) );
+    }
+
+    public function update( Authenticatable $user, DynamicContentType $type ): bool
+    {
+        return $user->can( applyFilters( 'dynamicContent.update', 'manage_dynamic_content', $type ) );
+    }
+
+    public function delete( Authenticatable $user, DynamicContentType $type ): bool
+    {
+        return $user->can( applyFilters( 'dynamicContent.delete', 'manage_dynamic_content', $type ) );
+    }
+}

--- a/src/Modules/DynamicContent/Providers/DynamicContentServiceProvider.php
+++ b/src/Modules/DynamicContent/Providers/DynamicContentServiceProvider.php
@@ -1,0 +1,168 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Modules\DynamicContent\Providers;
+
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Livewire\CollectionEditor;
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Livewire\FieldBuilder;
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Livewire\SingletonEditor;
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Livewire\TypeList;
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Managers\DynamicContentRecordManager;
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Managers\DynamicContentTypeManager;
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Managers\DynamicContentTypeRegistry;
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Managers\FieldTypeRegistry;
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Managers\ModifierRegistry;
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Models\DynamicContentRecord;
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Models\DynamicContentRecordValue;
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Models\DynamicContentType;
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Policies\DynamicContentRecordPolicy;
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Policies\DynamicContentTypePolicy;
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Services\DynamicContentAccessor;
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Services\DynamicContentResolver;
+use ArtisanPackUI\CMSFramework\Modules\Users\Managers\PermissionManager;
+use Illuminate\Support\Facades\Blade;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Gate;
+use Illuminate\Support\Facades\Route;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\ServiceProvider;
+use Livewire\Livewire;
+
+/**
+ * Wires up the DynamicContent module.
+ *
+ * @since 2.4.0
+ */
+class DynamicContentServiceProvider extends ServiceProvider
+{
+    public const CAPABILITY = 'manage_dynamic_content';
+
+    public function register(): void
+    {
+        $this->app->singleton( FieldTypeRegistry::class, fn () => new FieldTypeRegistry() );
+        $this->app->singleton( ModifierRegistry::class, fn () => new ModifierRegistry() );
+        $this->app->singleton( DynamicContentTypeRegistry::class, fn () => new DynamicContentTypeRegistry() );
+
+        $this->app->singleton( DynamicContentTypeManager::class, fn ( $app ) => new DynamicContentTypeManager(
+            $app->make( DynamicContentTypeRegistry::class ),
+        ) );
+
+        $this->app->singleton( DynamicContentRecordManager::class, fn () => new DynamicContentRecordManager() );
+
+        $this->app->singleton( DynamicContentAccessor::class, fn ( $app ) => new DynamicContentAccessor(
+            $app->make( DynamicContentTypeRegistry::class ),
+        ) );
+
+        $this->app->singleton( DynamicContentResolver::class, fn ( $app ) => new DynamicContentResolver(
+            $app->make( DynamicContentTypeRegistry::class ),
+            $app->make( DynamicContentAccessor::class ),
+            $app->make( FieldTypeRegistry::class ),
+            $app->make( ModifierRegistry::class ),
+        ) );
+
+        $this->loadHelpers();
+    }
+
+    public function boot(): void
+    {
+        $this->loadMigrationsFrom( __DIR__ . '/../database/migrations' );
+
+        Route::prefix( 'api/v1' )
+            ->middleware( 'api' )
+            ->group( __DIR__ . '/../routes/api.php' );
+
+        Gate::policy( DynamicContentType::class, DynamicContentTypePolicy::class );
+        Gate::policy( DynamicContentRecord::class, DynamicContentRecordPolicy::class );
+
+        // Resolver output is already HTML-safe: text-shaped field types
+        // escape at render time, rich-text/image stay intentionally raw.
+        // Emit via raw `echo` so rich-text markup isn't double-escaped.
+        Blade::directive( 'dynamicContent', function ( string $expression ): string {
+            return "<?php echo app( \\ArtisanPackUI\\CMSFramework\\Modules\\DynamicContent\\Services\\DynamicContentResolver::class )->render( (string) ( {$expression} ) ); ?>";
+        } );
+
+        $this->deferCapabilityRegistration();
+        $this->registerRecordEvents();
+        $this->registerViews();
+        $this->registerLivewireComponents();
+    }
+
+    protected function registerViews(): void
+    {
+        $this->loadViewsFrom( __DIR__ . '/../resources/views', 'ap-cms-dynamic-content' );
+    }
+
+    protected function registerLivewireComponents(): void
+    {
+        if ( ! class_exists( Livewire::class ) ) {
+            return;
+        }
+
+        Livewire::component( 'ap-cms-dynamic-content.type-list', TypeList::class );
+        Livewire::component( 'ap-cms-dynamic-content.field-builder', FieldBuilder::class );
+        Livewire::component( 'ap-cms-dynamic-content.singleton-editor', SingletonEditor::class );
+        Livewire::component( 'ap-cms-dynamic-content.collection-editor', CollectionEditor::class );
+    }
+
+    protected function loadHelpers(): void
+    {
+        $helpersPath = __DIR__ . '/../helpers.php';
+
+        if ( file_exists( $helpersPath ) ) {
+            require_once $helpersPath;
+        }
+    }
+
+    /**
+     * Defer the `manage_dynamic_content` capability registration until the
+     * app has fully booted. Running `Schema::hasTable('permissions')` inside
+     * a synchronous `boot()` costs one DB round-trip on every request; the
+     * capability only needs to exist once, at real bootstrap time (console
+     * migrations, one-shot bootstrap seeders), so we lift the probe into
+     * `booted()` where it runs once per process.
+     */
+    protected function deferCapabilityRegistration(): void
+    {
+        $this->app->booted( function (): void {
+            if ( ! class_exists( PermissionManager::class ) ) {
+                return;
+            }
+
+            if ( ! Schema::hasTable( 'permissions' ) ) {
+                return;
+            }
+
+            $this->app->make( PermissionManager::class )
+                ->register( self::CAPABILITY, __( 'Manage Dynamic Content' ) );
+        } );
+    }
+
+    /**
+     * Invalidate resolver-level cache AND accessor per-request memo on
+     * record write, so downstream reads see the fresh value.
+     */
+    protected function registerRecordEvents(): void
+    {
+        $bust = function ( DynamicContentRecord|DynamicContentRecordValue $model ): void {
+            $record = $model instanceof DynamicContentRecord ? $model : $model->record;
+
+            if ( null === $record || null === $record->type ) {
+                return;
+            }
+
+            $slug = $record->type->slug;
+
+            Cache::forget( 'dc.sig.' . $slug );
+
+            if ( $this->app->resolved( DynamicContentAccessor::class ) ) {
+                $this->app->make( DynamicContentAccessor::class )->forget( $slug );
+            }
+        };
+
+        DynamicContentRecord::saved( $bust );
+        DynamicContentRecord::deleted( $bust );
+        DynamicContentRecordValue::saved( $bust );
+        DynamicContentRecordValue::deleted( $bust );
+    }
+}

--- a/src/Modules/DynamicContent/Services/DynamicContentAccessor.php
+++ b/src/Modules/DynamicContent/Services/DynamicContentAccessor.php
@@ -1,0 +1,224 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Modules\DynamicContent\Services;
+
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Enums\Cardinality;
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Enums\Source;
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Managers\DynamicContentTypeRegistry;
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Models\DynamicContentRecord;
+use Illuminate\Support\Facades\Cache;
+
+/**
+ * Reads dynamic content records — DB-backed or code-registered.
+ *
+ * All reads flow through here so the resolver, block bindings, and REST
+ * endpoints share a single lazy-loading strategy and cache signature.
+ *
+ * @since 2.4.0
+ */
+class DynamicContentAccessor
+{
+    /**
+     * Per-request memoization: `[$typeSlug => list<array<string,mixed>>]`.
+     *
+     * The accessor is bound as a singleton, so this cache is scoped to a
+     * single HTTP request / job. Kills the N+1 that arises when a body
+     * has multiple tokens against the same collection
+     * (e.g. `{{team[0].name}} {{team[0].role}}`) — the collection now
+     * loads once and every token indexes into the in-memory array.
+     *
+     * Invalidated by {@see forget()}, which fires from the same record
+     * save/delete events that bust the resolver signature cache.
+     *
+     * @var array<string, list<array<string,mixed>>>
+     */
+    protected array $collectionMemo = [];
+
+    /**
+     * Per-request memoization for singleton reads: `[$typeSlug => array<string,mixed>|null]`.
+     *
+     * `null` is a valid memoized value ("no record persisted"), so we use
+     * a sentinel key check (`array_key_exists`) to distinguish memoized
+     * misses from cold entries.
+     *
+     * @var array<string, array<string,mixed>|null>
+     */
+    protected array $singletonMemo = [];
+
+    public function __construct( protected DynamicContentTypeRegistry $registry )
+    {
+    }
+
+    /**
+     * Clear per-request memoization. Called from the record save/delete
+     * event listener registered in {@see \ArtisanPackUI\CMSFramework\Modules\DynamicContent\Providers\DynamicContentServiceProvider}.
+     */
+    public function forget( ?string $typeSlug = null ): void
+    {
+        if ( null === $typeSlug ) {
+            $this->collectionMemo = [];
+            $this->singletonMemo  = [];
+
+            return;
+        }
+
+        unset( $this->collectionMemo[ $typeSlug ], $this->singletonMemo[ $typeSlug ] );
+    }
+
+    /**
+     * Fetch a singleton record's field values by type slug.
+     *
+     * Returns null when the type doesn't exist. Returns [] when the type
+     * exists but has no persisted record yet.
+     *
+     * @return array<string, mixed>|null
+     */
+    public function singleton( string $typeSlug ): ?array
+    {
+        if ( array_key_exists( $typeSlug, $this->singletonMemo ) ) {
+            return $this->singletonMemo[ $typeSlug ];
+        }
+
+        $type = $this->registry->get( $typeSlug );
+
+        if ( null === $type ) {
+            return $this->singletonMemo[ $typeSlug ] = null;
+        }
+
+        if ( Cardinality::Singleton !== $type['cardinality'] ) {
+            return $this->singletonMemo[ $typeSlug ] = null;
+        }
+
+        return $this->singletonMemo[ $typeSlug ] = $this->firstRecord( $type ) ?? $this->defaultsFromFields( $type );
+    }
+
+    /**
+     * Fetch a specific collection record by index (0-based).
+     *
+     * @return array<string, mixed>|null
+     */
+    public function collectionItem( string $typeSlug, int $index ): ?array
+    {
+        // Delegate through the memoized collection load so N tokens against
+        // the same collection (`{{team[0].x}} {{team[0].y}}`) share one query.
+        $records = $this->collection( $typeSlug );
+
+        return $records[ $index ] ?? null;
+    }
+
+    /**
+     * Return every record for a collection type as an array of field-value maps.
+     *
+     * Used by the visual-editor loop block and by REST list endpoints.
+     *
+     * @return list<array<string, mixed>>
+     */
+    public function collection( string $typeSlug ): array
+    {
+        if ( array_key_exists( $typeSlug, $this->collectionMemo ) ) {
+            return $this->collectionMemo[ $typeSlug ];
+        }
+
+        $type = $this->registry->get( $typeSlug );
+
+        if ( null === $type || Cardinality::Collection !== $type['cardinality'] ) {
+            return $this->collectionMemo[ $typeSlug ] = [];
+        }
+
+        if ( Source::Code === $type['source'] ) {
+            return $this->collectionMemo[ $typeSlug ] = $this->resolveCodeRecords( $type );
+        }
+
+        return $this->collectionMemo[ $typeSlug ] = DynamicContentRecord::query()
+            ->with( 'values.field', 'type.fields' )
+            ->where( 'dynamic_content_type_id', $type['db_id'] )
+            ->orderBy( 'order' )
+            ->orderBy( 'id' )
+            ->get()
+            ->map( fn ( DynamicContentRecord $r ) => $r->fieldValues() )
+            ->values()
+            ->all();
+    }
+
+    /**
+     * Return the cache signature for a type — used to key downstream caches.
+     */
+    public function signatureFor( string $typeSlug ): string
+    {
+        $type = $this->registry->get( $typeSlug );
+
+        if ( null === $type ) {
+            return "dc:{$typeSlug}:missing";
+        }
+
+        if ( Source::Code === $type['source'] ) {
+            return "dc:{$typeSlug}:code";
+        }
+
+        $stamp = Cache::rememberForever(
+            "dc.sig.{$typeSlug}",
+            fn () => (string) DynamicContentRecord::query()
+                ->where( 'dynamic_content_type_id', $type['db_id'] )
+                ->max( 'updated_at' ),
+        );
+
+        return "dc:{$typeSlug}:{$stamp}";
+    }
+
+    protected function firstRecord( array $type ): ?array
+    {
+        if ( Source::Code === $type['source'] ) {
+            $records = $this->resolveCodeRecords( $type );
+
+            return $records[0] ?? null;
+        }
+
+        $record = DynamicContentRecord::query()
+            ->with( 'values.field', 'type.fields' )
+            ->where( 'dynamic_content_type_id', $type['db_id'] )
+            ->orderBy( 'order' )
+            ->orderBy( 'id' )
+            ->first();
+
+        return null === $record ? null : $record->fieldValues();
+    }
+
+    protected function defaultsFromFields( array $type ): array
+    {
+        $out = [];
+
+        foreach ( $type['fields'] as $field ) {
+            $out[ $field['slug'] ] = $field['default'] ?? null;
+        }
+
+        return $out;
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    protected function resolveCodeRecords( array $type ): array
+    {
+        $records = $type['records'] ?? null;
+
+        if ( is_callable( $records ) ) {
+            $records = $records();
+        }
+
+        if ( null === $records ) {
+            return [];
+        }
+
+        $out = [];
+
+        foreach ( $records as $record ) {
+            if ( is_array( $record ) ) {
+                $out[] = $record;
+            }
+        }
+
+        return $out;
+    }
+}

--- a/src/Modules/DynamicContent/Services/DynamicContentResolver.php
+++ b/src/Modules/DynamicContent/Services/DynamicContentResolver.php
@@ -1,0 +1,319 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Modules\DynamicContent\Services;
+
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Enums\Cardinality;
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Managers\DynamicContentTypeRegistry;
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Managers\FieldTypeRegistry;
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Managers\ModifierRegistry;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Request;
+use Illuminate\Support\HtmlString;
+use Throwable;
+
+/**
+ * Resolves `{{source.field|modifier:arg}}` tokens in a string.
+ *
+ * Returns **HTML-safe** output: values are routed through their field
+ * type's `render()` which either escapes (text-shaped types) or emits
+ * intentional HTML (rich text). If a token can't be routed to a known
+ * field type the value is escaped defensively before returning.
+ *
+ * Missing sources / fields render as an empty string and log a warning to
+ * the `dynamic-content` channel. Resolution does NOT recurse — resolved
+ * output is not re-scanned for tokens.
+ *
+ * @since 2.4.0
+ */
+class DynamicContentResolver
+{
+    /**
+     * Matches `{{ source.field[.subfield|[index].field][|modifier:arg:arg]* }}`.
+     * The outer non-greedy body is deliberately narrow — no braces inside a token.
+     */
+    public const TOKEN_PATTERN = '/\{\{\s*([^{}]+?)\s*\}\}/';
+
+    public function __construct(
+        protected DynamicContentTypeRegistry $registry,
+        protected DynamicContentAccessor $accessor,
+        protected FieldTypeRegistry $fieldTypes,
+        protected ModifierRegistry $modifiers,
+    ) {
+    }
+
+    public function render( string $content, array $context = [] ): string
+    {
+        if ( '' === $content || ! str_contains( $content, '{{' ) ) {
+            return $content;
+        }
+
+        return (string) preg_replace_callback(
+            self::TOKEN_PATTERN,
+            fn ( array $match ) => $this->resolveOne( $match[0], $match[1], $context ),
+            $content,
+        );
+    }
+
+    /**
+     * Return a signature that summarizes the resolver state for the given content.
+     *
+     * Callers include this in their own cache keys so a token change invalidates
+     * their cached HTML.
+     */
+    public function signatureFor( string $content ): string
+    {
+        if ( ! preg_match_all( self::TOKEN_PATTERN, $content, $matches ) ) {
+            return 'dc:none';
+        }
+
+        $signatures = [];
+
+        foreach ( $matches[1] as $body ) {
+            $parsed = $this->parseToken( $body );
+
+            if ( null === $parsed ) {
+                continue;
+            }
+
+            $signatures[] = $this->accessor->signatureFor( $parsed['source'] );
+        }
+
+        return md5( implode( '|', $signatures ) );
+    }
+
+    protected function resolveOne( string $original, string $body, array $context ): string
+    {
+        $parsed = $this->parseToken( $body );
+
+        if ( null === $parsed ) {
+            $this->logMissing( $original, 'malformed', $context );
+
+            return '';
+        }
+
+        $value = $this->readValue( $parsed );
+
+        if ( null === $value && ! $this->hasDefaultModifier( $parsed['modifiers'] ) ) {
+            $this->logMissing( $original, 'unresolved', $context );
+        }
+
+        $value    = $this->applyModifiers( $value, $parsed['modifiers'] );
+        $rendered = $this->renderFieldValue( $parsed, $value );
+
+        return (string) $rendered;
+    }
+
+    /**
+     * @return array{source:string, path:array<int,int|string>, modifiers:array<int,array{slug:string,args:array<int,string>}>}|null
+     */
+    protected function parseToken( string $body ): ?array
+    {
+        $parts     = explode( '|', $body );
+        $accessor  = trim( array_shift( $parts ) );
+        $modifiers = [];
+
+        foreach ( $parts as $modifier ) {
+            $modifier = trim( $modifier );
+
+            if ( '' === $modifier ) {
+                continue;
+            }
+
+            $segments = explode( ':', $modifier );
+            $slug     = trim( array_shift( $segments ) );
+
+            if ( '' === $slug ) {
+                continue;
+            }
+
+            $modifiers[] = [
+                'slug' => $slug,
+                'args' => array_map( 'trim', $segments ),
+            ];
+        }
+
+        // Path parsing: `source.field.sub` or `source[0].field`
+        $segments = preg_split( '/[.\[\]]+/', $accessor, -1, PREG_SPLIT_NO_EMPTY );
+
+        if ( false === $segments || count( $segments ) < 1 ) {
+            return null;
+        }
+
+        $source = array_shift( $segments );
+        $path   = [];
+
+        foreach ( $segments as $segment ) {
+            $path[] = ctype_digit( $segment ) ? (int) $segment : $segment;
+        }
+
+        return [
+            'source'    => $source,
+            'path'      => $path,
+            'modifiers' => $modifiers,
+        ];
+    }
+
+    protected function readValue( array $parsed ): mixed
+    {
+        $type = $this->registry->get( $parsed['source'] );
+
+        if ( null === $type ) {
+            return null;
+        }
+
+        // Split path into an optional collection index followed by a field path.
+        $path       = $parsed['path'];
+        $firstIsInt = ! empty( $path ) && is_int( $path[0] );
+
+        if ( Cardinality::Collection === $type['cardinality'] ) {
+            $index  = $firstIsInt ? array_shift( $path ) : 0;
+            $record = $this->accessor->collectionItem( $parsed['source'], $index );
+        } else {
+            $record = $this->accessor->singleton( $parsed['source'] );
+        }
+
+        if ( null === $record ) {
+            return null;
+        }
+
+        return $this->traversePath( $record, $path );
+    }
+
+    protected function traversePath( mixed $value, array $path ): mixed
+    {
+        foreach ( $path as $segment ) {
+            if ( is_array( $value ) && array_key_exists( $segment, $value ) ) {
+                $value = $value[ $segment ];
+                continue;
+            }
+
+            return null;
+        }
+
+        return $value;
+    }
+
+    protected function applyModifiers( mixed $value, array $modifiers ): mixed
+    {
+        foreach ( $modifiers as $modifier ) {
+            $impl = $this->modifiers->get( $modifier['slug'] );
+
+            if ( null === $impl ) {
+                continue;
+            }
+
+            $value = $impl->apply( $value, $modifier['args'] );
+        }
+
+        return $value;
+    }
+
+    /**
+     * Route the value through its field type's `render()` so text-shaped
+     * types are HTML-escaped and rich-text stays raw. When we can't
+     * identify a field type (unknown source, no path, unknown field slug),
+     * fall back to escaping the value defensively.
+     */
+    protected function renderFieldValue( array $parsed, mixed $value ): HtmlString
+    {
+        $fieldSlug = $this->trailingFieldSlug( $parsed['path'] );
+        $type      = null === $fieldSlug ? null : $this->registry->get( $parsed['source'] );
+        $fieldMeta = null === $type ? null : ( $this->fieldsBySlug( $type )[ $fieldSlug ] ?? null );
+
+        if ( null !== $fieldMeta ) {
+            $impl = $this->fieldTypes->get( $fieldMeta['type'] );
+
+            if ( null !== $impl ) {
+                return $impl->render( $value, $fieldMeta['options'] ?? [] );
+            }
+        }
+
+        // Defensive fallback: an unroutable value is treated as untrusted text.
+        if ( $value instanceof HtmlString ) {
+            return $value;
+        }
+
+        if ( null === $value || ! is_scalar( $value ) ) {
+            return new HtmlString( '' );
+        }
+
+        return new HtmlString( e( (string) $value ) );
+    }
+
+    /**
+     * Return the last string segment of a path (the field slug), or null
+     * if the path doesn't end in one.
+     */
+    protected function trailingFieldSlug( array $path ): ?string
+    {
+        for ( $i = count( $path ) - 1; $i >= 0; $i-- ) {
+            if ( is_string( $path[ $i ] ) ) {
+                return $path[ $i ];
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Memoized fields-by-slug index for a normalized type definition.
+     *
+     * @param  array{fields:array<int,array<string,mixed>>}  $type
+     *
+     * @return array<string, array<string,mixed>>
+     */
+    protected function fieldsBySlug( array $type ): array
+    {
+        static $cache = [];
+
+        $key = $type['slug'] ?? spl_object_hash( (object) $type );
+
+        if ( isset( $cache[ $key ] ) ) {
+            return $cache[ $key ];
+        }
+
+        $out = [];
+
+        foreach ( $type['fields'] as $field ) {
+            $out[ $field['slug'] ] = $field;
+        }
+
+        return $cache[ $key ] = $out;
+    }
+
+    protected function hasDefaultModifier( array $modifiers ): bool
+    {
+        foreach ( $modifiers as $modifier ) {
+            if ( 'default' === $modifier['slug'] ) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    protected function logMissing( string $token, string $reason, array $context ): void
+    {
+        $channel = config( 'logging.channels.dynamic-content' ) ? 'dynamic-content' : 'stack';
+
+        try {
+            $url = Request::fullUrl();
+        } catch ( Throwable ) {
+            $url = null;
+        }
+
+        Log::channel( $channel )->warning(
+            'Dynamic content token failed to resolve',
+            [
+                'token'   => $token,
+                'reason'  => $reason,
+                'url'     => $url,
+                'user_id' => Auth::id(),
+                'context' => $context,
+            ],
+        );
+    }
+}

--- a/src/Modules/DynamicContent/database/migrations/2026_07_16_000001_create_dynamic_content_types_table.php
+++ b/src/Modules/DynamicContent/database/migrations/2026_07_16_000001_create_dynamic_content_types_table.php
@@ -1,0 +1,31 @@
+<?php
+
+declare( strict_types=1 );
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create( 'dynamic_content_types', function ( Blueprint $table ): void {
+            $table->id();
+            $table->string( 'slug' )->unique();
+            $table->string( 'name' );
+            $table->string( 'cardinality' )->default( 'singleton' );
+            $table->string( 'source' )->default( 'db' );
+            $table->text( 'description' )->nullable();
+            $table->string( 'icon' )->nullable();
+            $table->timestamps();
+
+            $table->index( 'source' );
+            $table->index( 'cardinality' );
+        } );
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists( 'dynamic_content_types' );
+    }
+};

--- a/src/Modules/DynamicContent/database/migrations/2026_07_16_000002_create_dynamic_content_fields_table.php
+++ b/src/Modules/DynamicContent/database/migrations/2026_07_16_000002_create_dynamic_content_fields_table.php
@@ -1,0 +1,35 @@
+<?php
+
+declare( strict_types=1 );
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create( 'dynamic_content_fields', function ( Blueprint $table ): void {
+            $table->id();
+            $table->foreignId( 'dynamic_content_type_id' )
+                ->constrained( 'dynamic_content_types' )
+                ->cascadeOnDelete();
+            $table->string( 'slug' );
+            $table->string( 'label' );
+            $table->string( 'type' );
+            $table->json( 'options' )->nullable();
+            $table->text( 'default_value' )->nullable();
+            $table->boolean( 'required' )->default( false );
+            $table->unsignedInteger( 'order' )->default( 0 );
+            $table->timestamps();
+
+            $table->unique( [ 'dynamic_content_type_id', 'slug' ] );
+            $table->index( 'order' );
+        } );
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists( 'dynamic_content_fields' );
+    }
+};

--- a/src/Modules/DynamicContent/database/migrations/2026_07_16_000003_create_dynamic_content_records_table.php
+++ b/src/Modules/DynamicContent/database/migrations/2026_07_16_000003_create_dynamic_content_records_table.php
@@ -1,0 +1,29 @@
+<?php
+
+declare( strict_types=1 );
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create( 'dynamic_content_records', function ( Blueprint $table ): void {
+            $table->id();
+            $table->foreignId( 'dynamic_content_type_id' )
+                ->constrained( 'dynamic_content_types' )
+                ->cascadeOnDelete();
+            $table->string( 'label' )->nullable();
+            $table->unsignedInteger( 'order' )->default( 0 );
+            $table->timestamps();
+
+            $table->index( [ 'dynamic_content_type_id', 'order' ] );
+        } );
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists( 'dynamic_content_records' );
+    }
+};

--- a/src/Modules/DynamicContent/database/migrations/2026_07_16_000004_create_dynamic_content_record_values_table.php
+++ b/src/Modules/DynamicContent/database/migrations/2026_07_16_000004_create_dynamic_content_record_values_table.php
@@ -1,0 +1,34 @@
+<?php
+
+declare( strict_types=1 );
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create( 'dynamic_content_record_values', function ( Blueprint $table ): void {
+            $table->id();
+            $table->foreignId( 'dynamic_content_record_id' )
+                ->constrained( 'dynamic_content_records' )
+                ->cascadeOnDelete();
+            $table->foreignId( 'dynamic_content_field_id' )
+                ->constrained( 'dynamic_content_fields' )
+                ->cascadeOnDelete();
+            $table->json( 'value' )->nullable();
+            $table->timestamps();
+
+            $table->unique(
+                [ 'dynamic_content_record_id', 'dynamic_content_field_id' ],
+                'dc_record_field_unique',
+            );
+        } );
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists( 'dynamic_content_record_values' );
+    }
+};

--- a/src/Modules/DynamicContent/helpers.php
+++ b/src/Modules/DynamicContent/helpers.php
@@ -1,0 +1,62 @@
+<?php
+
+declare( strict_types=1 );
+
+/**
+ * DynamicContent Module Helper Functions.
+ *
+ * SECURITY: dynamic content is a public content pipeline. `apRenderContent()`
+ * and the `@dynamicContent` Blade directive resolve tokens against every
+ * registered type without a per-request authorization check — the intent is
+ * that any content author who can write a token can substitute any dynamic
+ * content field. Do NOT store secrets in dynamic content records. See
+ * {@see ArtisanPackUI\CMSFramework\Modules\DynamicContent\Casts\DynamicContentCast}
+ * for the full note.
+ *
+ * @since 2.4.0
+ */
+
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Managers\DynamicContentTypeRegistry;
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Services\DynamicContentResolver;
+
+if ( ! function_exists( 'apRegisterDynamicContentType' ) ) {
+    /**
+     * Register a dynamic content type in code.
+     *
+     * @since 2.4.0
+     *
+     * @param  string  $slug  Unique type slug.
+     * @param  array<string, mixed>  $definition  Type definition (name, cardinality, fields, records).
+     */
+    function apRegisterDynamicContentType( string $slug, array $definition ): void
+    {
+        app( DynamicContentTypeRegistry::class )->registerCodeType( $slug, $definition );
+    }
+}
+
+if ( ! function_exists( 'apRenderContent' ) ) {
+    /**
+     * Render dynamic-content tokens inside a string.
+     *
+     * @since 2.4.0
+     *
+     * @param  string  $content  Content containing `{{source.field}}` tokens.
+     * @param  array<string, mixed>  $context  Optional context for logging.
+     */
+    function apRenderContent( string $content, array $context = [] ): string
+    {
+        return app( DynamicContentResolver::class )->render( $content, $context );
+    }
+}
+
+if ( ! function_exists( 'apDynamicContentSignature' ) ) {
+    /**
+     * Signature of the resolver's state for `$content` — for cache keys.
+     *
+     * @since 2.4.0
+     */
+    function apDynamicContentSignature( string $content ): string
+    {
+        return app( DynamicContentResolver::class )->signatureFor( $content );
+    }
+}

--- a/src/Modules/DynamicContent/resources/views/livewire/collection-editor.blade.php
+++ b/src/Modules/DynamicContent/resources/views/livewire/collection-editor.blade.php
@@ -1,0 +1,47 @@
+<div>
+    <h2>{{ $type->name }}</h2>
+
+    <button type="button" wire:click="create">{{ __( 'New Record' ) }}</button>
+
+    <table>
+        <thead>
+            <tr>
+                <th>{{ __( 'Label' ) }}</th>
+                <th>{{ __( 'Order' ) }}</th>
+                <th>{{ __( 'Actions' ) }}</th>
+            </tr>
+        </thead>
+        <tbody>
+            @foreach ( $records as $record )
+                <tr wire:key="record-{{ $record->id }}">
+                    <td>{{ $record->label }}</td>
+                    <td>{{ $record->order }}</td>
+                    <td>
+                        <button type="button" wire:click="edit({{ $record->id }})">{{ __( 'Edit' ) }}</button>
+                        <button type="button" wire:click="delete({{ $record->id }})">{{ __( 'Delete' ) }}</button>
+                    </td>
+                </tr>
+            @endforeach
+        </tbody>
+    </table>
+
+    {{ $records->links() }}
+
+    @if ( null !== $editingRecordId || ! empty( $editingValues ) )
+        <div>
+            <h3>{{ null === $editingRecordId ? __( 'New Record' ) : __( 'Edit Record' ) }}</h3>
+            <label>{{ __( 'Label' ) }}<input type="text" wire:model="editingLabel" /></label>
+
+            @foreach ( $type->fields as $field )
+                <div wire:key="editing-value-{{ $field->slug }}">
+                    <label>
+                        {{ $field->label }}
+                        <input type="text" wire:model="editingValues.{{ $field->slug }}" />
+                    </label>
+                </div>
+            @endforeach
+
+            <button type="button" wire:click="save">{{ __( 'Save' ) }}</button>
+        </div>
+    @endif
+</div>

--- a/src/Modules/DynamicContent/resources/views/livewire/field-builder.blade.php
+++ b/src/Modules/DynamicContent/resources/views/livewire/field-builder.blade.php
@@ -1,0 +1,35 @@
+<div>
+    <div>
+        <label>{{ __( 'Name' ) }}<input type="text" wire:model="name" /></label>
+        <label>{{ __( 'Slug' ) }}<input type="text" wire:model="slug" /></label>
+        <label>{{ __( 'Cardinality' ) }}
+            <select wire:model="cardinality">
+                <option value="singleton">{{ __( 'Singleton' ) }}</option>
+                <option value="collection">{{ __( 'Collection' ) }}</option>
+            </select>
+        </label>
+        <label>{{ __( 'Description' ) }}<textarea wire:model="description"></textarea></label>
+    </div>
+
+    <h3>{{ __( 'Fields' ) }}</h3>
+    @foreach ( $fields as $index => $field )
+        <div wire:key="field-{{ $index }}">
+            <input type="text" wire:model="fields.{{ $index }}.slug" :placeholder="__( 'Slug' )" />
+            <input type="text" wire:model="fields.{{ $index }}.label" :placeholder="__( 'Label' )" />
+            <select wire:model="fields.{{ $index }}.type">
+                @foreach ( $fieldTypes as $slug => $ft )
+                    <option value="{{ $slug }}">{{ $ft->label() }}</option>
+                @endforeach
+            </select>
+            <label><input type="checkbox" wire:model="fields.{{ $index }}.required" /> {{ __( 'Required' ) }}</label>
+            <input type="text" wire:model="fields.{{ $index }}.default" :placeholder="__( 'Default' )" />
+
+            <button type="button" wire:click="moveUp({{ $index }})">{{ __( 'Move up' ) }}</button>
+            <button type="button" wire:click="moveDown({{ $index }})">{{ __( 'Move down' ) }}</button>
+            <button type="button" wire:click="removeField({{ $index }})">{{ __( 'Remove' ) }}</button>
+        </div>
+    @endforeach
+
+    <button type="button" wire:click="addField">{{ __( 'Add Field' ) }}</button>
+    <button type="button" wire:click="save">{{ __( 'Save' ) }}</button>
+</div>

--- a/src/Modules/DynamicContent/resources/views/livewire/singleton-editor.blade.php
+++ b/src/Modules/DynamicContent/resources/views/livewire/singleton-editor.blade.php
@@ -1,0 +1,28 @@
+<div>
+    <h2>{{ $type->name }}</h2>
+
+    @foreach ( $type->fields as $field )
+        <div wire:key="value-{{ $field->slug }}">
+            <label>
+                {{ $field->label }}
+                @if ( 'rich_text' === $field->type )
+                    <textarea wire:model="values.{{ $field->slug }}"></textarea>
+                @elseif ( 'number' === $field->type )
+                    <input type="number" wire:model="values.{{ $field->slug }}" />
+                @elseif ( 'email' === $field->type )
+                    <input type="email" wire:model="values.{{ $field->slug }}" />
+                @elseif ( 'url' === $field->type )
+                    <input type="url" wire:model="values.{{ $field->slug }}" />
+                @elseif ( 'date' === $field->type )
+                    <input type="date" wire:model="values.{{ $field->slug }}" />
+                @elseif ( 'datetime' === $field->type )
+                    <input type="datetime-local" wire:model="values.{{ $field->slug }}" />
+                @else
+                    <input type="text" wire:model="values.{{ $field->slug }}" />
+                @endif
+            </label>
+        </div>
+    @endforeach
+
+    <button type="button" wire:click="save">{{ __( 'Save' ) }}</button>
+</div>

--- a/src/Modules/DynamicContent/resources/views/livewire/type-list.blade.php
+++ b/src/Modules/DynamicContent/resources/views/livewire/type-list.blade.php
@@ -1,0 +1,30 @@
+<div>
+    <table>
+        <thead>
+            <tr>
+                <th>{{ __( 'Name' ) }}</th>
+                <th>{{ __( 'Slug' ) }}</th>
+                <th>{{ __( 'Cardinality' ) }}</th>
+                <th>{{ __( 'Source' ) }}</th>
+                <th>{{ __( 'Actions' ) }}</th>
+            </tr>
+        </thead>
+        <tbody>
+            @foreach ( $types as $slug => $type )
+                <tr wire:key="type-{{ $slug }}">
+                    <td>{{ $type['name'] }}</td>
+                    <td><code>{{ $slug }}</code></td>
+                    <td>{{ $type['cardinality']->value }}</td>
+                    <td>{{ $type['source']->value }}</td>
+                    <td>
+                        @if ( 'db' === $type['source']->value && isset( $type['db_id'] ) )
+                            <button type="button" wire:click="delete({{ $type['db_id'] }})">{{ __( 'Delete' ) }}</button>
+                        @else
+                            <span title="{{ __( 'Code-registered types are read-only' ) }}">{{ __( 'Read-only' ) }}</span>
+                        @endif
+                    </td>
+                </tr>
+            @endforeach
+        </tbody>
+    </table>
+</div>

--- a/src/Modules/DynamicContent/routes/api.php
+++ b/src/Modules/DynamicContent/routes/api.php
@@ -1,0 +1,32 @@
+<?php
+
+declare( strict_types=1 );
+
+/**
+ * Dynamic Content module API routes.
+ *
+ * @since 2.4.0
+ */
+
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Http\Controllers\DynamicContentRecordController;
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Http\Controllers\DynamicContentResolverController;
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Http\Controllers\DynamicContentTypeController;
+use Illuminate\Support\Facades\Route;
+
+Route::prefix( 'dynamic-content' )->middleware( 'auth' )->group( function (): void {
+    Route::get( 'types', [ DynamicContentTypeController::class, 'index' ] );
+    Route::get( 'types/registered', [ DynamicContentTypeController::class, 'registered' ] );
+    Route::post( 'types', [ DynamicContentTypeController::class, 'store' ] );
+    Route::get( 'types/{type}', [ DynamicContentTypeController::class, 'show' ] );
+    Route::put( 'types/{type}', [ DynamicContentTypeController::class, 'update' ] );
+    Route::delete( 'types/{type}', [ DynamicContentTypeController::class, 'destroy' ] );
+
+    Route::get( 'types/{type}/records', [ DynamicContentRecordController::class, 'index' ] );
+    Route::post( 'types/{type}/records', [ DynamicContentRecordController::class, 'store' ] );
+    Route::get( 'types/{type}/records/{record}', [ DynamicContentRecordController::class, 'show' ] );
+    Route::put( 'types/{type}/records/{record}', [ DynamicContentRecordController::class, 'update' ] );
+    Route::delete( 'types/{type}/records/{record}', [ DynamicContentRecordController::class, 'destroy' ] );
+
+    Route::post( 'resolve', [ DynamicContentResolverController::class, 'resolve' ] )
+        ->middleware( 'throttle:60,1' );
+} );

--- a/src/Modules/OpenApi/Providers/OpenApiServiceProvider.php
+++ b/src/Modules/OpenApi/Providers/OpenApiServiceProvider.php
@@ -113,7 +113,7 @@ class OpenApiServiceProvider extends ServiceProvider
         $scrambleConfig['ui']       = ['title' => $info['title'] ?? 'ArtisanPack CMS Framework API'];
 
         $scrambleConfig['info'] = [
-            'version'     => $info['version'] ?? '2.3.0',
+            'version'     => $info['version'] ?? '2.4.0',
             'description' => $info['description'] ?? '',
         ];
 

--- a/src/Modules/Plugins/Exceptions/IncompatiblePluginException.php
+++ b/src/Modules/Plugins/Exceptions/IncompatiblePluginException.php
@@ -1,0 +1,69 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Modules\Plugins\Exceptions;
+
+use ArtisanPackUI\CMSFramework\Exceptions\CMSFrameworkException;
+
+/**
+ * Raised when a plugin's declared min_host_version is newer than the framework
+ * version installed in the host application.
+ *
+ * @since 2.4.0
+ */
+class IncompatiblePluginException extends CMSFrameworkException
+{
+    /**
+     * Slug of the plugin that failed the compatibility check.
+     *
+     * @since 2.4.0
+     */
+    public readonly string $pluginSlug;
+
+    /**
+     * The min_host_version the plugin manifest declared.
+     *
+     * @since 2.4.0
+     */
+    public readonly string $requiredVersion;
+
+    /**
+     * The framework version currently installed in the host.
+     *
+     * @since 2.4.0
+     */
+    public readonly string $hostVersion;
+
+    /**
+     * Construct with pre-resolved version metadata.
+     *
+     * @since 2.4.0
+     */
+    public function __construct( string $slug, string $requiredVersion, string $hostVersion )
+    {
+        parent::__construct(
+            "Plugin '{$slug}' requires cms-framework {$requiredVersion} or higher; host is running {$hostVersion}.",
+        );
+        $this->pluginSlug      = $slug;
+        $this->requiredVersion = $requiredVersion;
+        $this->hostVersion     = $hostVersion;
+    }
+
+    /**
+     * Named-constructor factory that matches the shape used by sibling plugin
+     * exceptions.
+     *
+     * @since 2.4.0
+     *
+     * @param  string  $slug  Plugin slug.
+     * @param  string  $requiredVersion  Semver declared as min_host_version.
+     * @param  string  $hostVersion  Framework version resolved from the host.
+     *
+     * @return self
+     */
+    public static function forVersion( string $slug, string $requiredVersion, string $hostVersion ): self
+    {
+        return new self( $slug, $requiredVersion, $hostVersion );
+    }
+}

--- a/src/Modules/Plugins/Http/Controllers/PluginsController.php
+++ b/src/Modules/Plugins/Http/Controllers/PluginsController.php
@@ -4,6 +4,7 @@ declare( strict_types=1 );
 
 namespace ArtisanPackUI\CMSFramework\Modules\Plugins\Http\Controllers;
 
+use ArtisanPackUI\CMSFramework\Modules\Plugins\Exceptions\IncompatiblePluginException;
 use ArtisanPackUI\CMSFramework\Modules\Plugins\Managers\PluginManager;
 use ArtisanPackUI\CMSFramework\Modules\Plugins\Managers\UpdateManager;
 use Dedoc\Scramble\Attributes\Group;
@@ -90,6 +91,14 @@ class PluginsController extends Controller
             return response()->json( [
                 'message' => 'Plugin activated successfully',
             ] );
+        } catch ( IncompatiblePluginException $e ) {
+            return response()->json( [
+                'message'          => $e->getMessage(),
+                'code'             => 'plugin_incompatible',
+                'plugin'           => $e->pluginSlug,
+                'required_version' => $e->requiredVersion,
+                'host_version'     => $e->hostVersion,
+            ], 409 );
         } catch ( Exception $e ) {
             return response()->json( [
                 'message' => 'Activation failed: ' . $e->getMessage(),

--- a/src/Modules/Plugins/Managers/PluginManager.php
+++ b/src/Modules/Plugins/Managers/PluginManager.php
@@ -5,17 +5,20 @@ declare( strict_types=1 );
 namespace ArtisanPackUI\CMSFramework\Modules\Plugins\Managers;
 
 use ArtisanPackUI\CMSFramework\Modules\Core\Managers\Concerns\HasManifestParsing;
+use ArtisanPackUI\CMSFramework\Modules\Plugins\Exceptions\IncompatiblePluginException;
 use ArtisanPackUI\CMSFramework\Modules\Plugins\Exceptions\PluginInstallationException;
 use ArtisanPackUI\CMSFramework\Modules\Plugins\Exceptions\PluginNotFoundException;
 use ArtisanPackUI\CMSFramework\Modules\Plugins\Exceptions\PluginValidationException;
 use ArtisanPackUI\CMSFramework\Modules\Plugins\Models\Plugin;
 use Composer\Autoload\ClassLoader;
+use Composer\InstalledVersions;
 use Exception;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\File;
 use RuntimeException;
+use Throwable;
 use ZipArchive;
 
 class PluginManager
@@ -183,28 +186,51 @@ class PluginManager
             throw PluginNotFoundException::forSlug( $slug );
         }
 
+        // Host-version compatibility gate (#183). Runs before any state mutation.
+        $this->assertHostVersionCompatible( $plugin );
+
         doAction( 'plugin.activating', $slug );
 
-        DB::transaction( function () use ( $plugin ): void {
-            // Register autoloader
-            if ( isset( $plugin->meta['autoload'] ) ) {
-                $this->registerAutoloader( $plugin->slug, $plugin->meta['autoload'] );
-            }
+        $priorPsr4           = [];
+        $migrationsAttempted = false;
 
-            // Run migrations
-            if ( isset( $plugin->meta['migrations_path'] ) ) {
-                $this->runMigrations( $plugin->slug, $plugin->meta['migrations_path'] );
-            }
+        try {
+            DB::transaction( function () use ( $plugin, &$priorPsr4, &$migrationsAttempted ): void {
+                if ( isset( $plugin->meta['autoload'] ) ) {
+                    // Snapshot the PSR-4 map BEFORE adding, so rollback can
+                    // restore prior paths for shared namespaces instead of
+                    // wiping them with setPsr4($ns, []).
+                    $priorPsr4 = $this->snapshotPsr4( $plugin->meta['autoload']['psr-4'] ?? [] );
+                    $this->registerAutoloader( $plugin->slug, $plugin->meta['autoload'] );
+                }
 
-            // Register service provider
-            if ( $plugin->hasServiceProvider() ) {
-                app()->register( $plugin->service_provider );
-            }
+                if ( isset( $plugin->meta['migrations_path'] ) ) {
+                    // Flip BEFORE the Artisan call so a mid-migration failure
+                    // (DDL auto-commits in MySQL/MariaDB) still triggers a
+                    // rollback attempt in the catch block.
+                    $migrationsAttempted = true;
+                    $this->runMigrations( $plugin->slug, $plugin->meta['migrations_path'] );
+                }
 
-            // Mark as active
-            $plugin->is_active = true;
-            $plugin->save();
-        } );
+                if ( $plugin->hasServiceProvider() ) {
+                    app()->register( $plugin->service_provider );
+                }
+
+                $this->seedPermissions( $plugin );
+
+                $plugin->is_active = true;
+                $plugin->save();
+            } );
+        } catch ( Throwable $e ) {
+            // Roll back any partial activation state (#182).
+            $this->rollbackFailedActivation( $plugin, $priorPsr4, $migrationsAttempted );
+
+            throw $e;
+        }
+
+        if ( config( 'cms.plugins.autoClearFrameworkCaches', false ) ) {
+            $this->clearFrameworkCaches();
+        }
 
         $this->clearCaches();
 
@@ -241,6 +267,9 @@ class PluginManager
         $plugin->is_active = false;
         $plugin->save();
 
+        if ( config( 'cms.plugins.autoClearFrameworkCaches', false ) ) {
+            $this->clearFrameworkCaches();
+        }
         $this->clearCaches();
 
         doAction( 'plugin.deactivated', $slug );
@@ -280,6 +309,21 @@ class PluginManager
 
         doAction( 'plugin.deleting', $slug );
 
+        // Opt-in migration rollback (#182). Guarded by manifest flag so hosts don't
+        // accidentally drop plugin-owned data.
+        if ( $plugin->rollback_migrations_on_delete && isset( $plugin->meta['migrations_path'] ) ) {
+            try {
+                $this->rollbackMigrations( $plugin->slug, $plugin->meta['migrations_path'] );
+            } catch ( Throwable $e ) {
+                logger()->error( "Failed to rollback migrations for plugin: {$slug}", [
+                    'exception' => $e->getMessage(),
+                ] );
+            }
+        }
+
+        // Remove seeded permissions (#182).
+        $this->removeSeededPermissions( $plugin );
+
         // Remove from database
         $plugin->delete();
 
@@ -291,6 +335,9 @@ class PluginManager
             }
         }
 
+        if ( config( 'cms.plugins.autoClearFrameworkCaches', false ) ) {
+            $this->clearFrameworkCaches();
+        }
         $this->clearCaches();
 
         doAction( 'plugin.deleted', $slug );
@@ -336,17 +383,48 @@ class PluginManager
      */
     protected function runMigrations( string $slug, string $migrationsPath ): void
     {
-        $fullPath = $this->getPluginsPath() . '/' . $slug . '/' . $migrationsPath;
-
-        if ( ! File::isDirectory( $fullPath ) ) {
+        $safePath = $this->resolveSecureMigrationsPath( $slug, $migrationsPath );
+        if ( null === $safePath ) {
             return;
         }
 
         // Run migrations using Artisan
         Artisan::call( 'migrate', [
-            '--path'  => str_replace( base_path(), '', $fullPath ),
+            '--path'  => str_replace( base_path(), '', $safePath ),
             '--force' => true,
         ] );
+    }
+
+    /**
+     * Resolve a plugin-declared migrations path and confirm it lives inside the
+     * plugin's own directory. Defense-in-depth against a malicious manifest
+     * whose migrations_path escaped via ".." (the schema validator also
+     * rejects those, but that runs at install time only).
+     */
+    protected function resolveSecureMigrationsPath( string $slug, string $migrationsPath ): ?string
+    {
+        $pluginDir = $this->getPluginsPath() . '/' . $slug;
+        $fullPath  = $pluginDir . '/' . ltrim( $migrationsPath, '/' );
+
+        if ( ! File::isDirectory( $fullPath ) ) {
+            return null;
+        }
+
+        $realFull   = realpath( $fullPath );
+        $realPlugin = realpath( $pluginDir );
+
+        if ( false === $realFull || false === $realPlugin ) {
+            return null;
+        }
+
+        // The resolved path must sit inside the plugin's own directory.
+        if ( ! str_starts_with( $realFull . DIRECTORY_SEPARATOR, $realPlugin . DIRECTORY_SEPARATOR ) ) {
+            logger()->warning( "Plugin '{$slug}' migrations_path resolved outside plugin dir; refusing to touch: {$realFull}" );
+
+            return null;
+        }
+
+        return $realFull;
     }
 
     /**
@@ -401,6 +479,83 @@ class PluginManager
         // Anchored at end to prevent injection attempts like "1.0.0'; DROP TABLE"
         if ( ! preg_match( '/^\d+\.\d+\.\d+$/', $manifest['version'] ) ) {
             throw PluginValidationException::invalidManifest( 'Invalid version format. Use semantic versioning (e.g., 1.0.0).' );
+        }
+
+        $this->validateOptionalManifestFields( $manifest );
+    }
+
+    /**
+     * Validate optional manifest fields introduced in the v2.4 schema extension.
+     *
+     * @throws PluginValidationException If any optional field is malformed.
+     */
+    protected function validateOptionalManifestFields( array $manifest ): void
+    {
+        if ( isset( $manifest['min_host_version'] ) ) {
+            if ( ! is_string( $manifest['min_host_version'] )
+                || ! preg_match( '/^\d+\.\d+\.\d+$/', $manifest['min_host_version'] ) ) {
+                throw PluginValidationException::invalidManifest( 'Invalid min_host_version format. Use semantic versioning (e.g., 1.0.0).' );
+            }
+        }
+
+        if ( isset( $manifest['federated_module'] ) ) {
+            $federated = $manifest['federated_module'];
+            if ( ! is_array( $federated )
+                || empty( $federated['entry'] )
+                || ! is_string( $federated['entry'] ) ) {
+                throw PluginValidationException::invalidManifest( 'Invalid federated_module. Must be an object with a non-empty string "entry".' );
+            }
+            if ( isset( $federated['exposes'] ) && ! is_array( $federated['exposes'] ) ) {
+                throw PluginValidationException::invalidManifest( 'Invalid federated_module.exposes. Must be an array of module names.' );
+            }
+        }
+
+        if ( isset( $manifest['nav_entries'] ) ) {
+            if ( ! is_array( $manifest['nav_entries'] ) || false === array_is_list( $manifest['nav_entries'] ) ) {
+                throw PluginValidationException::invalidManifest( 'Invalid nav_entries. Must be a list of entry objects.' );
+            }
+            foreach ( $manifest['nav_entries'] as $index => $entry ) {
+                if ( ! is_array( $entry ) || empty( $entry['slug'] ) || empty( $entry['label'] ) ) {
+                    throw PluginValidationException::invalidManifest( "Invalid nav_entries[{$index}]. Each entry needs a slug and a label." );
+                }
+            }
+        }
+
+        if ( isset( $manifest['permissions'] ) ) {
+            if ( ! is_array( $manifest['permissions'] ) || false === array_is_list( $manifest['permissions'] ) ) {
+                throw PluginValidationException::invalidManifest( 'Invalid permissions. Must be a list of permission slugs.' );
+            }
+            // Enforce a plugin-slug namespace prefix so seed/remove can't touch
+            // framework-owned or other-plugin permissions. Prevents a manifest
+            // like `permissions: ["manage_users"]` from wiping core rows on
+            // uninstall.
+            $prefix = $manifest['slug'] . '.';
+            foreach ( $manifest['permissions'] as $index => $permission ) {
+                if ( ! is_string( $permission ) || '' === trim( $permission ) ) {
+                    throw PluginValidationException::invalidManifest( "Invalid permissions[{$index}]. Each permission must be a non-empty string." );
+                }
+                if ( ! str_starts_with( $permission, $prefix ) ) {
+                    throw PluginValidationException::invalidManifest(
+                        "Invalid permissions[{$index}]. Plugin permissions must be prefixed with '{$prefix}' (got '{$permission}').",
+                    );
+                }
+            }
+        }
+
+        if ( isset( $manifest['migrations_path'] ) ) {
+            $migrationsPath = $manifest['migrations_path'];
+            if ( ! is_string( $migrationsPath ) || '' === $migrationsPath ) {
+                throw PluginValidationException::invalidManifest( 'Invalid migrations_path. Must be a non-empty relative string.' );
+            }
+            // Reject any traversal or absolute-path attempts. runMigrations()
+            // resolves this against the plugin directory; a value like
+            // "../../database/migrations" would otherwise re-run/rollback
+            // framework migrations.
+            if ( str_starts_with( $migrationsPath, '/' )
+                || str_contains( $migrationsPath, '..' )
+                || 1 === preg_match( '/^[A-Za-z]:/', $migrationsPath ) ) {
+                throw PluginValidationException::invalidManifest( 'Invalid migrations_path. Must be a relative path inside the plugin directory (no "..", no absolute paths).' );
+            }
         }
     }
 
@@ -552,6 +707,276 @@ class PluginManager
     protected function clearCaches(): void
     {
         Cache::forget( config( 'cms.plugins.cacheKey' ) );
+    }
+
+    /**
+     * Clear Laravel's route/config/view caches so stale plugin registrations
+     * don't linger after activation state changes (#182).
+     */
+    protected function clearFrameworkCaches(): void
+    {
+        foreach ( ['route:clear', 'config:clear', 'view:clear'] as $command ) {
+            try {
+                Artisan::call( $command );
+            } catch ( Throwable $e ) {
+                logger()->warning( "Framework cache clear failed for {$command}", [
+                    'exception' => $e->getMessage(),
+                ] );
+            }
+        }
+    }
+
+    /**
+     * Assert that the framework version installed in the host satisfies the
+     * plugin's declared minimum host version (#183).
+     *
+     * @throws IncompatiblePluginException When the host is older than required.
+     */
+    protected function assertHostVersionCompatible( Plugin $plugin ): void
+    {
+        $required = $plugin->min_host_version;
+        if ( null === $required ) {
+            return;
+        }
+
+        $hostVersion = $this->resolveHostFrameworkVersion();
+        if ( null === $hostVersion ) {
+            // Unknown host version (e.g. path-repo dev checkout). Log so it's
+            // visible, then be permissive — the framework itself is running, so
+            // outright refusing every plugin here would be worse than
+            // best-effort activation.
+            logger()->warning( "Skipping min_host_version check for plugin '{$plugin->slug}': host framework version unresolved." );
+
+            return;
+        }
+
+        $normalizedHost = $this->normalizeSemver( $hostVersion );
+        if ( null === $normalizedHost ) {
+            // Same permissive policy for parseable-but-non-semver host versions
+            // (dev-main, 2.4.x-dev). Consistent with the null-host branch above.
+            logger()->warning( "Skipping min_host_version check for plugin '{$plugin->slug}': host version '{$hostVersion}' is not a comparable semver." );
+
+            return;
+        }
+
+        if ( version_compare( $normalizedHost, $required, '<' ) ) {
+            throw IncompatiblePluginException::forVersion( $plugin->slug, $required, $hostVersion );
+        }
+    }
+
+    /**
+     * Resolve the framework's installed package version.
+     *
+     * Prefers the framework's own composer.json when it declares a clean
+     * semver — that's the authoritative source and works uniformly for both
+     * real Composer installs and path-repo / symlinked dev checkouts (where
+     * InstalledVersions might report a non-comparable branch alias like
+     * `dev-release/2.4`). Falls back to Composer's InstalledVersions if
+     * composer.json is missing or lacks an explicit version field.
+     */
+    protected function resolveHostFrameworkVersion(): ?string
+    {
+        $composerVersion = $this->readFrameworkComposerVersion();
+        if ( null !== $composerVersion && 1 === preg_match( '/^\d+\.\d+\.\d+/', $composerVersion ) ) {
+            return $composerVersion;
+        }
+
+        try {
+            $version = InstalledVersions::getVersion( 'artisanpack-ui/cms-framework' );
+            if ( null !== $version && '' !== $version ) {
+                return $version;
+            }
+        } catch ( Throwable $e ) {
+            // Fall through.
+        }
+
+        return $composerVersion;
+    }
+
+    /**
+     * Read the framework's own composer.json (relative to this file) and
+     * return its declared `version` if present.
+     */
+    protected function readFrameworkComposerVersion(): ?string
+    {
+        $composerPath = __DIR__ . '/../../../../composer.json';
+        if ( ! File::exists( $composerPath ) ) {
+            return null;
+        }
+
+        $decoded = json_decode( ( string ) File::get( $composerPath ), true );
+        if ( ! is_array( $decoded ) || empty( $decoded['version'] ) || ! is_string( $decoded['version'] ) ) {
+            return null;
+        }
+
+        return $decoded['version'];
+    }
+
+    /**
+     * Strip Composer version suffixes (e.g. `v` prefix, `+metadata`) down to a
+     * comparable semver string. Returns null for anything that isn't parseable
+     * so the caller can apply a consistent unknown-version policy instead of
+     * silently coercing to 0.0.0 (which would false-fail every plugin against
+     * a dev-* checkout).
+     */
+    protected function normalizeSemver( string $version ): ?string
+    {
+        $stripped = ltrim( $version, 'v' );
+        $stripped = preg_replace( '/[-+].*$/', '', $stripped ) ?? $stripped;
+
+        if ( ! preg_match( '/^\d+\.\d+\.\d+$/', $stripped ) ) {
+            return null;
+        }
+
+        return $stripped;
+    }
+
+    /**
+     * Seed permission slugs declared by the plugin manifest.
+     *
+     * Uses artisanpack-ui/rbac's Permission model when available; falls back to
+     * a no-op so tests and hosts without RBAC installed still succeed.
+     */
+    protected function seedPermissions( Plugin $plugin ): void
+    {
+        $permissions = $plugin->declared_permissions;
+        if ( empty( $permissions ) ) {
+            return;
+        }
+
+        $model = $this->rbacPermissionModel();
+        if ( null === $model ) {
+            return;
+        }
+
+        foreach ( $permissions as $slug ) {
+            try {
+                $model::firstOrCreate( ['slug' => $slug], ['name' => $slug] );
+            } catch ( Throwable $e ) {
+                logger()->warning( "Failed seeding permission '{$slug}' for plugin {$plugin->slug}", [
+                    'exception' => $e->getMessage(),
+                ] );
+            }
+        }
+    }
+
+    /**
+     * Remove plugin-declared permissions on deletion.
+     */
+    protected function removeSeededPermissions( Plugin $plugin ): void
+    {
+        $permissions = $plugin->declared_permissions;
+        if ( empty( $permissions ) ) {
+            return;
+        }
+
+        $model = $this->rbacPermissionModel();
+        if ( null === $model ) {
+            return;
+        }
+
+        try {
+            $model::whereIn( 'slug', $permissions )->delete();
+        } catch ( Throwable $e ) {
+            logger()->warning( "Failed removing permissions for plugin {$plugin->slug}", [
+                'exception' => $e->getMessage(),
+            ] );
+        }
+    }
+
+    /**
+     * Best-effort locator for artisanpack-ui/rbac's Permission model.
+     *
+     * @return class-string|null
+     */
+    protected function rbacPermissionModel(): ?string
+    {
+        $candidate = 'ArtisanPackUI\\RBAC\\Models\\Permission';
+
+        return class_exists( $candidate ) ? $candidate : null;
+    }
+
+    /**
+     * Roll back a plugin's migrations. Used on deletion (#182) when the plugin
+     * has opted into `rollback_migrations_on_delete`.
+     */
+    protected function rollbackMigrations( string $slug, string $migrationsPath ): void
+    {
+        $safePath = $this->resolveSecureMigrationsPath( $slug, $migrationsPath );
+        if ( null === $safePath ) {
+            return;
+        }
+
+        Artisan::call( 'migrate:rollback', [
+            '--path'  => str_replace( base_path(), '', $safePath ),
+            '--force' => true,
+        ] );
+    }
+
+    /**
+     * Best-effort teardown when a partial activation blew up (#182).
+     *
+     * @param  array<string,array<int,string>>  $priorPsr4  Snapshot of the PSR-4
+     *                                                      map for the plugin's
+     *                                                      namespaces BEFORE
+     *                                                      registerAutoloader ran.
+     */
+    protected function rollbackFailedActivation( Plugin $plugin, array $priorPsr4, bool $migrationsAttempted ): void
+    {
+        if ( $migrationsAttempted && isset( $plugin->meta['migrations_path'] ) ) {
+            try {
+                $this->rollbackMigrations( $plugin->slug, $plugin->meta['migrations_path'] );
+            } catch ( Throwable $e ) {
+                logger()->warning( "Rollback of migrations after failed activation of {$plugin->slug}", [
+                    'exception' => $e->getMessage(),
+                ] );
+            }
+        }
+
+        if ( ! empty( $priorPsr4 ) ) {
+            // Restore the PSR-4 mapping snapshot rather than wiping shared
+            // namespaces to []. setPsr4 replaces (not appends) so restoring the
+            // prior path list preserves other plugins that shared the prefix.
+            foreach ( $priorPsr4 as $namespace => $paths ) {
+                try {
+                    $this->classLoader->setPsr4( $namespace, $paths );
+                } catch ( Throwable $e ) {
+                    logger()->warning( "Failed restoring prior PSR-4 mapping for '{$namespace}' after failed activation of {$plugin->slug}", [
+                        'exception' => $e->getMessage(),
+                    ] );
+                }
+            }
+        }
+
+        // Ensure the plugin isn't stuck marked active.
+        try {
+            $plugin->is_active = false;
+            $plugin->save();
+        } catch ( Throwable $e ) {
+            // Transaction was rolled back; nothing to persist.
+        }
+
+        $this->clearCaches();
+    }
+
+    /**
+     * Capture the current PSR-4 path list for each namespace the plugin
+     * declares, so a failed activation can restore prior mappings without
+     * blowing away paths owned by other plugins/packages that share a prefix.
+     *
+     * @param  array<string,string>  $psr4  namespace => relative path
+     *
+     * @return array<string,array<int,string>>
+     */
+    protected function snapshotPsr4( array $psr4 ): array
+    {
+        $prior       = [];
+        $currentMap  = $this->classLoader->getPrefixesPsr4();
+        foreach ( array_keys( $psr4 ) as $namespace ) {
+            $prior[ $namespace ] = $currentMap[ $namespace ] ?? [];
+        }
+
+        return $prior;
     }
 
     /**

--- a/src/Modules/Plugins/Managers/UpdateManager.php
+++ b/src/Modules/Plugins/Managers/UpdateManager.php
@@ -4,6 +4,7 @@ declare( strict_types=1 );
 
 namespace ArtisanPackUI\CMSFramework\Modules\Plugins\Managers;
 
+use ArtisanPackUI\CMSFramework\Modules\Plugins\Exceptions\IncompatiblePluginException;
 use ArtisanPackUI\CMSFramework\Modules\Plugins\Exceptions\PluginUpdateException;
 use ArtisanPackUI\CMSFramework\Modules\Plugins\Models\Plugin;
 use Exception;
@@ -104,8 +105,10 @@ class UpdateManager
             return false; // No update available
         }
 
-        $wasActive  = $plugin->is_active;
-        $oldVersion = $plugin->version;
+        $wasActive              = $plugin->is_active;
+        $oldVersion             = $plugin->version;
+        $oldMeta                = $plugin->meta;
+        $oldServiceProvider     = $plugin->service_provider;
 
         doAction( 'plugin.updating', $slug, $oldVersion, $updateInfo['version'] );
 
@@ -151,11 +154,42 @@ class UpdateManager
             doAction( 'plugin.updated', $slug, $updateInfo['version'] );
 
             return true;
+        } catch ( IncompatiblePluginException $e ) {
+            // The DB row was already updated with the new manifest at step 6,
+            // but the reactivate at step 7 rejected the new min_host_version.
+            // Restore files AND DB so the plugin isn't stranded pointing at a
+            // version whose files no longer exist.
+            $this->restoreFromBackup( $slug, $backupPath );
+            $this->revertPluginRow( $plugin, $oldVersion, $oldMeta, $oldServiceProvider );
+
+            throw $e;
         } catch ( Exception $e ) {
             // Restore from backup on failure
             $this->restoreFromBackup( $slug, $backupPath );
+            $this->revertPluginRow( $plugin, $oldVersion, $oldMeta, $oldServiceProvider );
 
             throw PluginUpdateException::downloadFailed( $slug );
+        }
+    }
+
+    /**
+     * Reset the DB row to the pre-update version/manifest/service_provider so
+     * a failed update doesn't leave the row pointing at a version whose files
+     * were rolled back.
+     *
+     * @param  array|null  $oldMeta  Prior manifest snapshot.
+     */
+    protected function revertPluginRow( Plugin $plugin, string $oldVersion, ?array $oldMeta, ?string $oldServiceProvider ): void
+    {
+        try {
+            $plugin->version          = $oldVersion;
+            $plugin->meta             = $oldMeta;
+            $plugin->service_provider = $oldServiceProvider;
+            $plugin->save();
+        } catch ( Exception $e ) {
+            logger()->error( "Failed reverting plugin row after failed update: {$plugin->slug}", [
+                'exception' => $e->getMessage(),
+            ] );
         }
     }
 

--- a/src/Modules/Plugins/Models/Plugin.php
+++ b/src/Modules/Plugins/Models/Plugin.php
@@ -58,4 +58,61 @@ class Plugin extends Model
     {
         return ! empty( $this->service_provider );
     }
+
+    /**
+     * Minimum framework version this plugin declares support for.
+     */
+    public function getMinHostVersionAttribute(): ?string
+    {
+        $value = $this->meta['min_host_version'] ?? null;
+
+        return is_string( $value ) ? $value : null;
+    }
+
+    /**
+     * Federated frontend module descriptor from the manifest.
+     *
+     * @return array{entry:string,exposes?:array<int,string>}|null
+     */
+    public function getFederatedModuleAttribute(): ?array
+    {
+        $module = $this->meta['federated_module'] ?? null;
+
+        return is_array( $module ) ? $module : null;
+    }
+
+    /**
+     * Nav entries pre-declared by the plugin manifest.
+     *
+     * @return array<int,array<string,mixed>>
+     */
+    public function getNavEntriesAttribute(): array
+    {
+        $entries = $this->meta['nav_entries'] ?? [];
+
+        return is_array( $entries ) ? array_values( $entries ) : [];
+    }
+
+    /**
+     * Permission slugs the plugin wants seeded on activation.
+     *
+     * @return array<int,string>
+     */
+    public function getDeclaredPermissionsAttribute(): array
+    {
+        $permissions = $this->meta['permissions'] ?? [];
+        if ( ! is_array( $permissions ) ) {
+            return [];
+        }
+
+        return array_values( array_filter( $permissions, 'is_string' ) );
+    }
+
+    /**
+     * Whether the plugin has opted into migration rollback on deletion.
+     */
+    public function getRollbackMigrationsOnDeleteAttribute(): bool
+    {
+        return ( bool ) ( $this->meta['rollback_migrations_on_delete'] ?? false );
+    }
 }

--- a/src/Modules/Plugins/Providers/PluginsServiceProvider.php
+++ b/src/Modules/Plugins/Providers/PluginsServiceProvider.php
@@ -6,6 +6,7 @@ namespace ArtisanPackUI\CMSFramework\Modules\Plugins\Providers;
 
 use ArtisanPackUI\CMSFramework\Modules\Plugins\Managers\PluginManager;
 use ArtisanPackUI\CMSFramework\Modules\Plugins\Managers\UpdateManager;
+use ArtisanPackUI\CMSFramework\Modules\Plugins\Support\PluginRegistry;
 use Exception;
 use Illuminate\Support\ServiceProvider;
 use Schema;
@@ -25,6 +26,12 @@ class PluginsServiceProvider extends ServiceProvider
                 $app->make( PluginManager::class ),
             );
         } );
+
+        // Shared registry for plugin-declared nav entries and federated
+        // modules; PluginServiceProvider writes into it, framework filters
+        // read from it. Container-keyed by slug/name so re-registration under
+        // Octane is idempotent.
+        $this->app->singleton( PluginRegistry::class );
 
         // Merge config
         $this->mergeConfigFrom(
@@ -46,6 +53,8 @@ class PluginsServiceProvider extends ServiceProvider
         // Load migrations
         $this->loadMigrationsFrom( __DIR__ . '/../../../database/migrations' );
 
+        $this->registerPluginRegistryFilters();
+
         // Load active plugins EARLY in boot cycle
         // Only attempt if the plugins table exists (to handle fresh installations)
         try {
@@ -57,5 +66,28 @@ class PluginsServiceProvider extends ServiceProvider
             // Silently fail during installation/migration
             logger()->debug( 'Plugin loading skipped: ' . $e->getMessage() );
         }
+    }
+
+    /**
+     * Wire ONE filter callback per hook that surfaces the PluginRegistry
+     * contents. Registering once at framework boot avoids the Octane
+     * accumulation pattern where per-plugin boot() calls would add a fresh
+     * closure to the filter chain on every request.
+     */
+    protected function registerPluginRegistryFilters(): void
+    {
+        $registry = $this->app->make( PluginRegistry::class );
+
+        addFilter( 'ap.admin.menu', function ( array $menu ) use ( $registry ): array {
+            foreach ( $registry->navEntries() as $slug => $entry ) {
+                $menu[ $slug ] = array_merge( $entry, $menu[ $slug ] ?? [] );
+            }
+
+            return $menu;
+        } );
+
+        addFilter( 'ap.plugins.federatedModules', function ( array $modules ) use ( $registry ): array {
+            return array_merge( $modules, $registry->federatedModules() );
+        } );
     }
 }

--- a/src/Modules/Plugins/Support/PluginRegistry.php
+++ b/src/Modules/Plugins/Support/PluginRegistry.php
@@ -1,0 +1,75 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Modules\Plugins\Support;
+
+/**
+ * Container-bound singleton that holds runtime registrations made by plugin
+ * service providers (nav entries and federated module descriptors).
+ *
+ * Plugin providers push into this registry from boot(); the framework wires a
+ * single `ap.admin.menu` filter callback in PluginsServiceProvider that reads
+ * from it. This avoids adding a fresh closure to the filter chain on every
+ * request under Octane / RoadRunner (where the container persists across
+ * requests but boot() re-runs).
+ *
+ * @since 2.4.0
+ */
+class PluginRegistry
+{
+    /**
+     * Nav entries keyed by slug so duplicate registrations idempotently
+     * overwrite instead of accumulating.
+     *
+     * @var array<string,array<string,mixed>>
+     */
+    protected array $navEntries = [];
+
+    /**
+     * Federated module descriptors keyed by name.
+     *
+     * @var array<string,array{entry:string,exposes?:array<int,string>}>
+     */
+    protected array $federatedModules = [];
+
+    /**
+     * Register (or overwrite) a nav entry by slug.
+     *
+     * @param  array<string,mixed>  $entry  A normalized nav entry row.
+     */
+    public function setNavEntry( string $slug, array $entry ): void
+    {
+        $this->navEntries[ $slug ] = $entry;
+    }
+
+    /**
+     * All registered nav entries.
+     *
+     * @return array<string,array<string,mixed>>
+     */
+    public function navEntries(): array
+    {
+        return $this->navEntries;
+    }
+
+    /**
+     * Register (or overwrite) a federated module descriptor by name.
+     *
+     * @param  array{entry:string,exposes?:array<int,string>}  $descriptor
+     */
+    public function setFederatedModule( string $name, array $descriptor ): void
+    {
+        $this->federatedModules[ $name ] = $descriptor;
+    }
+
+    /**
+     * All registered federated module descriptors.
+     *
+     * @return array<string,array{entry:string,exposes?:array<int,string>}>
+     */
+    public function federatedModules(): array
+    {
+        return $this->federatedModules;
+    }
+}

--- a/src/Modules/Plugins/Support/PluginServiceProvider.php
+++ b/src/Modules/Plugins/Support/PluginServiceProvider.php
@@ -1,0 +1,269 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Modules\Plugins\Support;
+
+use ArtisanPackUI\CMSFramework\Modules\Admin\Managers\AdminMenuManager;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\ServiceProvider;
+use ReflectionClass;
+use RuntimeException;
+
+/**
+ * Base service provider for cms-framework plugins.
+ *
+ * Extending this class gives plugin authors a consistent, opinionated API for
+ * the most common registration patterns: admin pages, nav entries, federated
+ * frontend modules, and manifest-aware path/config helpers.
+ *
+ * Extending is optional — plain Laravel ServiceProviders continue to work — but
+ * `PluginManager` uses the presence of this base to expose richer metadata to
+ * host apps.
+ *
+ * @since 2.4.0
+ */
+abstract class PluginServiceProvider extends ServiceProvider
+{
+    /**
+     * Parsed plugin.json contents for the plugin backing this provider.
+     *
+     * @var array<string,mixed>|null
+     */
+    protected ?array $manifest = null;
+
+    /**
+     * Register a Blade or Inertia admin page.
+     *
+     * @param  string  $slug  Route/URL slug for the admin page.
+     * @param  array{title?:string,section?:string,view?:string,component?:string,capability?:string,icon?:string,order?:int}  $config
+     */
+    protected function registerAdminPage( string $slug, array $config ): void
+    {
+        /** @var AdminMenuManager $menu */
+        $menu = $this->app->make( AdminMenuManager::class );
+
+        $title   = $config['title'] ?? ucfirst( $slug );
+        $section = $config['section'] ?? null;
+
+        $options = array_filter( [
+            'action'     => $config['view'] ?? $config['component'] ?? '',
+            'capability' => $config['capability'] ?? 'access_admin_dashboard',
+            'icon'       => $config['icon'] ?? 'fas.puzzle-piece',
+            'order'      => $config['order'] ?? 50,
+            'menuTitle'  => $config['menuTitle'] ?? $title,
+        ], fn ( $value ) => null !== $value );
+
+        $menu->addPage( $title, $slug, $section, $options );
+    }
+
+    /**
+     * Inject a nav entry into the admin menu.
+     *
+     * The entry is stored in the container-bound PluginRegistry so a single
+     * framework-owned filter callback surfaces all plugin nav entries in one
+     * place. Overwriting by slug is idempotent — repeated calls from the same
+     * plugin (e.g. under Octane) don't accumulate.
+     *
+     * @param  array{slug:string,label:string,url?:string,icon?:string,iconId?:string,permission?:string,order?:int,external?:bool,parent?:string}  $entry
+     */
+    protected function registerNavEntry( array $entry ): void
+    {
+        if ( empty( $entry['slug'] ) || empty( $entry['label'] ) ) {
+            throw new RuntimeException( 'registerNavEntry requires slug and label.' );
+        }
+
+        $slug = ( string ) $entry['slug'];
+        $url  = $this->normalizeNavUrl( $entry['url'] ?? '#' );
+
+        $normalized = [
+            'title'      => $entry['label'],
+            'slug'       => $slug,
+            'parent'     => $entry['parent'] ?? null,
+            'section'    => null,
+            'icon'       => $entry['icon'] ?? ( $entry['iconId'] ?? '' ),
+            'iconId'     => $entry['iconId'] ?? ( $entry['icon'] ?? '' ),
+            'capability' => $entry['permission'] ?? '',
+            'permission' => $entry['permission'] ?? '',
+            'order'      => ( int ) ( $entry['order'] ?? 50 ),
+            'route'      => $url,
+            'menuTitle'  => $entry['label'],
+            'label'      => $entry['label'],
+            'url'        => $url,
+            'external'   => ( bool ) ( $entry['external'] ?? false ),
+        ];
+
+        $this->pluginRegistry()->setNavEntry( $slug, $normalized );
+    }
+
+    /**
+     * Register a Module Federation entry so host apps that support runtime-loaded
+     * React pages can discover and mount plugin frontend modules.
+     *
+     * @param  array<int,string>  $exposes  Optional list of exposed module names.
+     */
+    protected function registerFederatedModule( string $name, string $entryPath, array $exposes = [] ): void
+    {
+        $descriptor = [
+            'entry' => $entryPath,
+        ];
+
+        if ( ! empty( $exposes ) ) {
+            $descriptor['exposes'] = array_values( $exposes );
+        }
+
+        $this->pluginRegistry()->setFederatedModule( $name, $descriptor );
+    }
+
+    /**
+     * Resolve a path relative to the plugin's installation directory.
+     */
+    protected function pluginPath( ?string $subpath = null ): string
+    {
+        $root = base_path( config( 'cms.plugins.directory', 'plugins' ) . '/' . $this->pluginSlug() );
+
+        if ( null === $subpath ) {
+            return $root;
+        }
+
+        return $root . '/' . ltrim( $subpath, '/' );
+    }
+
+    /**
+     * Read the plugin's manifest (or a specific key via dot notation).
+     */
+    protected function pluginConfig( ?string $key = null ): mixed
+    {
+        $manifest = $this->loadManifest();
+
+        if ( null === $key ) {
+            return $manifest;
+        }
+
+        $value = $manifest;
+        foreach ( explode( '.', $key ) as $segment ) {
+            if ( ! is_array( $value ) || ! array_key_exists( $segment, $value ) ) {
+                return null;
+            }
+            $value = $value[ $segment ];
+        }
+
+        return $value;
+    }
+
+    /**
+     * Slug used to locate the plugin directory. Defaults to the manifest's
+     * `slug`; plugins may override for edge cases (multi-plugin repos, etc).
+     */
+    protected function pluginSlug(): string
+    {
+        $manifest = $this->loadManifest();
+
+        if ( empty( $manifest['slug'] ) ) {
+            throw new RuntimeException( 'Unable to determine plugin slug: manifest is missing a slug.' );
+        }
+
+        return ( string ) $manifest['slug'];
+    }
+
+    /**
+     * Load and cache the plugin's manifest. Walks up from the provider file
+     * looking for a plugin.json — but ONLY accepts a match whose directory is
+     * a direct child of the configured plugins directory. This prevents a
+     * malicious plugin from adopting an unrelated manifest (host root, vendor
+     * subdir, or another plugin) by placing its provider deep in a vendor
+     * tree.
+     *
+     * @return array<string,mixed>
+     */
+    protected function loadManifest(): array
+    {
+        if ( null !== $this->manifest ) {
+            return $this->manifest;
+        }
+
+        $reflection    = new ReflectionClass( static::class );
+        $file          = ( string ) $reflection->getFileName();
+        $pluginsRoot   = realpath( base_path( config( 'cms.plugins.directory', 'plugins' ) ) );
+        $realProvider  = realpath( $file );
+
+        if ( false === $pluginsRoot || false === $realProvider ) {
+            return $this->manifest = [];
+        }
+
+        // Provider must live under the plugins directory. Reject anything else
+        // (host root, vendor, other packages) outright.
+        if ( ! str_starts_with( $realProvider . DIRECTORY_SEPARATOR, $pluginsRoot . DIRECTORY_SEPARATOR ) ) {
+            return $this->manifest = [];
+        }
+
+        // Walk from the provider's dir up to the plugins root (bounded by the
+        // real directory hierarchy, not a magic depth). The plugin's own root
+        // is a direct child of pluginsRoot — that's the ONLY manifest we
+        // trust.
+        $dir = dirname( $realProvider );
+        while ( $dir !== $pluginsRoot && str_starts_with( $dir . DIRECTORY_SEPARATOR, $pluginsRoot . DIRECTORY_SEPARATOR ) ) {
+            $parent = dirname( $dir );
+            if ( $parent === $pluginsRoot ) {
+                // $dir is the plugin's own root directory.
+                $candidate = $dir . '/plugin.json';
+                if ( File::exists( $candidate ) ) {
+                    $decoded = json_decode( ( string ) File::get( $candidate ), true );
+                    if ( is_array( $decoded ) ) {
+                        return $this->manifest = $decoded;
+                    }
+                }
+                break;
+            }
+            if ( $parent === $dir ) {
+                break;
+            }
+            $dir = $parent;
+        }
+
+        return $this->manifest = [];
+    }
+
+    /**
+     * Resolve the shared PluginRegistry singleton, binding a fresh one if the
+     * host container hasn't done so yet (defensive — the framework's
+     * PluginsServiceProvider is the canonical binder).
+     */
+    protected function pluginRegistry(): PluginRegistry
+    {
+        if ( ! $this->app->bound( PluginRegistry::class ) ) {
+            $this->app->singleton( PluginRegistry::class );
+        }
+
+        return $this->app->make( PluginRegistry::class );
+    }
+
+    /**
+     * Sanitize a plugin-supplied URL before it enters the nav registry.
+     * Rejects unsafe schemes; falls back to '#' for anything not obviously a
+     * navigation target. AdminMenuManager also sanitizes on render, but
+     * blocking at the ingress point keeps the registry itself clean.
+     */
+    protected function normalizeNavUrl( string $url ): string
+    {
+        $trimmed = trim( $url );
+        if ( '' === $trimmed ) {
+            return '#';
+        }
+
+        if ( str_starts_with( $trimmed, '/' ) || str_starts_with( $trimmed, '#' ) ) {
+            return $trimmed;
+        }
+
+        if ( 1 === preg_match( '#^([a-zA-Z][a-zA-Z0-9+.\-]*):#', $trimmed, $matches ) ) {
+            $scheme = strtolower( $matches[1] );
+            if ( in_array( $scheme, ['http', 'https', 'mailto', 'tel'], true ) ) {
+                return $trimmed;
+            }
+
+            return '#';
+        }
+
+        return $trimmed;
+    }
+}

--- a/src/Modules/Plugins/config/plugins.php
+++ b/src/Modules/Plugins/config/plugins.php
@@ -52,4 +52,20 @@ return [
     'updateCheckTimeout' => 10, // HTTP request timeout in seconds
     'updateCacheTtl'     => 43200, // 12 hours in seconds
     'backupPath'         => 'plugin-backups', // Relative to storage_path()
+
+    /*
+    |--------------------------------------------------------------------------
+    | Auto-clear Framework Caches on Lifecycle Events
+    |--------------------------------------------------------------------------
+    | If true, activate/deactivate/delete will run route:clear, config:clear
+    | and view:clear so newly (un)registered plugin routes/views take effect
+    | immediately. This is convenient in development but is a blunt hammer in
+    | production hosts that rely on `route:cache` / `config:cache` for
+    | performance — every toggle deletes the compiled cache files, causing a
+    | measurable latency regression until the next deploy rebuilds them.
+    |
+    | Default: false. Enable it explicitly in development, or when your
+    | deployment pipeline handles rebuilds on demand.
+    */
+    'autoClearFrameworkCaches' => env( 'PLUGINS_AUTO_CLEAR_FRAMEWORK_CACHES', false ),
 ];

--- a/tests/Feature/DynamicContent/DynamicContentApiTest.php
+++ b/tests/Feature/DynamicContent/DynamicContentApiTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Managers\DynamicContentTypeManager;
+use ArtisanPackUI\CMSFramework\Tests\Support\TestUser;
+use Illuminate\Support\Facades\Gate;
+
+beforeEach( function (): void {
+    $this->user = TestUser::create( [
+        'name'     => 'Admin',
+        'email'    => 'a@example.com',
+        'password' => bcrypt( 'x' ),
+    ] );
+
+    Gate::define( 'manage_dynamic_content', fn () => true );
+} );
+
+test( 'authenticated user can list types', function (): void {
+    app( DynamicContentTypeManager::class )->create( [
+        'slug'        => 'business_info',
+        'name'        => 'Business Info',
+        'cardinality' => 'singleton',
+        'fields'      => [],
+    ] );
+
+    $this->actingAs( $this->user )
+        ->getJson( '/api/v1/dynamic-content/types' )
+        ->assertOk()
+        ->assertJsonStructure( [ 'data' => [ [ 'slug', 'name', 'cardinality', 'source' ] ] ] );
+} );
+
+test( 'unauthenticated user is rejected', function (): void {
+    $this->getJson( '/api/v1/dynamic-content/types' )->assertUnauthorized();
+} );
+
+test( 'resolve preview endpoint returns rendered content', function (): void {
+    $type = app( DynamicContentTypeManager::class )->create( [
+        'slug'        => 'brand',
+        'name'        => 'Brand',
+        'cardinality' => 'singleton',
+        'fields'      => [ [ 'slug' => 'name', 'label' => 'Name', 'type' => 'text' ] ],
+    ] );
+
+    app( ArtisanPackUI\CMSFramework\Modules\DynamicContent\Managers\DynamicContentRecordManager::class )
+        ->create( $type, [ 'values' => [ 'name' => 'Acme' ] ] );
+
+    $this->actingAs( $this->user )
+        ->postJson( '/api/v1/dynamic-content/resolve', [ 'content' => 'Hi from {{brand.name}}' ] )
+        ->assertOk()
+        ->assertJsonPath( 'data.rendered', 'Hi from Acme' );
+} );

--- a/tests/Feature/DynamicContent/ResolverTest.php
+++ b/tests/Feature/DynamicContent/ResolverTest.php
@@ -1,0 +1,203 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Enums\Cardinality;
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Managers\DynamicContentRecordManager;
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Managers\DynamicContentTypeManager;
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Services\DynamicContentResolver;
+
+beforeEach( function (): void {
+    $this->typeManager   = app( DynamicContentTypeManager::class );
+    $this->recordManager = app( DynamicContentRecordManager::class );
+    $this->resolver      = app( DynamicContentResolver::class );
+} );
+
+test( 'resolves singleton tokens', function (): void {
+    $type = $this->typeManager->create( [
+        'slug'        => 'business_info',
+        'name'        => 'Business Info',
+        'cardinality' => 'singleton',
+        'fields'      => [
+            [ 'slug' => 'phone', 'label' => 'Phone', 'type' => 'phone' ],
+            [ 'slug' => 'email', 'label' => 'Email', 'type' => 'email' ],
+        ],
+    ] );
+
+    $this->recordManager->create( $type, [
+        'values' => [ 'phone' => '555-1212', 'email' => 'hi@example.com' ],
+    ] );
+
+    $out = $this->resolver->render(
+        'Call {{business_info.phone}} or email {{business_info.email}}.',
+    );
+
+    expect( $out )->toBe( 'Call 555-1212 or email hi@example.com.' );
+} );
+
+test( 'resolves collection tokens via index', function (): void {
+    $type = $this->typeManager->create( [
+        'slug'        => 'team',
+        'name'        => 'Team',
+        'cardinality' => 'collection',
+        'fields'      => [ [ 'slug' => 'name', 'label' => 'Name', 'type' => 'text' ] ],
+    ] );
+
+    $this->recordManager->create( $type, [ 'label' => 'A', 'values' => [ 'name' => 'Alice' ] ] );
+    $this->recordManager->create( $type, [ 'label' => 'B', 'values' => [ 'name' => 'Bob' ] ] );
+
+    expect( $this->resolver->render( 'Lead: {{team[0].name}}' ) )->toBe( 'Lead: Alice' );
+    expect( $this->resolver->render( 'Second: {{team[1].name}}' ) )->toBe( 'Second: Bob' );
+} );
+
+test( 'missing source renders empty and does not leak braces', function (): void {
+    $out = $this->resolver->render( 'Hello {{unknown.thing}} world' );
+
+    expect( $out )->toBe( 'Hello  world' );
+} );
+
+test( 'default modifier applies when value is missing', function (): void {
+    $type = $this->typeManager->create( [
+        'slug'        => 'site',
+        'name'        => 'Site',
+        'cardinality' => 'singleton',
+        'fields'      => [ [ 'slug' => 'tag', 'label' => 'Tag', 'type' => 'text' ] ],
+    ] );
+
+    $this->recordManager->create( $type, [ 'values' => [ 'tag' => null ] ] );
+
+    expect( $this->resolver->render( '{{site.tag|default:none}}' ) )->toBe( 'none' );
+} );
+
+test( 'upper modifier transforms resolved value', function (): void {
+    $type = $this->typeManager->create( [
+        'slug'        => 'brand',
+        'name'        => 'Brand',
+        'cardinality' => 'singleton',
+        'fields'      => [ [ 'slug' => 'name', 'label' => 'Name', 'type' => 'text' ] ],
+    ] );
+
+    $this->recordManager->create( $type, [ 'values' => [ 'name' => 'acme' ] ] );
+
+    expect( $this->resolver->render( '{{brand.name|upper}}' ) )->toBe( 'ACME' );
+} );
+
+test( 'resolver does not recurse into resolved output', function (): void {
+    $type = $this->typeManager->create( [
+        'slug'        => 'nested',
+        'name'        => 'Nested',
+        'cardinality' => 'singleton',
+        'fields'      => [ [ 'slug' => 'ref', 'label' => 'Ref', 'type' => 'text' ] ],
+    ] );
+
+    $this->recordManager->create( $type, [ 'values' => [ 'ref' => '{{nested.ref}}' ] ] );
+
+    expect( $this->resolver->render( 'Value: {{nested.ref}}' ) )->toBe( 'Value: {{nested.ref}}' );
+} );
+
+test( 'malformed tokens with braces do not throw', function (): void {
+    $out = $this->resolver->render( '{{ }} and {{ .field }}' );
+
+    expect( $out )->toBeString();
+} );
+
+test( 'code-registered types resolve alongside db types', function (): void {
+    apRegisterDynamicContentType( 'from_code', [
+        'name'        => 'From Code',
+        'cardinality' => Cardinality::Singleton,
+        'fields'      => [
+            [ 'slug' => 'greeting', 'label' => 'Greeting', 'type' => 'text' ],
+        ],
+        'records' => [
+            [ 'greeting' => 'Howdy' ],
+        ],
+    ] );
+
+    expect( $this->resolver->render( '{{from_code.greeting}}' ) )->toBe( 'Howdy' );
+} );
+
+test( 'signatureFor returns a stable string when there are no tokens', function (): void {
+    expect( $this->resolver->signatureFor( 'plain content' ) )->toBe( 'dc:none' );
+} );
+
+test( 'text field values are HTML-escaped on render', function (): void {
+    $type = $this->typeManager->create( [
+        'slug'        => 'settings',
+        'name'        => 'Settings',
+        'cardinality' => 'singleton',
+        'fields'      => [ [ 'slug' => 'tagline', 'label' => 'Tagline', 'type' => 'text' ] ],
+    ] );
+
+    $this->recordManager->create( $type, [ 'values' => [ 'tagline' => '<script>alert(1)</script>' ] ] );
+
+    $out = $this->resolver->render( 'Site: {{settings.tagline}}' );
+
+    expect( $out )->not->toContain( '<script>' );
+    expect( $out )->toContain( '&lt;script&gt;' );
+} );
+
+test( 'rich text field values render raw HTML', function (): void {
+    $type = $this->typeManager->create( [
+        'slug'        => 'article',
+        'name'        => 'Article',
+        'cardinality' => 'singleton',
+        'fields'      => [ [ 'slug' => 'body', 'label' => 'Body', 'type' => 'rich_text' ] ],
+    ] );
+
+    $this->recordManager->create( $type, [ 'values' => [ 'body' => '<p>Hello <strong>world</strong></p>' ] ] );
+
+    $out = $this->resolver->render( '{{article.body}}' );
+
+    expect( $out )->toContain( '<p>' );
+    expect( $out )->toContain( '<strong>' );
+} );
+
+test( 'unrouted values are escaped defensively', function (): void {
+    // No such type — value stays null and renders as empty; but if a source
+    // exists without a field-type match, the fallback path must escape.
+    apRegisterDynamicContentType( 'brandcode', [
+        'name'        => 'Brand',
+        'cardinality' => Cardinality::Singleton,
+        'fields'      => [ [ 'slug' => 'raw', 'label' => 'Raw', 'type' => 'nonexistent_type' ] ],
+        'records'     => [ [ 'raw' => '<img src=x onerror=alert(1)>' ] ],
+    ] );
+
+    $out = $this->resolver->render( '{{brandcode.raw}}' );
+
+    expect( $out )->not->toContain( '<img' );
+    expect( $out )->toContain( '&lt;img' );
+} );
+
+test( 'nl2br modifier output is not double-escaped by field renderer', function (): void {
+    $type = $this->typeManager->create( [
+        'slug'        => 'notes',
+        'name'        => 'Notes',
+        'cardinality' => 'singleton',
+        'fields'      => [ [ 'slug' => 'body', 'label' => 'Body', 'type' => 'text' ] ],
+    ] );
+
+    $this->recordManager->create( $type, [ 'values' => [ 'body' => "line1\nline2" ] ] );
+
+    $out = $this->resolver->render( '{{notes.body|nl2br}}' );
+
+    expect( $out )->toContain( '<br' );
+    expect( $out )->toContain( 'line1' );
+    expect( $out )->toContain( 'line2' );
+} );
+
+test( 'slug is immutable on update at the manager level', function (): void {
+    $type = $this->typeManager->create( [
+        'slug'        => 'immutable',
+        'name'        => 'Immutable',
+        'cardinality' => 'singleton',
+        'fields'      => [],
+    ] );
+
+    $this->typeManager->update( $type, [
+        'slug' => 'renamed',
+        'name' => 'Renamed',
+    ] );
+
+    expect( $type->fresh()->slug )->toBe( 'immutable' );
+    expect( $type->fresh()->name )->toBe( 'Renamed' );
+} );

--- a/tests/Feature/Plugins/HostVersionCompatibilityTest.php
+++ b/tests/Feature/Plugins/HostVersionCompatibilityTest.php
@@ -1,0 +1,72 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\CMSFramework\Modules\Plugins\Exceptions\IncompatiblePluginException;
+use ArtisanPackUI\CMSFramework\Modules\Plugins\Managers\PluginManager;
+use ArtisanPackUI\CMSFramework\Modules\Plugins\Models\Plugin;
+use ArtisanPackUI\CMSFramework\Tests\Support\TestUser;
+
+beforeEach( function (): void {
+    $this->manager = app( PluginManager::class );
+    $this->admin   = TestUser::factory()->create();
+} );
+
+it( 'refuses to activate a plugin requiring a newer host version', function (): void {
+    Plugin::create( [
+        'slug'      => 'future-plugin',
+        'name'      => 'Future Plugin',
+        'version'   => '1.0.0',
+        'is_active' => false,
+        'meta'      => [
+            'slug'             => 'future-plugin',
+            'name'             => 'Future Plugin',
+            'version'          => '1.0.0',
+            'min_host_version' => '999.0.0',
+        ],
+    ] );
+
+    try {
+        $this->manager->activate( 'future-plugin' );
+        $this->fail( 'Expected IncompatiblePluginException was not thrown.' );
+    } catch ( IncompatiblePluginException $e ) {
+        expect( $e->pluginSlug )->toBe( 'future-plugin' )
+            ->and( $e->requiredVersion )->toBe( '999.0.0' )
+            ->and( $e->hostVersion )->not->toBe( '' );
+    }
+
+    $plugin = Plugin::where( 'slug', 'future-plugin' )->first();
+    expect( $plugin->is_active )->toBeFalse();
+} );
+
+it( 'activates when no min_host_version is declared', function (): void {
+    Plugin::create( [
+        'slug'      => 'legacy-plugin',
+        'name'      => 'Legacy Plugin',
+        'version'   => '1.0.0',
+        'is_active' => false,
+        'meta'      => ['slug' => 'legacy-plugin'],
+    ] );
+
+    expect( $this->manager->activate( 'legacy-plugin' ) )->toBeTrue();
+} );
+
+it( 'returns a 409 with a structured payload when activation fails on incompatibility', function (): void {
+    Plugin::create( [
+        'slug'      => 'future-plugin',
+        'name'      => 'Future Plugin',
+        'version'   => '1.0.0',
+        'is_active' => false,
+        'meta'      => [
+            'slug'             => 'future-plugin',
+            'min_host_version' => '999.0.0',
+        ],
+    ] );
+
+    $response = $this->actingAs( $this->admin )->postJson( '/api/v1/plugins/future-plugin/activate' );
+
+    $response->assertStatus( 409 )
+        ->assertJsonPath( 'code', 'plugin_incompatible' )
+        ->assertJsonPath( 'plugin', 'future-plugin' )
+        ->assertJsonPath( 'required_version', '999.0.0' );
+} );

--- a/tests/Feature/Plugins/PluginLifecycleRollbackTest.php
+++ b/tests/Feature/Plugins/PluginLifecycleRollbackTest.php
@@ -1,0 +1,122 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\CMSFramework\Modules\Plugins\Managers\PluginManager;
+use ArtisanPackUI\CMSFramework\Modules\Plugins\Models\Plugin;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Schema;
+
+beforeEach( function (): void {
+    $this->manager         = app( PluginManager::class );
+    $this->testPluginsPath = __DIR__ . '/../../Support/Plugins';
+    $this->pluginsPath     = base_path( 'plugins' );
+    File::ensureDirectoryExists( $this->pluginsPath );
+} );
+
+afterEach( function (): void {
+    if ( File::exists( $this->pluginsPath . '/plugin-with-migrations' ) ) {
+        File::deleteDirectory( $this->pluginsPath . '/plugin-with-migrations' );
+    }
+    Schema::dropIfExists( 'plugin_test_table' );
+} );
+
+it( 'rolls back plugin state when activation raises mid-flight', function (): void {
+    Plugin::create( [
+        'slug'             => 'broken-plugin',
+        'name'             => 'Broken Plugin',
+        'version'          => '1.0.0',
+        'is_active'        => false,
+        'service_provider' => 'NonExistent\\ServiceProvider\\ThatDoesNotExist',
+        'meta'             => ['slug' => 'broken-plugin'],
+    ] );
+
+    try {
+        $this->manager->activate( 'broken-plugin' );
+    } catch ( Throwable $e ) {
+        // Expected — nonexistent provider blows up during registration.
+    }
+
+    $plugin = Plugin::where( 'slug', 'broken-plugin' )->first();
+
+    expect( $plugin->is_active )->toBeFalse();
+} );
+
+it( 'rolls back plugin migrations on delete when the manifest opts in', function (): void {
+    File::copyDirectory(
+        $this->testPluginsPath . '/plugin-with-migrations',
+        $this->pluginsPath . '/plugin-with-migrations',
+    );
+
+    $manifest                                  = json_decode( File::get( $this->pluginsPath . '/plugin-with-migrations/plugin.json' ), true );
+    $manifest['rollback_migrations_on_delete'] = true;
+
+    Plugin::create( [
+        'slug'      => $manifest['slug'],
+        'name'      => $manifest['name'],
+        'version'   => $manifest['version'],
+        'is_active' => false,
+        'meta'      => $manifest,
+    ] );
+
+    $this->manager->activate( 'plugin-with-migrations' );
+
+    expect( Schema::hasTable( 'plugin_test_table' ) )->toBeTrue();
+
+    $this->manager->delete( 'plugin-with-migrations' );
+
+    expect( Schema::hasTable( 'plugin_test_table' ) )->toBeFalse();
+} );
+
+it( 'refuses to touch a migrations_path that resolves outside the plugin directory', function (): void {
+    // Simulate a legacy plugin row that pre-dates the schema validator: meta
+    // has a traversal-y migrations_path. The runtime guard in
+    // resolveSecureMigrationsPath should reject it silently.
+    File::copyDirectory(
+        $this->testPluginsPath . '/valid-plugin',
+        $this->pluginsPath . '/valid-plugin',
+    );
+
+    Plugin::create( [
+        'slug'      => 'valid-plugin',
+        'name'      => 'Valid Plugin',
+        'version'   => '1.0.0',
+        'is_active' => false,
+        'meta'      => [
+            'slug'                          => 'valid-plugin',
+            'migrations_path'               => '../../database/migrations',
+            'rollback_migrations_on_delete' => true,
+        ],
+    ] );
+
+    // Snapshot: the framework's own plugins table exists.
+    expect( Schema::hasTable( 'plugins' ) )->toBeTrue();
+
+    $this->manager->delete( 'valid-plugin' );
+
+    // The framework schema must NOT have been rolled back.
+    expect( Schema::hasTable( 'plugins' ) )->toBeTrue();
+} );
+
+it( 'leaves plugin migrations in place when opt-in flag is absent', function (): void {
+    File::copyDirectory(
+        $this->testPluginsPath . '/plugin-with-migrations',
+        $this->pluginsPath . '/plugin-with-migrations',
+    );
+
+    $manifest = json_decode( File::get( $this->pluginsPath . '/plugin-with-migrations/plugin.json' ), true );
+
+    Plugin::create( [
+        'slug'      => $manifest['slug'],
+        'name'      => $manifest['name'],
+        'version'   => $manifest['version'],
+        'is_active' => false,
+        'meta'      => $manifest,
+    ] );
+
+    $this->manager->activate( 'plugin-with-migrations' );
+    $this->manager->delete( 'plugin-with-migrations' );
+
+    // Table persists because we did not opt in to rollback.
+    expect( Schema::hasTable( 'plugin_test_table' ) )->toBeTrue();
+} );

--- a/tests/Unit/Admin/AdminMenuManagerFilterTest.php
+++ b/tests/Unit/Admin/AdminMenuManagerFilterTest.php
@@ -1,0 +1,152 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\CMSFramework\Modules\Admin\Managers\AdminMenuManager;
+use Illuminate\Support\Facades\Gate;
+
+beforeEach( function (): void {
+    $this->manager = new AdminMenuManager;
+
+    // Allow everything EXCEPT the sentinel used by the Gate re-check test,
+    // so that test can prove enforceCapabilities strips filter-injected
+    // entries the current user isn't allowed to see.
+    Gate::before( fn ( ?Illuminate\Contracts\Auth\Authenticatable $user, string $ability ) => 'never_granted' === $ability ? null : true );
+
+    // Reset the hooks registry between tests so filter callbacks don't leak.
+    removeAllFilters( 'ap.admin.menu' );
+} );
+
+afterEach( function (): void {
+    removeAllFilters( 'ap.admin.menu' );
+} );
+
+describe( 'ap.admin.menu filter', function (): void {
+    it( 'fires when getAdminMenu is called', function (): void {
+        $called = false;
+        addFilter( 'ap.admin.menu', function ( array $menu ) use ( &$called ): array {
+            $called = true;
+
+            return $menu;
+        } );
+
+        $this->manager->getAdminMenu();
+
+        expect( $called )->toBeTrue();
+    } );
+
+    it( 'lets a subscriber inject a new top-level entry', function (): void {
+        addFilter( 'ap.admin.menu', function ( array $menu ): array {
+            $menu['plugin-entry'] = [
+                'title' => 'Plugin Entry',
+                'slug'  => 'plugin-entry',
+                'label' => 'Plugin Entry',
+                'url'   => '/admin/plugin-entry',
+                'order' => 10,
+            ];
+
+            return $menu;
+        } );
+
+        $menu = $this->manager->getAdminMenu();
+
+        expect( $menu )->toHaveKey( 'plugin-entry' )
+            ->and( $menu['plugin-entry']['label'] )->toBe( 'Plugin Entry' );
+    } );
+
+    it( 'lets a subscriber remove an entry', function (): void {
+        $this->manager->addPage( 'Dashboard', 'dashboard', null, ['icon' => 'x', 'capability' => ''] );
+
+        addFilter( 'ap.admin.menu', function ( array $menu ): array {
+            unset( $menu['dashboard'] );
+
+            return $menu;
+        } );
+
+        $menu = $this->manager->getAdminMenu();
+
+        expect( $menu )->not->toHaveKey( 'dashboard' );
+    } );
+} );
+
+describe( 'filter Gate re-check', function (): void {
+    it( 'drops filter-injected entries whose permission the user does not hold', function (): void {
+        // The beforeEach's allow-all returns null (falls through to defines)
+        // for the 'never_granted' sentinel, so Gate::allows resolves it to
+        // false — exactly the state an unauthorized user would hit.
+        addFilter( 'ap.admin.menu', function ( array $menu ): array {
+            $menu['gated'] = [
+                'title'      => 'Gated',
+                'slug'       => 'gated',
+                'label'      => 'Gated',
+                'url'        => '/gated',
+                'permission' => 'never_granted',
+                'external'   => false,
+            ];
+
+            return $menu;
+        } );
+
+        $menu = $this->manager->getAdminMenu();
+
+        expect( $menu )->not->toHaveKey( 'gated' );
+    } );
+} );
+
+describe( 'top-level slug with slashes', function (): void {
+    it( 'stores a route name with slashes replaced by dots', function (): void {
+        Gate::before( fn ( ?Illuminate\Contracts\Auth\Authenticatable $user, string $ability ) => true );
+
+        $this->manager->addPage( 'Reports', 'packages/reports', null, ['capability' => ''] );
+
+        $menu = $this->manager->getAdminMenu();
+
+        expect( $menu['packages/reports']['route'] )->toBe( 'admin.packages.reports' );
+    } );
+} );
+
+describe( 'extended menu row shape', function (): void {
+    it( 'adds label/iconId/permission/url/external to items', function (): void {
+        $this->manager->addPage( 'Dashboard', 'dashboard', null, [
+            'icon'       => 'fas.home',
+            'capability' => '',
+        ] );
+
+        $menu = $this->manager->getAdminMenu();
+
+        expect( $menu['dashboard'] )
+            ->toHaveKey( 'label' )
+            ->toHaveKey( 'iconId' )
+            ->toHaveKey( 'url' )
+            ->toHaveKey( 'external' );
+
+        expect( $menu['dashboard']['label'] )->toBe( 'Dashboard' )
+            ->and( $menu['dashboard']['iconId'] )->toBe( 'fas.home' )
+            ->and( $menu['dashboard']['external'] )->toBeFalse();
+    } );
+
+    it( 'includes the permission field when the item has a capability', function (): void {
+        Gate::define( 'view_admin_dashboard', fn ( $user = null ) => true );
+
+        $this->manager->addPage( 'Dashboard', 'dashboard', null, [
+            'icon'       => 'fas.home',
+            'capability' => 'view_admin_dashboard',
+        ] );
+
+        $menu = $this->manager->getAdminMenu();
+
+        expect( $menu['dashboard']['permission'] )->toBe( 'view_admin_dashboard' );
+    } );
+
+    it( 'keeps the pre-existing keys for Blade back-compat', function (): void {
+        $this->manager->addPage( 'Dashboard', 'dashboard', null, ['icon' => 'fas.home', 'capability' => ''] );
+
+        $menu = $this->manager->getAdminMenu();
+
+        expect( $menu['dashboard'] )
+            ->toHaveKey( 'title' )
+            ->toHaveKey( 'route' )
+            ->toHaveKey( 'icon' )
+            ->toHaveKey( 'capability' );
+    } );
+} );

--- a/tests/Unit/ContentTypes/ContentEditExtensionsTest.php
+++ b/tests/Unit/ContentTypes/ContentEditExtensionsTest.php
@@ -1,0 +1,94 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Managers\ContentEditExtensions;
+
+test( 'panels() returns filter-registered panels ordered by order', function (): void {
+    $manager = new ContentEditExtensions;
+
+    addFilter( 'ap.admin.contentEdit.panels', function ( array $panels ): array {
+        $panels[] = ['slug' => 'seo', 'title' => 'SEO', 'component' => 'SeoPanel', 'order' => 20];
+        $panels[] = ['slug' => 'schedule', 'title' => 'Schedule', 'component' => 'SchedulePanel', 'order' => 5];
+
+        return $panels;
+    } );
+
+    $panels = $manager->panels( ['contentType' => 'post', 'recordId' => 42] );
+
+    expect( $panels )->toHaveCount( 2 );
+    expect( $panels[0]['slug'] )->toBe( 'schedule' );
+    expect( $panels[1]['slug'] )->toBe( 'seo' );
+} );
+
+test( 'panels() filters by contentTypes restriction', function (): void {
+    $manager = new ContentEditExtensions;
+
+    addFilter( 'ap.admin.contentEdit.panels', function ( array $panels ): array {
+        $panels[] = ['slug' => 'gallery', 'title' => 'Gallery', 'component' => 'GalleryPanel', 'contentTypes' => ['portfolio']];
+        $panels[] = ['slug' => 'universal', 'title' => 'Universal', 'component' => 'AllPanel', 'contentTypes' => ['*']];
+        $panels[] = ['slug' => 'no-restriction', 'title' => 'Any', 'component' => 'AnyPanel'];
+
+        return $panels;
+    } );
+
+    $portfolioPanels = $manager->panels( ['contentType' => 'portfolio'] );
+    $postPanels      = $manager->panels( ['contentType' => 'post'] );
+
+    expect( array_column( $portfolioPanels, 'slug' ) )->toBe( ['gallery', 'universal', 'no-restriction'] );
+    expect( array_column( $postPanels, 'slug' ) )->toBe( ['universal', 'no-restriction'] );
+} );
+
+test( 'panels() rejects entries missing slug or component', function (): void {
+    $manager = new ContentEditExtensions;
+
+    addFilter( 'ap.admin.contentEdit.panels', function ( array $panels ): array {
+        $panels[] = ['title' => 'No slug', 'component' => 'X'];
+        $panels[] = ['slug' => 'no-component', 'title' => 'Bad'];
+        $panels[] = ['slug' => 'ok', 'title' => 'Good', 'component' => 'OkPanel'];
+
+        return $panels;
+    } );
+
+    $panels = $manager->panels( [] );
+
+    expect( array_column( $panels, 'slug' ) )->toBe( ['ok'] );
+} );
+
+test( 'tabs() and beforeEditor()/afterEditor() honor the same filter contract', function (): void {
+    $manager = new ContentEditExtensions;
+
+    addFilter( 'ap.admin.contentEdit.tabs', function ( array $items ): array {
+        $items[] = ['slug' => 'reviews', 'title' => 'Reviews', 'component' => 'ReviewsTab'];
+
+        return $items;
+    } );
+    addFilter( 'ap.admin.contentEdit.beforeEditor', function ( array $items ): array {
+        $items[] = ['slug' => 'banner', 'title' => 'Banner', 'component' => 'BannerBlock'];
+
+        return $items;
+    } );
+    addFilter( 'ap.admin.contentEdit.afterEditor', function ( array $items ): array {
+        $items[] = ['slug' => 'footer', 'title' => 'Footer', 'component' => 'FooterBlock'];
+
+        return $items;
+    } );
+
+    expect( $manager->tabs( ['contentType' => 'post'] )[0]['slug'] )->toBe( 'reviews' );
+    expect( $manager->beforeEditor( ['contentType' => 'post'] )[0]['slug'] )->toBe( 'banner' );
+    expect( $manager->afterEditor( ['contentType' => 'post'] )[0]['slug'] )->toBe( 'footer' );
+} );
+
+test( 'saveData() runs the payload through the filter and preserves fallback', function (): void {
+    $manager = new ContentEditExtensions;
+
+    addFilter( 'ap.admin.contentEdit.saveData', function ( array $data ): array {
+        $data['title'] = strtoupper( $data['title'] );
+
+        return $data;
+    } );
+
+    $result = $manager->saveData( ['title' => 'hello'], ['contentType' => 'post'] );
+
+    expect( $result['title'] )->toBe( 'HELLO' );
+} );

--- a/tests/Unit/ContentTypes/ContentTypeManagerTest.php
+++ b/tests/Unit/ContentTypes/ContentTypeManagerTest.php
@@ -234,3 +234,124 @@ test( 'registered content types merges database and filtered content types', fun
     expect( $registeredTypes )->toHaveKey( 'posts' );
     expect( $registeredTypes )->toHaveKey( 'custom' );
 } );
+
+test( 'get content type returns filter-registered content type as unpersisted model', function (): void {
+    $manager = new ContentTypeManager;
+
+    $manager->register( [
+        'name'        => 'Filter Only',
+        'slug'        => 'filter-only',
+        'table_name'  => 'filter_only',
+        'model_class' => 'App\\Models\\FilterOnly',
+        'supports'    => ['title'],
+    ] );
+
+    $contentType = $manager->getContentType( 'filter-only' );
+
+    expect( $contentType )->not->toBeNull();
+    expect( $contentType )->toBeInstanceOf( ContentType::class );
+    expect( $contentType->slug )->toBe( 'filter-only' );
+    expect( $contentType->name )->toBe( 'Filter Only' );
+    expect( $contentType->exists )->toBeFalse();
+    expect( $contentType->supportsFeature( 'title' ) )->toBeTrue();
+} );
+
+test( 'get content type prefers database entry over filter entry for the same slug', function (): void {
+    $manager = new ContentTypeManager;
+
+    ContentType::create( [
+        'name'          => 'DB Version',
+        'slug'          => 'shared',
+        'table_name'    => 'shared',
+        'model_class'   => 'App\\Models\\Shared',
+        'public'        => true,
+        'show_in_admin' => true,
+    ] );
+
+    $manager->register( [
+        'name'        => 'Filter Version',
+        'slug'        => 'shared',
+        'table_name'  => 'shared',
+        'model_class' => 'App\\Models\\SharedFilter',
+    ] );
+
+    $contentType = $manager->getContentType( 'shared' );
+
+    expect( $contentType->name )->toBe( 'DB Version' );
+    expect( $contentType->exists )->toBeTrue();
+} );
+
+test( 'updateContentType refuses filter-only slugs (no phantom INSERT)', function (): void {
+    $manager = new ContentTypeManager;
+
+    $manager->register( [
+        'name'        => 'Filter Only',
+        'slug'        => 'filter-only-update',
+        'table_name'  => 'filter_only_update',
+        'model_class' => 'App\\Models\\FilterOnly',
+    ] );
+
+    expect( fn () => $manager->updateContentType( 'filter-only-update', ['name' => 'Renamed'] ) )
+        ->toThrow( Exception::class, 'not found' );
+
+    expect( ContentType::where( 'slug', 'filter-only-update' )->exists() )->toBeFalse();
+} );
+
+test( 'deleteContentType returns false for filter-only slugs and never no-op-deletes', function (): void {
+    $manager = new ContentTypeManager;
+
+    $manager->register( [
+        'name'        => 'Filter Only',
+        'slug'        => 'filter-only-delete',
+        'table_name'  => 'filter_only_delete',
+        'model_class' => 'App\\Models\\FilterOnly',
+    ] );
+
+    expect( $manager->deleteContentType( 'filter-only-delete' ) )->toBeFalse();
+} );
+
+test( 'filter-hydrated content type strips persistence-critical keys', function (): void {
+    $manager = new ContentTypeManager;
+
+    $manager->register( [
+        'id'          => 999,
+        'created_at'  => '2020-01-01 00:00:00',
+        'name'        => 'Sneaky',
+        'slug'        => 'sneaky',
+        'table_name'  => 'sneaky',
+        'model_class' => 'App\\Models\\Sneaky',
+    ] );
+
+    $contentType = $manager->getContentType( 'sneaky' );
+
+    expect( $contentType->id )->toBeNull();
+    expect( $contentType->created_at )->toBeNull();
+    expect( $contentType->slug )->toBe( 'sneaky' );
+} );
+
+test( 'getPersistedContentType never returns filter-hydrated entries', function (): void {
+    $manager = new ContentTypeManager;
+
+    $manager->register( [
+        'name'        => 'Filter Only',
+        'slug'        => 'persist-check',
+        'table_name'  => 'persist_check',
+        'model_class' => 'App\\Models\\PersistCheck',
+    ] );
+
+    expect( $manager->getPersistedContentType( 'persist-check' ) )->toBeNull();
+} );
+
+test( 'content type exists returns true for filter-registered content types', function (): void {
+    $manager = new ContentTypeManager;
+
+    $manager->register( [
+        'name'        => 'Filter Only',
+        'slug'        => 'filter-existence',
+        'table_name'  => 'filter_existence',
+        'model_class' => 'App\\Models\\FilterExistence',
+    ] );
+
+    expect( $manager->contentTypeExists( 'filter-existence' ) )->toBeTrue();
+    expect( $manager->contentTypeExists( 'nonexistent' ) )->toBeFalse();
+} );

--- a/tests/Unit/ContentTypes/CustomFieldManagerTest.php
+++ b/tests/Unit/ContentTypes/CustomFieldManagerTest.php
@@ -2,6 +2,7 @@
 
 declare( strict_types=1 );
 
+use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Managers\ContentTypeManager;
 use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Managers\CustomFieldManager;
 use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Models\ContentType;
 use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Models\CustomField;
@@ -425,5 +426,149 @@ test( 'update field handles content type changes', function (): void {
     expect( Schema::hasColumn( 'test_pages_ct', 'custom_field' ) )->toBeTrue();
 
     Schema::dropIfExists( 'test_posts_ct' );
-    Schema::dropIfExists( 'test_pages_ct');
-});
+    Schema::dropIfExists( 'test_pages_ct' );
+} );
+
+test( 'get fields for content type merges DB and filter-registered fields', function (): void {
+    $manager = new CustomFieldManager;
+
+    CustomField::create( [
+        'name'          => 'DB Field',
+        'key'           => 'db_field',
+        'type'          => 'text',
+        'column_type'   => 'string',
+        'content_types' => ['posts'],
+        'order'         => 1,
+        'required'      => false,
+    ] );
+
+    $manager->registerField( [
+        'name'          => 'Plugin Field',
+        'key'           => 'plugin_field',
+        'type'          => 'text',
+        'column_type'   => 'string',
+        'content_types' => ['posts'],
+        'order'         => 2,
+        'required'      => false,
+    ] );
+
+    $manager->registerField( [
+        'name'          => 'Other Content Type Field',
+        'key'           => 'wrong_ct',
+        'type'          => 'text',
+        'column_type'   => 'string',
+        'content_types' => ['pages'],
+    ] );
+
+    $fields = $manager->getFieldsForContentType( 'posts' );
+    $keys   = $fields->pluck( 'key' )->all();
+
+    expect( $keys )->toContain( 'db_field' );
+    expect( $keys )->toContain( 'plugin_field' );
+    expect( $keys )->not->toContain( 'wrong_ct' );
+} );
+
+test( 'filter-registered fields are marked as metadata storage', function (): void {
+    $manager = new CustomFieldManager;
+
+    $manager->registerField( [
+        'name'          => 'Plugin Field',
+        'key'           => 'plugin_stored_field',
+        'type'          => 'text',
+        'column_type'   => 'string',
+        'content_types' => ['posts'],
+    ] );
+
+    $fields = $manager->getFieldsForContentType( 'posts' );
+    $plugin = $fields->firstWhere( 'key', 'plugin_stored_field' );
+
+    expect( $plugin )->not->toBeNull();
+    expect( $plugin->exists )->toBeFalse();
+    expect( $plugin->storageMode() )->toBe( 'metadata' );
+} );
+
+test( 'createField refuses to run Schema::table against a filter-only content type', function (): void {
+    // A plugin registers a content type with table_name pointing at a real
+    // host table. An admin creating a custom field must NOT trigger a schema
+    // mutation on that table.
+    $manager    = new CustomFieldManager;
+    $ctManager  = app( ContentTypeManager::class );
+
+    Schema::create( 'attacker_target', function ( $table ): void {
+        $table->id();
+        $table->string( 'legit_column' );
+        $table->timestamps();
+    } );
+
+    $ctManager->register( [
+        'name'        => 'Attacker CT',
+        'slug'        => 'attacker-ct',
+        'table_name'  => 'attacker_target', // Plugin picks a real host table.
+        'model_class' => 'App\\Models\\Attacker',
+    ] );
+
+    $field = $manager->createField( [
+        'name'          => 'Injected',
+        'key'           => 'injected_col',
+        'type'          => 'text',
+        'column_type'   => 'string',
+        'content_types' => ['attacker-ct'],
+        'order'         => 1,
+        'required'      => false,
+    ] );
+
+    expect( $field )->toBeInstanceOf( CustomField::class );
+    expect( Schema::hasColumn( 'attacker_target', 'injected_col' ) )->toBeFalse();
+
+    Schema::dropIfExists( 'attacker_target' );
+} );
+
+test( 'filter-registered custom fields strip persistence-critical keys on hydration', function (): void {
+    $manager = new CustomFieldManager;
+
+    $manager->registerField( [
+        'id'            => 999,
+        'created_at'    => '2020-01-01 00:00:00',
+        'name'          => 'Sneaky Field',
+        'key'           => 'sneaky',
+        'type'          => 'text',
+        'column_type'   => 'string',
+        'content_types' => ['posts'],
+    ] );
+
+    $field = $manager->getFieldsForContentType( 'posts' )->firstWhere( 'key', 'sneaky' );
+
+    expect( $field )->not->toBeNull();
+    expect( $field->id )->toBeNull();
+    expect( $field->created_at )->toBeNull();
+    expect( $field->exists )->toBeFalse();
+} );
+
+test( 'DB entry wins over filter entry when keys collide', function (): void {
+    $manager = new CustomFieldManager;
+
+    CustomField::create( [
+        'name'          => 'DB Version',
+        'key'           => 'shared_key',
+        'type'          => 'text',
+        'column_type'   => 'string',
+        'content_types' => ['posts'],
+        'order'         => 1,
+        'required'      => false,
+    ] );
+
+    $manager->registerField( [
+        'name'          => 'Filter Version',
+        'key'           => 'shared_key',
+        'type'          => 'text',
+        'column_type'   => 'string',
+        'content_types' => ['posts'],
+    ] );
+
+    $fields  = $manager->getFieldsForContentType( 'posts' );
+    $matches = $fields->where( 'key', 'shared_key' );
+
+    expect( $matches )->toHaveCount( 1 );
+    expect( $matches->first()->name )->toBe( 'DB Version' );
+    expect( $matches->first()->exists )->toBeTrue();
+} );

--- a/tests/Unit/ContentTypes/CustomFieldTypeRegistryTest.php
+++ b/tests/Unit/ContentTypes/CustomFieldTypeRegistryTest.php
@@ -1,0 +1,117 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Enums\FieldType;
+use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Registries\CustomFieldTypeRegistry;
+use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Support\FieldTypeDefinition;
+
+test( 'registry pre-registers every built-in FieldType enum case', function (): void {
+    $registry = new CustomFieldTypeRegistry;
+
+    $slugs = $registry->slugs();
+
+    foreach ( FieldType::cases() as $case ) {
+        expect( $slugs )->toContain( $case->value );
+        expect( $registry->get( $case->value ) )->toBeInstanceOf( FieldTypeDefinition::class );
+    }
+} );
+
+test( 'registry allows registering new plugin field types via register()', function (): void {
+    $registry = new CustomFieldTypeRegistry;
+
+    $registry->register( new FieldTypeDefinition(
+        slug       : 'map_picker',
+        label      : 'Map Picker',
+        columnType : 'string',
+    ) );
+
+    expect( $registry->has( 'map_picker' ) )->toBeTrue();
+    expect( $registry->get( 'map_picker' )->label )->toBe( 'Map Picker' );
+} );
+
+test( 'registry surfaces filter-registered field types via all()', function (): void {
+    $registry = new CustomFieldTypeRegistry;
+
+    addFilter( 'ap.contentTypes.registeredFieldTypes', function ( array $types ): array {
+        $types['image_gallery'] = [
+            'slug'        => 'image_gallery',
+            'label'       => 'Image Gallery',
+            'column_type' => 'text',
+        ];
+
+        return $types;
+    } );
+
+    expect( $registry->has( 'image_gallery' ) )->toBeTrue();
+    expect( $registry->get( 'image_gallery' )->columnType )->toBe( 'text' );
+} );
+
+test( 'registry accepts FieldTypeDefinition instances from filter', function (): void {
+    $registry = new CustomFieldTypeRegistry;
+
+    addFilter( 'ap.contentTypes.registeredFieldTypes', function ( array $types ): array {
+        $types['color_picker'] = new FieldTypeDefinition(
+            slug       : 'color_picker',
+            label      : 'Color Picker',
+            columnType : 'string',
+        );
+
+        return $types;
+    } );
+
+    expect( $registry->get( 'color_picker' ) )->not->toBeNull();
+    expect( $registry->get( 'color_picker' )->label )->toBe( 'Color Picker' );
+} );
+
+test( 'apRegisterFieldType helper registers on the shared singleton', function (): void {
+    $definition = apRegisterFieldType( 'phone_verified', [
+        'label'       => 'Verified Phone',
+        'column_type' => 'string',
+    ] );
+
+    expect( $definition )->toBeInstanceOf( FieldTypeDefinition::class );
+    expect( $definition->slug )->toBe( 'phone_verified' );
+    expect( apGetFieldType( 'phone_verified' ) )->not->toBeNull();
+    expect( apRegisteredFieldTypes() )->toHaveKey( 'phone_verified' );
+} );
+
+test( 'registry silently drops filter entries with non-scalar slug or label', function (): void {
+    $registry = new CustomFieldTypeRegistry;
+
+    addFilter( 'ap.contentTypes.registeredFieldTypes', function ( array $types ): array {
+        $types['bad_slug']   = ['slug' => ['nested', 'array'], 'label' => 'Bad'];
+        $types['bad_label']  = ['slug' => 'bad_label', 'label' => (object) ['ha' => 'ha']];
+        $types['empty_slug'] = ['slug' => '   ', 'label' => 'Blank'];
+        $types['good_one']   = ['slug' => 'good_one', 'label' => 'Good'];
+
+        return $types;
+    } );
+
+    $slugs = $registry->slugs();
+
+    expect( $slugs )->toContain( 'good_one' );
+    expect( $slugs )->not->toContain( 'bad_slug' );
+    expect( $slugs )->not->toContain( 'bad_label' );
+    expect( $slugs )->not->toContain( '' );
+    expect( $slugs )->not->toContain( '   ' );
+} );
+
+test( 'FieldTypeDefinition fromArray maps camelCase and snake_case keys', function (): void {
+    $definition = FieldTypeDefinition::fromArray( [
+        'slug'              => 'rating_stars',
+        'label'             => 'Rating',
+        'columnType'        => 'integer',
+        'validationRules'   => ['integer', 'between:1,5'],
+        'editorComponent'   => 'RatingEditor',
+        'rendererComponent' => 'RatingRenderer',
+        'meta'              => ['icon' => 'star'],
+    ] );
+
+    expect( $definition->slug )->toBe( 'rating_stars' );
+    expect( $definition->columnType )->toBe( 'integer' );
+    expect( $definition->validationRules )->toBe( ['integer', 'between:1,5'] );
+    expect( $definition->editorComponent )->toBe( 'RatingEditor' );
+    expect( $definition->rendererComponent )->toBe( 'RatingRenderer' );
+    expect( $definition->meta )->toBe( ['icon' => 'star'] );
+} );

--- a/tests/Unit/ContentTypes/HasCustomFieldsTest.php
+++ b/tests/Unit/ContentTypes/HasCustomFieldsTest.php
@@ -1,0 +1,227 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Managers\CustomFieldManager;
+use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Models\Concerns\HasCustomFields;
+use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Models\CustomField;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Test-only content-type model with a `metadata` JSON column, exercising
+ * the HasCustomFields metadata-storage code path for filter-registered
+ * fields.
+ */
+class TestHasCustomFieldsPost extends Model
+{
+    use HasCustomFields;
+
+    protected $table = 'test_hcf_posts';
+
+    protected $guarded = [];
+
+    protected $casts = [
+        'metadata' => 'array',
+    ];
+}
+
+beforeEach( function (): void {
+    $this->artisan( 'migrate', ['--database' => 'testing'] );
+
+    Schema::dropIfExists( 'test_hcf_posts' );
+    Schema::create( 'test_hcf_posts', function ( $table ): void {
+        $table->id();
+        $table->string( 'title' );
+        $table->json( 'metadata' )->nullable();
+        $table->timestamps();
+    } );
+} );
+
+afterEach( function (): void {
+    Schema::dropIfExists( 'test_hcf_posts' );
+} );
+
+test( 'reads filter-registered field value from metadata', function (): void {
+    app( CustomFieldManager::class )->registerField( [
+        'name'          => 'Plugin Field',
+        'key'           => 'plugin_note',
+        'type'          => 'text',
+        'column_type'   => 'string',
+        'content_types' => ['test_hcf_posts'],
+        'default_value' => 'unset',
+    ] );
+
+    $post           = new TestHasCustomFieldsPost;
+    $post->title    = 'Hello';
+    $post->metadata = ['plugin_note' => 'stored via metadata'];
+    $post->save();
+
+    $reloaded = TestHasCustomFieldsPost::find( $post->id );
+
+    expect( $reloaded->plugin_note )->toBe( 'stored via metadata' );
+} );
+
+test( 'writes filter-registered field value into metadata', function (): void {
+    app( CustomFieldManager::class )->registerField( [
+        'name'          => 'Plugin Field',
+        'key'           => 'plugin_bio',
+        'type'          => 'text',
+        'column_type'   => 'string',
+        'content_types' => ['test_hcf_posts'],
+    ] );
+
+    $post             = new TestHasCustomFieldsPost;
+    $post->title      = 'Bio Post';
+    $post->plugin_bio = 'A short bio.';
+    $post->save();
+
+    $reloaded = TestHasCustomFieldsPost::find( $post->id );
+
+    expect( $reloaded->metadata )->toHaveKey( 'plugin_bio' );
+    expect( $reloaded->metadata['plugin_bio'] )->toBe( 'A short bio.' );
+    expect( $reloaded->plugin_bio )->toBe( 'A short bio.' );
+} );
+
+test( 'reads default_value when metadata is missing the key', function (): void {
+    app( CustomFieldManager::class )->registerField( [
+        'name'          => 'Plugin Field',
+        'key'           => 'plugin_default',
+        'type'          => 'text',
+        'column_type'   => 'string',
+        'content_types' => ['test_hcf_posts'],
+        'default_value' => 'default from field',
+    ] );
+
+    $post        = new TestHasCustomFieldsPost;
+    $post->title = 'No plugin data yet';
+    $post->save();
+
+    expect( $post->plugin_default )->toBe( 'default from field' );
+} );
+
+test( 'plugin custom field key colliding with a real column does NOT hijack the column', function (): void {
+    // Ensures a rogue plugin cannot shadow a host attribute by registering
+    // a filter-scoped custom field whose key matches a real DB column.
+    app( CustomFieldManager::class )->registerField( [
+        'name'          => 'Hijack Attempt',
+        'key'           => 'title', // Real column on `test_hcf_posts`.
+        'type'          => 'text',
+        'column_type'   => 'string',
+        'content_types' => ['test_hcf_posts'],
+    ] );
+
+    $post        = new TestHasCustomFieldsPost;
+    $post->title = 'Legit Title';
+    $post->save();
+
+    $reloaded = TestHasCustomFieldsPost::find( $post->id );
+
+    expect( $reloaded->title )->toBe( 'Legit Title' );
+    expect( $reloaded->metadata )->toBeNull();
+} );
+
+test( 'plugin custom field key colliding with a cast attribute does NOT hijack it', function (): void {
+    // Casts declared via `casts()` method (per Laravel 12 convention) must
+    // still short-circuit — the trait consults `getCasts()`, not `$casts`.
+    app( CustomFieldManager::class )->registerField( [
+        'name'          => 'Hijack Attempt',
+        'key'           => 'metadata', // The cast attribute itself.
+        'type'          => 'text',
+        'column_type'   => 'string',
+        'content_types' => ['test_hcf_posts'],
+    ] );
+
+    $post           = new TestHasCustomFieldsPost;
+    $post->title    = 'Post';
+    $post->metadata = ['user_supplied' => 'ok'];
+    $post->save();
+
+    $reloaded = TestHasCustomFieldsPost::find( $post->id );
+
+    expect( $reloaded->metadata )->toBe( ['user_supplied' => 'ok'] );
+} );
+
+test( 'plugin custom field write on a model without metadata column fails loud', function (): void {
+    // A HasCustomFields model that has no metadata column must not silently
+    // drop plugin writes — throw so the plugin author sees the misuse.
+    Schema::dropIfExists( 'test_no_meta_hcf' );
+    Schema::create( 'test_no_meta_hcf', function ( $table ): void {
+        $table->id();
+        $table->string( 'title' );
+        $table->timestamps();
+    } );
+
+    $model = new class extends Model {
+        use HasCustomFields;
+
+        protected $table = 'test_no_meta_hcf';
+
+        protected $guarded = [];
+    };
+
+    app( CustomFieldManager::class )->registerField( [
+        'name'          => 'Plugin Field',
+        'key'           => 'plugin_only',
+        'type'          => 'text',
+        'column_type'   => 'string',
+        'content_types' => ['test_no_meta_hcf'],
+    ] );
+
+    expect( fn () => $model->plugin_only = 'boom' )
+        ->toThrow( RuntimeException::class, 'no `metadata` JSON column' );
+
+    Schema::dropIfExists( 'test_no_meta_hcf' );
+} );
+
+test( 'getCustomFieldsForType is memoized per instance', function (): void {
+    app( CustomFieldManager::class )->registerField( [
+        'name'          => 'Plugin Field',
+        'key'           => 'memoized_field',
+        'type'          => 'text',
+        'column_type'   => 'string',
+        'content_types' => ['test_hcf_posts'],
+    ] );
+
+    $post        = new TestHasCustomFieldsPost;
+    $post->title = 'x';
+    $post->save();
+
+    Illuminate\Support\Facades\DB::enableQueryLog();
+    Illuminate\Support\Facades\DB::flushQueryLog();
+
+    // First lookup populates the cache; subsequent lookups must not requery.
+    $post->getCustomFieldsForType();
+    $post->getCustomFieldsForType();
+    $post->getCustomFieldsForType();
+
+    expect( Illuminate\Support\Facades\DB::getQueryLog() )->toHaveCount( 1 );
+
+    Illuminate\Support\Facades\DB::disableQueryLog();
+} );
+
+test( 'DB-registered field values still flow through physical columns', function (): void {
+    Schema::table( 'test_hcf_posts', function ( $table ): void {
+        $table->string( 'db_field' )->nullable();
+    } );
+
+    CustomField::create( [
+        'name'          => 'DB Field',
+        'key'           => 'db_field',
+        'type'          => 'text',
+        'column_type'   => 'string',
+        'content_types' => ['test_hcf_posts'],
+        'order'         => 1,
+        'required'      => false,
+    ] );
+
+    $post           = new TestHasCustomFieldsPost;
+    $post->title    = 'DB Post';
+    $post->db_field = 'column value';
+    $post->save();
+
+    $reloaded = TestHasCustomFieldsPost::find( $post->id );
+
+    expect( $reloaded->db_field )->toBe( 'column value' );
+    expect( $reloaded->metadata )->toBeNull();
+} );

--- a/tests/Unit/ContentTypes/TaxonomyManagerTest.php
+++ b/tests/Unit/ContentTypes/TaxonomyManagerTest.php
@@ -1,0 +1,179 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Managers\TaxonomyManager;
+use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Models\Taxonomy;
+
+beforeEach( function (): void {
+    $this->artisan( 'migrate', ['--database' => 'testing'] );
+} );
+
+test( 'get taxonomy returns filter-registered taxonomy as unpersisted model', function (): void {
+    $manager = new TaxonomyManager;
+
+    $manager->registerTaxonomy( [
+        'name'              => 'Filter Category',
+        'slug'              => 'filter-category',
+        'content_type_slug' => 'posts',
+        'hierarchical'      => true,
+        'show_in_admin'     => true,
+    ] );
+
+    $taxonomy = $manager->getTaxonomy( 'filter-category' );
+
+    expect( $taxonomy )->not->toBeNull();
+    expect( $taxonomy )->toBeInstanceOf( Taxonomy::class );
+    expect( $taxonomy->slug )->toBe( 'filter-category' );
+    expect( $taxonomy->name )->toBe( 'Filter Category' );
+    expect( $taxonomy->content_type_slug )->toBe( 'posts' );
+    expect( $taxonomy->exists )->toBeFalse();
+} );
+
+test( 'get taxonomy prefers database entry over filter entry', function (): void {
+    $manager = new TaxonomyManager;
+
+    Taxonomy::create( [
+        'name'              => 'DB Tag',
+        'slug'              => 'shared-tag',
+        'content_type_slug' => 'posts',
+        'hierarchical'      => false,
+        'show_in_admin'     => true,
+    ] );
+
+    $manager->registerTaxonomy( [
+        'name'              => 'Filter Tag',
+        'slug'              => 'shared-tag',
+        'content_type_slug' => 'posts',
+    ] );
+
+    $taxonomy = $manager->getTaxonomy( 'shared-tag' );
+
+    expect( $taxonomy->name )->toBe( 'DB Tag' );
+    expect( $taxonomy->exists )->toBeTrue();
+} );
+
+test( 'taxonomy exists returns true for filter-registered taxonomies', function (): void {
+    $manager = new TaxonomyManager;
+
+    $manager->registerTaxonomy( [
+        'name'              => 'Filter Series',
+        'slug'              => 'filter-series',
+        'content_type_slug' => 'posts',
+    ] );
+
+    expect( $manager->taxonomyExists( 'filter-series' ) )->toBeTrue();
+    expect( $manager->taxonomyExists( 'nonexistent-taxonomy' ) )->toBeFalse();
+} );
+
+test( 'get taxonomies for content type merges DB and filter entries', function (): void {
+    $manager = new TaxonomyManager;
+
+    Taxonomy::create( [
+        'name'              => 'DB Category',
+        'slug'              => 'db-category',
+        'content_type_slug' => 'posts',
+        'hierarchical'      => true,
+        'show_in_admin'     => true,
+    ] );
+
+    $manager->registerTaxonomy( [
+        'name'              => 'Filter Category',
+        'slug'              => 'filter-category',
+        'content_type_slug' => 'posts',
+    ] );
+
+    $manager->registerTaxonomy( [
+        'name'              => 'Wrong Content Type',
+        'slug'              => 'other',
+        'content_type_slug' => 'pages',
+    ] );
+
+    $taxonomies = $manager->getTaxonomiesForContentType( 'posts' );
+
+    $slugs = $taxonomies->pluck( 'slug' )->all();
+    expect( $slugs )->toContain( 'db-category' );
+    expect( $slugs )->toContain( 'filter-category' );
+    expect( $slugs )->not->toContain( 'other' );
+} );
+
+test( 'get taxonomies for content type prefers DB entry when slugs collide', function (): void {
+    $manager = new TaxonomyManager;
+
+    Taxonomy::create( [
+        'name'              => 'DB Version',
+        'slug'              => 'collision',
+        'content_type_slug' => 'posts',
+        'hierarchical'      => true,
+        'show_in_admin'     => true,
+    ] );
+
+    $manager->registerTaxonomy( [
+        'name'              => 'Filter Version',
+        'slug'              => 'collision',
+        'content_type_slug' => 'posts',
+    ] );
+
+    $taxonomies = $manager->getTaxonomiesForContentType( 'posts' );
+
+    $collision = $taxonomies->firstWhere( 'slug', 'collision' );
+    expect( $collision )->not->toBeNull();
+    expect( $collision->name )->toBe( 'DB Version' );
+    expect( $collision->exists )->toBeTrue();
+} );
+
+test( 'updateTaxonomy refuses filter-only slugs (no phantom INSERT)', function (): void {
+    $manager = new TaxonomyManager;
+
+    $manager->registerTaxonomy( [
+        'name'              => 'Filter Only',
+        'slug'              => 'filter-only-tag',
+        'content_type_slug' => 'posts',
+    ] );
+
+    expect( fn () => $manager->updateTaxonomy( 'filter-only-tag', ['name' => 'Renamed'] ) )
+        ->toThrow( Exception::class, 'not found' );
+
+    expect( Taxonomy::where( 'slug', 'filter-only-tag' )->exists() )->toBeFalse();
+} );
+
+test( 'deleteTaxonomy returns false for filter-only slugs', function (): void {
+    $manager = new TaxonomyManager;
+
+    $manager->registerTaxonomy( [
+        'name'              => 'Filter Only',
+        'slug'              => 'filter-only-delete',
+        'content_type_slug' => 'posts',
+    ] );
+
+    expect( $manager->deleteTaxonomy( 'filter-only-delete' ) )->toBeFalse();
+} );
+
+test( 'filter-hydrated taxonomy strips persistence-critical keys', function (): void {
+    $manager = new TaxonomyManager;
+
+    $manager->registerTaxonomy( [
+        'id'                => 999,
+        'created_at'        => '2020-01-01 00:00:00',
+        'name'              => 'Sneaky',
+        'slug'              => 'sneaky-tag',
+        'content_type_slug' => 'posts',
+    ] );
+
+    $taxonomy = $manager->getTaxonomy( 'sneaky-tag' );
+
+    expect( $taxonomy->id )->toBeNull();
+    expect( $taxonomy->created_at )->toBeNull();
+} );
+
+test( 'getPersistedTaxonomy never returns filter-hydrated entries', function (): void {
+    $manager = new TaxonomyManager;
+
+    $manager->registerTaxonomy( [
+        'name'              => 'Filter Only',
+        'slug'              => 'persist-tag',
+        'content_type_slug' => 'posts',
+    ] );
+
+    expect( $manager->getPersistedTaxonomy( 'persist-tag' ) )->toBeNull();
+} );

--- a/tests/Unit/DynamicContent/ModifiersTest.php
+++ b/tests/Unit/DynamicContent/ModifiersTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Modifiers\DateModifier;
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Modifiers\DefaultModifier;
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Modifiers\LowerModifier;
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Modifiers\Nl2brModifier;
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Modifiers\TimeModifier;
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Modifiers\TruncateModifier;
+use ArtisanPackUI\CMSFramework\Modules\DynamicContent\Modifiers\UpperModifier;
+
+test( 'default modifier substitutes when empty', function (): void {
+    $m = new DefaultModifier();
+
+    expect( $m->apply( null, [ 'fallback' ] ) )->toBe( 'fallback' );
+    expect( $m->apply( '', [ 'fallback' ] ) )->toBe( 'fallback' );
+    expect( $m->apply( 'value', [ 'fallback' ] ) )->toBe( 'value' );
+} );
+
+test( 'upper modifier uppercases strings', function (): void {
+    expect( ( new UpperModifier() )->apply( 'abc', [] ) )->toBe( 'ABC' );
+    expect( ( new UpperModifier() )->apply( 42, [] ) )->toBe( 42 );
+} );
+
+test( 'lower modifier lowercases strings', function (): void {
+    expect( ( new LowerModifier() )->apply( 'ABC', [] ) )->toBe( 'abc' );
+} );
+
+test( 'truncate modifier respects length', function (): void {
+    $m = new TruncateModifier();
+    expect( $m->apply( 'short', [ '10' ] ) )->toBe( 'short' );
+    expect( $m->apply( 'this is a long string', [ '4' ] ) )->toBe( 'this…' );
+} );
+
+test( 'date modifier formats parseable input', function (): void {
+    expect( ( new DateModifier() )->apply( '2026-07-16', [ 'Y-m-d' ] ) )->toBe( '2026-07-16' );
+    expect( ( new DateModifier() )->apply( null, [ 'Y-m-d' ] ) )->toBe( '' );
+} );
+
+test( 'time modifier reassembles colon-split args', function (): void {
+    // "time:g:i a" -> args ['g','i a']
+    expect( ( new TimeModifier() )->apply( '2026-07-16 15:04', [ 'g', 'i a' ] ) )->toBe( '3:04 pm' );
+} );
+
+test( 'nl2br modifier converts newlines and returns HtmlString', function (): void {
+    $result = ( new Nl2brModifier() )->apply( "a\nb", [] );
+    expect( $result )->toBeInstanceOf( Illuminate\Support\HtmlString::class );
+    expect( (string) $result )->toContain( '<br' );
+} );
+
+test( 'nl2br modifier escapes HTML in input before adding br tags', function (): void {
+    $result = ( new Nl2brModifier() )->apply( "<img src=x onerror=alert(1)>\nnext", [] );
+    $out    = (string) $result;
+    expect( $out )->not->toContain( '<img' );
+    expect( $out )->toContain( '&lt;img' );
+    expect( $out )->toContain( '<br' );
+} );

--- a/tests/Unit/OpenApi/OpenApiServiceProviderTest.php
+++ b/tests/Unit/OpenApi/OpenApiServiceProviderTest.php
@@ -36,7 +36,7 @@ test( 'openapi config has default values', function (): void {
 
     expect( $config['enabled'] )->toBeTrue();
     expect( $config['info']['title'] )->toBe( 'ArtisanPack CMS Framework API' );
-    expect( $config['info']['version'] )->toBe( '2.3.0' );
+    expect( $config['info']['version'] )->toBe( '2.4.0' );
     expect( $config['ui_path'] )->toBe( '/docs/api/cms' );
     expect( $config['document_path'] )->toBe( '/docs/api/cms.json' );
 } );

--- a/tests/Unit/Plugins/ManifestSchemaExtensionTest.php
+++ b/tests/Unit/Plugins/ManifestSchemaExtensionTest.php
@@ -1,0 +1,177 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\CMSFramework\Modules\Plugins\Exceptions\PluginValidationException;
+use ArtisanPackUI\CMSFramework\Modules\Plugins\Managers\PluginManager;
+use ArtisanPackUI\CMSFramework\Modules\Plugins\Models\Plugin;
+
+beforeEach( function (): void {
+    $this->manager = new PluginManager;
+    $this->base    = [
+        'slug'    => 'test-plugin',
+        'name'    => 'Test Plugin',
+        'version' => '1.0.0',
+    ];
+} );
+
+describe( 'min_host_version', function (): void {
+    it( 'accepts a valid semver', function (): void {
+        $manifest = array_merge( $this->base, ['min_host_version' => '2.4.0'] );
+
+        expect( fn () => invokeMethod( $this->manager, 'validateManifest', [$manifest] ) )
+            ->not->toThrow( PluginValidationException::class );
+    } );
+
+    it( 'rejects a malformed version string', function (): void {
+        $manifest = array_merge( $this->base, ['min_host_version' => 'v2.4'] );
+
+        expect( fn () => invokeMethod( $this->manager, 'validateManifest', [$manifest] ) )
+            ->toThrow( PluginValidationException::class, 'Invalid min_host_version' );
+    } );
+} );
+
+describe( 'federated_module', function (): void {
+    it( 'accepts an entry-only descriptor', function (): void {
+        $manifest = array_merge( $this->base, [
+            'federated_module' => ['entry' => 'dist/remoteEntry.js'],
+        ] );
+
+        expect( fn () => invokeMethod( $this->manager, 'validateManifest', [$manifest] ) )
+            ->not->toThrow( PluginValidationException::class );
+    } );
+
+    it( 'rejects a missing entry', function (): void {
+        $manifest = array_merge( $this->base, ['federated_module' => ['exposes' => ['a']]] );
+
+        expect( fn () => invokeMethod( $this->manager, 'validateManifest', [$manifest] ) )
+            ->toThrow( PluginValidationException::class, 'Invalid federated_module' );
+    } );
+
+    it( 'rejects a non-array exposes', function (): void {
+        $manifest = array_merge( $this->base, [
+            'federated_module' => ['entry' => 'x.js', 'exposes' => 'oops'],
+        ] );
+
+        expect( fn () => invokeMethod( $this->manager, 'validateManifest', [$manifest] ) )
+            ->toThrow( PluginValidationException::class, 'exposes' );
+    } );
+} );
+
+describe( 'nav_entries', function (): void {
+    it( 'accepts a well-formed list', function (): void {
+        $manifest = array_merge( $this->base, [
+            'nav_entries' => [
+                ['slug' => 'reports', 'label' => 'Reports'],
+            ],
+        ] );
+
+        expect( fn () => invokeMethod( $this->manager, 'validateManifest', [$manifest] ) )
+            ->not->toThrow( PluginValidationException::class );
+    } );
+
+    it( 'rejects entries missing slug/label', function (): void {
+        $manifest = array_merge( $this->base, [
+            'nav_entries' => [
+                ['slug' => 'reports'],
+            ],
+        ] );
+
+        expect( fn () => invokeMethod( $this->manager, 'validateManifest', [$manifest] ) )
+            ->toThrow( PluginValidationException::class, 'nav_entries[0]' );
+    } );
+
+    it( 'rejects associative arrays', function (): void {
+        $manifest = array_merge( $this->base, [
+            'nav_entries' => ['not' => 'a list'],
+        ] );
+
+        expect( fn () => invokeMethod( $this->manager, 'validateManifest', [$manifest] ) )
+            ->toThrow( PluginValidationException::class );
+    } );
+} );
+
+describe( 'permissions', function (): void {
+    it( 'accepts a list of properly-namespaced slugs', function (): void {
+        $manifest = array_merge( $this->base, [
+            'permissions' => ['test-plugin.reports.view', 'test-plugin.reports.export'],
+        ] );
+
+        expect( fn () => invokeMethod( $this->manager, 'validateManifest', [$manifest] ) )
+            ->not->toThrow( PluginValidationException::class );
+    } );
+
+    it( 'rejects non-string entries', function (): void {
+        $manifest = array_merge( $this->base, ['permissions' => ['test-plugin.reports.view', 42]] );
+
+        expect( fn () => invokeMethod( $this->manager, 'validateManifest', [$manifest] ) )
+            ->toThrow( PluginValidationException::class );
+    } );
+
+    it( 'rejects permissions that are not prefixed with the plugin slug', function (): void {
+        // Without this rule a plugin could name framework-owned permissions
+        // ('manage_users') and delete them on uninstall.
+        $manifest = array_merge( $this->base, [
+            'permissions' => ['manage_users'],
+        ] );
+
+        expect( fn () => invokeMethod( $this->manager, 'validateManifest', [$manifest] ) )
+            ->toThrow( PluginValidationException::class, 'must be prefixed' );
+    } );
+} );
+
+describe( 'migrations_path', function (): void {
+    it( 'accepts a valid relative path', function (): void {
+        $manifest = array_merge( $this->base, ['migrations_path' => 'database/migrations'] );
+
+        expect( fn () => invokeMethod( $this->manager, 'validateManifest', [$manifest] ) )
+            ->not->toThrow( PluginValidationException::class );
+    } );
+
+    it( 'rejects a traversal attempt', function (): void {
+        $manifest = array_merge( $this->base, ['migrations_path' => '../../database/migrations'] );
+
+        expect( fn () => invokeMethod( $this->manager, 'validateManifest', [$manifest] ) )
+            ->toThrow( PluginValidationException::class, 'no ".."' );
+    } );
+
+    it( 'rejects an absolute path', function (): void {
+        $manifest = array_merge( $this->base, ['migrations_path' => '/etc/passwd'] );
+
+        expect( fn () => invokeMethod( $this->manager, 'validateManifest', [$manifest] ) )
+            ->toThrow( PluginValidationException::class );
+    } );
+} );
+
+describe( 'Plugin model accessors', function (): void {
+    it( 'exposes the new manifest fields ergonomically', function (): void {
+        $plugin = new Plugin( [
+            'slug'    => 'test-plugin',
+            'name'    => 'Test Plugin',
+            'version' => '1.0.0',
+            'meta'    => [
+                'min_host_version'              => '2.4.0',
+                'federated_module'              => ['entry' => 'dist/remoteEntry.js', 'exposes' => ['./App']],
+                'nav_entries'                   => [['slug' => 'x', 'label' => 'X']],
+                'permissions'                   => ['test-plugin.reports.view'],
+                'rollback_migrations_on_delete' => true,
+            ],
+        ] );
+
+        expect( $plugin->min_host_version )->toBe( '2.4.0' )
+            ->and( $plugin->federated_module )->toMatchArray( ['entry' => 'dist/remoteEntry.js'] )
+            ->and( $plugin->nav_entries )->toHaveCount( 1 )
+            ->and( $plugin->declared_permissions )->toBe( ['test-plugin.reports.view'] )
+            ->and( $plugin->rollback_migrations_on_delete )->toBeTrue();
+    } );
+
+    it( 'returns sensible defaults when manifest fields are absent', function (): void {
+        $plugin = new Plugin( ['slug' => 'x', 'name' => 'X', 'version' => '1.0.0', 'meta' => []] );
+
+        expect( $plugin->min_host_version )->toBeNull()
+            ->and( $plugin->federated_module )->toBeNull()
+            ->and( $plugin->nav_entries )->toBe( [] )
+            ->and( $plugin->declared_permissions )->toBe( [] )
+            ->and( $plugin->rollback_migrations_on_delete )->toBeFalse();
+    } );
+} );

--- a/tests/Unit/Plugins/PluginServiceProviderTest.php
+++ b/tests/Unit/Plugins/PluginServiceProviderTest.php
@@ -1,0 +1,200 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\CMSFramework\Modules\Admin\Managers\AdminMenuManager;
+use ArtisanPackUI\CMSFramework\Modules\Plugins\Support\PluginRegistry;
+use ArtisanPackUI\CMSFramework\Modules\Plugins\Support\PluginServiceProvider;
+use Illuminate\Support\Facades\Gate;
+
+beforeEach( function (): void {
+    Gate::before( fn ( ?Illuminate\Contracts\Auth\Authenticatable $user, string $ability ) => true );
+
+    removeAllFilters( 'ap.admin.menu' );
+    removeAllFilters( 'ap.plugins.federatedModules' );
+
+    $this->app->singleton( AdminMenuManager::class, fn () => new AdminMenuManager );
+    $this->app->singleton( PluginRegistry::class );
+
+    // Wire the same single-callback filter the framework's PluginsServiceProvider
+    // sets up, so registry contents surface in the admin menu.
+    $registry = app( PluginRegistry::class );
+    addFilter( 'ap.admin.menu', function ( array $menu ) use ( $registry ): array {
+        foreach ( $registry->navEntries() as $slug => $entry ) {
+            $menu[ $slug ] = array_merge( $entry, $menu[ $slug ] ?? [] );
+        }
+
+        return $menu;
+    } );
+    addFilter( 'ap.plugins.federatedModules', function ( array $modules ) use ( $registry ): array {
+        return array_merge( $modules, $registry->federatedModules() );
+    } );
+} );
+
+afterEach( function (): void {
+    removeAllFilters( 'ap.admin.menu' );
+    removeAllFilters( 'ap.plugins.federatedModules' );
+} );
+
+it( 'registers an admin page through the AdminMenuManager', function (): void {
+    $provider = new class( app() ) extends PluginServiceProvider {
+        public function boot(): void
+        {
+            $this->registerAdminPage( 'my-plugin', [
+                'title'      => 'My Plugin',
+                'icon'       => 'fas.star',
+                'capability' => '',
+            ] );
+        }
+
+        protected function loadManifest(): array
+        {
+            return $this->manifest = ['slug' => 'my-plugin'];
+        }
+    };
+
+    $provider->boot();
+
+    $menu = app( AdminMenuManager::class )->getAdminMenu();
+
+    expect( $menu )->toHaveKey( 'my-plugin' )
+        ->and( $menu['my-plugin']['label'] )->toBe( 'My Plugin' );
+} );
+
+it( 'injects a nav entry via the ap.admin.menu filter', function (): void {
+    $provider = new class( app() ) extends PluginServiceProvider {
+        public function boot(): void
+        {
+            $this->registerNavEntry( [
+                'slug'       => 'reports',
+                'label'      => 'Reports',
+                'url'        => '/admin/reports',
+                'icon'       => 'fas.chart-bar',
+                'permission' => 'reports.view',
+            ] );
+        }
+
+        protected function loadManifest(): array
+        {
+            return $this->manifest = ['slug' => 'reports-plugin'];
+        }
+    };
+
+    $provider->boot();
+
+    $menu = app( AdminMenuManager::class )->getAdminMenu();
+
+    expect( $menu )->toHaveKey( 'reports' )
+        ->and( $menu['reports']['url'] )->toBe( '/admin/reports' )
+        ->and( $menu['reports']['permission'] )->toBe( 'reports.view' )
+        ->and( $menu['reports']['external'] )->toBeFalse();
+} );
+
+it( 'sanitizes javascript: URLs in nav entries down to #', function (): void {
+    $provider = new class( app() ) extends PluginServiceProvider {
+        public function boot(): void
+        {
+            $this->registerNavEntry( [
+                'slug'  => 'evil',
+                'label' => 'Docs',
+                'url'   => 'javascript:alert(1)',
+            ] );
+        }
+
+        protected function loadManifest(): array
+        {
+            return $this->manifest = ['slug' => 'evil-plugin'];
+        }
+    };
+
+    $provider->boot();
+
+    $menu = app( AdminMenuManager::class )->getAdminMenu();
+
+    expect( $menu['evil']['url'] )->toBe( '#' );
+} );
+
+it( 'is idempotent when the same nav entry is registered twice', function (): void {
+    $provider = new class( app() ) extends PluginServiceProvider {
+        public function boot(): void
+        {
+            $this->registerNavEntry( [
+                'slug'  => 'reports',
+                'label' => 'Reports',
+                'url'   => '/admin/reports',
+            ] );
+            $this->registerNavEntry( [
+                'slug'  => 'reports',
+                'label' => 'Reports v2',
+                'url'   => '/admin/reports',
+            ] );
+        }
+
+        protected function loadManifest(): array
+        {
+            return $this->manifest = ['slug' => 'reports-plugin'];
+        }
+    };
+
+    $provider->boot();
+
+    $entries = app( PluginRegistry::class )->navEntries();
+
+    expect( $entries )->toHaveCount( 1 )
+        ->and( $entries['reports']['label'] )->toBe( 'Reports v2' );
+} );
+
+it( 'exposes federated modules via a filter', function (): void {
+    $provider = new class( app() ) extends PluginServiceProvider {
+        public function boot(): void
+        {
+            $this->registerFederatedModule( 'reports', 'dist/remoteEntry.js', ['./App'] );
+        }
+
+        protected function loadManifest(): array
+        {
+            return $this->manifest = ['slug' => 'reports-plugin'];
+        }
+    };
+
+    $provider->boot();
+
+    $modules = applyFilters( 'ap.plugins.federatedModules', [] );
+
+    expect( $modules )->toHaveKey( 'reports' )
+        ->and( $modules['reports']['entry'] )->toBe( 'dist/remoteEntry.js' )
+        ->and( $modules['reports']['exposes'] )->toBe( ['./App'] );
+} );
+
+it( 'resolves pluginPath and pluginConfig from the manifest', function (): void {
+    $provider = new class( app() ) extends PluginServiceProvider {
+        public function boot(): void
+        {
+        }
+
+        public function exposePluginPath( ?string $subpath = null ): string
+        {
+            return $this->pluginPath( $subpath );
+        }
+
+        public function exposePluginConfig( ?string $key = null ): mixed
+        {
+            return $this->pluginConfig( $key );
+        }
+
+        protected function loadManifest(): array
+        {
+            return $this->manifest = [
+                'slug'   => 'my-plugin',
+                'name'   => 'My Plugin',
+                'nested' => ['key' => 'value'],
+            ];
+        }
+    };
+
+    expect( $provider->exposePluginPath() )->toEndWith( '/plugins/my-plugin' )
+        ->and( $provider->exposePluginPath( 'resources/js' ) )->toEndWith( '/plugins/my-plugin/resources/js' )
+        ->and( $provider->exposePluginConfig( 'name' ) )->toBe( 'My Plugin' )
+        ->and( $provider->exposePluginConfig( 'nested.key' ) )->toBe( 'value' )
+        ->and( $provider->exposePluginConfig( 'missing' ) )->toBeNull();
+} );


### PR DESCRIPTION
## Release Information

- **Release Version:** v2.4.0
- **Release Date:** 2026-07-16
- **Release Type:** Minor
- **Release Branch:** `release/2.4`
- **Target Branch:** `main`

## Release Summary

v2.4.0 lands two large workstreams: a brand-new **site-wide dynamic content system** (define a piece of content once, reference it anywhere via `{{source.field|mod:arg}}` merge tokens) and a **complete plugin extensibility pass** across ten issues (`#179–#188`) that fills in the plugin.json schema, admin menu filter, `PluginServiceProvider` base class, host-version compat gate, transactional lifecycle, content-type/taxonomy filter merging, `CustomFieldTypeRegistry`, metadata-column custom fields, `ContentEditExtensions`, and a plugin authoring guide + example. A security hardening pass on the plugin system is included in both merges.

## Changelog

### Added

- **Dynamic content system** (#178) — New `src/Modules/DynamicContent/` module. Four migrations, 11 built-in field types, 7 modifiers, `DynamicContentResolver` (65KB `/resolve` cap + throttle), `apRenderContent()` helper + `@dynamicContent` Blade directive, `DynamicContentCast`, filter-driven authz (`manage_dynamic_content`), REST endpoints under `/api/v1/dynamic-content/*`, Livewire admin surface, and auto-resolve wiring into `HasRenderedBlockContent::renderContent()`.
- **Plugin system v2.4** (#179, #180, #181, #182, #183, #190) — Extended `plugin.json` schema (`min_host_version`, `federated_module`, `nav_entries`, `permissions`, `migrations_path`, `rollback_migrations_on_delete`); `ap.admin.menu` filter with React/Inertia row shape and post-filter capability re-check; `PluginServiceProvider` base class with `registerAdminPage`/`registerNavEntry`/`registerFederatedModule`/`pluginPath`/`pluginConfig` (Octane-safe `PluginRegistry` singleton); host-version enforcement via `IncompatiblePluginException` (structured 409); transactional activation with PSR-4 snapshot/restore rollback, opt-in migration rollback on delete, namespace-scoped permission seed/unseed, optional framework cache clears.
- **Complete plugin extensibility** (#184, #185, #186, #187, #188, #191) — Singular content-type/taxonomy getters merge filter-registered entries as unpersisted models (`getPersistedContentType`/`getPersistedTaxonomy` for privileged paths); `CustomFieldTypeRegistry` + `FieldTypeDefinition` with all 16 built-in `FieldType` enum cases pre-registered and an `apRegisterFieldType()` helper; `CustomFieldManager::getFieldsForContentType()` merges DB + filter fields and routes metadata-storage fields to the model's `metadata` JSON column via a rewritten `HasCustomFields` trait; `ContentEditExtensions` (panels, tabs, before/after editor, saveData); plugin authoring guide (`docs/plugin-authoring.md`) and `examples/hello-world-plugin/` skeleton.

### Security

- **Plugin system hardening** (#190, #191) — Manifest `migrations_path` traversal rejected (schema + runtime realpath check); permission slugs namespace-prefixed so seed/unseed cannot touch core or other plugin rows; `Gate::allows` re-applied after `ap.admin.menu`; URL scheme allow-list on `registerNavEntry`/`resolveRouteUrl`; `PluginServiceProvider` manifest walk constrained to direct children of the plugins root; `HasCustomFields` cannot shadow host attributes (`password`, `is_admin`, `metadata`); `__set` on filter-registered fields throws when host has no `metadata` column; `update/deleteContentType`/`update/deleteTaxonomy` refuse filter-only slugs (was silently `INSERT`ing phantom rows); `forceFill` strips `id`/`created_at`/`updated_at`/`deleted_at`; `CustomFieldTypeRegistry` rejects malformed filter entries; `getCustomFieldsForType` memoized per instance and flushed on `saved`/`deleted`.

## Issues and Pull Requests

**Issues Fixed:**
- Closes #178
- Closes #179, Closes #180, Closes #181, Closes #182, Closes #183
- Closes #184, Closes #185, Closes #186, Closes #187, Closes #188

**Related PRs:**
- #189 (dynamic content)
- #190 (plugin system v2.4 — schema/filter/base provider/compat/lifecycle)
- #191 (complete plugin extensibility)

## Breaking Changes

- [x] No breaking changes
- [ ] Breaking changes documented below

`CustomField.type` cast changed from `FieldType::class` to `string`, but the existing enum path is preserved via the new `fieldTypeEnum()` accessor and all 16 built-in `FieldType` cases are pre-registered in `CustomFieldTypeRegistry`, so no consumer code has to move.

## Testing Checklist

- [x] All automated tests passing (1128 passed, 7 skipped)
- [ ] Manual testing completed
- [ ] Accessibility tests passing
- [ ] Performance tests passing (if applicable)
- [x] Security scan completed (composer audit: no advisories)
- [ ] Tested in staging environment
- [ ] Database migrations tested (if applicable)

**Testing notes:** `composer audit` clean. Full Pest suite green with `memory_limit=1G` (default 128M OOMs during PHP 8.5 autoload — not new to this release).

## Documentation Checklist

- [x] CHANGELOG updated
- [ ] README updated (if needed)
- [ ] API documentation updated (if needed)
- [ ] Migration guide written (if breaking changes)
- [ ] Release notes written
- [ ] Wiki updated (if applicable)

## Pre-Release Checklist

- [x] Version number updated in all necessary files (`composer.json`, `config/cms-framework.php`, `OpenApiServiceProvider` fallback)
- [ ] Git tag prepared: `v2.4.0`
- [x] Release branch created/updated: `release/2.4`
- [x] Dependencies updated and tested (composer.lock re-synced; no security advisories)
- [ ] Build artifacts generated
- [ ] Deployment plan reviewed
- [ ] Rollback plan prepared
- [ ] Stakeholders notified

## Notes

Outdated dependencies noted but intentionally not bumped in this release:

- `laravel/framework 12 → 13` (major)
- `laravel/tinker 2 → 3` (major)
- `livewire/livewire 3 → 4` (major)
- `orchestra/testbench 10 → 11`, `pestphp/pest 3 → 4`, `squizlabs/php_codesniffer 3 → 4` (dev-only majors)
- `dedoc/scramble 0.13.32 → 0.13.35`, `friendsofphp/php-cs-fixer 3.95.12 → 3.95.15`, `nunomaduro/collision 8.9.4 → 8.9.5` (patch)

Framework already permits `illuminate/support: ^12.0|^13.0`; Laravel 13 selection is a downstream host concern.

---

**Release Manager:** @jacobmartella
