### PR TITLE
fix: stream update downloads to disk and catch fatals so hosts recover

### DIFF
--- a/src/Modules/Core/Updates/Managers/ApplicationUpdateManager.php
+++ b/src/Modules/Core/Updates/Managers/ApplicationUpdateManager.php
@@ -9,12 +9,12 @@ use ArtisanPackUI\CMSFramework\Modules\Core\Updates\Exceptions\UpdateException;
 use ArtisanPackUI\CMSFramework\Modules\Core\Updates\UpdateChecker;
 use ArtisanPackUI\CMSFramework\Modules\Core\Updates\UpdateCheckerFactory;
 use ArtisanPackUI\CMSFramework\Modules\Core\Updates\ValueObjects\UpdateInfo;
-use Exception;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Process;
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
+use Throwable;
 use ZipArchive;
 
 /**
@@ -112,7 +112,7 @@ class ApplicationUpdateManager
             $this->disableMaintenanceMode();
 
             return true;
-        } catch ( Exception $e ) {
+        } catch ( Throwable $e ) {
             // Rollback on failure
             $this->handleUpdateFailure( $e );
 
@@ -557,7 +557,7 @@ class ApplicationUpdateManager
     {
         try {
             Artisan::call( 'migrate', ['--force' => true] );
-        } catch ( Exception $e ) {
+        } catch ( Throwable $e ) {
             throw UpdateException::migrationFailed( $e->getMessage() );
         }
     }
@@ -600,7 +600,7 @@ class ApplicationUpdateManager
     {
         try {
             Artisan::call( 'down', ['--render' => 'errors::503'] );
-        } catch ( Exception $e ) {
+        } catch ( Throwable $e ) {
             throw UpdateException::maintenanceModeFailure( 'enable' );
         }
     }
@@ -616,7 +616,7 @@ class ApplicationUpdateManager
     {
         try {
             Artisan::call( 'up' );
-        } catch ( Exception $e ) {
+        } catch ( Throwable $e ) {
             throw UpdateException::maintenanceModeFailure( 'disable' );
         }
     }
@@ -626,9 +626,9 @@ class ApplicationUpdateManager
      *
      * @since 1.0.0
      *
-     * @param  Exception  $exception  The exception that caused failure
+     * @param  Throwable  $exception  The throwable that caused failure
      */
-    protected function handleUpdateFailure( Exception $exception ): void
+    protected function handleUpdateFailure( Throwable $exception ): void
     {
         // Log the original exception for debugging
         \Illuminate\Support\Facades\Log::error( 'Update failed, beginning rollback', [
@@ -641,15 +641,18 @@ class ApplicationUpdateManager
         // Attempt to disable maintenance mode
         try {
             $this->disableMaintenanceMode();
-        } catch ( Exception $e ) {
-            // Maintenance mode failure is not critical during rollback
+        } catch ( Throwable $e ) {
+            \Illuminate\Support\Facades\Log::error(
+                'Failed to disable maintenance mode during update rollback; host may remain in maintenance mode.',
+                ['exception' => $e->getMessage()],
+            );
         }
 
         // If we have a backup, attempt rollback
         if ( $this->backupPath && File::exists( $this->backupPath ) ) {
             try {
                 $this->rollback( $this->backupPath );
-            } catch ( Exception $e ) {
+            } catch ( Throwable $e ) {
                 // Rollback failed - this is critical
                 throw UpdateException::rollbackFailed( $e->getMessage());
             }

--- a/src/Modules/Core/Updates/Sources/GitHubUpdateSource.php
+++ b/src/Modules/Core/Updates/Sources/GitHubUpdateSource.php
@@ -11,6 +11,7 @@ use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Str;
 use InvalidArgumentException;
+use Throwable;
 
 /**
  * GitHub Update Source
@@ -159,17 +160,22 @@ class GitHubUpdateSource implements UpdateSourceInterface
             $headers['Authorization'] = "token {$this->accessToken}";
         }
 
-        $response = Http::withHeaders( $headers )
-            ->timeout( config( 'cms.updates.download_timeout', 300 ) )
-            ->get( $downloadUrl );
+        try {
+            $response = Http::withHeaders( $headers )
+                ->timeout( config( 'cms.updates.download_timeout', 300 ) )
+                ->sink( $tempPath )
+                ->get( $downloadUrl );
 
-        if ( ! $response->successful() ) {
-            throw UpdateException::downloadFailed( $downloadUrl );
+            if ( ! $response->successful() ) {
+                throw UpdateException::downloadFailed( $downloadUrl );
+            }
+
+            return $tempPath;
+        } catch ( Throwable $e ) {
+            File::delete( $tempPath );
+
+            throw $e;
         }
-
-        File::put( $tempPath, $response->body() );
-
-        return $tempPath;
     }
 
     /**

--- a/src/Modules/Core/Updates/Sources/GitLabUpdateSource.php
+++ b/src/Modules/Core/Updates/Sources/GitLabUpdateSource.php
@@ -151,17 +151,22 @@ class GitLabUpdateSource implements UpdateSourceInterface
             $headers['PRIVATE-TOKEN'] = $this->accessToken;
         }
 
-        $response = Http::withHeaders( $headers )
-            ->timeout( config( 'cms.updates.download_timeout', 300 ) )
-            ->get( $downloadUrl );
+        try {
+            $response = Http::withHeaders( $headers )
+                ->timeout( config( 'cms.updates.download_timeout', 300 ) )
+                ->sink( $tempPath )
+                ->get( $downloadUrl );
 
-        if ( ! $response->successful() ) {
-            throw UpdateException::downloadFailed( $downloadUrl );
+            if ( ! $response->successful() ) {
+                throw UpdateException::downloadFailed( $downloadUrl );
+            }
+
+            return $tempPath;
+        } catch ( Throwable $e ) {
+            File::delete( $tempPath );
+
+            throw $e;
         }
-
-        File::put( $tempPath, $response->body() );
-
-        return $tempPath;
     }
 
     /**

--- a/tests/Unit/Updates/ApplicationUpdateManagerTest.php
+++ b/tests/Unit/Updates/ApplicationUpdateManagerTest.php
@@ -8,6 +8,7 @@ use ArtisanPackUI\CMSFramework\Modules\Core\Updates\Exceptions\UpdateException;
 use ArtisanPackUI\CMSFramework\Modules\Core\Updates\Managers\ApplicationUpdateManager;
 use ArtisanPackUI\CMSFramework\Modules\Core\Updates\UpdateChecker;
 use ArtisanPackUI\CMSFramework\Modules\Core\Updates\ValueObjects\UpdateInfo;
+use Error;
 use Illuminate\Support\Facades\Log;
 use Orchestra\Testbench\TestCase;
 use ReflectionClass;
@@ -283,6 +284,52 @@ class ApplicationUpdateManagerTest extends TestCase
         $method->setAccessible( true );
 
         $method->invoke( $manager, '/does/not/matter.zip', $updateInfo, '2.0.0' );
+    }
+
+    /**
+     * Test that a fatal `\Error` during the update disables maintenance mode
+     * and rethrows the error, rather than leaving the host stranded.
+     *
+     * @since 2.5.1
+     */
+    public function test_perform_update_disables_maintenance_mode_on_fatal_error(): void
+    {
+        config( ['cms.updates.backup_enabled' => false] );
+
+        $manager = new class extends ApplicationUpdateManager {
+            public array $modeCalls = [];
+
+            protected function enableMaintenanceMode(): void
+            {
+                $this->modeCalls[] = 'enable';
+            }
+
+            protected function disableMaintenanceMode(): void
+            {
+                $this->modeCalls[] = 'disable';
+            }
+        };
+
+        $updateInfo = new UpdateInfo(
+            currentVersion: '1.0.0',
+            latestVersion: '2.0.0',
+            downloadUrl: 'https://example.com/update.zip',
+        );
+
+        $checker = $this->createMock( UpdateChecker::class );
+        $checker->method( 'checkForUpdate' )->willReturn( $updateInfo );
+        $checker->method( 'downloadUpdate' )->willThrowException( new Error( 'Simulated fatal error' ) );
+
+        $manager->setUpdateChecker( $checker );
+
+        try {
+            $manager->performUpdate();
+            $this->fail( 'Expected Error to be thrown.' );
+        } catch ( Error $e ) {
+            $this->assertSame( 'Simulated fatal error', $e->getMessage() );
+        }
+
+        $this->assertSame( ['enable', 'disable'], $manager->modeCalls );
     }
 
     /**

--- a/tests/Unit/Updates/GitHubUpdateSourceTest.php
+++ b/tests/Unit/Updates/GitHubUpdateSourceTest.php
@@ -289,6 +289,81 @@ class GitHubUpdateSourceTest extends TestCase
     }
 
     /**
+     * Test GitHub source streams the download to disk via `sink` rather than
+     * buffering the response body in memory.
+     *
+     * @since 2.5.1
+     */
+    public function test_download_streams_response_to_sink(): void
+    {
+        Http::fake( [
+            'api.github.com/repos/user/repo/releases/tags/v2.0.0' => Http::response( [
+                'tag_name'    => 'v2.0.0',
+                'prerelease'  => false,
+                'zipball_url' => 'https://api.github.com/repos/user/repo/zipball/v2.0.0',
+                'assets'      => [
+                    [
+                        'name'                 => 'app-2.0.0.zip',
+                        'browser_download_url' => 'https://example.com/app-2.0.0.zip',
+                    ],
+                ],
+            ], 200 ),
+            'example.com/app-2.0.0.zip' => Http::response( 'zip-bytes', 200 ),
+        ] );
+
+        $source = new GitHubUpdateSource( 'https://github.com/user/repo', '1.0.0' );
+
+        $tempPath = $source->downloadUpdate( 'v2.0.0' );
+
+        $this->assertFileExists( $tempPath );
+        $this->assertSame( 'zip-bytes', file_get_contents( $tempPath ) );
+
+        @unlink( $tempPath );
+    }
+
+    /**
+     * Test GitHub source removes the partial download file when the HTTP
+     * response is not successful.
+     *
+     * @since 2.5.1
+     */
+    public function test_download_cleans_up_partial_file_on_http_failure(): void
+    {
+        Http::fake( [
+            'api.github.com/repos/user/repo/releases/tags/v2.0.0' => Http::response( [
+                'tag_name'    => 'v2.0.0',
+                'prerelease'  => false,
+                'zipball_url' => 'https://api.github.com/repos/user/repo/zipball/v2.0.0',
+                'assets'      => [
+                    [
+                        'name'                 => 'app-2.0.0.zip',
+                        'browser_download_url' => 'https://example.com/app-2.0.0.zip',
+                    ],
+                ],
+            ], 200 ),
+            'example.com/app-2.0.0.zip' => Http::response( 'partial', 500 ),
+        ] );
+
+        $tempDir = storage_path( 'app/temp' );
+
+        if ( is_dir( $tempDir ) ) {
+            foreach ( glob( $tempDir . '/update-*.zip' ) ?: [] as $file ) {
+                @unlink( $file );
+            }
+        }
+
+        $source = new GitHubUpdateSource( 'https://github.com/user/repo', '1.0.0' );
+
+        try {
+            $source->downloadUpdate( 'v2.0.0' );
+            $this->fail( 'Expected UpdateException to be thrown.' );
+        } catch ( UpdateException $e ) {
+            $leftover = is_dir( $tempDir ) ? glob( $tempDir . '/update-*.zip' ) : [];
+            $this->assertSame( [], $leftover, 'Expected partial download to be removed on failure.' );
+        }
+    }
+
+    /**
      * Define environment setup.
      *
      * @since 1.0.0

--- a/tests/Unit/Updates/GitLabUpdateSourceTest.php
+++ b/tests/Unit/Updates/GitLabUpdateSourceTest.php
@@ -856,6 +856,70 @@ class GitLabUpdateSourceTest extends TestCase
     }
 
     /**
+     * Test GitLab source streams the download to disk via `sink` rather than
+     * buffering the response body in memory.
+     *
+     * @since 2.5.1
+     */
+    public function test_download_streams_response_to_sink(): void
+    {
+        Http::fake( [
+            'gitlab.com/api/v4/projects/user%2Frepo/releases/v2.0.0' => Http::response( [
+                'tag_name'    => 'v2.0.0',
+                'description' => 'Release',
+                'created_at'  => '2024-12-15T10:00:00.000Z',
+            ], 200 ),
+            'gitlab.com/api/v4/projects/user%2Frepo/repository/archive.zip*' => Http::response( 'zip-bytes', 200 ),
+        ] );
+
+        $source = new GitLabUpdateSource( 'https://gitlab.com/user/repo', '1.0.0' );
+
+        $tempPath = $source->downloadUpdate( 'v2.0.0' );
+
+        $this->assertFileExists( $tempPath );
+        $this->assertSame( 'zip-bytes', file_get_contents( $tempPath ) );
+
+        @unlink( $tempPath );
+    }
+
+    /**
+     * Test GitLab source removes the partial download file when the HTTP
+     * response is not successful.
+     *
+     * @since 2.5.1
+     */
+    public function test_download_cleans_up_partial_file_on_http_failure(): void
+    {
+        Http::fake( [
+            'gitlab.com/api/v4/projects/user%2Frepo/releases/v2.0.0' => Http::response( [
+                'tag_name'    => 'v2.0.0',
+                'description' => 'Release',
+                'created_at'  => '2024-12-15T10:00:00.000Z',
+            ], 200 ),
+            'gitlab.com/api/v4/projects/user%2Frepo/repository/archive.zip*' => Http::response( 'partial', 500 ),
+        ] );
+
+        $tempDir = storage_path( 'app/temp' );
+
+        // Ensure no stale update-*.zip files from prior tests.
+        if ( is_dir( $tempDir ) ) {
+            foreach ( glob( $tempDir . '/update-*.zip' ) ?: [] as $file ) {
+                @unlink( $file );
+            }
+        }
+
+        $source = new GitLabUpdateSource( 'https://gitlab.com/user/repo', '1.0.0' );
+
+        try {
+            $source->downloadUpdate( 'v2.0.0' );
+            $this->fail( 'Expected UpdateException to be thrown.' );
+        } catch ( UpdateException $e ) {
+            $leftover = is_dir( $tempDir ) ? glob( $tempDir . '/update-*.zip' ) : [];
+            $this->assertSame( [], $leftover, 'Expected partial download to be removed on failure.' );
+        }
+    }
+
+    /**
      * Define environment setup.
      *
      * @since 1.0.0


### PR DESCRIPTION
## Description

Fixes two bugs in the application-update flow that combined to strand hosts in maintenance mode when a release tarball pushed past PHP's `memory_limit`.

**Bug A (OOM).** `GitLabUpdateSource::downloadUpdate` and `GitHubUpdateSource::downloadUpdate` buffered the whole release tarball into memory via `$response->body()`. Any release ~half the size of `memory_limit` (default 128M → ~65M zip) was enough to OOM inside Guzzle's `Utils::copyToString()`.

**Bug B (stranded site).** `ApplicationUpdateManager::performUpdate` caught `\Exception`, which doesn't match PHP's `\Error` hierarchy. When Bug A hit, the fatal escaped the try/catch, `handleUpdateFailure()` never ran, and maintenance mode was never lifted — whole host 503'd until someone SSH'd in and ran `php artisan up`.

**Closes:** #214

## Type of Change

- [x] Bug fix (fixes an issue)

## Related Issue

**Issue:** #214

## Motivation and Context

Observed on a real host: Keystone CMS 0.2.0 → 0.2.1 update from an admin. OOM'd on download, whole site 503'd until manual recovery.

## Changes Made

- `GitLabUpdateSource::downloadUpdate` and `GitHubUpdateSource::downloadUpdate` now use `Http::sink($tempPath)` — Guzzle writes the response body straight to the file handle, no in-memory buffering.
- A single `catch (Throwable)` in each source deletes the partial temp file on either transport failure or a non-2xx response, then rethrows.
- `ApplicationUpdateManager::performUpdate` (and every other `catch (Exception)` in the class — `runMigrations`, `enableMaintenanceMode`, `disableMaintenanceMode`, `rollback` retries, `handleUpdateFailure`'s inner catches) now catches `\Throwable`, so fatal errors still trigger rollback + maintenance-mode teardown. `handleUpdateFailure(Throwable)` signature widened to match.
- `handleUpdateFailure`'s previously-silent `disableMaintenanceMode()` failure is now logged at `error` level — if maintenance mode can't be lifted, at least the admin gets a signal in the logs.

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS
- PHP Version: 8.4
- Project Version: 2.5.1

**Tests Performed:**
1. Full package Pest suite: 1388 passed, 7 skipped (unchanged).
2. Manually confirmed streaming download + partial-file cleanup + fatal-error recovery paths.

## Tests Added

- [x] Unit tests added/updated
- [x] All tests passing

**Test details:**

- `GitLabUpdateSourceTest::test_download_streams_response_to_sink` — asserts the file exists with the expected content after download.
- `GitLabUpdateSourceTest::test_download_cleans_up_partial_file_on_http_failure` — asserts no `update-*.zip` remains in `storage/app/temp/` after a 500 response.
- `GitHubUpdateSourceTest` — the same two tests.
- `ApplicationUpdateManagerTest::test_perform_update_disables_maintenance_mode_on_fatal_error` — injects a checker that throws `\Error` on `downloadUpdate`, uses an anonymous subclass to track enable/disable calls, and asserts the `\Error` still propagates while maintenance mode is properly toggled off.

## Follow-ups

- `CustomJsonUpdateSource::downloadUpdate` (`src/Modules/Core/Updates/Sources/CustomJsonUpdateSource.php`) has the identical OOM pattern (`$response->body()` + `File::put`). Issue #214's implementation tasks scope to GitLab + GitHub only; filing a follow-up issue for the CustomJson fix. Once that lands, `deletePartialDownload` + the temp-path builder become good candidates for extraction into a shared base or trait.

## Pre-Submission Checklist

- [x] Code passes all tests
- [x] Code has been linted (php-cs-fixer)
- [x] Code follows project style guide
- [x] Self-review completed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved update failure handling, including fatal errors, to ensure maintenance mode is disabled and rollback procedures run reliably.
  * Update downloads now stream directly to temporary files, reducing memory usage.
  * Failed or interrupted downloads automatically remove incomplete temporary files.

* **Tests**
  * Added coverage for fatal update errors, streamed downloads, and cleanup after failed downloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->