### PR TITLE
Release v2.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+## [2.5.2] - 2026-07-22
+
+### Fixed
+
+- **Application updater still OOM'd post-download on 128M hosts** ([#219](https://github.com/ArtisanPack-UI/cms-framework/issues/219)) — 2.5.1's streaming-download fix was only half the fight. The release archive still OOM'd at `guzzlehttp/psr7/Utils.php:124` (`Utils::copyToString`) because a downstream `ResponseReceived` listener (Telescope-style) called `$response->body()` on the sink stream and pulled the whole ZIP back into a PHP string, and `ApplicationUpdateManager::extractUpdate()` then loaded each ZIP entry into memory via `getFromIndex()`. A new `StreamsDownloadsToDisk` trait shared by all three update sources wraps `Http::sink()` with a `withResponseMiddleware` that closes the sink body as soon as Guzzle hands the response back — before Laravel dispatches `ResponseReceived`, so any listener calling `body()` gets an empty string instead of copying the archive. `extractUpdate()` now streams each ZIP entry with `$zip->getStream()` + chunked `fread`/`fwrite` instead of `getFromIndex()`, so a single large file inside the release archive can't OOM mid-extraction either. Regression fences: one test per update source asserts the recorded PSR-7 response body is unreadable after `downloadUpdate()` returns, and `ApplicationUpdateManagerTest` runs `extractUpdate()` against a real ZIP under a scoped base path and confirms streamed extraction produces byte-for-byte copies.
+- **`NotificationController::index` `TypeError` on every admin poll** ([#220](https://github.com/ArtisanPack-UI/cms-framework/issues/220)) — `NotificationController::index` passed the raw string from `?limit=…` straight to `NotificationManager::getUserNotifications( int $limit, … )`, tripping a `TypeError` under `strict_types` on every admin poll (roughly every 30s) and drowning `storage/logs/laravel.log` in dozens of exceptions per minute. Swapped `$request->input()` for `$request->integer()` so the value is coerced at the controller boundary, and dropped the now-unneeded `phpcs:ignore`. Existing validation (`sometimes|integer|min:1|max:100`) still rejects non-numeric input with a 422. A new `NotificationControllerTest` covers the string→int coercion path, the default limit, and the validation-rejection regression fence.
+
 ## [2.5.1] - 2026-07-22
 
 ### Fixed

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "description": "Adds in the back end support for building a CMS with any front end framework.",
   "type": "library",
   "license": "MIT",
-  "version": "2.5.1",
+  "version": "2.5.2",
   "autoload": {
     "psr-4": {
       "ArtisanPackUI\\CMSFramework\\": "src/",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2515e2284443c6400f57bb4570b2b15b",
+    "content-hash": "e27c91108a0c3d94822a2805a84cb085",
     "packages": [
         {
             "name": "artisanpack-ui/accessibility",

--- a/src/Modules/Core/Updates/Managers/ApplicationUpdateManager.php
+++ b/src/Modules/Core/Updates/Managers/ApplicationUpdateManager.php
@@ -462,13 +462,35 @@ class ApplicationUpdateManager
                 File::makeDirectory( $targetDir, 0755, true );
             }
 
-            // Extract file
-            $fileContent = $zip->getFromIndex( $i );
-            if ( false === $fileContent ) {
+            // Stream the entry to disk rather than materializing it as a PHP
+            // string via `getFromIndex()`. On a 128M host, a single large file
+            // inside the release (bundled JS/CSS, images) can otherwise OOM in
+            // the middle of extraction.
+            $entryStream = $zip->getStream( $filename );
+            if ( false === $entryStream ) {
                 continue;
             }
 
-            File::put( $fullTargetPath, $fileContent );
+            $out = @fopen( $fullTargetPath, 'wb' );
+            if ( false === $out ) {
+                fclose( $entryStream );
+
+                continue;
+            }
+
+            try {
+                while ( ! feof( $entryStream ) ) {
+                    $chunk = fread( $entryStream, 1024 * 1024 );
+                    if ( false === $chunk || '' === $chunk ) {
+                        break;
+                    }
+
+                    fwrite( $out, $chunk );
+                }
+            } finally {
+                fclose( $entryStream );
+                fclose( $out );
+            }
 
             // Preserve file permissions if available
             if ( isset( $stat['external_attributes'] ) ) {

--- a/src/Modules/Core/Updates/Sources/CustomJsonUpdateSource.php
+++ b/src/Modules/Core/Updates/Sources/CustomJsonUpdateSource.php
@@ -6,10 +6,9 @@ namespace ArtisanPackUI\CMSFramework\Modules\Core\Updates\Sources;
 
 use ArtisanPackUI\CMSFramework\Modules\Core\Updates\Contracts\UpdateSourceInterface;
 use ArtisanPackUI\CMSFramework\Modules\Core\Updates\Exceptions\UpdateException;
+use ArtisanPackUI\CMSFramework\Modules\Core\Updates\Support\StreamsDownloadsToDisk;
 use ArtisanPackUI\CMSFramework\Modules\Core\Updates\ValueObjects\UpdateInfo;
-use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Http;
-use Throwable;
 
 /**
  * Custom JSON Update Source
@@ -20,6 +19,8 @@ use Throwable;
  */
 class CustomJsonUpdateSource implements UpdateSourceInterface
 {
+    use StreamsDownloadsToDisk;
+
     /**
      * Query parameters for authentication or other purposes.
      *
@@ -113,29 +114,7 @@ class CustomJsonUpdateSource implements UpdateSourceInterface
             throw UpdateException::missingRequiredField( 'download_url' );
         }
 
-        $downloadUrl = $data['download_url'];
-
-        $tempPath = storage_path( 'app/temp/update-' . time() . '.zip' );
-
-        if ( ! File::exists( dirname( $tempPath ) ) ) {
-            File::makeDirectory( dirname( $tempPath ), 0755, true );
-        }
-
-        try {
-            $response = Http::timeout( config( 'cms.updates.download_timeout', 300 ) )
-                ->sink( $tempPath )
-                ->get( $downloadUrl );
-
-            if ( ! $response->successful() ) {
-                throw UpdateException::downloadFailed( $downloadUrl );
-            }
-
-            return $tempPath;
-        } catch ( Throwable $e ) {
-            File::delete( $tempPath );
-
-            throw $e;
-        }
+        return $this->streamDownloadToTempFile( $data['download_url'] );
     }
 
     /**

--- a/src/Modules/Core/Updates/Sources/GitHubUpdateSource.php
+++ b/src/Modules/Core/Updates/Sources/GitHubUpdateSource.php
@@ -6,12 +6,11 @@ namespace ArtisanPackUI\CMSFramework\Modules\Core\Updates\Sources;
 
 use ArtisanPackUI\CMSFramework\Modules\Core\Updates\Contracts\UpdateSourceInterface;
 use ArtisanPackUI\CMSFramework\Modules\Core\Updates\Exceptions\UpdateException;
+use ArtisanPackUI\CMSFramework\Modules\Core\Updates\Support\StreamsDownloadsToDisk;
 use ArtisanPackUI\CMSFramework\Modules\Core\Updates\ValueObjects\UpdateInfo;
-use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Str;
 use InvalidArgumentException;
-use Throwable;
 
 /**
  * GitHub Update Source
@@ -22,6 +21,8 @@ use Throwable;
  */
 class GitHubUpdateSource implements UpdateSourceInterface
 {
+    use StreamsDownloadsToDisk;
+
     /**
      * GitHub access token for authentication.
      *
@@ -148,34 +149,12 @@ class GitHubUpdateSource implements UpdateSourceInterface
             $downloadUrl = $this->extractDownloadUrl( $release );
         }
 
-        $tempPath = storage_path( 'app/temp/update-' . bin2hex( random_bytes( 16 ) ) . '.zip' );
-
-        // Ensure temp directory exists
-        if ( ! File::exists( dirname( $tempPath ) ) ) {
-            File::makeDirectory( dirname( $tempPath ), 0755, true );
-        }
-
         $headers = [];
         if ( $this->accessToken ) {
             $headers['Authorization'] = "token {$this->accessToken}";
         }
 
-        try {
-            $response = Http::withHeaders( $headers )
-                ->timeout( config( 'cms.updates.download_timeout', 300 ) )
-                ->sink( $tempPath )
-                ->get( $downloadUrl );
-
-            if ( ! $response->successful() ) {
-                throw UpdateException::downloadFailed( $downloadUrl );
-            }
-
-            return $tempPath;
-        } catch ( Throwable $e ) {
-            File::delete( $tempPath );
-
-            throw $e;
-        }
+        return $this->streamDownloadToTempFile( $downloadUrl, $headers );
     }
 
     /**

--- a/src/Modules/Core/Updates/Sources/GitLabUpdateSource.php
+++ b/src/Modules/Core/Updates/Sources/GitLabUpdateSource.php
@@ -6,8 +6,8 @@ namespace ArtisanPackUI\CMSFramework\Modules\Core\Updates\Sources;
 
 use ArtisanPackUI\CMSFramework\Modules\Core\Updates\Contracts\UpdateSourceInterface;
 use ArtisanPackUI\CMSFramework\Modules\Core\Updates\Exceptions\UpdateException;
+use ArtisanPackUI\CMSFramework\Modules\Core\Updates\Support\StreamsDownloadsToDisk;
 use ArtisanPackUI\CMSFramework\Modules\Core\Updates\ValueObjects\UpdateInfo;
-use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
 use InvalidArgumentException;
@@ -22,6 +22,8 @@ use Throwable;
  */
 class GitLabUpdateSource implements UpdateSourceInterface
 {
+    use StreamsDownloadsToDisk;
+
     /**
      * GitLab access token.
      *
@@ -140,33 +142,12 @@ class GitLabUpdateSource implements UpdateSourceInterface
             $downloadUrl = $this->extractDownloadUrl( $release );
         }
 
-        $tempPath = storage_path( 'app/temp/update-' . bin2hex( random_bytes( 16 ) ) . '.zip' );
-
-        if ( ! File::exists( dirname( $tempPath ) ) ) {
-            File::makeDirectory( dirname( $tempPath ), 0755, true );
-        }
-
         $headers = [];
         if ( $this->accessToken ) {
             $headers['PRIVATE-TOKEN'] = $this->accessToken;
         }
 
-        try {
-            $response = Http::withHeaders( $headers )
-                ->timeout( config( 'cms.updates.download_timeout', 300 ) )
-                ->sink( $tempPath )
-                ->get( $downloadUrl );
-
-            if ( ! $response->successful() ) {
-                throw UpdateException::downloadFailed( $downloadUrl );
-            }
-
-            return $tempPath;
-        } catch ( Throwable $e ) {
-            File::delete( $tempPath );
-
-            throw $e;
-        }
+        return $this->streamDownloadToTempFile( $downloadUrl, $headers );
     }
 
     /**

--- a/src/Modules/Core/Updates/Support/StreamsDownloadsToDisk.php
+++ b/src/Modules/Core/Updates/Support/StreamsDownloadsToDisk.php
@@ -1,0 +1,79 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Modules\Core\Updates\Support;
+
+use ArtisanPackUI\CMSFramework\Modules\Core\Updates\Exceptions\UpdateException;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Http;
+use Psr\Http\Message\ResponseInterface;
+use Throwable;
+
+/**
+ * Stream update downloads straight to disk, closing the response body before
+ * downstream HTTP listeners can materialize the release archive in memory.
+ *
+ * `Http::sink()` already writes the response body to a file rather than a PHP
+ * string, but the resulting `Illuminate\Http\Client\Response` still exposes a
+ * PSR-7 stream over that file. Third-party listeners on `ResponseReceived`
+ * (Telescope, Sentry, custom monitoring) that call `$response->body()` will
+ * then copy the entire archive back into a string via
+ * `GuzzleHttp\Psr7\Utils::copyToString`, blowing the 128M `memory_limit` on
+ * any release near ~half of it.
+ *
+ * This trait wraps `Http::sink()` with a response middleware that closes the
+ * sink body as soon as Guzzle hands the response back — before the `Response`
+ * wrapper is constructed and before `ResponseReceived` fires — so any later
+ * `body()` call returns an empty string rather than reloading the archive.
+ *
+ * @since 2.5.2
+ */
+trait StreamsDownloadsToDisk
+{
+    /**
+     * Download the given URL to a fresh temp file, streaming the body straight
+     * to disk and closing the underlying sink stream before anyone can pull it
+     * back into memory.
+     *
+     * @since 2.5.2
+     *
+     * @param  string  $downloadUrl  Absolute URL of the release archive.
+     * @param  array<string, string>  $headers  Request headers to send.
+     *
+     * @throws UpdateException When the response is not a 2xx.
+     * @throws Throwable On transport errors (partial file is removed first).
+     *
+     * @return string Absolute path to the downloaded file.
+     */
+    protected function streamDownloadToTempFile( string $downloadUrl, array $headers = [] ): string
+    {
+        $tempPath = storage_path( 'app/temp/update-' . bin2hex( random_bytes( 16 ) ) . '.zip' );
+
+        if ( ! File::exists( dirname( $tempPath ) ) ) {
+            File::makeDirectory( dirname( $tempPath ), 0755, true );
+        }
+
+        try {
+            $response = Http::withHeaders( $headers )
+                ->timeout( config( 'cms.updates.download_timeout', 300 ) )
+                ->withResponseMiddleware( function ( ResponseInterface $response ): ResponseInterface {
+                    $response->getBody()->close();
+
+                    return $response;
+                } )
+                ->sink( $tempPath )
+                ->get( $downloadUrl );
+
+            if ( ! $response->successful() ) {
+                throw UpdateException::downloadFailed( $downloadUrl );
+            }
+
+            return $tempPath;
+        } catch ( Throwable $e ) {
+            File::delete( $tempPath );
+
+            throw $e;
+        }
+    }
+}

--- a/src/Modules/Notifications/Http/Controllers/NotificationController.php
+++ b/src/Modules/Notifications/Http/Controllers/NotificationController.php
@@ -58,8 +58,7 @@ class NotificationController extends Controller
             'unread_only' => 'sometimes|boolean',
         ] );
 
-        // phpcs:ignore ArtisanPackUIStandard.Security.ValidatedSanitizedInput.InputNotValidated -- Validated above
-        $limit      = $request->input( 'limit', 10 );
+        $limit      = $request->integer( 'limit', 10 );
         $unreadOnly = $request->boolean( 'unread_only', false );
 
         $notifications = $this->notificationManager->getUserNotifications(

--- a/tests/Feature/Notifications/NotificationControllerTest.php
+++ b/tests/Feature/Notifications/NotificationControllerTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\CMSFramework\Modules\Notifications\Models\Notification;
+use ArtisanPackUI\CMSFramework\Tests\Support\TestUser as User;
+
+uses( Illuminate\Foundation\Testing\RefreshDatabase::class );
+
+test( 'index endpoint coerces string limit query param without TypeError', function (): void {
+    $user = User::factory()->create();
+
+    for ( $i = 0; $i < 3; $i++ ) {
+        $notification = Notification::factory()->create();
+        $notification->users()->attach( $user->id, ['is_read' => false, 'is_dismissed' => false] );
+    }
+
+    $response = $this->actingAs( $user, 'sanctum' )
+        ->getJson( '/api/v1/notifications?limit=2' );
+
+    $response->assertOk();
+    expect( $response->json( 'data' ) )->toHaveCount( 2 );
+} );
+
+test( 'index endpoint uses default limit when none provided', function (): void {
+    $user = User::factory()->create();
+
+    for ( $i = 0; $i < 5; $i++ ) {
+        $notification = Notification::factory()->create();
+        $notification->users()->attach( $user->id, ['is_read' => false, 'is_dismissed' => false] );
+    }
+
+    $response = $this->actingAs( $user, 'sanctum' )
+        ->getJson( '/api/v1/notifications' );
+
+    $response->assertOk();
+    expect( $response->json( 'data' ) )->toHaveCount( 5 );
+} );
+
+test( 'index endpoint rejects non-integer limit values', function (): void {
+    $user = User::factory()->create();
+
+    $response = $this->actingAs( $user, 'sanctum' )
+        ->getJson( '/api/v1/notifications?limit=abc' );
+
+    $response->assertStatus( 422 );
+} );

--- a/tests/Unit/Updates/ApplicationUpdateManagerTest.php
+++ b/tests/Unit/Updates/ApplicationUpdateManagerTest.php
@@ -12,6 +12,7 @@ use Error;
 use Illuminate\Support\Facades\Log;
 use Orchestra\Testbench\TestCase;
 use ReflectionClass;
+use ZipArchive;
 
 /**
  * Application Update Manager Tests
@@ -330,6 +331,98 @@ class ApplicationUpdateManagerTest extends TestCase
         }
 
         $this->assertSame( ['enable', 'disable'], $manager->modeCalls );
+    }
+
+    /**
+     * Regression for #219: `extractUpdate` must stream each ZIP entry to disk
+     * via `getStream()` rather than loading it into memory with
+     * `getFromIndex()`, otherwise a single large file inside the release
+     * archive OOMs on 128M hosts mid-extraction.
+     *
+     * @since 2.5.2
+     */
+    public function test_extract_update_streams_entries_to_disk(): void
+    {
+        $tempRoot = sys_get_temp_dir() . '/cmsfw-extract-' . bin2hex( random_bytes( 6 ) );
+        $target   = $tempRoot . '/target';
+        mkdir( $target, 0755, true );
+
+        $zipPath  = $tempRoot . '/update.zip';
+        $largeBig = str_repeat( 'x', 65536 );
+
+        $zip = new ZipArchive;
+        $this->assertTrue( true === $zip->open( $zipPath, ZipArchive::CREATE | ZipArchive::OVERWRITE ) );
+        $zip->addFromString( 'release-root/app/Model.php', "<?php\n" . $largeBig );
+        $zip->addFromString( 'release-root/routes/web.php', "<?php\nRoute::get('/', fn () => 'ok');\n" );
+        $zip->close();
+
+        $manager = new class( $target ) extends ApplicationUpdateManager {
+            public function __construct( protected string $extractRoot )
+            {
+            }
+
+            public function extractInto( string $zipPath ): void
+            {
+                $this->extractUpdate( $zipPath );
+            }
+        };
+
+        // Point the application base path to our temp target so `base_path()`
+        // inside extractUpdate resolves to a scratch directory instead of the
+        // testbench root.
+        $originalBase = base_path();
+        app()->setBasePath( $target );
+
+        try {
+            $manager->extractInto( $zipPath );
+
+            $this->assertFileExists( $target . '/app/Model.php' );
+            $this->assertFileExists( $target . '/routes/web.php' );
+            $this->assertSame(
+                strlen( "<?php\n" . $largeBig ),
+                filesize( $target . '/app/Model.php' ),
+                'Streamed extraction should produce a byte-for-byte copy of the ZIP entry.',
+            );
+        } finally {
+            app()->setBasePath( $originalBase );
+            @unlink( $zipPath );
+            $this->removeDirectory( $target );
+            @rmdir( $tempRoot );
+        }
+    }
+
+    /**
+     * Recursively remove a directory used by extraction tests.
+     *
+     * @since 2.5.2
+     */
+    protected function removeDirectory( string $path ): void
+    {
+        if ( ! is_dir( $path ) ) {
+            return;
+        }
+
+        $items = scandir( $path );
+
+        if ( false === $items ) {
+            return;
+        }
+
+        foreach ( $items as $item ) {
+            if ( '.' === $item || '..' === $item ) {
+                continue;
+            }
+
+            $full = $path . DIRECTORY_SEPARATOR . $item;
+
+            if ( is_dir( $full ) ) {
+                $this->removeDirectory( $full );
+            } else {
+                @unlink( $full );
+            }
+        }
+
+        @rmdir( $path );
     }
 
     /**

--- a/tests/Unit/Updates/CustomJsonUpdateSourceTest.php
+++ b/tests/Unit/Updates/CustomJsonUpdateSourceTest.php
@@ -335,6 +335,45 @@ class CustomJsonUpdateSourceTest extends TestCase
     }
 
     /**
+     * Regression for #219: after the download returns, the response body stream
+     * must be closed so that downstream `ResponseReceived` listeners cannot
+     * copy the release archive back into a PHP string.
+     *
+     * @since 2.5.2
+     */
+    public function test_download_closes_response_body_to_prevent_oom(): void
+    {
+        Http::fake( [
+            'example.com/updates.json' => Http::response( [
+                'version'      => '2.0.0',
+                'download_url' => 'https://example.com/releases/cms-2.0.0.zip',
+            ], 200 ),
+            'example.com/releases/cms-2.0.0.zip' => Http::response( 'zip-bytes', 200 ),
+        ] );
+
+        $source = new CustomJsonUpdateSource( 'https://example.com/updates.json', '1.0.0' );
+
+        $tempPath = $source->downloadUpdate( 'latest' );
+
+        try {
+            $downloadResponse = null;
+            foreach ( Http::recorded() as [$request, $response] ) {
+                if ( 'https://example.com/releases/cms-2.0.0.zip' === $request->url() ) {
+                    $downloadResponse = $response;
+                }
+            }
+
+            $this->assertNotNull( $downloadResponse, 'Expected the download response to be recorded.' );
+            $this->assertFalse(
+                $downloadResponse->toPsrResponse()->getBody()->isReadable(),
+                'Expected the release-archive response body to be closed after download.',
+            );
+        } finally {
+            @unlink( $tempPath );
+        }
+    }
+
+    /**
      * Define environment setup.
      *
      * @since 1.0.0

--- a/tests/Unit/Updates/GitHubUpdateSourceTest.php
+++ b/tests/Unit/Updates/GitHubUpdateSourceTest.php
@@ -364,6 +364,53 @@ class GitHubUpdateSourceTest extends TestCase
     }
 
     /**
+     * Regression for #219: after the download returns, the response body stream
+     * must be closed so that downstream `ResponseReceived` listeners (e.g.
+     * Telescope, Sentry) that call `$response->body()` cannot copy the release
+     * archive back into a PHP string via `GuzzleHttp\Psr7\Utils::copyToString`.
+     *
+     * @since 2.5.2
+     */
+    public function test_download_closes_response_body_to_prevent_oom(): void
+    {
+        Http::fake( [
+            'api.github.com/repos/user/repo/releases/tags/v2.0.0' => Http::response( [
+                'tag_name'    => 'v2.0.0',
+                'prerelease'  => false,
+                'zipball_url' => 'https://api.github.com/repos/user/repo/zipball/v2.0.0',
+                'assets'      => [
+                    [
+                        'name'                 => 'app-2.0.0.zip',
+                        'browser_download_url' => 'https://example.com/app-2.0.0.zip',
+                    ],
+                ],
+            ], 200 ),
+            'example.com/app-2.0.0.zip' => Http::response( 'zip-bytes', 200 ),
+        ] );
+
+        $source = new GitHubUpdateSource( 'https://github.com/user/repo', '1.0.0' );
+
+        $tempPath = $source->downloadUpdate( 'v2.0.0' );
+
+        try {
+            $downloadResponse = null;
+            foreach ( Http::recorded() as [$request, $response] ) {
+                if ( 'https://example.com/app-2.0.0.zip' === $request->url() ) {
+                    $downloadResponse = $response;
+                }
+            }
+
+            $this->assertNotNull( $downloadResponse, 'Expected the download response to be recorded.' );
+            $this->assertFalse(
+                $downloadResponse->toPsrResponse()->getBody()->isReadable(),
+                'Expected the release-archive response body to be closed after download.',
+            );
+        } finally {
+            @unlink( $tempPath );
+        }
+    }
+
+    /**
      * Define environment setup.
      *
      * @since 1.0.0

--- a/tests/Unit/Updates/GitLabUpdateSourceTest.php
+++ b/tests/Unit/Updates/GitLabUpdateSourceTest.php
@@ -920,6 +920,46 @@ class GitLabUpdateSourceTest extends TestCase
     }
 
     /**
+     * Regression for #219: after the download returns, the response body stream
+     * must be closed so that downstream `ResponseReceived` listeners cannot
+     * copy the release archive back into a PHP string.
+     *
+     * @since 2.5.2
+     */
+    public function test_download_closes_response_body_to_prevent_oom(): void
+    {
+        Http::fake( [
+            'gitlab.com/api/v4/projects/user%2Frepo/releases/v2.0.0' => Http::response( [
+                'tag_name'    => 'v2.0.0',
+                'description' => 'Release',
+                'created_at'  => '2024-12-15T10:00:00.000Z',
+            ], 200 ),
+            'gitlab.com/api/v4/projects/user%2Frepo/repository/archive.zip*' => Http::response( 'zip-bytes', 200 ),
+        ] );
+
+        $source = new GitLabUpdateSource( 'https://gitlab.com/user/repo', '1.0.0' );
+
+        $tempPath = $source->downloadUpdate( 'v2.0.0' );
+
+        try {
+            $downloadResponse = null;
+            foreach ( Http::recorded() as [$request, $response] ) {
+                if ( str_contains( $request->url(), 'repository/archive.zip' ) ) {
+                    $downloadResponse = $response;
+                }
+            }
+
+            $this->assertNotNull( $downloadResponse, 'Expected the download response to be recorded.' );
+            $this->assertFalse(
+                $downloadResponse->toPsrResponse()->getBody()->isReadable(),
+                'Expected the release-archive response body to be closed after download.',
+            );
+        } finally {
+            @unlink( $tempPath );
+        }
+    }
+
+    /**
      * Define environment setup.
      *
      * @since 1.0.0


### PR DESCRIPTION
## Release Information

- **Release Version:** v2.5.2
- **Release Date:** 2026-07-22
- **Release Type:** Patch
- **Release Branch:** `release/2.5.2`
- **Target Branch:** `main`

## Release Summary

Patch release with two fixes finishing off the 128M-host updater story from 2.5.0/2.5.1 and killing a strict-types `TypeError` that was flooding admin logs.

## Changelog

### Fixed

- **Application updater still OOM'd post-download on 128M hosts** (#219) — closes the second half of the 2.5.1 streaming fix. A downstream `ResponseReceived` listener could still pull the whole ZIP into memory via `$response->body()`, and `ApplicationUpdateManager::extractUpdate()` was loading each ZIP entry into memory via `getFromIndex()`. A new `StreamsDownloadsToDisk` trait (shared by the three update sources) wraps `Http::sink()` with a `withResponseMiddleware` that closes the sink body before Laravel dispatches `ResponseReceived`. `extractUpdate()` now streams each ZIP entry with `$zip->getStream()` + chunked `fread`/`fwrite`. Regression tests: one per source asserts the recorded PSR-7 response body is unreadable after `downloadUpdate()` returns, and a new `ApplicationUpdateManagerTest` case runs `extractUpdate()` against a real ZIP under a scoped base path.
- **`NotificationController::index` `TypeError` on every admin poll** (#220) — the raw string from `?limit=…` was passed straight to `NotificationManager::getUserNotifications( int $limit, … )`, tripping a strict-types `TypeError` on every ~30s admin poll and drowning `storage/logs/laravel.log`. Swapped `$request->input()` for `$request->integer()` so the value is coerced at the controller boundary; existing `sometimes|integer|min:1|max:100` validation still rejects non-numeric input with 422. New `NotificationControllerTest` covers coercion, default limit, and the validation-rejection regression fence.

## Issues and Pull Requests

**Issues Fixed:**
- Closes #219
- Closes #220

**Related PRs:**
- #221
- #222

## Breaking Changes

- [x] No breaking changes

## Testing Checklist

- [x] All automated tests passing (1397 passed, 7 skipped, 3518 assertions)
- [x] Security scan completed (4 medium advisories on transitive `guzzlehttp/guzzle` <7.15.1; unrelated to this release, tracked separately)

## Documentation Checklist

- [x] CHANGELOG updated
- [x] `docs/` reviewed — no changes required for this patch release
- [x] README unchanged (no version-pinned references affected)

## Pre-Release Checklist

- [x] Version number updated in `composer.json` (2.5.1 → 2.5.2)
- [x] Release branch pushed: `release/2.5.2`
- [x] `composer.lock` in sync

## Post-Release Tasks

- [ ] Tag created: `v2.5.2`
- [ ] Release notes published

## Notes

The 2.5.0 → 2.5.1 → 2.5.2 sequence closes the updater OOM story in three passes:
- 2.5.0 (#214): streamed download for GitLab/GitHub update sources
- 2.5.1 (#216): same fix ported to `CustomJsonUpdateSource`
- 2.5.2 (#219): closes the sink body against `ResponseReceived` listeners, and streams ZIP extraction

---

**Release Manager:** @jacob-martella