### PR TITLE
fix: stream CustomJsonUpdateSource downloads to sink

### DIFF
--- a/src/Modules/Core/Updates/Sources/CustomJsonUpdateSource.php
+++ b/src/Modules/Core/Updates/Sources/CustomJsonUpdateSource.php
@@ -9,6 +9,7 @@ use ArtisanPackUI\CMSFramework\Modules\Core\Updates\Exceptions\UpdateException;
 use ArtisanPackUI\CMSFramework\Modules\Core\Updates\ValueObjects\UpdateInfo;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Http;
+use Throwable;
 
 /**
  * Custom JSON Update Source
@@ -120,16 +121,21 @@ class CustomJsonUpdateSource implements UpdateSourceInterface
             File::makeDirectory( dirname( $tempPath ), 0755, true );
         }
 
-        $response = Http::timeout( config( 'cms.updates.download_timeout', 300 ) )
-            ->get( $downloadUrl );
+        try {
+            $response = Http::timeout( config( 'cms.updates.download_timeout', 300 ) )
+                ->sink( $tempPath )
+                ->get( $downloadUrl );
 
-        if ( ! $response->successful() ) {
-            throw UpdateException::downloadFailed( $downloadUrl );
+            if ( ! $response->successful() ) {
+                throw UpdateException::downloadFailed( $downloadUrl );
+            }
+
+            return $tempPath;
+        } catch ( Throwable $e ) {
+            File::delete( $tempPath );
+
+            throw $e;
         }
-
-        File::put( $tempPath, $response->body() );
-
-        return $tempPath;
     }
 
     /**

--- a/tests/Unit/Updates/CustomJsonUpdateSourceTest.php
+++ b/tests/Unit/Updates/CustomJsonUpdateSourceTest.php
@@ -274,6 +274,67 @@ class CustomJsonUpdateSourceTest extends TestCase
     }
 
     /**
+     * Test custom JSON source streams the download to disk via `sink` rather than
+     * buffering the response body in memory.
+     *
+     * @since 2.5.1
+     */
+    public function test_download_streams_response_to_sink(): void
+    {
+        Http::fake( [
+            'example.com/updates.json' => Http::response( [
+                'version'      => '2.0.0',
+                'download_url' => 'https://example.com/releases/cms-2.0.0.zip',
+            ], 200 ),
+            'example.com/releases/cms-2.0.0.zip' => Http::response( 'zip-bytes', 200 ),
+        ] );
+
+        $source = new CustomJsonUpdateSource( 'https://example.com/updates.json', '1.0.0' );
+
+        $tempPath = $source->downloadUpdate( 'latest' );
+
+        $this->assertFileExists( $tempPath );
+        $this->assertSame( 'zip-bytes', file_get_contents( $tempPath ) );
+
+        @unlink( $tempPath );
+    }
+
+    /**
+     * Test custom JSON source removes the partial download file when the HTTP
+     * response is not successful.
+     *
+     * @since 2.5.1
+     */
+    public function test_download_cleans_up_partial_file_on_http_failure(): void
+    {
+        Http::fake( [
+            'example.com/updates.json' => Http::response( [
+                'version'      => '2.0.0',
+                'download_url' => 'https://example.com/releases/cms-2.0.0.zip',
+            ], 200 ),
+            'example.com/releases/cms-2.0.0.zip' => Http::response( 'partial', 500 ),
+        ] );
+
+        $tempDir = storage_path( 'app/temp' );
+
+        if ( is_dir( $tempDir ) ) {
+            foreach ( glob( $tempDir . '/update-*.zip' ) ?: [] as $file ) {
+                @unlink( $file );
+            }
+        }
+
+        $source = new CustomJsonUpdateSource( 'https://example.com/updates.json', '1.0.0' );
+
+        try {
+            $source->downloadUpdate( 'latest' );
+            $this->fail( 'Expected UpdateException to be thrown.' );
+        } catch ( UpdateException $e ) {
+            $leftover = is_dir( $tempDir ) ? glob( $tempDir . '/update-*.zip' ) : [];
+            $this->assertSame( [], $leftover, 'Expected partial download to be removed on failure.' );
+        }
+    }
+
+    /**
      * Define environment setup.
      *
      * @since 1.0.0


### PR DESCRIPTION
## Description

Mirror the #214/#215 fix on `CustomJsonUpdateSource::downloadUpdate` — replace `Http::get()` + `File::put($tempPath, $response->body())` with `Http::sink($tempPath)->get()` so Guzzle streams the response body straight to disk instead of buffering the whole tarball into a string (which OOMs on any release archive larger than half of PHP's `memory_limit`). Wrap the download in `try / catch (Throwable)` so both transport-level throws and non-2xx responses delete the partial file before rethrowing.

**Closes:** #216

## Type of Change

- [x] Bug fix (fixes an issue)

## Related Issue

**Issue:** #216

## Motivation and Context

#214 fixed the same OOM pattern in `GitLabUpdateSource` and `GitHubUpdateSource`, but #215's implementation was explicitly scoped to those two sources. `CustomJsonUpdateSource` still buffered the entire release archive via `$response->body()`, so any host using the custom-JSON strategy against a real-world tarball would OOM inside Guzzle's `Utils::copyToString()`. Post-#214 the site now recovers (maintenance mode lifts, rollback runs), but the download itself still fails every time on affected hosts. This PR brings the third source in line.

## Changes Made

- `src/Modules/Core/Updates/Sources/CustomJsonUpdateSource.php` — swap buffering `Http::get()` + `File::put()` for `Http::sink($tempPath)->get()` inside a `try { ... } catch (Throwable) { File::delete($tempPath); throw; }` block; add `use Throwable;`.
- `tests/Unit/Updates/CustomJsonUpdateSourceTest.php` — add `test_download_streams_response_to_sink` and `test_download_cleans_up_partial_file_on_http_failure`, mirroring the pair added for GitLab/GitHub in #215.

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS
- PHP Version: 8.4.3
- Project Version: 2.5.1

**Tests Performed:**
1. `./vendor/bin/pest tests/Unit/Updates/CustomJsonUpdateSourceTest.php` — 14 passed
2. Full package Pest suite — 1390 passed, 7 skipped
3. `./vendor/bin/php-cs-fixer fix` on both changed files — no formatting changes needed

## Accessibility Tests Run

N/A — server-side update pipeline, no UI surface.

## Tests Added

- [x] Unit tests added/updated
- [x] All tests passing

**Test details:** Two regression tests mirroring #215: one asserts the file is written via `sink` (happy path), one asserts the partial file is removed when the HTTP response is not successful.

## Documentation

N/A — no user-facing API change; internal behavior swap.

## Pre-Submission Checklist

- [x] Code passes all tests
- [x] Code has been linted
- [x] Code follows project style guide
- [x] Self-review completed
- [x] No new warnings generated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Update downloads now stream directly to disk, reducing memory usage for large archives.
  * Failed or interrupted downloads automatically remove incomplete temporary files.
  * Improved download reliability when the server returns an unsuccessful response.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->