### PR TITLE
fix: keep sink'd download response body observer-safe for ResponseReceived listeners

### DIFF
--- a/src/Modules/Core/Updates/Support/StreamsDownloadsToDisk.php
+++ b/src/Modules/Core/Updates/Support/StreamsDownloadsToDisk.php
@@ -5,6 +5,7 @@ declare( strict_types=1 );
 namespace ArtisanPackUI\CMSFramework\Modules\Core\Updates\Support;
 
 use ArtisanPackUI\CMSFramework\Modules\Core\Updates\Exceptions\UpdateException;
+use GuzzleHttp\Psr7\Utils;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Http;
 use Psr\Http\Message\ResponseInterface;
@@ -23,9 +24,11 @@ use Throwable;
  * any release near ~half of it.
  *
  * This trait wraps `Http::sink()` with a response middleware that closes the
- * sink body as soon as Guzzle hands the response back — before the `Response`
- * wrapper is constructed and before `ResponseReceived` fires — so any later
- * `body()` call returns an empty string rather than reloading the archive.
+ * sink body as soon as Guzzle hands the response back and swaps in a fresh
+ * in-memory empty stream — before the `Response` wrapper is constructed and
+ * before `ResponseReceived` fires — so any later `body()` call returns an
+ * empty string rather than reloading the archive or throwing on a detached
+ * stream (see #224 for the Herd Pro / Telescope / Debugbar interaction).
  *
  * @since 2.5.2
  */
@@ -60,7 +63,7 @@ trait StreamsDownloadsToDisk
                 ->withResponseMiddleware( function ( ResponseInterface $response ): ResponseInterface {
                     $response->getBody()->close();
 
-                    return $response;
+                    return $response->withBody( Utils::streamFor( '' ) );
                 } )
                 ->sink( $tempPath )
                 ->get( $downloadUrl );

--- a/tests/Unit/Updates/CustomJsonUpdateSourceTest.php
+++ b/tests/Unit/Updates/CustomJsonUpdateSourceTest.php
@@ -7,6 +7,8 @@ namespace ArtisanPackUI\CMSFramework\Tests\Unit\Updates;
 use ArtisanPackUI\CMSFramework\Modules\Core\Updates\Exceptions\UpdateException;
 use ArtisanPackUI\CMSFramework\Modules\Core\Updates\Sources\CustomJsonUpdateSource;
 use ArtisanPackUI\CMSFramework\Modules\Core\Updates\ValueObjects\UpdateInfo;
+use Illuminate\Http\Client\Events\ResponseReceived;
+use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Http;
 use Orchestra\Testbench\TestCase;
 
@@ -335,13 +337,16 @@ class CustomJsonUpdateSourceTest extends TestCase
     }
 
     /**
-     * Regression for #219: after the download returns, the response body stream
-     * must be closed so that downstream `ResponseReceived` listeners cannot
-     * copy the release archive back into a PHP string.
+     * Regression for #219 / #224: after the download returns, the response body
+     * must be safely inspectable by downstream `ResponseReceived` listeners
+     * (Herd Pro's HTTP watcher, Telescope, Debugbar, custom monitoring). The
+     * body is swapped for a fresh empty stream so `->body()` returns `''`
+     * instead of copying the release archive back into a PHP string (#219) or
+     * throwing "Stream is detached" on the closed sink stream (#224).
      *
      * @since 2.5.2
      */
-    public function test_download_closes_response_body_to_prevent_oom(): void
+    public function test_download_response_body_is_observer_safe(): void
     {
         Http::fake( [
             'example.com/updates.json' => Http::response( [
@@ -351,23 +356,23 @@ class CustomJsonUpdateSourceTest extends TestCase
             'example.com/releases/cms-2.0.0.zip' => Http::response( 'zip-bytes', 200 ),
         ] );
 
+        $seen = [];
+        Event::listen(
+            ResponseReceived::class,
+            function ( ResponseReceived $event ) use ( &$seen ): void {
+                $seen[ $event->request->url() ] = $event->response->body();
+            },
+        );
+
         $source = new CustomJsonUpdateSource( 'https://example.com/updates.json', '1.0.0' );
 
         $tempPath = $source->downloadUpdate( 'latest' );
 
         try {
-            $downloadResponse = null;
-            foreach ( Http::recorded() as [$request, $response] ) {
-                if ( 'https://example.com/releases/cms-2.0.0.zip' === $request->url() ) {
-                    $downloadResponse = $response;
-                }
-            }
-
-            $this->assertNotNull( $downloadResponse, 'Expected the download response to be recorded.' );
-            $this->assertFalse(
-                $downloadResponse->toPsrResponse()->getBody()->isReadable(),
-                'Expected the release-archive response body to be closed after download.',
-            );
+            $this->assertFileExists( $tempPath );
+            $this->assertSame( 'zip-bytes', file_get_contents( $tempPath ) );
+            $this->assertArrayHasKey( 'https://example.com/releases/cms-2.0.0.zip', $seen );
+            $this->assertSame( '', $seen['https://example.com/releases/cms-2.0.0.zip'] );
         } finally {
             @unlink( $tempPath );
         }

--- a/tests/Unit/Updates/GitHubUpdateSourceTest.php
+++ b/tests/Unit/Updates/GitHubUpdateSourceTest.php
@@ -7,6 +7,8 @@ namespace ArtisanPackUI\CMSFramework\Tests\Unit\Updates;
 use ArtisanPackUI\CMSFramework\Modules\Core\Updates\Exceptions\UpdateException;
 use ArtisanPackUI\CMSFramework\Modules\Core\Updates\Sources\GitHubUpdateSource;
 use ArtisanPackUI\CMSFramework\Modules\Core\Updates\ValueObjects\UpdateInfo;
+use Illuminate\Http\Client\Events\ResponseReceived;
+use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Http;
 use InvalidArgumentException;
 use Orchestra\Testbench\TestCase;
@@ -364,14 +366,16 @@ class GitHubUpdateSourceTest extends TestCase
     }
 
     /**
-     * Regression for #219: after the download returns, the response body stream
-     * must be closed so that downstream `ResponseReceived` listeners (e.g.
-     * Telescope, Sentry) that call `$response->body()` cannot copy the release
-     * archive back into a PHP string via `GuzzleHttp\Psr7\Utils::copyToString`.
+     * Regression for #219 / #224: after the download returns, the response body
+     * must be safely inspectable by downstream `ResponseReceived` listeners
+     * (Herd Pro's HTTP watcher, Telescope, Debugbar, custom monitoring). The
+     * body is swapped for a fresh empty stream so `->body()` returns `''`
+     * instead of copying the release archive back into a PHP string (#219) or
+     * throwing "Stream is detached" on the closed sink stream (#224).
      *
      * @since 2.5.2
      */
-    public function test_download_closes_response_body_to_prevent_oom(): void
+    public function test_download_response_body_is_observer_safe(): void
     {
         Http::fake( [
             'api.github.com/repos/user/repo/releases/tags/v2.0.0' => Http::response( [
@@ -388,23 +392,23 @@ class GitHubUpdateSourceTest extends TestCase
             'example.com/app-2.0.0.zip' => Http::response( 'zip-bytes', 200 ),
         ] );
 
+        $seen = [];
+        Event::listen(
+            ResponseReceived::class,
+            function ( ResponseReceived $event ) use ( &$seen ): void {
+                $seen[ $event->request->url() ] = $event->response->body();
+            },
+        );
+
         $source = new GitHubUpdateSource( 'https://github.com/user/repo', '1.0.0' );
 
         $tempPath = $source->downloadUpdate( 'v2.0.0' );
 
         try {
-            $downloadResponse = null;
-            foreach ( Http::recorded() as [$request, $response] ) {
-                if ( 'https://example.com/app-2.0.0.zip' === $request->url() ) {
-                    $downloadResponse = $response;
-                }
-            }
-
-            $this->assertNotNull( $downloadResponse, 'Expected the download response to be recorded.' );
-            $this->assertFalse(
-                $downloadResponse->toPsrResponse()->getBody()->isReadable(),
-                'Expected the release-archive response body to be closed after download.',
-            );
+            $this->assertFileExists( $tempPath );
+            $this->assertSame( 'zip-bytes', file_get_contents( $tempPath ) );
+            $this->assertArrayHasKey( 'https://example.com/app-2.0.0.zip', $seen );
+            $this->assertSame( '', $seen['https://example.com/app-2.0.0.zip'] );
         } finally {
             @unlink( $tempPath );
         }

--- a/tests/Unit/Updates/GitLabUpdateSourceTest.php
+++ b/tests/Unit/Updates/GitLabUpdateSourceTest.php
@@ -7,6 +7,8 @@ namespace ArtisanPackUI\CMSFramework\Tests\Unit\Updates;
 use ArtisanPackUI\CMSFramework\Modules\Core\Updates\Exceptions\UpdateException;
 use ArtisanPackUI\CMSFramework\Modules\Core\Updates\Sources\GitLabUpdateSource;
 use ArtisanPackUI\CMSFramework\Modules\Core\Updates\ValueObjects\UpdateInfo;
+use Illuminate\Http\Client\Events\ResponseReceived;
+use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
 use InvalidArgumentException;
@@ -920,13 +922,16 @@ class GitLabUpdateSourceTest extends TestCase
     }
 
     /**
-     * Regression for #219: after the download returns, the response body stream
-     * must be closed so that downstream `ResponseReceived` listeners cannot
-     * copy the release archive back into a PHP string.
+     * Regression for #219 / #224: after the download returns, the response body
+     * must be safely inspectable by downstream `ResponseReceived` listeners
+     * (Herd Pro's HTTP watcher, Telescope, Debugbar, custom monitoring). The
+     * body is swapped for a fresh empty stream so `->body()` returns `''`
+     * instead of copying the release archive back into a PHP string (#219) or
+     * throwing "Stream is detached" on the closed sink stream (#224).
      *
      * @since 2.5.2
      */
-    public function test_download_closes_response_body_to_prevent_oom(): void
+    public function test_download_response_body_is_observer_safe(): void
     {
         Http::fake( [
             'gitlab.com/api/v4/projects/user%2Frepo/releases/v2.0.0' => Http::response( [
@@ -937,23 +942,25 @@ class GitLabUpdateSourceTest extends TestCase
             'gitlab.com/api/v4/projects/user%2Frepo/repository/archive.zip*' => Http::response( 'zip-bytes', 200 ),
         ] );
 
+        $seen = [];
+        Event::listen(
+            ResponseReceived::class,
+            function ( ResponseReceived $event ) use ( &$seen ): void {
+                if ( str_contains( $event->request->url(), 'repository/archive.zip' ) ) {
+                    $seen[ $event->request->url() ] = $event->response->body();
+                }
+            },
+        );
+
         $source = new GitLabUpdateSource( 'https://gitlab.com/user/repo', '1.0.0' );
 
         $tempPath = $source->downloadUpdate( 'v2.0.0' );
 
         try {
-            $downloadResponse = null;
-            foreach ( Http::recorded() as [$request, $response] ) {
-                if ( str_contains( $request->url(), 'repository/archive.zip' ) ) {
-                    $downloadResponse = $response;
-                }
-            }
-
-            $this->assertNotNull( $downloadResponse, 'Expected the download response to be recorded.' );
-            $this->assertFalse(
-                $downloadResponse->toPsrResponse()->getBody()->isReadable(),
-                'Expected the release-archive response body to be closed after download.',
-            );
+            $this->assertFileExists( $tempPath );
+            $this->assertSame( 'zip-bytes', file_get_contents( $tempPath ) );
+            $this->assertCount( 1, $seen, 'Expected the download response to fan out to listeners.' );
+            $this->assertSame( '', reset( $seen ) );
         } finally {
             @unlink( $tempPath );
         }


### PR DESCRIPTION
## Description

The self-updater sinks the release archive straight to disk via `Http::sink()` and closes the underlying stream in a response middleware to keep listeners from copying the archive back into memory (#219). But closing the `LazyOpenStream` **detaches** it, so any `ResponseReceived` listener that calls `$response->body()` — Herd Pro's `HttpClientWatcher`, Telescope, Debugbar, custom monitoring — throws `Stream is detached` from `GuzzleHttp\Psr7\LazyOpenStream::eof()`. The whole update pipeline succeeds (download, hash, extract, file swap, composer install, migrations) and *then* dies during the trailing event fanout, at which point the framework catches it as an update failure and rolls back a successfully-applied update.

The fix: after closing the sink stream, swap the response body for a fresh in-memory empty stream via `Utils::streamFor('')` in the same `withResponseMiddleware`. `body()` now returns `''` safely for any observer, before the `Response` wrapper is constructed and before `ResponseReceived` fires.

**Closes:** #224

## Type of Change

- [x] Bug fix (fixes an issue)

## Related Issue

**Issue:** #224

## Motivation and Context

Follow-up to #214 / #219. Those hardened the download itself (stream to disk instead of buffering; close the response body to prevent OOM). This one hardens the *response* the download returns so it can survive listeners running afterwards — the exact scenario that shows up on any Herd Pro / Telescope / Debugbar host. Without this, users can't self-update via the admin UI on any dev-tooling-enabled host and have to fall back to composer, which defeats the whole point of the self-updater.

## Changes Made

- `StreamsDownloadsToDisk::streamDownloadToTempFile()` — after closing the sink stream in `withResponseMiddleware`, return `$response->withBody(Utils::streamFor(''))` so subsequent `body()` calls read an empty in-memory stream instead of throwing on the detached `LazyOpenStream`.
- Replaced the three source-test observer-safety assertions (GitLab / GitHub / CustomJson) with a real `ResponseReceived` listener that calls `->body()` — the exact code path Herd Pro's `HttpClientWatcher`, Telescope, and Debugbar all take. The prior assertions only inspected `Http::recorded()` and would have missed both the original #219 OOM and this #224 detach behavior.
- Updated the trait docblock to reference the new behavior and #224.

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS with Laravel Herd Pro
- Browser (if applicable): N/A (server-side error)
- PHP Version: 8.4.23
- Project Version: cms-framework 2.5.3 (host: Keystone CMS 0.2.0 → 0.2.2)

**Tests Performed:**
1. `./vendor/bin/pest tests/Unit/Updates tests/Feature/Updates` — 97 passed
2. Manually exercised the update flow on a Herd Pro Keystone trial site: `/admin/settings/updates` now completes 0.2.0 → 0.2.2 without the "Stream is detached" rollback
3. Ran the same flow with Laravel Telescope installed to confirm the fix covers the Telescope HTTP watcher path

## Accessibility Tests Run

- [x] N/A — server-side error path, no user-facing markup changed

**Details:** No UI changes.

## Tests Added

- [x] Unit tests added/updated
- [x] All tests passing

**Test details:**

Rewrote `test_download_response_body_is_observer_safe` in all three source test classes to register an actual `ResponseReceived` listener (via `Event::listen`) that calls `$event->response->body()`, then asserts:
1. The temp file was written with the expected zip bytes
2. The listener saw the download URL fan out
3. `body()` returned `''` instead of throwing

This is the exact failure mode #224 describes. Pre-fix, these tests would have failed with `RuntimeException: Stream is detached`.

## Documentation

- [x] Inline code documentation added

**Documentation details:** Updated the `StreamsDownloadsToDisk` trait docblock to describe both the #219 (OOM prevention) and #224 (detached-stream prevention) invariants the empty-body swap enforces.

## Pre-Submission Checklist

- [x] Followed contributing guidelines
- [x] Checked for other open PRs for same update
- [x] Code passes all tests
- [x] Code has been linted
- [x] Accessibility tests completed
- [x] Code follows project style guide
- [x] Self-review completed
- [x] Comments added for complex code
- [x] No new warnings generated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved update downloads to prevent downstream response observers from accessing large archive contents after the download completes.
  * Preserved downloaded files while ensuring later response-body checks return an empty value, reducing memory-related risks.

* **Tests**
  * Added regression coverage across supported update sources to verify safe response inspection and correct temporary-file contents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->