### PR TITLE
fix: coerce notifications limit query param to int at controller boundary

### DIFF
--- a/src/Modules/Notifications/Http/Controllers/NotificationController.php
+++ b/src/Modules/Notifications/Http/Controllers/NotificationController.php
@@ -58,8 +58,7 @@ class NotificationController extends Controller
             'unread_only' => 'sometimes|boolean',
         ] );
 
-        // phpcs:ignore ArtisanPackUIStandard.Security.ValidatedSanitizedInput.InputNotValidated -- Validated above
-        $limit      = $request->input( 'limit', 10 );
+        $limit      = $request->integer( 'limit', 10 );
         $unreadOnly = $request->boolean( 'unread_only', false );
 
         $notifications = $this->notificationManager->getUserNotifications(

--- a/tests/Feature/Notifications/NotificationControllerTest.php
+++ b/tests/Feature/Notifications/NotificationControllerTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\CMSFramework\Modules\Notifications\Models\Notification;
+use ArtisanPackUI\CMSFramework\Tests\Support\TestUser as User;
+
+uses( Illuminate\Foundation\Testing\RefreshDatabase::class );
+
+test( 'index endpoint coerces string limit query param without TypeError', function (): void {
+    $user = User::factory()->create();
+
+    for ( $i = 0; $i < 3; $i++ ) {
+        $notification = Notification::factory()->create();
+        $notification->users()->attach( $user->id, ['is_read' => false, 'is_dismissed' => false] );
+    }
+
+    $response = $this->actingAs( $user, 'sanctum' )
+        ->getJson( '/api/v1/notifications?limit=2' );
+
+    $response->assertOk();
+    expect( $response->json( 'data' ) )->toHaveCount( 2 );
+} );
+
+test( 'index endpoint uses default limit when none provided', function (): void {
+    $user = User::factory()->create();
+
+    for ( $i = 0; $i < 5; $i++ ) {
+        $notification = Notification::factory()->create();
+        $notification->users()->attach( $user->id, ['is_read' => false, 'is_dismissed' => false] );
+    }
+
+    $response = $this->actingAs( $user, 'sanctum' )
+        ->getJson( '/api/v1/notifications' );
+
+    $response->assertOk();
+    expect( $response->json( 'data' ) )->toHaveCount( 5 );
+} );
+
+test( 'index endpoint rejects non-integer limit values', function (): void {
+    $user = User::factory()->create();
+
+    $response = $this->actingAs( $user, 'sanctum' )
+        ->getJson( '/api/v1/notifications?limit=abc' );
+
+    $response->assertStatus( 422 );
+} );


### PR DESCRIPTION
## Description

`NotificationController::index` was passing the raw string value of `?limit=...` (query-string params are always strings until coerced) straight to `NotificationManager::getUserNotifications(int $limit, ...)`. Under `declare(strict_types=1)`, this tripped a `TypeError` on every admin poll (~every 30s), flooding `storage/logs/laravel.log` with dozens of entries per minute and drowning real errors during triage.

Fix is a one-line swap at the boundary — `$request->input('limit', 10)` → `$request->integer('limit', 10)` — plus removal of the now-unneeded `phpcs:ignore` (verified `integer()` doesn't trip `ValidatedSanitizedInput.InputNotValidated`). Existing validation (`sometimes|integer|min:1|max:100`) still rejects non-numeric input with 422 before coercion runs.

**Closes:** #220

## Type of Change

- [x] Bug fix (fixes an issue)

## Related Issue

**Issue:** #220

## Motivation and Context

The poller runs on every admin route, so every admin session on every host generates ~120 `TypeError` entries per hour. Beyond the obvious log noise, it actively hurt observability — while triaging the updater OOM (Keystone CMS #124) I initially missed the real OOM entries because they were buried under this exception spam.

## Changes Made

- `src/Modules/Notifications/Http/Controllers/NotificationController.php`: swap `$request->input('limit', 10)` → `$request->integer('limit', 10)`; drop the now-unnecessary `phpcs:ignore` line
- `tests/Feature/Notifications/NotificationControllerTest.php`: new feature test file covering the coercion path, the default, and the validation-rejection regression fence

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS (Laravel Herd)
- PHP Version: 8.4.23
- Project Version: cms-framework `release/2.5.2`

**Tests Performed:**
1. `./vendor/bin/pest tests/Feature/Notifications/NotificationControllerTest.php` — 3/3 passing
2. `./vendor/bin/pest tests/Feature/Notifications tests/Unit/Notifications` — 88/88 passing (no regressions in the module)
3. `./vendor/bin/php-cs-fixer fix` — clean, no changes
4. `./vendor/bin/phpcs` on the touched files — no new violations introduced by this diff (6 pre-existing errors in the controller and the shared project-wide test-style errors remain untouched)

## Accessibility Tests Run

- [x] N/A — backend/API-only change, no UI surface

## Tests Added

- [x] Integration tests added/updated
- [x] All tests passing

**Test details:**

Three tests in `NotificationControllerTest.php`:

1. **`index endpoint coerces string limit query param without TypeError`** — the actual fix guard. Hits `/api/v1/notifications?limit=2` (the URL-string case that was crashing) and asserts 200 + 2 items. Without the fix this would raise `TypeError` and 500.
2. **`index endpoint uses default limit when none provided`** — canary on the default value.
3. **`index endpoint rejects non-integer limit values`** — regression fence on the existing `integer` validation rule (not testing the fix itself; documenting that validation still catches garbage before coercion runs).

## Documentation

- [x] N/A — bug fix with no public API surface change; `getUserNotifications()` signature is unchanged.

## Pre-Submission Checklist

- [x] Followed contributing guidelines
- [x] Checked for other open PRs for same update
- [x] Code passes all tests
- [x] Code has been linted (`php-cs-fixer` clean)
- [x] Accessibility tests completed (N/A — no UI)
- [x] Code follows project style guide
- [x] Self-review completed
- [x] Comments added for complex code (nothing complex added)
- [x] No new warnings generated