### PR TITLE
Release v2.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+## [2.5.1] - 2026-07-22
+
+### Fixed
+
+- **`CustomJsonUpdateSource` OOM on large release tarballs** ([#216](https://github.com/ArtisanPack-UI/cms-framework/issues/216)) — `CustomJsonUpdateSource::downloadUpdate()` previously buffered the entire release archive into a string via `$response->body()` before writing it to disk with `File::put()`, which OOM'd inside Guzzle's `Utils::copyToString()` on any tarball larger than roughly half of PHP's `memory_limit`. The download now streams straight to disk via `Http::sink($tempPath)->get()`, mirroring the fix applied to `GitLabUpdateSource` and `GitHubUpdateSource` in 2.5.0 (#214). Both a transport-level throw and a non-2xx response now clean up the partial file via a shared `catch (Throwable)` block before rethrowing.
+
 ## [2.5.0] - 2026-07-21
 
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "description": "Adds in the back end support for building a CMS with any front end framework.",
   "type": "library",
   "license": "MIT",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "autoload": {
     "psr-4": {
       "ArtisanPackUI\\CMSFramework\\": "src/",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d66d535cc8269f0defc28d87a4b6e15e",
+    "content-hash": "2515e2284443c6400f57bb4570b2b15b",
     "packages": [
         {
             "name": "artisanpack-ui/accessibility",

--- a/config/cms-framework.php
+++ b/config/cms-framework.php
@@ -32,7 +32,7 @@ return [
 
         'info' => [
             'title'       => 'ArtisanPack CMS Framework API',
-            'version'     => '2.5.0',
+            'version'     => '2.5.1',
             'description' => 'RESTful API for the ArtisanPack CMS Framework. Provides endpoints for managing posts, pages, content types, users, roles, permissions, settings, notifications, plugins, and themes.',
         ],
 

--- a/src/Modules/Core/Updates/Managers/ApplicationUpdateManager.php
+++ b/src/Modules/Core/Updates/Managers/ApplicationUpdateManager.php
@@ -9,12 +9,12 @@ use ArtisanPackUI\CMSFramework\Modules\Core\Updates\Exceptions\UpdateException;
 use ArtisanPackUI\CMSFramework\Modules\Core\Updates\UpdateChecker;
 use ArtisanPackUI\CMSFramework\Modules\Core\Updates\UpdateCheckerFactory;
 use ArtisanPackUI\CMSFramework\Modules\Core\Updates\ValueObjects\UpdateInfo;
-use Exception;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Process;
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
+use Throwable;
 use ZipArchive;
 
 /**
@@ -112,7 +112,7 @@ class ApplicationUpdateManager
             $this->disableMaintenanceMode();
 
             return true;
-        } catch ( Exception $e ) {
+        } catch ( Throwable $e ) {
             // Rollback on failure
             $this->handleUpdateFailure( $e );
 
@@ -557,7 +557,7 @@ class ApplicationUpdateManager
     {
         try {
             Artisan::call( 'migrate', ['--force' => true] );
-        } catch ( Exception $e ) {
+        } catch ( Throwable $e ) {
             throw UpdateException::migrationFailed( $e->getMessage() );
         }
     }
@@ -600,7 +600,7 @@ class ApplicationUpdateManager
     {
         try {
             Artisan::call( 'down', ['--render' => 'errors::503'] );
-        } catch ( Exception $e ) {
+        } catch ( Throwable $e ) {
             throw UpdateException::maintenanceModeFailure( 'enable' );
         }
     }
@@ -616,7 +616,7 @@ class ApplicationUpdateManager
     {
         try {
             Artisan::call( 'up' );
-        } catch ( Exception $e ) {
+        } catch ( Throwable $e ) {
             throw UpdateException::maintenanceModeFailure( 'disable' );
         }
     }
@@ -626,9 +626,9 @@ class ApplicationUpdateManager
      *
      * @since 1.0.0
      *
-     * @param  Exception  $exception  The exception that caused failure
+     * @param  Throwable  $exception  The throwable that caused failure
      */
-    protected function handleUpdateFailure( Exception $exception ): void
+    protected function handleUpdateFailure( Throwable $exception ): void
     {
         // Log the original exception for debugging
         \Illuminate\Support\Facades\Log::error( 'Update failed, beginning rollback', [
@@ -641,15 +641,18 @@ class ApplicationUpdateManager
         // Attempt to disable maintenance mode
         try {
             $this->disableMaintenanceMode();
-        } catch ( Exception $e ) {
-            // Maintenance mode failure is not critical during rollback
+        } catch ( Throwable $e ) {
+            \Illuminate\Support\Facades\Log::error(
+                'Failed to disable maintenance mode during update rollback; host may remain in maintenance mode.',
+                ['exception' => $e->getMessage()],
+            );
         }
 
         // If we have a backup, attempt rollback
         if ( $this->backupPath && File::exists( $this->backupPath ) ) {
             try {
                 $this->rollback( $this->backupPath );
-            } catch ( Exception $e ) {
+            } catch ( Throwable $e ) {
                 // Rollback failed - this is critical
                 throw UpdateException::rollbackFailed( $e->getMessage());
             }

--- a/src/Modules/Core/Updates/Sources/CustomJsonUpdateSource.php
+++ b/src/Modules/Core/Updates/Sources/CustomJsonUpdateSource.php
@@ -9,6 +9,7 @@ use ArtisanPackUI\CMSFramework\Modules\Core\Updates\Exceptions\UpdateException;
 use ArtisanPackUI\CMSFramework\Modules\Core\Updates\ValueObjects\UpdateInfo;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Http;
+use Throwable;
 
 /**
  * Custom JSON Update Source
@@ -120,16 +121,21 @@ class CustomJsonUpdateSource implements UpdateSourceInterface
             File::makeDirectory( dirname( $tempPath ), 0755, true );
         }
 
-        $response = Http::timeout( config( 'cms.updates.download_timeout', 300 ) )
-            ->get( $downloadUrl );
+        try {
+            $response = Http::timeout( config( 'cms.updates.download_timeout', 300 ) )
+                ->sink( $tempPath )
+                ->get( $downloadUrl );
 
-        if ( ! $response->successful() ) {
-            throw UpdateException::downloadFailed( $downloadUrl );
+            if ( ! $response->successful() ) {
+                throw UpdateException::downloadFailed( $downloadUrl );
+            }
+
+            return $tempPath;
+        } catch ( Throwable $e ) {
+            File::delete( $tempPath );
+
+            throw $e;
         }
-
-        File::put( $tempPath, $response->body() );
-
-        return $tempPath;
     }
 
     /**

--- a/src/Modules/Core/Updates/Sources/GitHubUpdateSource.php
+++ b/src/Modules/Core/Updates/Sources/GitHubUpdateSource.php
@@ -11,6 +11,7 @@ use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Str;
 use InvalidArgumentException;
+use Throwable;
 
 /**
  * GitHub Update Source
@@ -159,17 +160,22 @@ class GitHubUpdateSource implements UpdateSourceInterface
             $headers['Authorization'] = "token {$this->accessToken}";
         }
 
-        $response = Http::withHeaders( $headers )
-            ->timeout( config( 'cms.updates.download_timeout', 300 ) )
-            ->get( $downloadUrl );
+        try {
+            $response = Http::withHeaders( $headers )
+                ->timeout( config( 'cms.updates.download_timeout', 300 ) )
+                ->sink( $tempPath )
+                ->get( $downloadUrl );
 
-        if ( ! $response->successful() ) {
-            throw UpdateException::downloadFailed( $downloadUrl );
+            if ( ! $response->successful() ) {
+                throw UpdateException::downloadFailed( $downloadUrl );
+            }
+
+            return $tempPath;
+        } catch ( Throwable $e ) {
+            File::delete( $tempPath );
+
+            throw $e;
         }
-
-        File::put( $tempPath, $response->body() );
-
-        return $tempPath;
     }
 
     /**

--- a/src/Modules/Core/Updates/Sources/GitLabUpdateSource.php
+++ b/src/Modules/Core/Updates/Sources/GitLabUpdateSource.php
@@ -151,17 +151,22 @@ class GitLabUpdateSource implements UpdateSourceInterface
             $headers['PRIVATE-TOKEN'] = $this->accessToken;
         }
 
-        $response = Http::withHeaders( $headers )
-            ->timeout( config( 'cms.updates.download_timeout', 300 ) )
-            ->get( $downloadUrl );
+        try {
+            $response = Http::withHeaders( $headers )
+                ->timeout( config( 'cms.updates.download_timeout', 300 ) )
+                ->sink( $tempPath )
+                ->get( $downloadUrl );
 
-        if ( ! $response->successful() ) {
-            throw UpdateException::downloadFailed( $downloadUrl );
+            if ( ! $response->successful() ) {
+                throw UpdateException::downloadFailed( $downloadUrl );
+            }
+
+            return $tempPath;
+        } catch ( Throwable $e ) {
+            File::delete( $tempPath );
+
+            throw $e;
         }
-
-        File::put( $tempPath, $response->body() );
-
-        return $tempPath;
     }
 
     /**

--- a/src/Modules/OpenApi/Providers/OpenApiServiceProvider.php
+++ b/src/Modules/OpenApi/Providers/OpenApiServiceProvider.php
@@ -113,7 +113,7 @@ class OpenApiServiceProvider extends ServiceProvider
         $scrambleConfig['ui']       = ['title' => $info['title'] ?? 'ArtisanPack CMS Framework API'];
 
         $scrambleConfig['info'] = [
-            'version'     => $info['version'] ?? '2.5.0',
+            'version'     => $info['version'] ?? '2.5.1',
             'description' => $info['description'] ?? '',
         ];
 

--- a/tests/Unit/OpenApi/OpenApiServiceProviderTest.php
+++ b/tests/Unit/OpenApi/OpenApiServiceProviderTest.php
@@ -36,7 +36,7 @@ test( 'openapi config has default values', function (): void {
 
     expect( $config['enabled'] )->toBeTrue();
     expect( $config['info']['title'] )->toBe( 'ArtisanPack CMS Framework API' );
-    expect( $config['info']['version'] )->toBe( '2.5.0' );
+    expect( $config['info']['version'] )->toBe( '2.5.1' );
     expect( $config['ui_path'] )->toBe( '/docs/api/cms' );
     expect( $config['document_path'] )->toBe( '/docs/api/cms.json' );
 } );

--- a/tests/Unit/Updates/ApplicationUpdateManagerTest.php
+++ b/tests/Unit/Updates/ApplicationUpdateManagerTest.php
@@ -8,6 +8,7 @@ use ArtisanPackUI\CMSFramework\Modules\Core\Updates\Exceptions\UpdateException;
 use ArtisanPackUI\CMSFramework\Modules\Core\Updates\Managers\ApplicationUpdateManager;
 use ArtisanPackUI\CMSFramework\Modules\Core\Updates\UpdateChecker;
 use ArtisanPackUI\CMSFramework\Modules\Core\Updates\ValueObjects\UpdateInfo;
+use Error;
 use Illuminate\Support\Facades\Log;
 use Orchestra\Testbench\TestCase;
 use ReflectionClass;
@@ -283,6 +284,52 @@ class ApplicationUpdateManagerTest extends TestCase
         $method->setAccessible( true );
 
         $method->invoke( $manager, '/does/not/matter.zip', $updateInfo, '2.0.0' );
+    }
+
+    /**
+     * Test that a fatal `\Error` during the update disables maintenance mode
+     * and rethrows the error, rather than leaving the host stranded.
+     *
+     * @since 2.5.1
+     */
+    public function test_perform_update_disables_maintenance_mode_on_fatal_error(): void
+    {
+        config( ['cms.updates.backup_enabled' => false] );
+
+        $manager = new class extends ApplicationUpdateManager {
+            public array $modeCalls = [];
+
+            protected function enableMaintenanceMode(): void
+            {
+                $this->modeCalls[] = 'enable';
+            }
+
+            protected function disableMaintenanceMode(): void
+            {
+                $this->modeCalls[] = 'disable';
+            }
+        };
+
+        $updateInfo = new UpdateInfo(
+            currentVersion: '1.0.0',
+            latestVersion: '2.0.0',
+            downloadUrl: 'https://example.com/update.zip',
+        );
+
+        $checker = $this->createMock( UpdateChecker::class );
+        $checker->method( 'checkForUpdate' )->willReturn( $updateInfo );
+        $checker->method( 'downloadUpdate' )->willThrowException( new Error( 'Simulated fatal error' ) );
+
+        $manager->setUpdateChecker( $checker );
+
+        try {
+            $manager->performUpdate();
+            $this->fail( 'Expected Error to be thrown.' );
+        } catch ( Error $e ) {
+            $this->assertSame( 'Simulated fatal error', $e->getMessage() );
+        }
+
+        $this->assertSame( ['enable', 'disable'], $manager->modeCalls );
     }
 
     /**

--- a/tests/Unit/Updates/CustomJsonUpdateSourceTest.php
+++ b/tests/Unit/Updates/CustomJsonUpdateSourceTest.php
@@ -274,6 +274,67 @@ class CustomJsonUpdateSourceTest extends TestCase
     }
 
     /**
+     * Test custom JSON source streams the download to disk via `sink` rather than
+     * buffering the response body in memory.
+     *
+     * @since 2.5.1
+     */
+    public function test_download_streams_response_to_sink(): void
+    {
+        Http::fake( [
+            'example.com/updates.json' => Http::response( [
+                'version'      => '2.0.0',
+                'download_url' => 'https://example.com/releases/cms-2.0.0.zip',
+            ], 200 ),
+            'example.com/releases/cms-2.0.0.zip' => Http::response( 'zip-bytes', 200 ),
+        ] );
+
+        $source = new CustomJsonUpdateSource( 'https://example.com/updates.json', '1.0.0' );
+
+        $tempPath = $source->downloadUpdate( 'latest' );
+
+        $this->assertFileExists( $tempPath );
+        $this->assertSame( 'zip-bytes', file_get_contents( $tempPath ) );
+
+        @unlink( $tempPath );
+    }
+
+    /**
+     * Test custom JSON source removes the partial download file when the HTTP
+     * response is not successful.
+     *
+     * @since 2.5.1
+     */
+    public function test_download_cleans_up_partial_file_on_http_failure(): void
+    {
+        Http::fake( [
+            'example.com/updates.json' => Http::response( [
+                'version'      => '2.0.0',
+                'download_url' => 'https://example.com/releases/cms-2.0.0.zip',
+            ], 200 ),
+            'example.com/releases/cms-2.0.0.zip' => Http::response( 'partial', 500 ),
+        ] );
+
+        $tempDir = storage_path( 'app/temp' );
+
+        if ( is_dir( $tempDir ) ) {
+            foreach ( glob( $tempDir . '/update-*.zip' ) ?: [] as $file ) {
+                @unlink( $file );
+            }
+        }
+
+        $source = new CustomJsonUpdateSource( 'https://example.com/updates.json', '1.0.0' );
+
+        try {
+            $source->downloadUpdate( 'latest' );
+            $this->fail( 'Expected UpdateException to be thrown.' );
+        } catch ( UpdateException $e ) {
+            $leftover = is_dir( $tempDir ) ? glob( $tempDir . '/update-*.zip' ) : [];
+            $this->assertSame( [], $leftover, 'Expected partial download to be removed on failure.' );
+        }
+    }
+
+    /**
      * Define environment setup.
      *
      * @since 1.0.0

--- a/tests/Unit/Updates/GitHubUpdateSourceTest.php
+++ b/tests/Unit/Updates/GitHubUpdateSourceTest.php
@@ -289,6 +289,81 @@ class GitHubUpdateSourceTest extends TestCase
     }
 
     /**
+     * Test GitHub source streams the download to disk via `sink` rather than
+     * buffering the response body in memory.
+     *
+     * @since 2.5.1
+     */
+    public function test_download_streams_response_to_sink(): void
+    {
+        Http::fake( [
+            'api.github.com/repos/user/repo/releases/tags/v2.0.0' => Http::response( [
+                'tag_name'    => 'v2.0.0',
+                'prerelease'  => false,
+                'zipball_url' => 'https://api.github.com/repos/user/repo/zipball/v2.0.0',
+                'assets'      => [
+                    [
+                        'name'                 => 'app-2.0.0.zip',
+                        'browser_download_url' => 'https://example.com/app-2.0.0.zip',
+                    ],
+                ],
+            ], 200 ),
+            'example.com/app-2.0.0.zip' => Http::response( 'zip-bytes', 200 ),
+        ] );
+
+        $source = new GitHubUpdateSource( 'https://github.com/user/repo', '1.0.0' );
+
+        $tempPath = $source->downloadUpdate( 'v2.0.0' );
+
+        $this->assertFileExists( $tempPath );
+        $this->assertSame( 'zip-bytes', file_get_contents( $tempPath ) );
+
+        @unlink( $tempPath );
+    }
+
+    /**
+     * Test GitHub source removes the partial download file when the HTTP
+     * response is not successful.
+     *
+     * @since 2.5.1
+     */
+    public function test_download_cleans_up_partial_file_on_http_failure(): void
+    {
+        Http::fake( [
+            'api.github.com/repos/user/repo/releases/tags/v2.0.0' => Http::response( [
+                'tag_name'    => 'v2.0.0',
+                'prerelease'  => false,
+                'zipball_url' => 'https://api.github.com/repos/user/repo/zipball/v2.0.0',
+                'assets'      => [
+                    [
+                        'name'                 => 'app-2.0.0.zip',
+                        'browser_download_url' => 'https://example.com/app-2.0.0.zip',
+                    ],
+                ],
+            ], 200 ),
+            'example.com/app-2.0.0.zip' => Http::response( 'partial', 500 ),
+        ] );
+
+        $tempDir = storage_path( 'app/temp' );
+
+        if ( is_dir( $tempDir ) ) {
+            foreach ( glob( $tempDir . '/update-*.zip' ) ?: [] as $file ) {
+                @unlink( $file );
+            }
+        }
+
+        $source = new GitHubUpdateSource( 'https://github.com/user/repo', '1.0.0' );
+
+        try {
+            $source->downloadUpdate( 'v2.0.0' );
+            $this->fail( 'Expected UpdateException to be thrown.' );
+        } catch ( UpdateException $e ) {
+            $leftover = is_dir( $tempDir ) ? glob( $tempDir . '/update-*.zip' ) : [];
+            $this->assertSame( [], $leftover, 'Expected partial download to be removed on failure.' );
+        }
+    }
+
+    /**
      * Define environment setup.
      *
      * @since 1.0.0

--- a/tests/Unit/Updates/GitLabUpdateSourceTest.php
+++ b/tests/Unit/Updates/GitLabUpdateSourceTest.php
@@ -856,6 +856,70 @@ class GitLabUpdateSourceTest extends TestCase
     }
 
     /**
+     * Test GitLab source streams the download to disk via `sink` rather than
+     * buffering the response body in memory.
+     *
+     * @since 2.5.1
+     */
+    public function test_download_streams_response_to_sink(): void
+    {
+        Http::fake( [
+            'gitlab.com/api/v4/projects/user%2Frepo/releases/v2.0.0' => Http::response( [
+                'tag_name'    => 'v2.0.0',
+                'description' => 'Release',
+                'created_at'  => '2024-12-15T10:00:00.000Z',
+            ], 200 ),
+            'gitlab.com/api/v4/projects/user%2Frepo/repository/archive.zip*' => Http::response( 'zip-bytes', 200 ),
+        ] );
+
+        $source = new GitLabUpdateSource( 'https://gitlab.com/user/repo', '1.0.0' );
+
+        $tempPath = $source->downloadUpdate( 'v2.0.0' );
+
+        $this->assertFileExists( $tempPath );
+        $this->assertSame( 'zip-bytes', file_get_contents( $tempPath ) );
+
+        @unlink( $tempPath );
+    }
+
+    /**
+     * Test GitLab source removes the partial download file when the HTTP
+     * response is not successful.
+     *
+     * @since 2.5.1
+     */
+    public function test_download_cleans_up_partial_file_on_http_failure(): void
+    {
+        Http::fake( [
+            'gitlab.com/api/v4/projects/user%2Frepo/releases/v2.0.0' => Http::response( [
+                'tag_name'    => 'v2.0.0',
+                'description' => 'Release',
+                'created_at'  => '2024-12-15T10:00:00.000Z',
+            ], 200 ),
+            'gitlab.com/api/v4/projects/user%2Frepo/repository/archive.zip*' => Http::response( 'partial', 500 ),
+        ] );
+
+        $tempDir = storage_path( 'app/temp' );
+
+        // Ensure no stale update-*.zip files from prior tests.
+        if ( is_dir( $tempDir ) ) {
+            foreach ( glob( $tempDir . '/update-*.zip' ) ?: [] as $file ) {
+                @unlink( $file );
+            }
+        }
+
+        $source = new GitLabUpdateSource( 'https://gitlab.com/user/repo', '1.0.0' );
+
+        try {
+            $source->downloadUpdate( 'v2.0.0' );
+            $this->fail( 'Expected UpdateException to be thrown.' );
+        } catch ( UpdateException $e ) {
+            $leftover = is_dir( $tempDir ) ? glob( $tempDir . '/update-*.zip' ) : [];
+            $this->assertSame( [], $leftover, 'Expected partial download to be removed on failure.' );
+        }
+    }
+
+    /**
      * Define environment setup.
      *
      * @since 1.0.0


### PR DESCRIPTION
## Release Information

- **Release Version:** v2.5.1
- **Release Date:** 2026-07-22
- **Release Type:** Patch
- **Release Branch:** `release/2.5.1`
- **Target Branch:** `main`

## Release Summary

Patch release fixing an OOM condition in `CustomJsonUpdateSource::downloadUpdate()` when hosts using the custom-JSON update strategy pull real-world release tarballs. This is a follow-up to 2.5.0's #214/#215, which fixed the same pattern in `GitLabUpdateSource` and `GitHubUpdateSource` but was explicitly scoped to those two sources.

## Changelog

### Fixed

- **`CustomJsonUpdateSource` OOM on large release tarballs** ([#216](https://github.com/ArtisanPack-UI/cms-framework/issues/216)) — `CustomJsonUpdateSource::downloadUpdate()` previously buffered the entire release archive into a string via `$response->body()` before writing it to disk with `File::put()`, which OOM'd inside Guzzle's `Utils::copyToString()` on any tarball larger than roughly half of PHP's `memory_limit`. The download now streams straight to disk via `Http::sink($tempPath)->get()`, mirroring the fix applied to `GitLabUpdateSource` and `GitHubUpdateSource` in 2.5.0 (#214). Both a transport-level throw and a non-2xx response now clean up the partial file via a shared `catch (Throwable)` block before rethrowing.

## Issues and Pull Requests

**Issues Fixed:**
- Closes #216

**Related PRs:**
- #217

## Breaking Changes

- [x] No breaking changes

## Testing Checklist

- [x] All automated tests passing (1390 passed, 7 skipped)
- [x] Manual testing completed (bugfix PR)
- [x] Security scan completed (see dependency notes below)
- [ ] Tested in staging environment
- [x] Database migrations tested (N/A — no migrations in this release)

**Testing notes:**

Full package Pest suite: 1390 passed, 7 skipped, 0 failed. Two new regression tests in `CustomJsonUpdateSourceTest` cover the streamed-sink happy path and partial-file cleanup on HTTP failure.

## Documentation Checklist

- [x] CHANGELOG updated
- [x] README updated (no changes needed — patch release)
- [x] API documentation updated (no changes needed — patch release)
- [x] Migration guide written (N/A — no breaking changes)

## Version Number Verification

Updated 2.5.0 → 2.5.1 in:

- `composer.json`
- `config/cms-framework.php` (`openapi.info.version`)
- `src/Modules/OpenApi/Providers/OpenApiServiceProvider.php` (fallback in `$info['version']`)
- `tests/Unit/OpenApi/OpenApiServiceProviderTest.php` (matching expectation)
- `CHANGELOG.md` (new `[2.5.1]` section)

No stale `2.5.0` references remain in project version declarations. Historical "*(added in 2.5.0)*" annotations throughout `docs/` are left intact — those correctly record when features shipped.

## Dependency Notes

- **Lock file:** synced via `composer update --lock` after the version bump.
- **Security advisories:** `composer audit` reports 4 medium-severity advisories against `guzzlehttp/guzzle` (URI fragment disclosure, host-only cookie scope, unbounded response cookies, Proxy-Authorization forwarding). All resolve at `>=7.15.1`. These are upstream advisories on a transitive dependency and pre-date this release; addressing them is a separate maintenance concern from the 2.5.1 patch.
- **Outdated:** none flagged blocking. `composer outdated --direct` will surface any drift for follow-up work.