### PR TITLE
feat(site-editor): populate blocks for theme patterns in PatternResolver

### DIFF
--- a/src/Modules/SiteEditor/Resolution/PatternResolver.php
+++ b/src/Modules/SiteEditor/Resolution/PatternResolver.php
@@ -20,6 +20,7 @@ declare( strict_types=1 );
 namespace ArtisanPackUI\CMSFramework\Modules\SiteEditor\Resolution;
 
 use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Models\BlockPattern;
+use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Support\BlockMarkupParser;
 use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Support\PatternFileParser;
 use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Support\SlugValidator;
 use ArtisanPackUI\CMSFramework\Modules\Themes\Managers\ThemeManager;
@@ -249,7 +250,12 @@ class PatternResolver
             source         : BlockPattern::SOURCE_THEME,
             synced         : false,
             rawContent     : $parsed['content'],
-            blocks         : [],
+            // Parse the raw markup into WP-shape blocks up-front so pattern
+            // consumers (visual-editor's `PatternThumbnail`, Edit view) get
+            // the block tree in the initial payload rather than having to
+            // re-parse `rawContent` on the client. Previously hardcoded to
+            // `[]`, which forced the empty-state placeholder path (#204).
+            blocks         : BlockMarkupParser::parse( $parsed['content'] ),
             categories     : $parsed['categories'],
             blockTypes     : $parsed['block_types'],
             model          : null,
@@ -294,6 +300,6 @@ class PatternResolver
      */
     protected function humanizeSlug( string $slug ): string
     {
-        return ucwords( str_replace( ['-', '_'], ' ', $slug));
+        return ucwords( str_replace( ['-', '_'], ' ', $slug ) );
     }
 }

--- a/src/Modules/SiteEditor/Support/BlockMarkupParser.php
+++ b/src/Modules/SiteEditor/Support/BlockMarkupParser.php
@@ -1,0 +1,411 @@
+<?php
+
+/**
+ * Block Markup Parser
+ *
+ * Server-side port of the subset of WordPress's `parse_blocks()` we need to
+ * turn a raw block-markup string into the `[{blockName, attrs, innerBlocks,
+ * innerHTML, innerContent}, ...]` tree consumers expect. Emits the WP
+ * `parse_blocks()` shape verbatim — NOT the Gutenberg editor's BlockInstance
+ * shape (`{name, attributes, innerBlocks}`) that user patterns store in
+ * {@see \ArtisanPackUI\CMSFramework\Modules\SiteEditor\Models\BlockPattern}'s
+ * `block_content` column. The two shapes coexist in the pattern REST envelope's
+ * `content.blocks` field today; consumers that iterate blocks must sniff both
+ * key sets (see visual-editor's `PatternThumbnail.readBlockName` for the
+ * pattern).
+ *
+ * First consumer (#204): {@see PatternResolver::buildThemePattern()} — theme
+ * patterns are read from `.php` files on every request via
+ * {@see PatternFileParser}. Without a parsed block tree the pattern browser
+ * shows the "Empty pattern" placeholder for every shipped pattern. The parser
+ * is deliberately generic — the sibling `TemplateResolver` and
+ * `TemplatePartResolver` theme-file branches ship the same `blocks: []` gap
+ * and can drop this in as-is.
+ *
+ * ## Correctness scope
+ *
+ * The parser is a best-effort optimization for the common case, NOT a
+ * full-fidelity WP block parser. For editor correctness, the visual-editor
+ * client hydrates blocks via Gutenberg's own `parse(rawContent)` (see
+ * `hydrate-blocks.ts`), which is authoritative — this parser's output is
+ * only consumed by lightweight surfaces like the pattern thumbnail summary.
+ *
+ * Known limitations (any real-world case runs the client-side `parse()`
+ * fallback for correctness):
+ * - Unpaired `{` or `}` bytes inside a JSON attribute string value break
+ *   the regex's brace-balancing and cause the block to be interpreted as
+ *   freeform text. WP's real `WP_Block_Parser` uses a hand-coded tokenizer
+ *   specifically to sidestep this.
+ * - Mis-nested closers (e.g. `<!-- /wp:group -->` inside a `wp:paragraph`
+ *   body) get absorbed by the wrong recursion level. The outer container
+ *   looks closed even when its own closer was consumed elsewhere.
+ * - Block trees deeper than {@see self::MAX_DEPTH} are truncated at that
+ *   depth so we don't blow the PHP call stack under adversarial input.
+ * - PCRE runtime errors (backtrack / recursion / JIT stack limits) are
+ *   logged via `Log::warning` and treated as end-of-input so parsing
+ *   degrades to a partial tree rather than raising.
+ *
+ * @since      2.5.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Modules\SiteEditor\Support;
+
+use Illuminate\Support\Facades\Log;
+
+/**
+ * @since 2.5.0
+ */
+final class BlockMarkupParser
+{
+    /**
+     * Maximum nesting depth `parseChildren()` will recurse into before
+     * truncating a subtree. Chosen well below PHP's default C-stack and
+     * Xdebug's `max_nesting_level` (256) so a persisted-but-adversarial
+     * `block_content` payload can't crash the fpm worker on every render.
+     * Real theme patterns typically nest 3–6 levels; 64 is comfortable.
+     *
+     * @since 2.5.0
+     */
+    private const MAX_DEPTH = 64;
+
+    /**
+     * Match a block delimiter comment: `<!-- wp:namespace/name {json} -->`,
+     * `<!-- wp:namespace/name {json} /-->` (self-closing / void), or
+     * `<!-- /wp:namespace/name -->` (closer). The attribute JSON, if any,
+     * is captured verbatim and decoded per-match — the recursive `(?-1)`
+     * inside `attrs` balances nested `{}` inside the JSON blob. Note this
+     * balancing breaks when a JSON string value contains a lone `{` or `}`;
+     * see the class docblock's "Known limitations" section.
+     */
+    private const DELIMITER_REGEX = '/<!--\s+(?P<closer>\/)?wp:(?P<name>[a-z][a-z0-9_-]*\/[a-z][a-z0-9_-]*|[a-z][a-z0-9_-]*)\s*(?P<attrs>\{(?:(?>[^{}]+)|(?-1))*\})?\s*(?P<void>\/)?-->/';
+
+    /**
+     * UTF-8 byte-order mark. Some editors (older TextMate/Notepad) prepend
+     * one; stripping it here keeps a BOM'd theme-file from producing a
+     * spurious `blockName: null` freeform block for its own leading bytes.
+     *
+     * @since 2.5.0
+     */
+    private const UTF8_BOM = "\xEF\xBB\xBF";
+
+    /**
+     * Parse a raw block-markup string into the WP `parse_blocks()` shape.
+     *
+     * Freeform HTML between blocks becomes a `blockName: null` sibling with
+     * an empty attrs bag — matching what WP emits so downstream
+     * shape-agnostic consumers can treat the whole document as a uniform
+     * block list. An empty or whitespace-only input returns an empty array.
+     *
+     * @since 2.5.0
+     *
+     * @return array<int, array{blockName: string|null, attrs: array<string, mixed>, innerBlocks: array<int, array<string, mixed>>, innerHTML: string, innerContent: array<int, string|null>}>
+     */
+    public static function parse( string $markup ): array
+    {
+        if ( str_starts_with( $markup, self::UTF8_BOM ) ) {
+            $markup = substr( $markup, strlen( self::UTF8_BOM ) );
+        }
+
+        if ( '' === trim( $markup ) ) {
+            return [];
+        }
+
+        [$blocks] = self::parseChildren( $markup, 0, null, 0 );
+
+        return $blocks;
+    }
+
+    /**
+     * Walk `$markup` starting at `$offset`, collecting sibling blocks until
+     * either the end of input or a closer for `$parentName` is reached.
+     *
+     * Recursion feeds each open delimiter's body back through this method so
+     * innerBlocks are collected in the same pass — no separate tree walk.
+     * The returned offset points at the character immediately after the
+     * parent's closer (or at strlen for top-level calls) so the caller can
+     * resume from exactly where recursion left off. The returned
+     * `innerContent` interleaves freeform text with `null` markers (one per
+     * innerBlock, in document order) so a parent can carry the WP shape
+     * verbatim; top-level callers ignore it.
+     *
+     * A container that would recurse deeper than {@see self::MAX_DEPTH} is
+     * emitted with an empty `innerBlocks` / `innerContent`; its body is
+     * absorbed as-is into the parent's `innerHTML` via freeform text. The
+     * client's Gutenberg `parse()` fallback remains authoritative for the
+     * truncated subtree.
+     *
+     * @since 2.5.0
+     *
+     * @return array{0: array<int, array<string, mixed>>, 1: int, 2: array<int, string|null>}
+     *                                                                                        Tuple of `[blocks, nextOffset, innerContent]`.
+     */
+    private static function parseChildren( string $markup, int $offset, ?string $parentName, int $depth ): array
+    {
+        $blocks       = [];
+        $innerContent = [];
+        $cursor       = $offset;
+        $length       = strlen( $markup );
+
+        while ( $cursor < $length ) {
+            $matched = preg_match(
+                self::DELIMITER_REGEX,
+                $markup,
+                $match,
+                PREG_OFFSET_CAPTURE,
+                $cursor,
+            );
+
+            if ( false === $matched ) {
+                // PCRE runtime error — recursion / backtrack / JIT stack
+                // limit. Log the error code so silent parse truncation
+                // becomes observable, then treat the tail as freeform and
+                // fall out of the loop. Client-side Gutenberg `parse()`
+                // remains authoritative for correctness.
+                Log::warning(
+                    'BlockMarkupParser: preg_match failed; parse truncated at cursor.',
+                    [
+                        'pcre_error' => preg_last_error(),
+                        'cursor'     => $cursor,
+                        'length'     => $length,
+                    ],
+                );
+
+                self::absorbFreeform( substr( $markup, $cursor ), $parentName, $blocks, $innerContent );
+                $cursor = $length;
+
+                break;
+            }
+
+            if ( 1 !== $matched ) {
+                // No more delimiters — the rest of the buffer is freeform.
+                self::absorbFreeform( substr( $markup, $cursor ), $parentName, $blocks, $innerContent );
+                $cursor = $length;
+
+                break;
+            }
+
+            $delimiterOffset = (int) $match[0][1];
+            $delimiterText   = (string) $match[0][0];
+            $isCloser        = '' !== ( (string) ( $match['closer'][0] ?? '' ) );
+            $isVoid          = '' !== ( (string) ( $match['void'][0] ?? '' ) );
+            $name            = self::qualifyBlockName( (string) $match['name'][0] );
+            $attrsRaw        = (string) ( $match['attrs'][0] ?? '' );
+            $preText         = substr( $markup, $cursor, $delimiterOffset - $cursor );
+
+            if ( '' !== $preText ) {
+                self::absorbFreeform( $preText, $parentName, $blocks, $innerContent );
+            }
+
+            if ( $isCloser ) {
+                if ( null !== $parentName && $name === $parentName ) {
+                    return [
+                        $blocks,
+                        $delimiterOffset + strlen( $delimiterText ),
+                        $innerContent,
+                    ];
+                }
+
+                // Stray closer with no matching opener — treat the
+                // delimiter itself as freeform so we don't lose bytes.
+                self::absorbFreeform( $delimiterText, $parentName, $blocks, $innerContent );
+                $cursor = $delimiterOffset + strlen( $delimiterText );
+
+                continue;
+            }
+
+            $attrs          = self::decodeAttrs( $attrsRaw );
+            $afterDelimiter = $delimiterOffset + strlen( $delimiterText );
+
+            // Void blocks are just openers with no body — model them as an
+            // empty-children/empty-innerContent recursion so the assemble +
+            // parent-slot bookkeeping below runs the same tail for both
+            // shapes. `innerHtmlFrom([])` naturally returns ''.
+            if ( $isVoid ) {
+                $children   = [];
+                $childInner = [];
+                $nextCursor = $afterDelimiter;
+            } elseif ( $depth + 1 >= self::MAX_DEPTH ) {
+                // Depth cap — emit the opener as an empty container and
+                // stop recursing. The truncated body remains in `$markup`
+                // and will be re-absorbed as freeform by the caller once
+                // this call returns. Prevents PHP-stack blow-ups on
+                // adversarial input.
+                $children   = [];
+                $childInner = [];
+                $nextCursor = $afterDelimiter;
+            } else {
+                [$children, $nextCursor, $childInner] = self::parseChildren(
+                    $markup,
+                    $afterDelimiter,
+                    $name,
+                    $depth + 1,
+                );
+            }
+
+            $blocks[] = self::block(
+                $name,
+                $attrs,
+                $children,
+                self::innerHtmlFrom( $childInner ),
+                $childInner,
+            );
+
+            if ( null !== $parentName ) {
+                // A child block (void or container) contributes to the
+                // parent's innerContent as a `null` slot — the block itself
+                // is tracked via innerBlocks so its rendered HTML is not
+                // concatenated in. This keeps the parent's `innerContent`
+                // slots lined up 1:1 with `innerBlocks`.
+                $innerContent[] = null;
+            }
+
+            $cursor = $nextCursor;
+        }
+
+        return [$blocks, $cursor, $innerContent];
+    }
+
+    /**
+     * Route a freeform text segment into either the sibling block list
+     * (top-level walk) or the parent's innerContent slot list (nested walk).
+     *
+     * Top-level whitespace-only segments are dropped — they represent
+     * indentation between sibling top-level blocks and don't warrant a
+     * freeform entry. Nested walks keep every byte so a parent's
+     * `innerHTML` can round-trip verbatim.
+     *
+     * @since 2.5.0
+     *
+     * @param  array<int, array<string, mixed>>  $blocks
+     * @param  array<int, string|null>  $innerContent
+     */
+    private static function absorbFreeform( string $text, ?string $parentName, array &$blocks, array &$innerContent ): void
+    {
+        if ( null === $parentName ) {
+            if ( '' !== trim( $text ) ) {
+                $blocks[] = self::freeformBlock( $text );
+            }
+
+            return;
+        }
+
+        $innerContent[] = $text;
+    }
+
+    /**
+     * Concatenate the string entries of an `innerContent` list to produce
+     * a block's `innerHTML` — matches WP's convention that `innerHTML` is
+     * the sum of the freeform slots, with `null` (child-block) markers
+     * dropped.
+     *
+     * @since 2.5.0
+     *
+     * @param  array<int, string|null>  $innerContent
+     */
+    private static function innerHtmlFrom( array $innerContent ): string
+    {
+        $html = '';
+
+        foreach ( $innerContent as $slot ) {
+            if ( is_string( $slot ) ) {
+                $html .= $slot;
+            }
+        }
+
+        return $html;
+    }
+
+    /**
+     * Namespace-qualify a bare block name (e.g. `paragraph` → `core/paragraph`).
+     *
+     * WP's own parser stores block names verbatim, but its lookup layer
+     * treats an un-namespaced name as core. Doing the expansion here keeps
+     * downstream consumers (visual-editor tree walk, thumbnail
+     * `readBlockName`) from having to sniff the delimiter twice.
+     *
+     * @since 2.5.0
+     */
+    private static function qualifyBlockName( string $name ): string
+    {
+        return str_contains( $name, '/' ) ? $name : 'core/' . $name;
+    }
+
+    /**
+     * Decode a delimiter's attribute JSON, returning an empty bag on any
+     * failure — matches WP's forgiving behavior where a broken attrs blob
+     * degrades the block rather than dropping it entirely. Logs the JSON
+     * error so silent attr-loss becomes observable during theme dev.
+     *
+     * @since 2.5.0
+     *
+     * @return array<string, mixed>
+     */
+    private static function decodeAttrs( string $attrsRaw ): array
+    {
+        if ( '' === $attrsRaw ) {
+            return [];
+        }
+
+        $decoded = json_decode( $attrsRaw, true );
+
+        if ( is_array( $decoded ) ) {
+            return $decoded;
+        }
+
+        Log::warning(
+            'BlockMarkupParser: failed to decode block attribute JSON; degrading to empty attrs.',
+            [
+                'json_error' => json_last_error_msg(),
+                'attrs_raw'  => $attrsRaw,
+            ],
+        );
+
+        return [];
+    }
+
+    /**
+     * Assemble a block array in the WP `parse_blocks()` shape.
+     *
+     * @since 2.5.0
+     *
+     * @param  array<string, mixed>  $attrs
+     * @param  array<int, array<string, mixed>>  $innerBlocks
+     * @param  array<int, string|null>  $innerContent
+     *
+     * @return array{blockName: string|null, attrs: array<string, mixed>, innerBlocks: array<int, array<string, mixed>>, innerHTML: string, innerContent: array<int, string|null>}
+     */
+    private static function block( string $name, array $attrs, array $innerBlocks, string $innerHtml, array $innerContent ): array
+    {
+        return [
+            'blockName'    => $name,
+            'attrs'        => $attrs,
+            'innerBlocks'  => $innerBlocks,
+            'innerHTML'    => $innerHtml,
+            'innerContent' => $innerContent,
+        ];
+    }
+
+    /**
+     * Freeform HTML sitting between siblings becomes a `blockName: null`
+     * entry — matches what WP's parser emits so downstream shape-agnostic
+     * consumers keep working. Note: `null` here is the WP-spec value, not
+     * a sentinel — visual-editor's `PatternThumbnail` translates it to
+     * `core/freeform` for display.
+     *
+     * @since 2.5.0
+     *
+     * @return array{blockName: null, attrs: array<string, mixed>, innerBlocks: array<int, array<string, mixed>>, innerHTML: string, innerContent: array<int, string|null>}
+     */
+    private static function freeformBlock( string $html ): array
+    {
+        return [
+            'blockName'    => null,
+            'attrs'        => [],
+            'innerBlocks'  => [],
+            'innerHTML'    => $html,
+            'innerContent' => [$html],
+        ];
+    }
+}

--- a/tests/Unit/SiteEditor/BlockMarkupParserTest.php
+++ b/tests/Unit/SiteEditor/BlockMarkupParserTest.php
@@ -1,0 +1,269 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Support\BlockMarkupParser;
+
+describe( 'BlockMarkupParser::parse()', function (): void {
+    it( 'returns an empty array for empty or whitespace-only input', function (): void {
+        expect( BlockMarkupParser::parse( '' ) )->toBe( [] )
+            ->and( BlockMarkupParser::parse( "   \n\t  " ) )->toBe( [] );
+    } );
+
+    it( 'parses a single flat block with no attributes', function (): void {
+        $markup = '<!-- wp:paragraph --><p>Hello</p><!-- /wp:paragraph -->';
+
+        $blocks = BlockMarkupParser::parse( $markup );
+
+        expect( $blocks )->toHaveCount( 1 )
+            ->and( $blocks[0]['blockName'] )->toBe( 'core/paragraph' )
+            ->and( $blocks[0]['attrs'] )->toBe( [] )
+            ->and( $blocks[0]['innerBlocks'] )->toBe( [] )
+            ->and( $blocks[0]['innerHTML'] )->toBe( '<p>Hello</p>' );
+    } );
+
+    it( 'decodes attribute JSON verbatim, including nested objects', function (): void {
+        $markup = '<!-- wp:heading {"level":2,"style":{"typography":{"fontSize":"32px"}}} --><h2>Hi</h2><!-- /wp:heading -->';
+
+        $blocks = BlockMarkupParser::parse( $markup );
+
+        expect( $blocks[0]['attrs'] )->toBe( [
+            'level' => 2,
+            'style' => ['typography' => ['fontSize' => '32px']],
+        ] );
+    } );
+
+    it( 'expands unnamespaced block names to core/*', function (): void {
+        $markup = '<!-- wp:paragraph --><p>Hi</p><!-- /wp:paragraph -->';
+
+        expect( BlockMarkupParser::parse( $markup )[0]['blockName'] )->toBe( 'core/paragraph' );
+    } );
+
+    it( 'preserves namespaced block names verbatim', function (): void {
+        $markup = '<!-- wp:artisanpack/hero --><div>Hi</div><!-- /wp:artisanpack/hero -->';
+
+        expect( BlockMarkupParser::parse( $markup )[0]['blockName'] )->toBe( 'artisanpack/hero' );
+    } );
+
+    it( 'treats self-closing (void) blocks as attribute-only leaves', function (): void {
+        $markup = '<!-- wp:site-title /-->';
+
+        $blocks = BlockMarkupParser::parse( $markup );
+
+        expect( $blocks )->toHaveCount( 1 )
+            ->and( $blocks[0]['blockName'] )->toBe( 'core/site-title' )
+            ->and( $blocks[0]['innerBlocks'] )->toBe( [] )
+            ->and( $blocks[0]['innerHTML'] )->toBe( '' )
+            ->and( $blocks[0]['innerContent'] )->toBe( [] );
+    } );
+
+    it( 'nests innerBlocks under a container opener', function (): void {
+        $markup = <<<'HTML'
+<!-- wp:group --><div class="wp-block-group">
+    <!-- wp:heading --><h2>Title</h2><!-- /wp:heading -->
+    <!-- wp:paragraph --><p>Body</p><!-- /wp:paragraph -->
+</div><!-- /wp:group -->
+HTML;
+
+        $blocks = BlockMarkupParser::parse( $markup );
+
+        expect( $blocks )->toHaveCount( 1 )
+            ->and( $blocks[0]['blockName'] )->toBe( 'core/group' )
+            ->and( $blocks[0]['innerBlocks'] )->toHaveCount( 2 )
+            ->and( $blocks[0]['innerBlocks'][0]['blockName'] )->toBe( 'core/heading' )
+            ->and( $blocks[0]['innerBlocks'][0]['innerHTML'] )->toBe( '<h2>Title</h2>' )
+            ->and( $blocks[0]['innerBlocks'][1]['blockName'] )->toBe( 'core/paragraph' )
+            ->and( $blocks[0]['innerBlocks'][1]['innerHTML'] )->toBe( '<p>Body</p>' );
+    } );
+
+    it( 'interleaves freeform slots + null markers on innerContent and derives innerHTML from just the string slots', function (): void {
+        // Two invariants share the fixture: the innerContent shape
+        // (freeform slots interleaved with one `null` per innerBlock), and
+        // innerHTML as the concatenation of only the string slots — matches
+        // WP's own contract that innerHTML == implode of the string entries
+        // of innerContent.
+        $markup = <<<'HTML'
+<!-- wp:group --><div>
+<!-- wp:heading --><h2>H</h2><!-- /wp:heading -->
+</div><!-- /wp:group -->
+HTML;
+
+        $blocks = BlockMarkupParser::parse( $markup );
+
+        $slots = $blocks[0]['innerContent'];
+
+        expect( $slots )->toHaveCount( 3 )
+            ->and( $slots[0] )->toContain( '<div>' )
+            ->and( $slots[1] )->toBeNull()
+            ->and( $slots[2] )->toContain( '</div>' )
+            ->and( $blocks[0]['innerHTML'] )->toContain( '<div>' )
+            ->and( $blocks[0]['innerHTML'] )->toContain( '</div>' )
+            ->and( $blocks[0]['innerHTML'] )->not->toContain( '<h2>' );
+    } );
+
+    it( 'handles deep three-level nesting', function (): void {
+        $markup = <<<'HTML'
+<!-- wp:group --><div>
+    <!-- wp:columns --><div class="wp-block-columns">
+        <!-- wp:column --><div class="wp-block-column">
+            <!-- wp:paragraph --><p>Leaf</p><!-- /wp:paragraph -->
+        </div><!-- /wp:column -->
+    </div><!-- /wp:columns -->
+</div><!-- /wp:group -->
+HTML;
+
+        $blocks = BlockMarkupParser::parse( $markup );
+
+        expect( $blocks[0]['blockName'] )->toBe( 'core/group' )
+            ->and( $blocks[0]['innerBlocks'][0]['blockName'] )->toBe( 'core/columns' )
+            ->and( $blocks[0]['innerBlocks'][0]['innerBlocks'][0]['blockName'] )->toBe( 'core/column' )
+            ->and( $blocks[0]['innerBlocks'][0]['innerBlocks'][0]['innerBlocks'][0]['blockName'] )->toBe( 'core/paragraph' )
+            ->and( $blocks[0]['innerBlocks'][0]['innerBlocks'][0]['innerBlocks'][0]['innerHTML'] )->toBe( '<p>Leaf</p>' );
+    } );
+
+    it( 'returns multiple top-level siblings with indentation stripped between them', function (): void {
+        $markup = <<<'HTML'
+<!-- wp:heading --><h2>One</h2><!-- /wp:heading -->
+
+<!-- wp:paragraph --><p>Two</p><!-- /wp:paragraph -->
+HTML;
+
+        $blocks = BlockMarkupParser::parse( $markup );
+
+        // No freeform sibling for the blank line between the two — top-level
+        // whitespace-only text is dropped so consumers don't see phantom
+        // `blockName: null` entries.
+        expect( $blocks )->toHaveCount( 2 )
+            ->and( $blocks[0]['blockName'] )->toBe( 'core/heading' )
+            ->and( $blocks[1]['blockName'] )->toBe( 'core/paragraph' );
+    } );
+
+    it( 'emits a blockName-null freeform sibling for real HTML between top-level blocks', function (): void {
+        $markup = <<<'HTML'
+<!-- wp:heading --><h2>One</h2><!-- /wp:heading -->
+<p>Freeform in the middle.</p>
+<!-- wp:paragraph --><p>Two</p><!-- /wp:paragraph -->
+HTML;
+
+        $blocks = BlockMarkupParser::parse( $markup );
+
+        expect( $blocks )->toHaveCount( 3 )
+            ->and( $blocks[0]['blockName'] )->toBe( 'core/heading' )
+            ->and( $blocks[1]['blockName'] )->toBeNull()
+            ->and( $blocks[1]['innerHTML'] )->toContain( 'Freeform in the middle.' )
+            ->and( $blocks[2]['blockName'] )->toBe( 'core/paragraph' );
+    } );
+
+    it( 'degrades a block with malformed attribute JSON to an empty attrs bag rather than dropping it', function (): void {
+        // Trailing-comma JSON: brace-balanced (so the regex captures it),
+        // but `json_decode` returns null. The block must survive as a
+        // real `core/paragraph` with empty attrs — NOT collapse to a
+        // freeform sibling. Pinning both keys prevents a future regex
+        // tightening from silently switching the degradation path.
+        $markup = '<!-- wp:paragraph {"align":"center",} --><p>Body</p><!-- /wp:paragraph -->';
+
+        $blocks = BlockMarkupParser::parse( $markup );
+
+        expect( $blocks )->toHaveCount( 1 )
+            ->and( $blocks[0]['blockName'] )->toBe( 'core/paragraph' )
+            ->and( $blocks[0]['attrs'] )->toBe( [] )
+            ->and( $blocks[0]['innerHTML'] )->toContain( 'Body' );
+    } );
+
+    it( 'strips a leading UTF-8 BOM so BOM-prefixed pattern files do not emit a phantom freeform block', function (): void {
+        $markup = "\xEF\xBB\xBF<!-- wp:paragraph --><p>body</p><!-- /wp:paragraph -->";
+
+        $blocks = BlockMarkupParser::parse( $markup );
+
+        // Without BOM stripping the first byte-triplet would produce a
+        // top-level `blockName: null` sibling; the paragraph must be the
+        // only entry.
+        expect( $blocks )->toHaveCount( 1 )
+            ->and( $blocks[0]['blockName'] )->toBe( 'core/paragraph' );
+    } );
+
+    it( 'preserves innerBlocks/innerContent interleave ordering for containers with 2+ children', function (): void {
+        // Two innerBlocks with distinct freeform text between them —
+        // asserts the `[string, null, string, null, string]` interleave
+        // shape that WP contracts on. Without this coverage a regression
+        // that pushed all null markers to one end would still pass the
+        // single-child interleave case at line 79.
+        $markup = <<<'HTML'
+<!-- wp:group --><div>
+BEFORE
+<!-- wp:heading --><h2>H</h2><!-- /wp:heading -->
+MIDDLE
+<!-- wp:paragraph --><p>P</p><!-- /wp:paragraph -->
+AFTER
+</div><!-- /wp:group -->
+HTML;
+
+        $blocks = BlockMarkupParser::parse( $markup );
+
+        $slots = $blocks[0]['innerContent'];
+
+        // Expected shape: [pre-heading, null, between-heading-and-para, null, post-para]
+        expect( $slots )->toHaveCount( 5 )
+            ->and( $slots[0] )->toContain( 'BEFORE' )
+            ->and( $slots[1] )->toBeNull()
+            ->and( $slots[2] )->toContain( 'MIDDLE' )
+            ->and( $slots[3] )->toBeNull()
+            ->and( $slots[4] )->toContain( 'AFTER' )
+            ->and( $blocks[0]['innerBlocks'] )->toHaveCount( 2 )
+            ->and( $blocks[0]['innerBlocks'][0]['blockName'] )->toBe( 'core/heading' )
+            ->and( $blocks[0]['innerBlocks'][1]['blockName'] )->toBe( 'core/paragraph' );
+    } );
+
+    it( 'caps recursion at MAX_DEPTH so an adversarially-nested tree does not blow the PHP call stack', function (): void {
+        // 200 nested `wp:group` openers — well past the parser's MAX_DEPTH
+        // cap. The exact truncation shape is implementation detail (the
+        // capped level flattens its remaining openers into siblings, and
+        // unmatched closers at the top level become freeform); the
+        // invariant we care about is "parse() returns without raising or
+        // exhausting the C stack, and the outer `core/group` is still
+        // recognizable as the first result".
+        $depth   = 200;
+        $openers = str_repeat( '<!-- wp:group --><div>', $depth );
+        $closers = str_repeat( '</div><!-- /wp:group -->', $depth );
+
+        $blocks = BlockMarkupParser::parse( $openers . 'leaf' . $closers );
+
+        expect( $blocks )->not->toBe( [] )
+            ->and( $blocks[0]['blockName'] )->toBe( 'core/group' );
+    } );
+
+    it( 'parses a realistic full theme pattern (group > heading + paragraph + buttons > button)', function (): void {
+        $markup = <<<'HTML'
+<!-- wp:group {"style":{"spacing":{"padding":{"top":"2rem"}}},"backgroundColor":"primary","layout":{"type":"constrained"}} -->
+<div class="wp-block-group has-primary-background-color has-background" style="padding-top:2rem">
+    <!-- wp:heading {"level":2,"textAlign":"center"} -->
+    <h2 class="has-text-align-center">Try the editor</h2>
+    <!-- /wp:heading -->
+
+    <!-- wp:paragraph {"align":"center"} -->
+    <p class="has-text-align-center">Demo copy.</p>
+    <!-- /wp:paragraph -->
+
+    <!-- wp:buttons {"layout":{"type":"flex","justifyContent":"center"}} -->
+    <div class="wp-block-buttons">
+        <!-- wp:button -->
+        <div class="wp-block-button"><a class="wp-block-button__link">Open</a></div>
+        <!-- /wp:button -->
+    </div>
+    <!-- /wp:buttons -->
+</div>
+<!-- /wp:group -->
+HTML;
+
+        $blocks = BlockMarkupParser::parse( $markup );
+
+        expect( $blocks )->toHaveCount( 1 )
+            ->and( $blocks[0]['blockName'] )->toBe( 'core/group' )
+            ->and( $blocks[0]['attrs']['backgroundColor'] )->toBe( 'primary' )
+            ->and( $blocks[0]['innerBlocks'] )->toHaveCount( 3 )
+            ->and( $blocks[0]['innerBlocks'][0]['blockName'] )->toBe( 'core/heading' )
+            ->and( $blocks[0]['innerBlocks'][1]['blockName'] )->toBe( 'core/paragraph' )
+            ->and( $blocks[0]['innerBlocks'][2]['blockName'] )->toBe( 'core/buttons' )
+            ->and( $blocks[0]['innerBlocks'][2]['innerBlocks'][0]['blockName'] )->toBe( 'core/button' );
+    } );
+} );

--- a/tests/Unit/SiteEditor/PatternResolverTest.php
+++ b/tests/Unit/SiteEditor/PatternResolverTest.php
@@ -65,7 +65,39 @@ PHP );
             ->and( $result->blockTypes )->toEqual( ['core/post-content'] )
             ->and( $result->rawContent )->toContain( 'Hero copy' )
             ->and( $result->synced )->toBeFalse()
-            ->and( $result->wpId() )->toBe( 0 );
+            ->and( $result->wpId() )->toBe( 0 )
+            // Theme patterns must carry a parsed block tree in `blocks` so
+            // visual-editor's pattern browser and Edit view don't fall
+            // through to the "Empty pattern" placeholder (#204).
+            ->and( $result->blocks )->toHaveCount( 1 )
+            ->and( $result->blocks[0]['blockName'] )->toBe( 'core/paragraph' )
+            ->and( $result->blocks[0]['innerHTML'] )->toContain( 'Hero copy' );
+    } );
+
+    it( 'parses a nested container theme pattern into a full innerBlocks tree', function (): void {
+        File::put( $this->themeFiles . '/cta.php', <<<'PHP'
+<?php
+/**
+ * Title: CTA
+ * Categories: featured
+ */
+?>
+<!-- wp:group {"backgroundColor":"primary"} -->
+<div class="wp-block-group">
+    <!-- wp:heading {"level":2} --><h2>Try it</h2><!-- /wp:heading -->
+    <!-- wp:paragraph --><p>Body</p><!-- /wp:paragraph -->
+</div>
+<!-- /wp:group -->
+PHP );
+
+        $result = $this->resolver->resolve( 'cta' );
+
+        expect( $result->blocks )->toHaveCount( 1 )
+            ->and( $result->blocks[0]['blockName'] )->toBe( 'core/group' )
+            ->and( $result->blocks[0]['attrs'] )->toBe( ['backgroundColor' => 'primary'] )
+            ->and( $result->blocks[0]['innerBlocks'] )->toHaveCount( 2 )
+            ->and( $result->blocks[0]['innerBlocks'][0]['blockName'] )->toBe( 'core/heading' )
+            ->and( $result->blocks[0]['innerBlocks'][1]['blockName'] )->toBe( 'core/paragraph' );
     } );
 
     it( 'falls back to a humanized slug when the theme file omits the Title header', function (): void {
@@ -226,7 +258,7 @@ describe( 'PatternResolver::toFilterMap()', function (): void {
  * Block Types: core/post-content
  */
 ?>
-<!-- hero -->
+<!-- wp:paragraph --><p>Hero</p><!-- /wp:paragraph -->
 PHP );
 
         $map = $this->resolver->toFilterMap();
@@ -245,7 +277,12 @@ PHP );
             ] )
             ->and( $map['hero']['slug'] )->toBe( 'hero' )
             ->and( $map['hero']['source'] )->toBe( BlockPattern::SOURCE_THEME )
-            ->and( $map['hero']['synced'] )->toBeFalse();
+            ->and( $map['hero']['synced'] )->toBeFalse()
+            // The filter payload must ship a parsed block tree so the
+            // visual-editor consumer doesn't fall through to the empty-
+            // state placeholder for theme-shipped patterns (#204).
+            ->and( $map['hero']['blocks'] )->toHaveCount( 1 )
+            ->and( $map['hero']['blocks'][0]['blockName'] )->toBe( 'core/paragraph' );
     } );
 } );
 


### PR DESCRIPTION
## Description

`PatternResolver::buildThemePattern()` previously hardcoded `blocks: []`, which caused every theme-shipped pattern to render as an "Empty pattern" placeholder in the visual-editor pattern browser (all 82 patterns on ArtisanPack UI's dev-sample theme) and open as an empty canvas until the client's `hydrateBlocks()` re-parsed `content.raw`.

This PR ports a subset of WordPress's `parse_blocks()` into a new `BlockMarkupParser` support class and wires it into the theme-file branch of the resolver.

**Closes:** #204

## Type of Change

- [x] Bug fix (fixes an issue)
- [x] Enhancement (improves existing functionality)

## Related Issue

**Issue:** #204

## Motivation and Context

Issue #204 describes theme patterns rendering as empty placeholders because `buildThemePattern()` hardcoded `blocks: []`. The issue lists three options; visual-editor already has the client-side workaround (option 3) via `PatternThumbnail`'s `parse(rawContent)` fallback. This PR takes option 1 (server-side parse) so the initial payload carries usable blocks and the client's fallback becomes the exception path rather than the norm.

## Changes Made

- **New:** `src/Modules/SiteEditor/Support/BlockMarkupParser.php` — hand-rolled PHP port of a subset of WP's `parse_blocks()`. Emits the WP shape `{blockName, attrs, innerBlocks, innerHTML, innerContent}` and handles flat blocks, nested containers, void (self-closing) blocks, freeform HTML between blocks, and forgiving attr JSON decoding.
- **Modified:** `src/Modules/SiteEditor/Resolution/PatternResolver.php` — `buildThemePattern()` now calls `BlockMarkupParser::parse($parsed['content'])` instead of hardcoding `[]`.
- **New:** `tests/Unit/SiteEditor/BlockMarkupParserTest.php` — 15 test cases covering flat, nested, void, freeform, malformed JSON, BOM stripping, depth-cap, multi-child interleaving, and a realistic full-pattern round-trip.
- **Modified:** `tests/Unit/SiteEditor/PatternResolverTest.php` — augmented existing tests to assert theme patterns now ship populated `blocks`; added a nested-container assertion; updated the `toFilterMap` fixture.

## Design notes (from local `/code-review`)

The parser is documented as a **best-effort optimization for the common case**, not a full-fidelity WP block parser. Client-side Gutenberg `parse(rawContent)` in `hydrateBlocks()` remains authoritative for editor correctness. Known limitations are called out in the class docblock:

- Unpaired `{` or `}` bytes inside a JSON attribute string value break the regex's brace-balancing and cause the block to be interpreted as freeform. WP's real `WP_Block_Parser` uses a hand-coded tokenizer specifically to sidestep this.
- Mis-nested closers (e.g. `<!-- /wp:group -->` inside a `wp:paragraph` body) get absorbed by the wrong recursion level.
- Block trees deeper than `MAX_DEPTH` (64) truncate at that depth to prevent PHP call-stack blow-ups under adversarial input.
- PCRE runtime errors (backtrack / recursion / JIT stack limits) are logged via `Log::warning` and treated as end-of-input so parsing degrades to a partial tree rather than raising.

For the pattern-thumbnail summary and the Edit view's raw-first hydration path, these limitations are cosmetic at worst.

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS 15.5
- Browser: Chrome / visual-editor pattern browser
- PHP Version: 8.4.23
- Project Version: cms-framework 2.5 (release/2.5)

**Tests Performed:**
1. `./vendor/bin/pest tests/Unit/SiteEditor/` — 127 tests passing (399 assertions), including 15 new `BlockMarkupParserTest` cases + augmented `PatternResolverTest`.
2. Manual test in the artisanpack-ui-dev app: theme patterns in the "Unsynced patterns" view now render their block-tree summary (e.g. Call to Action shows `core/group > core/heading, core/paragraph, core/buttons > core/button`) instead of the "Empty pattern" placeholder.
3. Verified Edit view still opens correctly for theme patterns — client-side `parse(rawContent)` in `hydrateBlocks()` is the authoritative path and this change doesn't affect it.

## Accessibility Tests Run

- [x] N/A — server-side parser has no direct accessibility surface. Existing pattern-browser a11y is unaffected.

## Tests Added

- [x] Unit tests added/updated
- [x] All tests passing

**Test details:** 15 new cases in `BlockMarkupParserTest.php` covering parse shape, freeform siblings, BOM stripping, depth-cap recursion, multi-child interleaving, malformed JSON degradation, and a realistic nested pattern. `PatternResolverTest.php` augmented with block-tree assertions on the theme-pattern happy path.

## Documentation

- [x] Inline code documentation added

**Documentation details:** Class docblock on `BlockMarkupParser` documents the WP-shape output, known limitations, and the "client-side Gutenberg parse remains authoritative" contract.

## Follow-ups (out of scope for this PR)

Surfaced during `/code-review`; not addressed here to keep the PR scoped to #204:

1. **`TemplateResolver` / `TemplatePartResolver` have the same `blocks: []` gap.** The parser is generic and can drop into both — will file as follow-up issues.
2. **`PatternThumbnail.readBlockName` (visual-editor) returns `core/missing` for `blockName: null` freeform entries** — should return `core/freeform` to match what Gutenberg's own `parse()` produces on the client-side path. Will file in the visual-editor repo.
3. **`PatternThumbnail` docblock in visual-editor references the removed `blocks: []` sentinel** — will update alongside #2.
4. **Wire-size doubling on the theme-pattern REST payload** — `content.raw` + `content.blocks[*].innerHTML/innerContent` now carry overlapping data. If we want to pay the parse cost, we could drop `innerHTML`/`innerContent` from the serialized envelope since no client consumer reads them.
5. **`PatternResolver::all()` / `toFilterMap()` are not memoized per-request.** Every filter fire re-walks the themes directory + re-parses. Cheap win but requires an invalidation contract for `cloneToUser` and filter contributors — separate scoped work.
6. **Cross-request pattern-file cache** — flagged in #204 itself as "needs its own cache layer keyed on file mtime + content hash". Follow-up.

## Pre-Submission Checklist

- [x] Followed contributing guidelines
- [x] Code passes all tests (127/127 in `tests/Unit/SiteEditor/`)
- [x] Code has been linted (`composer fix` applied)
- [x] Self-review completed (via `/simplify` and `/code-review` skill passes)
- [x] Comments added for complex code

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Theme-backed patterns now include structured block data when resolved.
  * Added support for parsing WordPress-style block markup, including nested, void, namespaced, and freeform content.

* **Bug Fixes**
  * Improved handling of malformed block attributes, stray delimiters, UTF-8 BOMs, and deeply nested content.

* **Tests**
  * Added comprehensive coverage for block parsing and theme pattern resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->