### PR TITLE
feat(themes): add Theme base class for per-request behavior (#198)

### DIFF
--- a/src/Modules/Themes/Contracts/Theme.php
+++ b/src/Modules/Themes/Contracts/Theme.php
@@ -1,0 +1,185 @@
+<?php
+
+/**
+ * Theme base class.
+ *
+ * Optional per-request extension point for themes that need to run PHP on
+ * every request — enqueue CSS/JS, register image sizes, add REST endpoints,
+ * or filter block output. Themes stay fully backward compatible when this
+ * file is absent from the theme directory.
+ *
+ * @since      2.5.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Modules\Themes\Contracts;
+
+use ArtisanPackUI\CMSFramework\Modules\Themes\Support\EnqueuedAssets;
+
+/**
+ * Abstract base class themes may extend to hook into the per-request
+ * lifecycle.
+ *
+ * Discovery: cms-framework looks for `themes/{slug}/Theme.php` at boot
+ * when a theme is active. If present, the class following the
+ * `Themes\{PascalSlug}\Theme` naming convention (or the class named
+ * in the manifest's `themeClass` key) is instantiated and its lifecycle
+ * methods are invoked once per request.
+ *
+ * Order of invocation, once per request:
+ *
+ *   1. `registerImageSizes()` — declare image sizes before any request
+ *      code (e.g. controllers) would need them.
+ *   2. `boot()` — general per-request setup. Analog to WordPress's
+ *      `after_setup_theme` + `wp_enqueue_scripts`.
+ *   3. `extend()` — final extension point for custom REST endpoints,
+ *      block filters, etc.
+ *
+ * Enqueue methods (`frontendStyles()`, `editorStyles()`,
+ * `frontendScripts()`) are called lazily when the corresponding Blade
+ * directive renders. They should be pure — returning the same list
+ * each call — since the framework does not cache them for you.
+ *
+ * @since 2.5.0
+ */
+abstract class Theme
+{
+    /**
+     * Constructs the Theme instance.
+     *
+     * The active theme's slug is injected so subclasses can build asset
+     * URLs, resolve theme-relative paths, or key cache entries without
+     * hardcoding the slug (which may differ from the class namespace in
+     * multi-slug repos).
+     *
+     * @since 2.5.0
+     *
+     * @param  string  $slug  Slug of the theme this instance backs.
+     */
+    public function __construct( protected string $slug )
+    {
+    }
+
+    /**
+     * Fires on every request after `registerImageSizes()` and before
+     * `extend()`.
+     *
+     * Analog to WordPress's `after_setup_theme` + `wp_enqueue_scripts`.
+     * Override to run per-request setup that isn't captured by the
+     * dedicated enqueue / image-size / extension hooks.
+     *
+     * @since 2.5.0
+     */
+    public function boot(): void
+    {
+    }
+
+    /**
+     * Returns the CSS files to enqueue on the front-end.
+     *
+     * Each entry is either:
+     *  - a string — a path relative to the theme's `assets/` directory
+     *    (e.g. `'main.css'`), or
+     *  - an array with a `src` key and any subset of `media`, `deps`,
+     *    `ver` — the URL is still resolved from `assets/`.
+     *
+     * String keys become the enqueue handle; numeric keys derive the
+     * handle from the file basename.
+     *
+     * @since 2.5.0
+     *
+     * @return array<int|string, array<string, mixed>|string>
+     */
+    public function frontendStyles(): array
+    {
+        return [];
+    }
+
+    /**
+     * Returns the CSS files to enqueue inside the editor canvas.
+     *
+     * Analog to WordPress's `add_editor_style`. Same entry shape as
+     * {@see frontendStyles()}.
+     *
+     * @since 2.5.0
+     *
+     * @return array<int|string, array<string, mixed>|string>
+     */
+    public function editorStyles(): array
+    {
+        return [];
+    }
+
+    /**
+     * Returns the JS files to enqueue on the front-end.
+     *
+     * Each entry is either:
+     *  - a string — a path relative to the theme's `assets/` directory
+     *    (e.g. `'main.js'`), or
+     *  - an array with a `src` key and any subset of `defer`, `async`,
+     *    `deps`, `ver`, `type`, `module` — the URL is still resolved
+     *    from `assets/`.
+     *
+     * @since 2.5.0
+     *
+     * @return array<int|string, array<string, mixed>|string>
+     */
+    public function frontendScripts(): array
+    {
+        return [];
+    }
+
+    /**
+     * Registers custom image sizes at boot.
+     *
+     * Runs before `boot()` so any request code that queries image
+     * variants sees the theme's registrations. The default implementation
+     * is a no-op; override to call the host app's image-size registry.
+     *
+     * @since 2.5.0
+     */
+    public function registerImageSizes(): void
+    {
+    }
+
+    /**
+     * Final extension point for anything the dedicated hooks don't cover.
+     *
+     * Runs after `boot()` — a good place to bind custom REST endpoints
+     * (via the router), register block filters (via `addFilter()`), or
+     * wire event listeners that depend on the theme being fully set up.
+     *
+     * @since 2.5.0
+     */
+    public function extend(): void
+    {
+    }
+
+    /**
+     * Slug of the theme this instance backs.
+     *
+     * @since 2.5.0
+     */
+    public function slug(): string
+    {
+        return $this->slug;
+    }
+
+    /**
+     * Build a URL to an asset shipped in the theme's `assets/` directory.
+     *
+     * The URL resolves against the `themes.assets` named route, which the
+     * `ThemesServiceProvider` registers as `/themes/{slug}/assets/{path}`.
+     *
+     * @since 2.5.0
+     *
+     * @param  string  $path  Path relative to the theme's `assets/` directory.
+     *
+     * @return string Absolute asset URL for the current theme.
+     */
+    public function assetUrl( string $path ): string
+    {
+        return EnqueuedAssets::assetUrl( $this->slug, $path );
+    }
+}

--- a/src/Modules/Themes/Http/Controllers/ThemeAssetsController.php
+++ b/src/Modules/Themes/Http/Controllers/ThemeAssetsController.php
@@ -1,0 +1,197 @@
+<?php
+
+/**
+ * Theme Assets Controller.
+ *
+ * Serves static assets bundled inside a theme's `assets/` directory over
+ * HTTP so themes can enqueue their own CSS/JS/fonts/vendor files without
+ * publishing anything to the host app.
+ *
+ * @since      2.5.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Modules\Themes\Http\Controllers;
+
+use Illuminate\Http\Request;
+use Illuminate\Routing\Controller;
+use Illuminate\Support\Facades\File;
+use Symfony\Component\HttpFoundation\BinaryFileResponse;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Serves files from `themes/{slug}/assets/{path}`.
+ *
+ * The route is intentionally public — theme CSS/JS are shipped as static
+ * bytes, not gated content — but the handler must still reject any
+ * attempt to escape the theme's `assets/` directory or read files from
+ * disk locations the theme didn't intend to expose.
+ *
+ * @since 2.5.0
+ */
+class ThemeAssetsController extends Controller
+{
+    /**
+     * Allowed asset file extensions.
+     *
+     * Kept intentionally narrow; new extensions must be added
+     * consciously so a compromised or careless theme cannot serve
+     * arbitrary file types (e.g. `.php`, `.env`).
+     *
+     * @var array<int, string>
+     */
+    protected const ALLOWED_EXTENSIONS = [
+        'css', 'js', 'mjs', 'map',
+        'png', 'jpg', 'jpeg', 'gif', 'webp', 'avif', 'svg', 'ico',
+        'woff', 'woff2', 'ttf', 'otf', 'eot',
+        'json', 'xml', 'txt',
+        'mp4', 'webm', 'mp3', 'ogg',
+    ];
+
+    /**
+     * Explicit MIME map for the extensions in {@see ALLOWED_EXTENSIONS}.
+     *
+     * `BinaryFileResponse` defers to `finfo`, which classifies text-based
+     * assets (CSS, JS, source maps, JSON) as `text/plain` — enough for
+     * strict-MIME browsers to reject a stylesheet or ES module. This map
+     * pins the correct type for every allowed extension so the browser
+     * treats the response the way the theme intended.
+     *
+     * @var array<string, string>
+     */
+    protected const MIME_MAP = [
+        'css'   => 'text/css',
+        'js'    => 'application/javascript',
+        'mjs'   => 'application/javascript',
+        'map'   => 'application/json',
+        'json'  => 'application/json',
+        'xml'   => 'application/xml',
+        'txt'   => 'text/plain',
+        'svg'   => 'image/svg+xml',
+        'png'   => 'image/png',
+        'jpg'   => 'image/jpeg',
+        'jpeg'  => 'image/jpeg',
+        'gif'   => 'image/gif',
+        'webp'  => 'image/webp',
+        'avif'  => 'image/avif',
+        'ico'   => 'image/x-icon',
+        'woff'  => 'font/woff',
+        'woff2' => 'font/woff2',
+        'ttf'   => 'font/ttf',
+        'otf'   => 'font/otf',
+        'eot'   => 'application/vnd.ms-fontobject',
+        'mp4'   => 'video/mp4',
+        'webm'  => 'video/webm',
+        'mp3'   => 'audio/mpeg',
+        'ogg'   => 'audio/ogg',
+    ];
+
+    /**
+     * Serve a static asset from a theme's `assets/` directory.
+     *
+     * Rejects requests that:
+     *  - carry an invalid slug (must match the ThemeManager's slug pattern)
+     *  - carry an empty or traversal-laden path
+     *  - resolve outside the theme's `assets/` directory
+     *  - target a file with a disallowed extension
+     *  - target a file that does not exist
+     *
+     * @since 2.5.0
+     *
+     * @param  string  $slug  Theme slug (route parameter).
+     * @param  string  $path  Path under the theme's `assets/` directory.
+     */
+    public function show( Request $request, string $slug, string $path ): BinaryFileResponse|Response
+    {
+        if ( ! $this->isValidSlug( $slug ) ) {
+            return response( '', Response::HTTP_NOT_FOUND );
+        }
+
+        // Normalize Windows-style backslashes so the traversal check below
+        // covers `..\` as well as `..\/`. `realpath()` would catch the
+        // eventual escape either way, but layering the check keeps the
+        // early-return contract honest across platforms.
+        $path = str_replace( '\\', '/', trim( $path ) );
+
+        if ( '' === $path
+            || str_contains( $path, "\0" )
+            || preg_match( '#(^|/)\.\.(/|$)#', $path )
+            || str_starts_with( $path, '/' ) ) {
+            return response( '', Response::HTTP_NOT_FOUND );
+        }
+
+        $extension = strtolower( pathinfo( $path, PATHINFO_EXTENSION ) );
+        if ( '' === $extension || ! in_array( $extension, self::ALLOWED_EXTENSIONS, true ) ) {
+            return response( '', Response::HTTP_NOT_FOUND );
+        }
+
+        $themesBase = base_path( config( 'cms.themes.directory', 'themes' ) );
+        $assetsBase = $themesBase . '/' . $slug . '/assets';
+        $realBase   = realpath( $assetsBase );
+
+        if ( false === $realBase ) {
+            return response( '', Response::HTTP_NOT_FOUND );
+        }
+
+        $fullPath = $realBase . '/' . ltrim( $path, '/' );
+        $realFull = realpath( $fullPath );
+
+        if ( false === $realFull
+            || ! str_starts_with( $realFull . DIRECTORY_SEPARATOR, $realBase . DIRECTORY_SEPARATOR ) ) {
+            return response( '', Response::HTTP_NOT_FOUND );
+        }
+
+        if ( ! File::isFile( $realFull ) ) {
+            return response( '', Response::HTTP_NOT_FOUND );
+        }
+
+        $response = new BinaryFileResponse( $realFull );
+
+        // Pin the Content-Type from the extension: BinaryFileResponse's
+        // finfo-based guess classifies CSS/JS/JSON/source-maps as
+        // `text/plain`, which strict-MIME browsers refuse to apply to a
+        // `<link rel=stylesheet>` or ES `<script type=module>`.
+        if ( isset( self::MIME_MAP[ $extension ] ) ) {
+            $response->headers->set( 'Content-Type', self::MIME_MAP[ $extension ] );
+        }
+
+        // Defense-in-depth against MIME sniffing on older browsers with
+        // relaxed enforcement (`X-Content-Type-Options: nosniff` is a
+        // no-op on modern strict browsers but closes the loophole on
+        // legacy ones).
+        $response->headers->set( 'X-Content-Type-Options', 'nosniff' );
+
+        // SVG hardening: an uploaded theme could ship `logo.svg` with an
+        // inline `<script>`; served with `image/svg+xml` from our origin
+        // it would execute in the app's security context (same-origin
+        // cookies attach). CSP `sandbox` blocks script execution in the
+        // top-level document; `Content-Disposition: attachment` prevents
+        // the browser from rendering the SVG inline when navigated to
+        // directly. Both together neutralize the vector while keeping
+        // `<img src="…svg">` (which never executes SVG scripts anyway)
+        // working from theme markup.
+        if ( 'svg' === $extension ) {
+            $response->headers->set( 'Content-Security-Policy', "default-src 'none'; style-src 'unsafe-inline'; sandbox" );
+            $response->headers->set( 'Content-Disposition', 'attachment' );
+        }
+
+        $response->setPublic();
+        $response->setMaxAge( (int) config( 'cms.themes.assetsMaxAge', 3600 ) );
+
+        return $response;
+    }
+
+    /**
+     * Validate a slug against the ThemeManager's canonical pattern.
+     *
+     * Duplicates the check rather than reaching into ThemeManager so
+     * a request rejected here never hits any theme resolution logic.
+     *
+     * @since 2.5.0
+     */
+    protected function isValidSlug( string $slug ): bool
+    {
+        return '' !== $slug && 1 === preg_match( '/^[a-zA-Z0-9_-]+$/', $slug );
+    }
+}

--- a/src/Modules/Themes/Managers/ThemeManager.php
+++ b/src/Modules/Themes/Managers/ThemeManager.php
@@ -793,6 +793,23 @@ class ThemeManager
                 }
             }
         }
+
+        // Manifest override for the Theme base-class discovery
+        // (issue #198). ThemeLoader also runs a runtime
+        // reflection-based provenance check to prove the resolved
+        // class actually lives in the theme's own Theme.php; the
+        // pattern check here rejects obviously malformed values at
+        // install time so a bad upload never reaches disk.
+        if ( array_key_exists( 'themeClass', $manifest ) ) {
+            $themeClass = $manifest['themeClass'];
+
+            if ( ! is_string( $themeClass )
+                || 1 !== preg_match( '/^[A-Za-z_][A-Za-z0-9_]*(\\\\[A-Za-z_][A-Za-z0-9_]*)*$/', ltrim( $themeClass, '\\' ) ) ) {
+                throw ThemeValidationException::invalidManifest(
+                    "Field 'themeClass' must be a fully-qualified PHP class name.",
+                );
+            }
+        }
     }
 
     /**

--- a/src/Modules/Themes/Providers/ThemesServiceProvider.php
+++ b/src/Modules/Themes/Providers/ThemesServiceProvider.php
@@ -15,7 +15,10 @@ namespace ArtisanPackUI\CMSFramework\Modules\Themes\Providers;
 use ArtisanPackUI\CMSFramework\Modules\Settings\Enums\SettingType;
 use ArtisanPackUI\CMSFramework\Modules\Settings\Managers\SettingsManager;
 use ArtisanPackUI\CMSFramework\Modules\Themes\Managers\ThemeManager;
+use ArtisanPackUI\CMSFramework\Modules\Themes\Support\EnqueuedAssets;
+use ArtisanPackUI\CMSFramework\Modules\Themes\Support\ThemeLoader;
 use ArtisanPackUI\CMSFramework\Modules\Themes\Validation\WpThemeJsonValidator;
+use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\ServiceProvider;
 
 /**
@@ -25,7 +28,9 @@ use Illuminate\Support\ServiceProvider;
  * - Registers ThemeManager as a singleton
  * - Merges theme configuration
  * - Registers theme view paths
- * - Loads theme API routes
+ * - Loads theme API + web routes
+ * - Boots the active theme's optional `Theme.php` (per-request lifecycle)
+ * - Registers theme-asset Blade directives
  * - Registers default theme settings
  *
  * @since 1.0.0
@@ -53,6 +58,11 @@ class ThemesServiceProvider extends ServiceProvider
             );
         } );
 
+        // Register ThemeLoader as singleton — one per-request boot pass.
+        $this->app->singleton( ThemeLoader::class, function ( $app ) {
+            return new ThemeLoader( $app->make( ThemeManager::class ) );
+        } );
+
         // Merge config
         $this->mergeConfigFrom(
             __DIR__ . '/../config/themes.php',
@@ -65,7 +75,9 @@ class ThemesServiceProvider extends ServiceProvider
      *
      * Performs the following bootstrap operations:
      * - Registers the active theme's view path with Laravel's view finder
-     * - Loads theme API routes
+     * - Loads theme API + web routes
+     * - Boots the active theme's Theme.php (if present)
+     * - Registers the theme-asset Blade directives
      * - Registers the default 'themes.activeTheme' setting with sanitization
      *
      * @since 1.0.0
@@ -81,8 +93,16 @@ class ThemesServiceProvider extends ServiceProvider
         $themeManager = $this->app->make( ThemeManager::class );
         $themeManager->registerThemeViewPath();
 
-        // Load API routes
+        // Load routes
         $this->loadRoutesFrom( __DIR__ . '/../routes/api.php' );
+        $this->loadRoutesFrom( __DIR__ . '/../routes/web.php' );
+
+        // Boot the active theme's Theme.php once per request. `activeTheme()`
+        // caches the result, so downstream Blade directives that resolve
+        // ThemeLoader hit the cached instance instead of re-running boot().
+        $this->app->make( ThemeLoader::class )->activeTheme();
+
+        $this->registerThemeAssetBladeDirectives();
 
         // Register default setting
         $settingsManager = $this->app->make( SettingsManager::class );
@@ -92,5 +112,138 @@ class ThemesServiceProvider extends ServiceProvider
             fn ( $value ) => is_string( $value ) ? sanitizeText( $value ) : '',
             SettingType::String,
         );
+    }
+
+    /**
+     * Render the `@themeFrontendStyles` directive output.
+     *
+     * @since 2.5.0
+     *
+     * @internal Blade directive callback; not part of the public API.
+     */
+    public static function renderFrontendStyles(): string
+    {
+        [$slug, $entries] = self::resolveEntries( 'frontendStyles' );
+
+        if ( null === $slug ) {
+            return '';
+        }
+
+        $entries = applyFilters( 'ap.themes.frontendStyles', $entries, $slug );
+
+        if ( ! is_array( $entries ) ) {
+            return '';
+        }
+
+        return EnqueuedAssets::renderStyles( $slug, $entries );
+    }
+
+    /**
+     * Render the `@themeEditorStyles` directive output.
+     *
+     * @since 2.5.0
+     *
+     * @internal Blade directive callback; not part of the public API.
+     */
+    public static function renderEditorStyles(): string
+    {
+        [$slug, $entries] = self::resolveEntries( 'editorStyles' );
+
+        if ( null === $slug ) {
+            return '';
+        }
+
+        $entries = applyFilters( 'ap.themes.editorStyles', $entries, $slug );
+
+        if ( ! is_array( $entries ) ) {
+            return '';
+        }
+
+        return EnqueuedAssets::renderStyles( $slug, $entries );
+    }
+
+    /**
+     * Render the `@themeFrontendScripts` directive output.
+     *
+     * @since 2.5.0
+     *
+     * @internal Blade directive callback; not part of the public API.
+     */
+    public static function renderFrontendScripts(): string
+    {
+        [$slug, $entries] = self::resolveEntries( 'frontendScripts' );
+
+        if ( null === $slug ) {
+            return '';
+        }
+
+        $entries = applyFilters( 'ap.themes.frontendScripts', $entries, $slug );
+
+        if ( ! is_array( $entries ) ) {
+            return '';
+        }
+
+        return EnqueuedAssets::renderScripts( $slug, $entries );
+    }
+
+    /**
+     * Register the theme-asset Blade directives.
+     *
+     * All directives no-op when no active theme is loaded or the loaded
+     * theme did not extend the Theme base class. Filters:
+     *
+     *  - `ap.themes.frontendStyles` — mutate the front-end style list
+     *  - `ap.themes.editorStyles`   — mutate the editor style list
+     *  - `ap.themes.frontendScripts` — mutate the front-end script list
+     *
+     * All three filters receive `(array $entries, string $slug)`. Third
+     * parties may add packages of styles/scripts by hooking these
+     * filters without needing to subclass Theme.
+     *
+     * @since 2.5.0
+     */
+    protected function registerThemeAssetBladeDirectives(): void
+    {
+        Blade::directive( 'themeFrontendStyles', function (): string {
+            return '<?php echo \\' . self::class . '::renderFrontendStyles(); ?>';
+        } );
+
+        Blade::directive( 'themeEditorStyles', function (): string {
+            return '<?php echo \\' . self::class . '::renderEditorStyles(); ?>';
+        } );
+
+        Blade::directive( 'themeFrontendScripts', function (): string {
+            return '<?php echo \\' . self::class . '::renderFrontendScripts(); ?>';
+        } );
+    }
+
+    /**
+     * Resolve the active theme's slug + one of its enqueue lists.
+     *
+     * Returns `[null, []]` when no theme is loaded so the calling
+     * directive can silently emit an empty string instead of crashing
+     * a Blade render on the front-end.
+     *
+     * @since 2.5.0
+     *
+     * @param  string  $method  Theme method to invoke (`frontendStyles`, etc).
+     *
+     * @return array{0: string|null, 1: array<int|string, mixed>}
+     */
+    protected static function resolveEntries( string $method ): array
+    {
+        $theme = app( ThemeLoader::class )->activeTheme();
+
+        if ( null === $theme ) {
+            return [null, []];
+        }
+
+        $entries = $theme->{$method}();
+
+        if ( ! is_array( $entries)) {
+            $entries = [];
+        }
+
+        return [$theme->slug(), $entries];
     }
 }

--- a/src/Modules/Themes/Support/EnqueuedAssets.php
+++ b/src/Modules/Themes/Support/EnqueuedAssets.php
@@ -1,0 +1,267 @@
+<?php
+
+/**
+ * Enqueued Assets renderer.
+ *
+ * Normalizes the `frontendStyles()` / `editorStyles()` / `frontendScripts()`
+ * arrays returned by a {@see \ArtisanPackUI\CMSFramework\Modules\Themes\Contracts\Theme}
+ * into escaped `<link>` / `<script>` tags for the corresponding Blade
+ * directives.
+ *
+ * @since      2.5.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Modules\Themes\Support;
+
+use Illuminate\Support\Facades\URL;
+
+/**
+ * Renders theme-declared style / script enqueues.
+ *
+ * Kept static so the Blade directives can call the renderer without
+ * wiring an instance through the container each compile.
+ *
+ * @since 2.5.0
+ */
+class EnqueuedAssets
+{
+    /**
+     * Render a list of theme-declared styles as `<link>` tags.
+     *
+     * Entries are normalized into a `{handle, src, media, ver, deps}`
+     * shape, deduplicated by handle (first entry wins), and each
+     * attribute is HTML-attribute-escaped. External URLs (`https://`,
+     * `//cdn.example`) pass through unchanged; relative entries resolve
+     * against the theme's `assets/` route.
+     *
+     * @since 2.5.0
+     *
+     * @param  string  $slug  Active theme slug.
+     * @param  array<int|string, array<string, mixed>|string>  $styles
+     *
+     * @return string Concatenated `<link>` tags, or empty string if none.
+     */
+    public static function renderStyles( string $slug, array $styles ): string
+    {
+        $tags = [];
+
+        foreach ( self::normalize( $slug, $styles ) as $handle => $entry ) {
+            $attrs = [
+                'rel'  => 'stylesheet',
+                'id'   => $handle . '-css',
+                'href' => self::withVersion( $entry['src'], $entry['ver'] ?? null ),
+            ];
+
+            if ( ! empty( $entry['media'] ) ) {
+                $attrs['media'] = (string) $entry['media'];
+            }
+
+            $tags[] = '<link' . self::renderAttributes( $attrs ) . ' />';
+        }
+
+        return implode( "\n", $tags );
+    }
+
+    /**
+     * Render a list of theme-declared scripts as `<script>` tags.
+     *
+     * Same normalization as {@see renderStyles()}. Supports `defer`,
+     * `async`, `type`, and `module` flags per entry.
+     *
+     * @since 2.5.0
+     *
+     * @param  string  $slug  Active theme slug.
+     * @param  array<int|string, array<string, mixed>|string>  $scripts
+     *
+     * @return string Concatenated `<script>` tags, or empty string if none.
+     */
+    public static function renderScripts( string $slug, array $scripts ): string
+    {
+        $tags = [];
+
+        foreach ( self::normalize( $slug, $scripts ) as $handle => $entry ) {
+            $attrs = [
+                'id'  => $handle . '-js',
+                'src' => self::withVersion( $entry['src'], $entry['ver'] ?? null ),
+            ];
+
+            $type = $entry['type'] ?? null;
+            if ( ! empty( $entry['module'] ) ) {
+                $type = 'module';
+            }
+            if ( null !== $type && '' !== $type ) {
+                $attrs['type'] = (string) $type;
+            }
+
+            if ( ! empty( $entry['defer'] ) ) {
+                $attrs['defer'] = true;
+            }
+
+            if ( ! empty( $entry['async'] ) ) {
+                $attrs['async'] = true;
+            }
+
+            $tags[] = '<script' . self::renderAttributes( $attrs ) . '></script>';
+        }
+
+        return implode( "\n", $tags );
+    }
+
+    /**
+     * Resolve a URL for a theme-relative asset.
+     *
+     * Points at the `themes.assets` named route registered by the
+     * ThemesServiceProvider. Slug and path traversal are validated at
+     * the route handler.
+     *
+     * @since 2.5.0
+     *
+     * @param  string  $slug  Theme slug.
+     * @param  string  $path  Path relative to the theme's `assets/` directory.
+     *
+     * @return string Absolute asset URL.
+     */
+    public static function assetUrl( string $slug, string $path ): string
+    {
+        $path = ltrim( $path, '/' );
+
+        return URL::route( 'themes.assets', [
+            'slug' => $slug,
+            'path' => $path,
+        ] );
+    }
+
+    /**
+     * Normalize enqueue entries into a `{handle => {src, media, ver, deps, ...}}` map.
+     *
+     * Rules:
+     *  - String entry: treated as `src`; handle is derived from the
+     *    array key (if string) or the file basename (if numeric).
+     *  - Array entry: `src` is required; other keys are copied through.
+     *  - Handles collide → first wins, subsequent entries are dropped.
+     *  - Missing / non-string `src` values drop the entry silently so a
+     *    malformed theme return doesn't emit a broken tag.
+     *
+     * Entries with an absolute URL (`https://…`, `//cdn.example`, or a
+     * leading `/`) keep the URL as-is. Relative entries are resolved
+     * against the theme's asset route.
+     *
+     * @since 2.5.0
+     *
+     * @param  string  $slug  Active theme slug.
+     * @param  array<int|string, array<string, mixed>|string>  $entries
+     *
+     * @return array<string, array<string, mixed>>
+     */
+    protected static function normalize( string $slug, array $entries ): array
+    {
+        $normalized = [];
+
+        foreach ( $entries as $key => $entry ) {
+            if ( is_string( $entry ) ) {
+                $src   = $entry;
+                $extra = [];
+            } elseif ( is_array( $entry ) && isset( $entry['src'] ) && is_string( $entry['src'] ) ) {
+                $src   = $entry['src'];
+                $extra = $entry;
+                unset( $extra['src'] );
+            } else {
+                continue;
+            }
+
+            $src = trim( $src );
+            if ( '' === $src ) {
+                continue;
+            }
+
+            $handle = is_string( $key )
+                ? $key
+                : pathinfo( $src, PATHINFO_FILENAME );
+
+            if ( '' === $handle || isset( $normalized[ $handle ] ) ) {
+                continue;
+            }
+
+            $normalized[ $handle ] = array_merge( $extra, [
+                'src' => self::resolveSrc( $slug, $src ),
+            ] );
+        }
+
+        return $normalized;
+    }
+
+    /**
+     * Resolve a source string to a URL. Absolute URLs and root-relative
+     * paths pass through; everything else is routed through the theme
+     * asset route.
+     *
+     * @since 2.5.0
+     *
+     * @param  string  $slug  Active theme slug.
+     * @param  string  $src  Raw src value from a theme entry.
+     *
+     * @return string Resolved URL.
+     */
+    protected static function resolveSrc( string $slug, string $src ): string
+    {
+        if ( str_starts_with( $src, 'http://' )
+            || str_starts_with( $src, 'https://' )
+            || str_starts_with( $src, '//' )
+            || str_starts_with( $src, '/' ) ) {
+            return $src;
+        }
+
+        return self::assetUrl( $slug, $src );
+    }
+
+    /**
+     * Append a `?ver=` query string when a version is provided. Skipped
+     * when the URL already carries a query string.
+     *
+     * @since 2.5.0
+     */
+    protected static function withVersion( string $url, mixed $version ): string
+    {
+        if ( null === $version || '' === $version ) {
+            return $url;
+        }
+
+        if ( str_contains( $url, '?' ) ) {
+            return $url;
+        }
+
+        return $url . '?ver=' . rawurlencode( (string) $version );
+    }
+
+    /**
+     * Render an attribute map to an HTML attribute string. Boolean-true
+     * values emit the bare attribute; string values are HTML-attribute
+     * encoded.
+     *
+     * @since 2.5.0
+     *
+     * @param  array<string, bool|string>  $attributes
+     */
+    protected static function renderAttributes( array $attributes ): string
+    {
+        $rendered = '';
+
+        foreach ( $attributes as $name => $value ) {
+            if ( true === $value ) {
+                $rendered .= ' ' . $name;
+
+                continue;
+            }
+
+            if ( false === $value || null === $value) {
+                continue;
+            }
+
+            $rendered .= ' ' . $name . '="' . htmlspecialchars( (string) $value, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') . '"';
+        }
+
+        return $rendered;
+    }
+}

--- a/src/Modules/Themes/Support/ThemeLoader.php
+++ b/src/Modules/Themes/Support/ThemeLoader.php
@@ -1,0 +1,256 @@
+<?php
+
+/**
+ * Theme Loader.
+ *
+ * Discovers and instantiates the active theme's optional `Theme.php` file,
+ * driving the per-request lifecycle documented on
+ * {@see \ArtisanPackUI\CMSFramework\Modules\Themes\Contracts\Theme}.
+ *
+ * @since      2.5.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Modules\Themes\Support;
+
+use ArtisanPackUI\CMSFramework\Modules\Themes\Contracts\Theme;
+use ArtisanPackUI\CMSFramework\Modules\Themes\Managers\ThemeManager;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Log;
+use ReflectionClass;
+use ReflectionException;
+use Throwable;
+
+/**
+ * Resolves and boots the active theme's PHP entry point.
+ *
+ * Singleton — instantiated once per request. Callers should treat
+ * `activeTheme()` as the single source of truth for the request's Theme
+ * instance so the lifecycle methods don't fire twice.
+ *
+ * **Octane / long-running workers.** The loader uses `require_once`, so
+ * once a worker has loaded a theme's `Theme.php`, PHP will not re-read
+ * the file even if it changes on disk, and switching to a different
+ * theme in the same worker leaves the previous class definition
+ * resident (PHP cannot unload classes). Operators running under Octane,
+ * RoadRunner, or Swoole should reload their workers after a theme is
+ * installed or activated — e.g. by wiring `php artisan octane:reload`
+ * to the `theme.installed` / `theme.activated` hooks.
+ *
+ * @since 2.5.0
+ */
+class ThemeLoader
+{
+    /**
+     * Resolved theme instance for this request, or null when no theme is
+     * active or the active theme does not ship a Theme.php.
+     */
+    protected ?Theme $theme = null;
+
+    /**
+     * True once we've attempted resolution — used to distinguish "not
+     * resolved yet" from "resolved to null".
+     */
+    protected bool $resolved = false;
+
+    /**
+     * Constructs the loader.
+     *
+     * @since 2.5.0
+     */
+    public function __construct( protected ThemeManager $themeManager )
+    {
+    }
+
+    /**
+     * Return the resolved Theme instance for this request, or null.
+     *
+     * First call runs discovery: loads `themes/{slug}/Theme.php` (if
+     * present), instantiates the class per the naming convention, and
+     * fires `registerImageSizes()`, `boot()`, and `extend()` in order.
+     * Subsequent calls return the cached instance.
+     *
+     * Any Throwable raised during discovery or boot is caught and
+     * logged — a broken theme file must not take down the whole
+     * application. The theme is treated as not-loaded for the remainder
+     * of the request.
+     *
+     * @since 2.5.0
+     */
+    public function activeTheme(): ?Theme
+    {
+        if ( $this->resolved ) {
+            return $this->theme;
+        }
+
+        $this->resolved = true;
+        $this->theme    = null;
+
+        $active = $this->themeManager->getActiveTheme();
+
+        if ( null === $active || empty( $active['slug'] ) || ! is_string( $active['slug'] ) ) {
+            return null;
+        }
+
+        $slug     = $active['slug'];
+        $filePath = base_path( config( 'cms.themes.directory', 'themes' ) . '/' . $slug . '/Theme.php' );
+
+        if ( ! File::exists( $filePath ) ) {
+            return null;
+        }
+
+        try {
+            require_once $filePath;
+        } catch ( Throwable $e ) {
+            Log::warning( 'Failed to load theme Theme.php file.', [
+                'slug'  => $slug,
+                'path'  => $filePath,
+                'error' => $e->getMessage(),
+            ] );
+
+            return null;
+        }
+
+        $class = $this->resolveClassName( $slug, $active );
+
+        if ( null === $class || ! class_exists( $class ) ) {
+            Log::warning( 'Theme.php loaded but expected class was not found.', [
+                'slug'  => $slug,
+                'class' => $class,
+            ] );
+
+            return null;
+        }
+
+        if ( ! is_subclass_of( $class, Theme::class ) ) {
+            Log::warning( 'Theme class does not extend the Theme base class.', [
+                'slug'     => $slug,
+                'class'    => $class,
+                'expected' => Theme::class,
+            ] );
+
+            return null;
+        }
+
+        // Provenance check: reject any resolved class that does not live
+        // inside the theme's own Theme.php on disk. Without this, a
+        // hostile theme could ship a `themeClass` manifest key that
+        // points at any first-party or vendor class extending Theme —
+        // both triggering autoload side effects and running that class's
+        // boot() with the wrong slug.
+        try {
+            $reflection = new ReflectionClass( $class );
+        } catch ( ReflectionException $e ) {
+            Log::warning( 'Failed to reflect theme class.', [
+                'slug'  => $slug,
+                'class' => $class,
+                'error' => $e->getMessage(),
+            ] );
+
+            return null;
+        }
+
+        $classFile = $reflection->getFileName();
+        $realClass = false !== $classFile ? realpath( $classFile ) : false;
+        $realTheme = realpath( $filePath );
+
+        if ( false === $realClass || false === $realTheme || $realClass !== $realTheme ) {
+            Log::warning( 'Theme class was not declared in the theme\'s own Theme.php; refusing to load.', [
+                'slug'          => $slug,
+                'class'         => $class,
+                'declaredIn'    => $classFile,
+                'expectedFile'  => $filePath,
+            ] );
+
+            return null;
+        }
+
+        try {
+            /** @var Theme $instance */
+            $instance = new $class( $slug );
+
+            $instance->registerImageSizes();
+            $instance->boot();
+            $instance->extend();
+        } catch ( Throwable $e ) {
+            Log::warning( 'Theme boot failed.', [
+                'slug'  => $slug,
+                'class' => $class,
+                'error' => $e->getMessage(),
+            ] );
+
+            return null;
+        }
+
+        return $this->theme = $instance;
+    }
+
+    /**
+     * Reset the cached instance so the next `activeTheme()` call
+     * re-runs discovery. Intended for tests that swap themes mid-run;
+     * production code should never need this.
+     *
+     * @since 2.5.0
+     */
+    public function reset(): void
+    {
+        $this->theme    = null;
+        $this->resolved = false;
+    }
+
+    /**
+     * Determine the Theme class name to instantiate.
+     *
+     * Order:
+     *   1. Manifest `themeClass` (fully-qualified) — escape hatch for
+     *      multi-slug repos or custom namespaces.
+     *   2. `Themes\{PascalSlug}\Theme` — the framework convention.
+     *
+     * @since 2.5.0
+     *
+     * @param  string  $slug  Active theme slug.
+     * @param  array<string, mixed>  $manifest  Parsed theme.json.
+     *
+     * @return string|null Fully-qualified class name, or null if the
+     *                     manifest override is invalid.
+     */
+    protected function resolveClassName( string $slug, array $manifest ): ?string
+    {
+        if ( isset( $manifest['themeClass'] ) ) {
+            $override = $manifest['themeClass'];
+
+            if ( ! is_string( $override ) ) {
+                return null;
+            }
+
+            $override = ltrim( trim( $override ), '\\' );
+
+            // Constrain to valid PHP class name characters and reject
+            // empty / relative names. The reflection-based provenance
+            // check in activeTheme() enforces file identity, but keeping
+            // the shape strict here means we never try to autoload
+            // attacker-chosen strings just to observe the failure.
+            if ( '' === $override
+                || 1 !== preg_match( '/^[A-Za-z_][A-Za-z0-9_]*(\\\\[A-Za-z_][A-Za-z0-9_]*)*$/', $override ) ) {
+                return null;
+            }
+
+            return $override;
+        }
+
+        return 'Themes\\' . $this->pascalCase( $slug ) . '\\Theme';
+    }
+
+    /**
+     * Convert a kebab / snake-case slug to PascalCase.
+     *
+     * @since 2.5.0
+     */
+    protected function pascalCase( string $slug ): string
+    {
+        $parts = preg_split( '/[-_]+/', $slug ) ?: [];
+
+        return implode( '', array_map( 'ucfirst', $parts ) );
+    }
+}

--- a/src/Modules/Themes/config/themes.php
+++ b/src/Modules/Themes/config/themes.php
@@ -84,4 +84,17 @@ return [
         'application/zip',
         'application/x-zip-compressed',
     ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Theme Asset Cache
+    |--------------------------------------------------------------------------
+    |
+    | Cache-Control max-age (in seconds) applied to responses served by the
+    | ThemeAssetsController. Themes ship static bytes, so a warm CDN edge
+    | can safely hold them for the full TTL — bumped up in production if
+    | your bundler emits fingerprinted filenames.
+    |
+    */
+    'assetsMaxAge' => 3600,
 ];

--- a/src/Modules/Themes/routes/web.php
+++ b/src/Modules/Themes/routes/web.php
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * Themes Web Routes
+ *
+ * Public routes for serving static theme assets bundled inside the theme's
+ * `assets/` directory. Unlike the API routes, these are unauthenticated —
+ * theme CSS/JS/fonts are static bytes, not gated content.
+ *
+ * @since      2.5.0
+ */
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\CMSFramework\Modules\Themes\Http\Controllers\ThemeAssetsController;
+use Illuminate\Support\Facades\Route;
+
+/*
+|--------------------------------------------------------------------------
+| Theme Asset Routes
+|--------------------------------------------------------------------------
+|
+| Serves files from `themes/{slug}/assets/{path}` over HTTP so themes can
+| enqueue their own CSS/JS/fonts without publishing anything to the host
+| app. Path-traversal and extension checks live in the controller.
+|
+*/
+
+Route::get( '/themes/{slug}/assets/{path}', [ThemeAssetsController::class, 'show'] )
+    ->where( 'path', '.*' )
+    ->name( 'themes.assets');

--- a/tests/Feature/Themes/ThemeBaseClassTest.php
+++ b/tests/Feature/Themes/ThemeBaseClassTest.php
@@ -1,0 +1,503 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\CMSFramework\Modules\Settings\Managers\SettingsManager;
+use ArtisanPackUI\CMSFramework\Modules\Themes\Support\ThemeLoader;
+use Illuminate\Support\Facades\Blade;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\File;
+
+beforeEach( function (): void {
+    $this->themesPath = base_path( 'themes' );
+    $this->testSlugs  = [];
+
+    File::ensureDirectoryExists( $this->themesPath );
+
+    config()->set( 'cms.themes.cacheEnabled', false );
+    Cache::forget( config( 'cms.themes.cacheKey', 'cms.themes.discovered' ) );
+
+    // Clear filter listeners we may register during a test.
+    foreach ( ['ap.themes.frontendStyles', 'ap.themes.editorStyles', 'ap.themes.frontendScripts'] as $hook ) {
+        removeAllFilters( $hook );
+    }
+} );
+
+afterEach( function (): void {
+    foreach ( $this->testSlugs as $slug ) {
+        $path = $this->themesPath . '/' . $slug;
+        if ( File::exists( $path ) ) {
+            File::deleteDirectory( $path );
+        }
+    }
+
+    foreach ( ['ap.themes.frontendStyles', 'ap.themes.editorStyles', 'ap.themes.frontendScripts'] as $hook ) {
+        removeAllFilters( $hook );
+    }
+} );
+
+/**
+ * Write a theme.json into a fresh directory and mark it active so
+ * ThemeLoader / GlobalStyles / etc. pick it up.
+ */
+function writeActiveTheme( string $themesPath, string $slug, array &$slugs, ?string $themePhp = null, array $extraManifest = [] ): void
+{
+    $slugs[] = $slug;
+
+    $path = $themesPath . '/' . $slug;
+    File::ensureDirectoryExists( $path );
+    File::put( $path . '/theme.json', json_encode( array_merge( [
+        'slug'    => $slug,
+        'name'    => ucfirst( $slug ),
+        'version' => '1.0.0',
+    ], $extraManifest ) ) );
+
+    if ( null !== $themePhp ) {
+        File::put( $path . '/Theme.php', $themePhp );
+    }
+
+    app( SettingsManager::class )->updateSetting( 'themes.activeTheme', $slug );
+
+    app( ThemeLoader::class )->reset();
+}
+
+describe( 'ThemeLoader discovery', function (): void {
+    it( 'returns null when the active theme ships no Theme.php', function (): void {
+        writeActiveTheme( $this->themesPath, 'no-php-theme', $this->testSlugs );
+
+        expect( app( ThemeLoader::class )->activeTheme() )->toBeNull();
+    } );
+
+    it( 'instantiates the conventional class and calls the lifecycle methods in order', function (): void {
+        $slug = 'lifecycle-theme';
+
+        writeActiveTheme( $this->themesPath, $slug, $this->testSlugs, <<<'PHP'
+<?php
+
+namespace Themes\LifecycleTheme;
+
+use ArtisanPackUI\CMSFramework\Modules\Themes\Contracts\Theme as BaseTheme;
+
+class Theme extends BaseTheme
+{
+    public function registerImageSizes(): void
+    {
+        $GLOBALS['__theme_lifecycle_events'][] = 'images';
+    }
+
+    public function boot(): void
+    {
+        $GLOBALS['__theme_lifecycle_events'][] = 'boot';
+    }
+
+    public function extend(): void
+    {
+        $GLOBALS['__theme_lifecycle_events'][] = 'extend';
+    }
+}
+PHP );
+
+        $GLOBALS['__theme_lifecycle_events'] = [];
+
+        $theme = app( ThemeLoader::class )->activeTheme();
+
+        expect( $theme )->not->toBeNull();
+        expect( $theme->slug() )->toBe( $slug );
+        expect( $GLOBALS['__theme_lifecycle_events'] )->toBe( ['images', 'boot', 'extend'] );
+
+        unset( $GLOBALS['__theme_lifecycle_events'] );
+    } );
+
+    it( 'caches the theme instance so repeat calls do not re-boot', function (): void {
+        writeActiveTheme( $this->themesPath, 'cache-theme', $this->testSlugs, <<<'PHP'
+<?php
+
+namespace Themes\CacheTheme;
+
+use ArtisanPackUI\CMSFramework\Modules\Themes\Contracts\Theme as BaseTheme;
+
+class Theme extends BaseTheme
+{
+    public function boot(): void
+    {
+        $GLOBALS['__theme_cache_boots'] = ($GLOBALS['__theme_cache_boots'] ?? 0) + 1;
+    }
+}
+PHP );
+
+        $GLOBALS['__theme_cache_boots'] = 0;
+
+        $loader = app( ThemeLoader::class );
+        $loader->activeTheme();
+        $loader->activeTheme();
+        $loader->activeTheme();
+
+        expect( $GLOBALS['__theme_cache_boots'] )->toBe( 1 );
+
+        unset( $GLOBALS['__theme_cache_boots'] );
+    } );
+
+    it( 'honors a manifest themeClass override for custom namespaces', function (): void {
+        writeActiveTheme( $this->themesPath, 'override-theme', $this->testSlugs, <<<'PHP'
+<?php
+
+namespace Vendor\Custom;
+
+use ArtisanPackUI\CMSFramework\Modules\Themes\Contracts\Theme as BaseTheme;
+
+class OverrideTheme extends BaseTheme
+{
+    public function frontendStyles(): array
+    {
+        return ['override.css'];
+    }
+}
+PHP , ['themeClass' => 'Vendor\\Custom\\OverrideTheme'] );
+
+        $theme = app( ThemeLoader::class )->activeTheme();
+
+        expect( $theme )->not->toBeNull();
+        expect( $theme->frontendStyles() )->toBe( ['override.css'] );
+    } );
+
+    it( 'logs and returns null when the loaded class does not extend the Theme base', function (): void {
+        writeActiveTheme( $this->themesPath, 'not-a-theme', $this->testSlugs, <<<'PHP'
+<?php
+
+namespace Themes\NotATheme;
+
+class Theme
+{
+    // Missing base class.
+}
+PHP );
+
+        expect( app( ThemeLoader::class )->activeTheme() )->toBeNull();
+    } );
+
+    it( 'logs and returns null when boot() throws so a broken theme does not crash the app', function (): void {
+        writeActiveTheme( $this->themesPath, 'crashing-theme', $this->testSlugs, <<<'PHP'
+<?php
+
+namespace Themes\CrashingTheme;
+
+use ArtisanPackUI\CMSFramework\Modules\Themes\Contracts\Theme as BaseTheme;
+
+class Theme extends BaseTheme
+{
+    public function boot(): void
+    {
+        throw new \RuntimeException('theme is broken');
+    }
+}
+PHP );
+
+        expect( app( ThemeLoader::class )->activeTheme() )->toBeNull();
+    } );
+
+    it( 'refuses a themeClass override that resolves to a class declared outside the theme file', function (): void {
+        // Define a rogue Theme subclass in this test process, then have an
+        // uploaded theme.json try to point at it. The reflection-based
+        // provenance check must reject the load.
+        eval( 'namespace Rogue\\Vendor; class ImpostorTheme extends \\ArtisanPackUI\\CMSFramework\\Modules\\Themes\\Contracts\\Theme { public function boot(): void { $GLOBALS["__theme_impostor_booted"] = true; } }' );
+
+        writeActiveTheme( $this->themesPath, 'impostor-theme', $this->testSlugs, <<<'PHP'
+<?php
+// This file exists so ThemeLoader loads it, but declares an unrelated
+// class — the manifest override tries to redirect discovery elsewhere.
+PHP , ['themeClass' => 'Rogue\\Vendor\\ImpostorTheme'] );
+
+        $GLOBALS['__theme_impostor_booted'] = false;
+
+        expect( app( ThemeLoader::class )->activeTheme() )->toBeNull();
+        expect( $GLOBALS['__theme_impostor_booted'] )->toBeFalse();
+
+        unset( $GLOBALS['__theme_impostor_booted'] );
+    } );
+
+    it( 'rejects a malformed themeClass override before touching the autoloader', function (): void {
+        writeActiveTheme( $this->themesPath, 'bad-classname-theme', $this->testSlugs, <<<'PHP'
+<?php
+// Intentionally empty; the override should be rejected on shape alone.
+PHP , ['themeClass' => 'Not A Valid; Class Name'] );
+
+        expect( app( ThemeLoader::class )->activeTheme() )->toBeNull();
+    } );
+} );
+
+describe( 'Blade asset directives', function (): void {
+    it( '@themeFrontendStyles renders the theme-declared styles as link tags', function (): void {
+        writeActiveTheme( $this->themesPath, 'styles-theme', $this->testSlugs, <<<'PHP'
+<?php
+
+namespace Themes\StylesTheme;
+
+use ArtisanPackUI\CMSFramework\Modules\Themes\Contracts\Theme as BaseTheme;
+
+class Theme extends BaseTheme
+{
+    public function frontendStyles(): array
+    {
+        return [
+            'brand' => 'brand.css',
+            ['src' => 'print.css', 'media' => 'print'],
+        ];
+    }
+}
+PHP );
+
+        app( ThemeLoader::class )->activeTheme();
+
+        $html = Blade::render( '@themeFrontendStyles' );
+
+        expect( $html )->toContain( 'id="brand-css"' )
+            ->toContain( '/themes/styles-theme/assets/brand.css' )
+            ->toContain( 'id="print-css"' )
+            ->toContain( 'media="print"' );
+    } );
+
+    it( '@themeFrontendStyles emits an empty string when no theme is loaded', function (): void {
+        // No Theme.php shipped: loader returns null.
+        writeActiveTheme( $this->themesPath, 'silent-theme', $this->testSlugs );
+
+        expect( Blade::render( '@themeFrontendStyles' ) )->toBe( '' );
+    } );
+
+    it( 'ap.themes.frontendStyles filter can add and mutate styles', function (): void {
+        writeActiveTheme( $this->themesPath, 'filter-theme', $this->testSlugs, <<<'PHP'
+<?php
+
+namespace Themes\FilterTheme;
+
+use ArtisanPackUI\CMSFramework\Modules\Themes\Contracts\Theme as BaseTheme;
+
+class Theme extends BaseTheme
+{
+    public function frontendStyles(): array
+    {
+        return ['base.css'];
+    }
+}
+PHP );
+
+        addFilter( 'ap.themes.frontendStyles', function ( array $entries, string $slug ): array {
+            $entries[] = ['src' => 'https://cdn.example/vendor.css', 'ver' => '1.0'];
+
+            return $entries;
+        } );
+
+        app( ThemeLoader::class )->activeTheme();
+
+        $html = Blade::render( '@themeFrontendStyles' );
+
+        expect( $html )->toContain( '/themes/filter-theme/assets/base.css' )
+            ->toContain( 'https://cdn.example/vendor.css' );
+    } );
+
+    it( '@themeFrontendScripts renders script tags with defer support', function (): void {
+        writeActiveTheme( $this->themesPath, 'scripts-theme', $this->testSlugs, <<<'PHP'
+<?php
+
+namespace Themes\ScriptsTheme;
+
+use ArtisanPackUI\CMSFramework\Modules\Themes\Contracts\Theme as BaseTheme;
+
+class Theme extends BaseTheme
+{
+    public function frontendScripts(): array
+    {
+        return [
+            'menu' => ['src' => 'menu.js', 'defer' => true],
+        ];
+    }
+}
+PHP );
+
+        app( ThemeLoader::class )->activeTheme();
+
+        $html = Blade::render( '@themeFrontendScripts' );
+
+        expect( $html )->toContain( 'id="menu-js"' )
+            ->toContain( '/themes/scripts-theme/assets/menu.js' )
+            ->toMatch( '/<script[^>]* defer[ >]/' );
+    } );
+} );
+
+describe( 'Theme asset HTTP route', function (): void {
+    it( 'serves a CSS file from the theme assets directory', function (): void {
+        $slug = 'served-theme';
+        writeActiveTheme( $this->themesPath, $slug, $this->testSlugs );
+
+        File::ensureDirectoryExists( $this->themesPath . '/' . $slug . '/assets' );
+        File::put( $this->themesPath . '/' . $slug . '/assets/main.css', 'body { color: red; }' );
+
+        $response = $this->get( '/themes/' . $slug . '/assets/main.css' );
+
+        $response->assertOk();
+        expect( $response->headers->get( 'cache-control' ) )->toContain( 'max-age' );
+        expect( trim( $response->streamedContent() ?: (string) $response->getContent() ) )->toBe( 'body { color: red; }' );
+    } );
+
+    it( 'serves CSS with the text/css Content-Type, not text/plain', function (): void {
+        $slug = 'mime-css-theme';
+        writeActiveTheme( $this->themesPath, $slug, $this->testSlugs );
+
+        File::ensureDirectoryExists( $this->themesPath . '/' . $slug . '/assets' );
+        File::put( $this->themesPath . '/' . $slug . '/assets/main.css', 'body {}' );
+
+        $response = $this->get( '/themes/' . $slug . '/assets/main.css' );
+
+        $response->assertOk();
+        expect( $response->headers->get( 'content-type' ) )->toStartWith( 'text/css' );
+    } );
+
+    it( 'serves JS with the application/javascript Content-Type', function (): void {
+        $slug = 'mime-js-theme';
+        writeActiveTheme( $this->themesPath, $slug, $this->testSlugs );
+
+        File::ensureDirectoryExists( $this->themesPath . '/' . $slug . '/assets' );
+        File::put( $this->themesPath . '/' . $slug . '/assets/main.js', 'var x = 1;' );
+
+        $response = $this->get( '/themes/' . $slug . '/assets/main.js' );
+
+        $response->assertOk();
+        expect( $response->headers->get( 'content-type' ) )->toStartWith( 'application/javascript' );
+    } );
+
+    it( 'serves a nested asset file', function (): void {
+        $slug = 'nested-theme';
+        writeActiveTheme( $this->themesPath, $slug, $this->testSlugs );
+
+        File::ensureDirectoryExists( $this->themesPath . '/' . $slug . '/assets/fonts' );
+        File::put( $this->themesPath . '/' . $slug . '/assets/fonts/inter.woff2', 'FONT_BYTES' );
+
+        $this->get( '/themes/' . $slug . '/assets/fonts/inter.woff2' )->assertOk();
+    } );
+
+    it( 'returns 404 for a path traversal attempt', function (): void {
+        $slug = 'traversal-theme';
+        writeActiveTheme( $this->themesPath, $slug, $this->testSlugs );
+
+        // Put a file OUTSIDE assets/ that the traversal would target.
+        File::put( $this->themesPath . '/' . $slug . '/theme.json.attack', 'secret' );
+
+        // Route param uses .* so Laravel does not URL-normalize the traversal
+        // for us — we must send the literal segment.
+        $this->get( '/themes/' . $slug . '/assets/..%2Ftheme.json.attack' )
+            ->assertNotFound();
+    } );
+
+    it( 'returns 404 for a backslash traversal attempt', function (): void {
+        $slug = 'backslash-theme';
+        writeActiveTheme( $this->themesPath, $slug, $this->testSlugs );
+
+        File::put( $this->themesPath . '/' . $slug . '/theme.json.attack', 'secret' );
+
+        // Backslash-based traversal must be rejected by the same check on
+        // any platform, not only by realpath's after-the-fact boundary.
+        $this->get( '/themes/' . $slug . '/assets/..%5Ctheme.json.attack' )
+            ->assertNotFound();
+    } );
+
+    it( 'returns 404 for a symlink that escapes the assets directory', function (): void {
+        if ( ! function_exists( 'symlink' ) ) {
+            $this->markTestSkipped( 'symlink() unavailable on this platform.' );
+        }
+
+        $slug = 'symlink-theme';
+        writeActiveTheme( $this->themesPath, $slug, $this->testSlugs );
+
+        File::ensureDirectoryExists( $this->themesPath . '/' . $slug . '/assets' );
+        File::put( $this->themesPath . '/' . $slug . '/secret.css', 'body{}' );
+
+        // Symlink a file inside assets/ to a file outside assets/. The
+        // realpath-anchored boundary check must reject the request.
+        $link   = $this->themesPath . '/' . $slug . '/assets/escape.css';
+        $target = $this->themesPath . '/' . $slug . '/secret.css';
+
+        if ( file_exists( $link ) ) {
+            unlink( $link );
+        }
+
+        if ( false === @symlink( $target, $link ) ) {
+            $this->markTestSkipped( 'symlink() creation not permitted in this environment.' );
+        }
+
+        $this->get( '/themes/' . $slug . '/assets/escape.css' )->assertNotFound();
+    } );
+
+    it( 'sends X-Content-Type-Options: nosniff on every asset response', function (): void {
+        $slug = 'nosniff-theme';
+        writeActiveTheme( $this->themesPath, $slug, $this->testSlugs );
+
+        File::ensureDirectoryExists( $this->themesPath . '/' . $slug . '/assets' );
+        File::put( $this->themesPath . '/' . $slug . '/assets/main.css', 'body{}' );
+
+        $response = $this->get( '/themes/' . $slug . '/assets/main.css' );
+
+        $response->assertOk();
+        expect( $response->headers->get( 'x-content-type-options' ) )->toBe( 'nosniff' );
+    } );
+
+    it( 'hardens SVG responses with CSP sandbox + attachment disposition', function (): void {
+        $slug = 'svg-theme';
+        writeActiveTheme( $this->themesPath, $slug, $this->testSlugs );
+
+        File::ensureDirectoryExists( $this->themesPath . '/' . $slug . '/assets' );
+        File::put(
+            $this->themesPath . '/' . $slug . '/assets/logo.svg',
+            '<svg xmlns="http://www.w3.org/2000/svg"><script>alert(1)</script></svg>',
+        );
+
+        $response = $this->get( '/themes/' . $slug . '/assets/logo.svg' );
+
+        $response->assertOk();
+        expect( $response->headers->get( 'content-type' ) )->toStartWith( 'image/svg+xml' );
+        expect( $response->headers->get( 'content-security-policy' ) )->toContain( 'sandbox' );
+        expect( $response->headers->get( 'content-disposition' ) )->toStartWith( 'attachment' );
+    } );
+
+    it( 'returns 404 for a disallowed extension', function (): void {
+        $slug = 'disallowed-ext-theme';
+        writeActiveTheme( $this->themesPath, $slug, $this->testSlugs );
+
+        File::ensureDirectoryExists( $this->themesPath . '/' . $slug . '/assets' );
+        File::put( $this->themesPath . '/' . $slug . '/assets/hack.php', '<?php echo "boom";' );
+
+        $this->get( '/themes/' . $slug . '/assets/hack.php' )->assertNotFound();
+    } );
+
+    it( 'returns 404 for an invalid slug', function (): void {
+        $this->get( '/themes/bad..slug/assets/main.css' )->assertNotFound();
+    } );
+
+    it( 'returns 404 for a missing file', function (): void {
+        $slug = 'missing-file-theme';
+        writeActiveTheme( $this->themesPath, $slug, $this->testSlugs );
+
+        File::ensureDirectoryExists( $this->themesPath . '/' . $slug . '/assets' );
+
+        $this->get( '/themes/' . $slug . '/assets/nope.css' )->assertNotFound();
+    } );
+} );
+
+describe( 'Theme::assetUrl helper', function (): void {
+    it( 'builds an absolute URL to a theme asset', function (): void {
+        writeActiveTheme( $this->themesPath, 'helper-theme', $this->testSlugs, <<<'PHP'
+<?php
+
+namespace Themes\HelperTheme;
+
+use ArtisanPackUI\CMSFramework\Modules\Themes\Contracts\Theme as BaseTheme;
+
+class Theme extends BaseTheme
+{
+}
+PHP );
+
+        $theme = app( ThemeLoader::class )->activeTheme();
+
+        expect( $theme )->not->toBeNull();
+        expect( $theme->assetUrl( 'main.css' ) )->toContain( '/themes/helper-theme/assets/main.css' );
+    } );
+});

--- a/tests/Unit/Themes/EnqueuedAssetsTest.php
+++ b/tests/Unit/Themes/EnqueuedAssetsTest.php
@@ -1,0 +1,136 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\CMSFramework\Modules\Themes\Support\EnqueuedAssets;
+
+describe( 'EnqueuedAssets::renderStyles', function (): void {
+    it( 'returns an empty string for an empty list', function (): void {
+        expect( EnqueuedAssets::renderStyles( 'my-theme', [] ) )->toBe( '' );
+    } );
+
+    it( 'renders a bare string as a link tag with the derived handle', function (): void {
+        $rendered = EnqueuedAssets::renderStyles( 'my-theme', ['main.css'] );
+
+        expect( $rendered )->toContain( '<link' )
+            ->toContain( 'rel="stylesheet"' )
+            ->toContain( 'id="main-css"' )
+            ->toContain( '/themes/my-theme/assets/main.css' );
+    } );
+
+    it( 'uses an associative-array key as the enqueue handle', function (): void {
+        $rendered = EnqueuedAssets::renderStyles( 'my-theme', [
+            'brand' => 'brand.css',
+        ] );
+
+        expect( $rendered )->toContain( 'id="brand-css"' );
+    } );
+
+    it( 'emits the media attribute when provided', function (): void {
+        $rendered = EnqueuedAssets::renderStyles( 'my-theme', [
+            ['src' => 'print.css', 'media' => 'print'],
+        ] );
+
+        expect( $rendered )->toContain( 'media="print"' );
+    } );
+
+    it( 'appends a version query string only when the URL has none', function (): void {
+        $rendered = EnqueuedAssets::renderStyles( 'my-theme', [
+            ['src' => 'main.css', 'ver' => '1.2.3'],
+            ['src' => 'https://cdn.example/x.css?v=1', 'ver' => '9.9.9'],
+        ] );
+
+        expect( $rendered )->toContain( '/themes/my-theme/assets/main.css?ver=1.2.3' )
+            ->toContain( 'https://cdn.example/x.css?v=1' )
+            ->not->toContain( 'https://cdn.example/x.css?v=1?' )
+            ->not->toContain( 'https://cdn.example/x.css?v=1&ver=9.9.9' );
+    } );
+
+    it( 'passes absolute and root-relative URLs through unchanged', function (): void {
+        $rendered = EnqueuedAssets::renderStyles( 'my-theme', [
+            'cdn' => 'https://cdn.example/lib.css',
+            'app' => '/vendor/lib.css',
+        ] );
+
+        expect( $rendered )->toContain( 'href="https://cdn.example/lib.css"' )
+            ->toContain( 'href="/vendor/lib.css"' );
+    } );
+
+    it( 'silently drops entries with a missing or empty src', function (): void {
+        $rendered = EnqueuedAssets::renderStyles( 'my-theme', [
+            'bad-array'  => ['media' => 'print'],
+            'empty-str'  => '',
+            'null-entry' => null,
+            'good'       => 'main.css',
+        ] );
+
+        expect( $rendered )->toContain( 'id="good-css"' )
+            ->not->toContain( 'id="bad-array-css"' )
+            ->not->toContain( 'id="empty-str-css"' )
+            ->not->toContain( 'id="null-entry-css"' );
+    } );
+
+    it( 'drops duplicate handles — first entry wins', function (): void {
+        $rendered = EnqueuedAssets::renderStyles( 'my-theme', [
+            'brand' => 'first.css',
+            ['src'  => 'second.css'],
+            'brand' => 'third.css',
+        ] );
+
+        expect( $rendered )->toContain( '/themes/my-theme/assets/second.css' );
+        expect( substr_count( $rendered, 'id="brand-css"' ) )->toBe( 1 );
+    } );
+
+    it( 'HTML-escapes attribute values to prevent injection', function (): void {
+        $rendered = EnqueuedAssets::renderStyles( 'my-theme', [
+            'x' => ['src' => 'main.css', 'media' => 'print" onload="alert(1)'],
+        ] );
+
+        expect( $rendered )->not->toContain( '" onload="alert(1)' );
+        expect( $rendered )->toContain( '&quot;' );
+    } );
+} );
+
+describe( 'EnqueuedAssets::renderScripts', function (): void {
+    it( 'renders a bare string as a script tag with the derived handle', function (): void {
+        $rendered = EnqueuedAssets::renderScripts( 'my-theme', ['main.js'] );
+
+        expect( $rendered )->toContain( '<script' )
+            ->toContain( 'id="main-js"' )
+            ->toContain( '/themes/my-theme/assets/main.js' )
+            ->toContain( '></script>' );
+    } );
+
+    it( 'adds defer and async as bare boolean attributes', function (): void {
+        $rendered = EnqueuedAssets::renderScripts( 'my-theme', [
+            'a' => ['src' => 'a.js', 'defer' => true],
+            'b' => ['src' => 'b.js', 'async' => true],
+        ] );
+
+        expect( $rendered )->toMatch( '/<script[^>]* defer[ >]/' )
+            ->toMatch( '/<script[^>]* async[ >]/' );
+    } );
+
+    it( 'forces type="module" when module flag is set', function (): void {
+        $rendered = EnqueuedAssets::renderScripts( 'my-theme', [
+            'm' => ['src' => 'app.js', 'module' => true, 'type' => 'text/javascript'],
+        ] );
+
+        expect( $rendered )->toContain( 'type="module"' )
+            ->not->toContain( 'type="text/javascript"' );
+    } );
+} );
+
+describe( 'EnqueuedAssets::assetUrl', function (): void {
+    it( 'points at the themes.assets route with the given slug + path', function (): void {
+        $url = EnqueuedAssets::assetUrl( 'my-theme', 'main.css' );
+
+        expect( $url)->toContain( '/themes/my-theme/assets/main.css');
+    });
+
+    it( 'strips a leading slash from the path', function (): void {
+        $url = EnqueuedAssets::assetUrl( 'my-theme', '/main.css');
+
+        expect( $url)->toContain( '/themes/my-theme/assets/main.css');
+    });
+});

--- a/tests/Unit/Themes/ThemeManagerValidateManifestTest.php
+++ b/tests/Unit/Themes/ThemeManagerValidateManifestTest.php
@@ -345,4 +345,31 @@ describe( 'ThemeManager::validateManifest() via installFromZip()', function (): 
 
         expect( File::exists( $this->themesPath . '/rollback-theme' ) )->toBeFalse();
     } );
+
+    it( 'rejects an install when themeClass is not a well-formed class name', function (): void {
+        $zipPath = buildValidateZip( $this->tmpPath, 'bad-classname-install', [
+            'slug'       => 'bad-classname-install',
+            'name'       => 'Bad Class Name',
+            'version'    => '1.0.0',
+            'themeClass' => 'Not A Class; Name',
+        ], $this->testSlugs );
+
+        expect( fn () => $this->manager->installFromZip( $zipPath ) )
+            ->toThrow( ThemeValidationException::class, "Field 'themeClass' must be a fully-qualified PHP class name." );
+
+        expect( File::exists( $this->themesPath . '/bad-classname-install' ) )->toBeFalse();
+    } );
+
+    it( 'accepts an install with a well-formed themeClass override', function (): void {
+        $zipPath = buildValidateZip( $this->tmpPath, 'good-classname-install', [
+            'slug'       => 'good-classname-install',
+            'name'       => 'Good Class Name',
+            'version'    => '1.0.0',
+            'themeClass' => 'Vendor\\Custom\\CustomTheme',
+        ], $this->testSlugs );
+
+        $manifest = $this->manager->installFromZip( $zipPath );
+
+        expect( $manifest['themeClass'] )->toBe( 'Vendor\\Custom\\CustomTheme' );
+    } );
 } );


### PR DESCRIPTION
## Description

Themes may now ship an optional `themes/{slug}/Theme.php` that extends `ArtisanPackUI\CMSFramework\Modules\Themes\Contracts\Theme` to hook into the per-request lifecycle. Themes without a `Theme.php` are unaffected — behavior is fully backward compatible.

**Closes:** #198

## Type of Change

- [x] New feature (adds new functionality)

## Related Issue

**Issue:** #198

## Motivation and Context

cms-framework themes were static bundles: no PHP could run from inside a theme at request time, so themes couldn't enqueue their own CSS/JS, register custom REST endpoints, add block filters, ship vendor CSS (e.g. Font Awesome), or own their image sizes. The only lifecycle hooks were one-shot `theme.installing/installed/activating/activated` events on the host app's service provider. This PR gives themes the per-request extension point they need to behave like a real theme.

## Changes Made

- **New `Theme` abstract class** at `ArtisanPackUI\CMSFramework\Modules\Themes\Contracts\Theme` with `boot()`, `frontendStyles()`, `editorStyles()`, `frontendScripts()`, `registerImageSizes()`, `extend()`, plus `slug()` / `assetUrl()` helpers. All methods have no-op defaults so themes only override what they need.
- **`ThemeLoader`** discovers `themes/{slug}/Theme.php` at boot when a theme is active. Class-name convention: `Themes\{PascalSlug}\Theme`. Manifest `themeClass` key overrides for custom namespaces.
- **`ReflectionClass` provenance check** — the resolved class must be declared in the theme's own `Theme.php`; a hostile manifest cannot redirect discovery to an unrelated first-party or vendor `Theme` subclass.
- **`ThemeAssetsController`** serves `themes/{slug}/assets/{path}`: kebab-case slug regex, extension allowlist, path-traversal + backslash + null-byte + symlink-escape guards, explicit MIME map (browsers were rejecting stylesheets served as `text/plain`), `X-Content-Type-Options: nosniff`, and CSP `sandbox` + `Content-Disposition: attachment` for `.svg` (blocks stored-XSS from uploaded scripted SVGs served same-origin).
- **`EnqueuedAssets`** normalizes the enqueue arrays into `<link>` / `<script>` tags with HTML-attribute escaping, dedup by handle, `?ver=` cache-busting, `defer` / `async` / `module` support, and pass-through for absolute URLs.
- **Blade directives** `@themeFrontendStyles`, `@themeEditorStyles`, `@themeFrontendScripts` — silent no-op when no theme is loaded.
- **Filters** `ap.themes.frontendStyles`, `ap.themes.editorStyles`, `ap.themes.frontendScripts` — third parties can add/mutate enqueue lists without subclassing.
- **`ThemeManager::validateManifest`** rejects malformed `themeClass` values at upload time.
- **`themes.assetsMaxAge`** config option for the asset Cache-Control TTL (default 3600).

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS (Darwin 25.5.0)
- PHP Version: 8.4.23
- Project Version: 2.5 (release branch)

**Tests Performed:**
1. Full package suite: 1170 passed / 7 skipped / 0 failed (`php artisan test`, ~49s).
2. Theme-module subset: 106 passed / 3 skipped, including 33 new tests specifically covering the new surface.
3. Manual browser test in `artisanpack-ui-dev` against a live theme (`themes/dev-sample`) that ships `Theme.php` + `assets/*.css` + `assets/*.js`. Verified banner CSS applied, JS ran, all three lifecycle flags fired, `Content-Type: text/css`, `X-Content-Type-Options: nosniff`, SVG returns CSP sandbox + attachment.
4. Path-traversal / disallowed-extension / missing-file / invalid-slug routes all return 404.
5. Reviewed with an internal security-focused code review pass; two HIGH findings (SVG XSS, themeClass override) and three lower-severity findings all resolved before push.

## Accessibility Tests Run

- [x] N/A — this PR adds a server-side extension point and asset route; no UI surface is added. Existing theme accessibility characteristics are unaffected.

## Tests Added

- [x] Unit tests added
- [x] Integration tests added
- [x] All tests passing

**Test details:**

- `tests/Unit/Themes/EnqueuedAssetsTest.php` — 14 tests covering the enqueue normalizer (bare strings vs. keyed arrays, media/defer/async/module attributes, dedup, empty-src drops, HTML-attribute escaping against injection, absolute-URL passthrough, `?ver=` handling).
- `tests/Feature/Themes/ThemeBaseClassTest.php` — 21 tests covering: theme discovery (present / absent Theme.php, caching, subclass check, boot() throw handled), `themeClass` override (accepted for well-formed, rejected for malformed, rejected via reflection-provenance for impostor), Blade directives (rendered output + filter mutation + silent no-op), asset serving (CSS/JS/nested/traversal/backslash-traversal/symlink-escape/disallowed-ext/invalid-slug/missing-file/nosniff/SVG hardening).
- `tests/Unit/Themes/ThemeManagerValidateManifestTest.php` — 2 new tests covering install-time `themeClass` validation.

## Documentation

- [x] Inline code documentation added — every new class and every new / modified public method carries a full PHPDoc block; `ThemeLoader` docblock includes an Octane / long-running-worker caveat.
- [ ] Wiki update deferred — worth a follow-up docs page under `docs/themes/` (analog of `Lifecycle-Hooks.md`) once this lands.

## Pre-Submission Checklist

- [x] Followed contributing guidelines
- [x] Checked for other open PRs for same update
- [x] Code passes all tests (1170 passing)
- [x] Code has been linted (`composer fix` applied)
- [x] Accessibility tests completed (N/A — server-side change)
- [x] Code follows project style guide
- [x] Self-review completed
- [x] Comments added for complex code (security-sensitive branches carry rationale)
- [x] No new warnings generated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Theme lifecycle management enabling per-request initialization and asset management
  * Blade directives for rendering theme styles and scripts in templates (`@themeFrontendStyles`, `@themeEditorStyles`, `@themeFrontendScripts`)
  * Static asset serving for theme resources with security hardening and cache headers
  * Configurable cache control for theme asset responses

* **Tests**
  * Comprehensive feature and unit test coverage for theme discovery, asset rendering, HTTP serving, and theme lifecycle

<!-- end of auto-generated comment: release notes by coderabbit.ai -->