### PR TITLE
feat: emit per-block-element overrides under styles.blocks.{name}.elements.*

### DIFF
--- a/src/Modules/SiteEditor/Emission/GlobalStylesEmitter.php
+++ b/src/Modules/SiteEditor/Emission/GlobalStylesEmitter.php
@@ -60,8 +60,15 @@ class GlobalStylesEmitter
      * `styles.blocks.{namespace/name}` (#201), and translate WP-canonical
      * `var:preset|category|slug` values into real `var(...)` references
      * (#202).
+     *
+     * v4: emit per-block-element overrides under
+     * `styles.blocks.{name}.elements.{element}` as compound selectors
+     * with comma-joined element groups distributed across the block
+     * selector (`.wp-block-quote a`, `.wp-block-artisanpack-card h1,
+     * .wp-block-artisanpack-card h2, …`) so the child selector stays
+     * scoped to the block (#208).
      */
-    private const SCHEMA_VERSION = 'v3';
+    private const SCHEMA_VERSION = 'v4';
 
     /**
      * Flat theme.json → CSS property map for scalar-leaf declarations.
@@ -125,6 +132,23 @@ class GlobalStylesEmitter
         'right'  => 'right',
         'bottom' => 'bottom',
         'left'   => 'left',
+    ];
+
+    /**
+     * `styles.elements.{name}` → CSS selector map. Shared between the
+     * root-level per-element emission ({@see elementStyleBlocks()}) and
+     * the per-block-element emission ({@see blockElementStyleBlocks()})
+     * so both agree on which elements are supported and which selectors
+     * they map to. Comma-joined values are distributed across the parent
+     * block selector at the block-element call site — never concatenated
+     * — so the child selector doesn't leak out of block scope (#208).
+     *
+     * @var array<string, string>
+     */
+    private const ELEMENT_SELECTORS = [
+        'link'    => 'a',
+        'heading' => 'h1, h2, h3, h4, h5, h6',
+        'button'  => '.wp-element-button, .wp-block-button__link',
     ];
 
     /**
@@ -623,15 +647,9 @@ class GlobalStylesEmitter
             return [];
         }
 
-        $selectors = [
-            'link'    => 'a',
-            'heading' => 'h1, h2, h3, h4, h5, h6',
-            'button'  => '.wp-element-button, .wp-block-button__link',
-        ];
-
         $blocks = [];
 
-        foreach ( $selectors as $element => $selector ) {
+        foreach ( self::ELEMENT_SELECTORS as $element => $selector ) {
             if ( ! isset( $elements[ $element ] ) || ! is_array( $elements[ $element ] ) ) {
                 continue;
             }
@@ -684,14 +702,88 @@ class GlobalStylesEmitter
 
             $declarations = $this->stylesRootDeclarations( $blockStyles );
 
+            if ( [] !== $declarations ) {
+                $rules[] = $selector . ' {' . "\n" . $this->formatDeclarations( $declarations ) . "\n" . '}';
+            }
+
+            foreach ( $this->blockElementStyleBlocks( $selector, $blockStyles ) as $rule ) {
+                $rules[] = $rule;
+            }
+        }
+
+        return $rules;
+    }
+
+    /**
+     * Per-block-element rule blocks:
+     * `styles.blocks.{name}.elements.{element}` composes the parent
+     * block selector with each supported element selector from
+     * {@see ELEMENT_SELECTORS}. Comma-joined element selectors are
+     * distributed across the block selector so the child selector
+     * doesn't leak out of block scope:
+     *
+     *   `.wp-block-quote h1, .wp-block-quote h2, …`
+     *
+     * — not the naive concatenation `.wp-block-quote h1, h2, …`,
+     * which would let `h2` through `h6` apply globally (#208).
+     *
+     * @since 2.5.0
+     *
+     * @param  array<string, mixed>  $blockStyles
+     *
+     * @return array<int, string>
+     */
+    protected function blockElementStyleBlocks( string $blockSelector, array $blockStyles ): array
+    {
+        $elements = $blockStyles['elements'] ?? null;
+
+        if ( ! is_array( $elements ) ) {
+            return [];
+        }
+
+        $rules = [];
+
+        foreach ( self::ELEMENT_SELECTORS as $element => $elementSelector ) {
+            if ( ! isset( $elements[ $element ] ) || ! is_array( $elements[ $element ] ) ) {
+                continue;
+            }
+
+            $declarations = $this->stylesRootDeclarations( $elements[ $element ] );
+
             if ( [] === $declarations ) {
                 continue;
             }
 
-            $rules[] = $selector . ' {' . "\n" . $this->formatDeclarations( $declarations ) . "\n" . '}';
+            $composed = $this->composeBlockElementSelector( $blockSelector, $elementSelector );
+
+            $rules[] = $composed . ' {' . "\n" . $this->formatDeclarations( $declarations ) . "\n" . '}';
         }
 
         return $rules;
+    }
+
+    /**
+     * Distribute the parent block selector across each comma-separated
+     * child selector token so the emitted rule stays scoped to the block
+     * even when the element selector is a group (`h1, h2, …`) (#208).
+     *
+     * @since 2.5.0
+     */
+    protected function composeBlockElementSelector( string $blockSelector, string $elementSelector ): string
+    {
+        $parts = array_map( 'trim', explode( ',', $elementSelector ) );
+
+        $composed = [];
+
+        foreach ( $parts as $part ) {
+            if ( '' === $part ) {
+                continue;
+            }
+
+            $composed[] = $blockSelector . ' ' . $part;
+        }
+
+        return implode( ', ', $composed );
     }
 
     /**

--- a/tests/Unit/SiteEditor/GlobalStylesEmitterTest.php
+++ b/tests/Unit/SiteEditor/GlobalStylesEmitterTest.php
@@ -577,6 +577,212 @@ describe( 'GlobalStylesEmitter::emit()', function (): void {
 
         expect( $css )->toContain( 'background-color: var(--wp--preset--color--base);' );
     } );
+
+    it( 'emits per-block-element overrides under styles.blocks.{name}.elements.link (#208)', function (): void {
+        $resolved = makeResolved(
+            styles: [
+                'blocks' => [
+                    'core/quote' => [
+                        'elements' => [
+                            'link' => [
+                                'color' => ['text' => '#accent'],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        );
+
+        $this->resolver->shouldReceive( 'resolve' )->andReturn( $resolved );
+
+        $css = $this->emitter->emit();
+
+        expect( $css )
+            ->toContain( '.wp-block-quote a {' )
+            ->and( $css )->toContain( 'color: #accent;' );
+    } );
+
+    it( 'distributes comma-joined element selectors across the block selector for headings (#208)', function (): void {
+        $resolved = makeResolved(
+            styles: [
+                'blocks' => [
+                    'artisanpack/card' => [
+                        'elements' => [
+                            'heading' => [
+                                'typography' => [
+                                    'fontWeight'    => '700',
+                                    'letterSpacing' => '-0.01em',
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        );
+
+        $this->resolver->shouldReceive( 'resolve' )->andReturn( $resolved );
+
+        $css = $this->emitter->emit();
+
+        // Each child selector must be prefixed by the block selector so
+        // `h2` through `h6` don't leak out of block scope.
+        expect( $css )
+            ->toContain( '.wp-block-artisanpack-card h1, .wp-block-artisanpack-card h2, .wp-block-artisanpack-card h3, .wp-block-artisanpack-card h4, .wp-block-artisanpack-card h5, .wp-block-artisanpack-card h6 {' )
+            ->and( $css )->toContain( 'font-weight: 700;' )
+            ->and( $css )->toContain( 'letter-spacing: -0.01em;' )
+            // No naive concatenation that would leak `h2…h6` out of scope.
+            ->and( $css )->not->toContain( '.wp-block-artisanpack-card h1, h2' );
+    } );
+
+    it( 'distributes the button element selector too (#208)', function (): void {
+        $resolved = makeResolved(
+            styles: [
+                'blocks' => [
+                    'artisanpack/card' => [
+                        'elements' => [
+                            'button' => [
+                                'color' => ['background' => '#primary'],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        );
+
+        $this->resolver->shouldReceive( 'resolve' )->andReturn( $resolved );
+
+        $css = $this->emitter->emit();
+
+        expect( $css )
+            ->toContain( '.wp-block-artisanpack-card .wp-element-button, .wp-block-artisanpack-card .wp-block-button__link {' )
+            ->and( $css )->toContain( 'background-color: #primary;' );
+    } );
+
+    it( 'translates preset-var values inside per-block-element overrides (#208)', function (): void {
+        $resolved = makeResolved(
+            styles: [
+                'blocks' => [
+                    'core/quote' => [
+                        'elements' => [
+                            'link' => [
+                                'color' => ['text' => 'var:preset|color|accent'],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        );
+
+        $this->resolver->shouldReceive( 'resolve' )->andReturn( $resolved );
+
+        $css = $this->emitter->emit();
+
+        expect( $css )
+            ->toContain( '.wp-block-quote a {' )
+            ->and( $css )->toContain( 'color: var(--wp--preset--color--accent);' )
+            ->and( $css )->not->toContain( 'var:preset|' );
+    } );
+
+    it( 'skips malformed or empty per-block elements maps cleanly (#208)', function (): void {
+        $resolved = makeResolved(
+            styles: [
+                'blocks' => [
+                    'artisanpack/a' => [
+                        'elements' => 'not-an-array',
+                        'color'    => ['text' => '#111'],
+                    ],
+                    'artisanpack/b' => [
+                        'elements' => [
+                            'link'    => 'not-an-array',
+                            'heading' => [],
+                            'unknown' => ['color' => ['text' => '#f00']],
+                        ],
+                    ],
+                    'artisanpack/c' => [
+                        'elements' => [
+                            'link' => ['color' => ['text' => '#legit']],
+                        ],
+                    ],
+                ],
+            ],
+        );
+
+        $this->resolver->shouldReceive( 'resolve' )->andReturn( $resolved );
+
+        $css = $this->emitter->emit();
+
+        expect( $css )
+            // Base block rule still emits alongside the invalid elements map.
+            ->toContain( '.wp-block-artisanpack-a {' )
+            // No block-element rule for the scalar `elements` map on block a.
+            ->and( $css )->not->toContain( '.wp-block-artisanpack-a a' )
+            ->and( $css )->not->toContain( '.wp-block-artisanpack-a h1' )
+            // Malformed / unknown element entries on block b drop cleanly.
+            ->and( $css )->not->toContain( '.wp-block-artisanpack-b a' )
+            ->and( $css )->not->toContain( '.wp-block-artisanpack-b h1' )
+            // Legit entry on block c still emits.
+            ->and( $css )->toContain( '.wp-block-artisanpack-c a {' )
+            ->and( $css )->toContain( 'color: #legit;' );
+    } );
+
+    it( 'emits element rules for a block that declares only `elements.*` with no base-level styles (#208)', function (): void {
+        // Regression guard — a block whose only styles live under
+        // `elements.*` (no base color/typography/border/…) must still
+        // emit its per-element rules. The base rule is skipped when
+        // there are no base declarations, but the element loop keeps
+        // running.
+        $resolved = makeResolved(
+            styles: [
+                'blocks' => [
+                    'core/quote' => [
+                        'elements' => [
+                            'link' => [
+                                'color' => ['text' => '#accent'],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        );
+
+        $this->resolver->shouldReceive( 'resolve' )->andReturn( $resolved );
+
+        $css = $this->emitter->emit();
+
+        expect( $css )
+            ->toContain( '.wp-block-quote a {' )
+            ->and( $css )->toContain( 'color: #accent;' )
+            // No stray empty `.wp-block-quote { }` base rule when the
+            // block has no base-level declarations.
+            ->and( $css )->not->toContain( ".wp-block-quote {\n}" );
+    } );
+
+    it( 'emits both the base block rule and its per-element overrides together (#208)', function (): void {
+        $resolved = makeResolved(
+            styles: [
+                'blocks' => [
+                    'core/quote' => [
+                        'typography' => ['fontStyle' => 'italic'],
+                        'elements'   => [
+                            'link' => [
+                                'color' => ['text' => '#accent'],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        );
+
+        $this->resolver->shouldReceive( 'resolve' )->andReturn( $resolved );
+
+        $css = $this->emitter->emit();
+
+        expect( $css )
+            ->toContain( '.wp-block-quote {' )
+            ->and( $css )->toContain( 'font-style: italic;' )
+            ->and( $css )->toContain( '.wp-block-quote a {' )
+            ->and( $css )->toContain( 'color: #accent;' );
+    } );
 } );
 
 describe( 'GlobalStylesEmitter cache', function (): void {
@@ -604,7 +810,7 @@ describe( 'GlobalStylesEmitter cache', function (): void {
         // Cache key carries the schema version so a deploy with a
         // bumped emitter automatically busts every cached entry
         // (Keystone #53). Mirror that here.
-        $cacheKey = 'cms.global-styles.css.v3.test-theme.' . $resolved->contentHash();
+        $cacheKey = 'cms.global-styles.css.v4.test-theme.' . $resolved->contentHash();
         expect( Cache::has( $cacheKey ) )->toBeTrue();
 
         $this->emitter->invalidate();


### PR DESCRIPTION
## Description

Extends `GlobalStylesEmitter::blockStyleBlocks()` to recurse into each block's `elements` map after emitting the base block rule. For each supported element (`link` / `heading` / `button`), the emitter composes the block selector with the element selector and reuses `stylesRootDeclarations()` for the property walk — closing the last major theme.json v3 coverage gap in the styles panel.

**Closes:** #208

## Type of Change

- [x] Enhancement (improves existing functionality)

## Related Issue

**Issue:** #208

## Motivation and Context

WP theme.json v3 explicitly permits per-block element overrides — e.g. `styles.blocks."core/quote".elements.link` maps to `.wp-block-quote a { … }`. Before this PR, the emitter walked the base block styles but silently dropped anything under `styles.blocks.{name}.elements.*`, so themes that follow WP's own per-block-element pattern got no visible styling.

## Changes Made

- Extracted the `link` / `heading` / `button` selector map from `elementStyleBlocks()` into a shared `ELEMENT_SELECTORS` class constant.
- `blockStyleBlocks()` now emits the base rule (if any) followed by per-element rules via the new `blockElementStyleBlocks()` helper.
- `composeBlockElementSelector()` distributes comma-joined element selectors across the block selector — `.wp-block-quote h1, .wp-block-quote h2, …` — never the naive concatenation `.wp-block-quote h1, h2, …`, which would let `h2…h6` leak out of block scope.
- Bumped `SCHEMA_VERSION` v3 → v4 so cached CSS invalidates on deploy.
- Preset-var translation (`var:preset|color|accent`) propagates into per-block-element values for free via the shared walker.

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS
- PHP Version: 8.4.3
- Project Version: cms-framework release/2.5

**Tests Performed:**
1. `./vendor/bin/pest tests/Unit/SiteEditor/GlobalStylesEmitterTest.php` — 30 passed / 125 assertions
2. `./vendor/bin/pest --filter=GlobalStyles` — 69 passed / 250 assertions (no regressions in resolver / filter / API tests)
3. Manual browser verification against the dev-sample theme in `artisanpack-ui-dev` — the emitted CSS at `/dev/global-styles.css` produces:
   - `.wp-block-quote a { color: var(--wp--preset--color--primary); font-weight: 700; }`
   - `.wp-block-artisanpack-card h1, .wp-block-artisanpack-card h2, …, .wp-block-artisanpack-card h6 { … }` (distribution verified, no scope leak)
   - `.wp-block-artisanpack-card .wp-element-button, .wp-block-artisanpack-card .wp-block-button__link { … }`

## Tests Added

- [x] Unit tests added/updated
- [x] All tests passing

**Test details:**

7 new cases in `GlobalStylesEmitterTest.php` covering:
- Basic `styles.blocks."core/quote".elements.link` → `.wp-block-quote a` emission.
- Custom-namespace + heading with distributed selector correctness.
- Button element with distributed compound selector.
- Preset-var translation (`var:preset|color|accent`) propagating into per-block-element values.
- Malformed / empty `elements` maps skip cleanly.
- Base block rule + per-element overrides co-emit.
- Elements-only shape (no base declarations) still emits element rules.

Plus a schema-version bump in the cache-key assertion (v3 → v4).

## Backwards Compatibility

- [x] This is backwards compatible

Adds new emission for keys currently dropped; existing themes that don't use `styles.blocks.{name}.elements.*` see identical output. The `SCHEMA_VERSION` bump busts every cached entry on deploy.

## Documentation

- [x] Inline code documentation added

## Pre-Submission Checklist

- [x] Code passes all tests
- [x] Code has been linted (php-cs-fixer clean on touched files)
- [x] Self-review completed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for per-block element style overrides, including links, headings, and buttons.
  * Improved selector handling for comma-separated elements to ensure styles apply only within the intended block.
  * Added support for preset values in per-element block styles.

* **Bug Fixes**
  * Prevented malformed or empty element style configurations from affecting other styles.
  * Updated style caching to reflect the latest output format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->