### PR TITLE
fix: keep UpdateInfo.hasUpdate() honest after out-of-band version bumps

### DIFF
--- a/docs/self-updater.md
+++ b/docs/self-updater.md
@@ -40,6 +40,15 @@ When an update fails, the framework rolls back to the pre-update backup. Two beh
 
 - **When rollback itself fails, the resulting exception preserves the original update-failure message.** You'll see both `Rollback failed: {rollback error}. Original update error: {original error}. Manual intervention required.` — no more losing the actual first-error text.
 
+## Cached update info and out-of-band version bumps
+
+`UpdateChecker::checkForUpdate()` caches the resolved `UpdateInfo` value object under `cms.{type}.{slug}.update_check` for `cms.updates.cache_ttl` seconds (default 43,200s / 12h). The cached object contains both the feed's `latestVersion` and a snapshot of `config('app.version')` taken when the cache was populated.
+
+When the host's installed version changes *out-of-band* (a manual `composer install` on a release zip, an unzip-over-site, a deploy script) the framework keeps the cached feed data honest in two ways:
+
+- **`UpdateChecker::checkForUpdate()` discards the cached `UpdateInfo` when the cached `currentVersion` snapshot no longer matches `config('app.version')`** and re-fetches from the source. No stale positive for up to 12h.
+- **`UpdateInfo::hasUpdate()` reads `config('app.version')` at call time** rather than comparing against its own frozen `currentVersion`, so any cached instance still returns the correct answer even if the invalidation branch above hasn't fired yet. Falls back to the constructor value when the container has no bound `config`.
+
 ## Related config
 
 | Key | Purpose |

--- a/src/Modules/Core/Updates/Console/CheckForUpdateCommand.php
+++ b/src/Modules/Core/Updates/Console/CheckForUpdateCommand.php
@@ -56,7 +56,7 @@ class CheckForUpdateCommand extends Command
             if ( $updateInfo->hasUpdate() ) {
                 $this->newLine();
                 $this->info( '✓ Update available!' );
-                $this->line( "Current version: {$updateInfo->currentVersion}" );
+                $this->line( "Current version: {$updateInfo->resolveCurrentVersion()}" );
                 $this->line( "Latest version:  {$updateInfo->latestVersion}" );
 
                 if ( $updateInfo->releaseDate ) {

--- a/src/Modules/Core/Updates/Console/CheckForUpdateScheduled.php
+++ b/src/Modules/Core/Updates/Console/CheckForUpdateScheduled.php
@@ -53,7 +53,7 @@ class CheckForUpdateScheduled extends Command
 
                 // Log the available update
                 Log::info( 'Update available', [
-                    'current_version' => $updateInfo->currentVersion,
+                    'current_version' => $updateInfo->resolveCurrentVersion(),
                     'latest_version'  => $updateInfo->latestVersion,
                     'release_date'    => $updateInfo->releaseDate,
                 ] );

--- a/src/Modules/Core/Updates/Console/PerformUpdateCommand.php
+++ b/src/Modules/Core/Updates/Console/PerformUpdateCommand.php
@@ -58,7 +58,7 @@ class PerformUpdateCommand extends Command
 
             // Show update information
             $this->newLine();
-            $this->line( "Current version: {$updateInfo->currentVersion}" );
+            $this->line( "Current version: {$updateInfo->resolveCurrentVersion()}" );
             $this->line( "Update to:       {$version}" );
             $this->newLine();
 

--- a/src/Modules/Core/Updates/UpdateChecker.php
+++ b/src/Modules/Core/Updates/UpdateChecker.php
@@ -48,7 +48,18 @@ class UpdateChecker
 
         if ( config( 'cms.updates.cache_enabled', true ) ) {
             $cached = Cache::get( $cacheKey );
-            if ( $cached instanceof UpdateInfo ) {
+
+            // Discard cached UpdateInfo whose `currentVersion` snapshot
+            // disagrees with the currently installed version. Without this, an
+            // out-of-band version bump (manual `composer install`,
+            // unzip-over-site, deploy script) leaves the cache serving a stale
+            // "update available to X" for a site already on X, up to
+            // `cms.updates.cache_ttl` seconds. Belt-and-suspenders with
+            // `UpdateInfo::hasUpdate()`, which also re-reads the current
+            // version at call time. Hosts that never set `app.version` — in
+            // which case we have nothing fresher to compare against — keep
+            // the pre-2.5.3 "serve cache until TTL" behavior.
+            if ( $cached instanceof UpdateInfo && ! $this->cacheIsStale( $cached ) ) {
                 return $cached;
             }
         }
@@ -137,5 +148,23 @@ class UpdateChecker
     public function getSlug(): string
     {
         return $this->slug;
+    }
+
+    /**
+     * Decide whether a cached `UpdateInfo` should be evicted because the host's
+     * installed version has moved on out-of-band. When `app.version` is unset
+     * we have nothing fresher to compare against, so treat the cache as fresh.
+     *
+     * @since 2.5.3
+     */
+    protected function cacheIsStale( UpdateInfo $cached ): bool
+    {
+        $configured = config( 'app.version' );
+
+        if ( ! is_string( $configured ) || '' === $configured ) {
+            return false;
+        }
+
+        return $cached->currentVersion !== $configured;
     }
 }

--- a/src/Modules/Core/Updates/ValueObjects/UpdateInfo.php
+++ b/src/Modules/Core/Updates/ValueObjects/UpdateInfo.php
@@ -4,6 +4,7 @@ declare( strict_types=1 );
 
 namespace ArtisanPackUI\CMSFramework\Modules\Core\Updates\ValueObjects;
 
+use Illuminate\Container\Container;
 use InvalidArgumentException;
 
 /**
@@ -48,14 +49,43 @@ class UpdateInfo
     /**
      * Whether an update is available.
      *
-     * Computed from version comparison rather than stored state
-     * to prevent inconsistency.
+     * Reads the currently installed version fresh from `config('app.version')`
+     * at call time rather than comparing against the cached
+     * `$this->currentVersion` snapshot. Without this, a cached `UpdateInfo`
+     * survives an out-of-band version bump (manual `composer install`,
+     * unzip-over-site, deploy script) and keeps reporting a stale
+     * "update available" for up to `cms.updates.cache_ttl` seconds.
+     *
+     * Falls back to `$this->currentVersion` when `app.version` is unavailable
+     * — the pre-2.5.3 behavior — so callers that construct `UpdateInfo`
+     * directly for tests continue to work.
      *
      * @since 1.1.0
      */
     public function hasUpdate(): bool
     {
-        return version_compare( $this->latestVersion, $this->currentVersion, '>' );
+        return version_compare( $this->latestVersion, $this->resolveCurrentVersion(), '>' );
+    }
+
+    /**
+     * The currently installed version, read fresh from `config('app.version')`
+     * when the container is bootstrapped and the value is a non-empty string.
+     * Falls back to `$this->currentVersion` for non-Laravel callers, tests,
+     * or hosts that never set `app.version`.
+     *
+     * @since 2.5.3
+     */
+    public function resolveCurrentVersion(): string
+    {
+        if ( Container::getInstance()->bound( 'config' ) ) {
+            $configured = config( 'app.version' );
+
+            if ( is_string( $configured ) && '' !== $configured ) {
+                return $configured;
+            }
+        }
+
+        return $this->currentVersion;
     }
 
     /**
@@ -94,7 +124,7 @@ class UpdateInfo
     public function toArray(): array
     {
         return [
-            'current'               => $this->currentVersion,
+            'current'               => $this->resolveCurrentVersion(),
             'latest'                => $this->latestVersion,
             'hasUpdate'             => $this->hasUpdate(),
             'download_url'          => $this->downloadUrl,

--- a/tests/Unit/Updates/UpdateCheckerTest.php
+++ b/tests/Unit/Updates/UpdateCheckerTest.php
@@ -1,0 +1,228 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Tests\Unit\Updates;
+
+use ArtisanPackUI\CMSFramework\Modules\Core\Updates\Contracts\UpdateSourceInterface;
+use ArtisanPackUI\CMSFramework\Modules\Core\Updates\Enums\UpdateType;
+use ArtisanPackUI\CMSFramework\Modules\Core\Updates\UpdateChecker;
+use ArtisanPackUI\CMSFramework\Modules\Core\Updates\ValueObjects\UpdateInfo;
+use Illuminate\Support\Facades\Cache;
+use Orchestra\Testbench\TestCase;
+
+/**
+ * Update Checker Tests
+ *
+ * @since 2.5.3
+ */
+class UpdateCheckerTest extends TestCase
+{
+    /**
+     * Regression for #226: `UpdateChecker::checkForUpdate()` discards a cached
+     * `UpdateInfo` whose `currentVersion` snapshot no longer matches
+     * `config('app.version')`, forcing a fresh source check. Without this,
+     * an out-of-band version bump leaves the cache serving a stale
+     * "update available to X" for a site already on X, up to
+     * `cms.updates.cache_ttl` seconds.
+     *
+     * @since 2.5.3
+     */
+    public function test_check_for_update_discards_cache_when_current_version_moved(): void
+    {
+        config( ['app.version' => '0.2.2'] );
+
+        $cacheKey = 'cms.' . UpdateType::Application->value . '.test-app.update_check';
+
+        // Prime the cache with a snapshot from when the host was on 0.2.0.
+        Cache::put(
+            $cacheKey,
+            new UpdateInfo(
+                currentVersion: '0.2.0',
+                latestVersion: '0.2.2',
+                downloadUrl: 'https://example.com/update.zip',
+            ),
+            3600,
+        );
+
+        $freshInfo = new UpdateInfo(
+            currentVersion: '0.2.2',
+            latestVersion: '0.2.2',
+            downloadUrl: 'https://example.com/update.zip',
+        );
+
+        $source = new class( $freshInfo ) implements UpdateSourceInterface {
+            public int $checkCount = 0;
+
+            public function __construct( protected UpdateInfo $info )
+            {
+            }
+
+            public function supports( string $url ): bool
+            {
+                return true;
+            }
+
+            public function checkForUpdate(): UpdateInfo
+            {
+                $this->checkCount++;
+
+                return $this->info;
+            }
+
+            public function downloadUpdate( string $version ): string
+            {
+                return '/tmp/noop.zip';
+            }
+
+            public function setAuthentication( string|array $credentials ): void
+            {
+            }
+
+            public function getName(): string
+            {
+                return 'Fake';
+            }
+        };
+
+        $checker = new UpdateChecker( $source, UpdateType::Application, 'test-app' );
+
+        $result = $checker->checkForUpdate();
+
+        $this->assertSame( 1, $source->checkCount, 'Stale cache should have been discarded.' );
+        $this->assertSame( '0.2.2', $result->currentVersion );
+        $this->assertFalse( $result->hasUpdate() );
+    }
+
+    /**
+     * Regression for #226: a fresh cache whose `currentVersion` still matches
+     * `config('app.version')` is served without re-hitting the source.
+     *
+     * @since 2.5.3
+     */
+    public function test_check_for_update_serves_cache_when_current_version_matches(): void
+    {
+        config( ['app.version' => '0.2.0'] );
+
+        $cacheKey = 'cms.' . UpdateType::Application->value . '.test-app.update_check';
+
+        $cached = new UpdateInfo(
+            currentVersion: '0.2.0',
+            latestVersion: '0.2.2',
+            downloadUrl: 'https://example.com/update.zip',
+        );
+
+        Cache::put( $cacheKey, $cached, 3600 );
+
+        $source = new class implements UpdateSourceInterface {
+            public int $checkCount = 0;
+
+            public function supports( string $url ): bool
+            {
+                return true;
+            }
+
+            public function checkForUpdate(): UpdateInfo
+            {
+                $this->checkCount++;
+
+                return new UpdateInfo( '0.0.0', '0.0.0', '' );
+            }
+
+            public function downloadUpdate( string $version ): string
+            {
+                return '/tmp/noop.zip';
+            }
+
+            public function setAuthentication( string|array $credentials ): void
+            {
+            }
+
+            public function getName(): string
+            {
+                return 'Fake';
+            }
+        };
+
+        $checker = new UpdateChecker( $source, UpdateType::Application, 'test-app' );
+
+        $result = $checker->checkForUpdate();
+
+        $this->assertSame( 0, $source->checkCount, 'Fresh cache should have been served.' );
+        $this->assertSame( '0.2.0', $result->currentVersion );
+        $this->assertSame( '0.2.2', $result->latestVersion );
+    }
+
+    /**
+     * Regression for #226: when the host never sets `app.version`, the
+     * cache-staleness check has nothing fresher to compare against and must
+     * NOT evict the cache — otherwise the "unset app.version" case triggers a
+     * source hit on every read (worse than the pre-fix behavior).
+     *
+     * @since 2.5.3
+     */
+    public function test_check_for_update_serves_cache_when_app_version_unset(): void
+    {
+        config( ['app.version' => null] );
+
+        $cacheKey = 'cms.' . UpdateType::Application->value . '.test-app.update_check';
+
+        $cached = new UpdateInfo(
+            currentVersion: '0.2.0',
+            latestVersion: '0.2.2',
+            downloadUrl: 'https://example.com/update.zip',
+        );
+
+        Cache::put( $cacheKey, $cached, 3600 );
+
+        $source = new class implements UpdateSourceInterface {
+            public int $checkCount = 0;
+
+            public function supports( string $url ): bool
+            {
+                return true;
+            }
+
+            public function checkForUpdate(): UpdateInfo
+            {
+                $this->checkCount++;
+
+                return new UpdateInfo( '0.0.0', '0.0.0', '' );
+            }
+
+            public function downloadUpdate( string $version ): string
+            {
+                return '/tmp/noop.zip';
+            }
+
+            public function setAuthentication( string|array $credentials ): void
+            {
+            }
+
+            public function getName(): string
+            {
+                return 'Fake';
+            }
+        };
+
+        $checker = new UpdateChecker( $source, UpdateType::Application, 'test-app' );
+
+        $result = $checker->checkForUpdate();
+
+        $this->assertSame( 0, $source->checkCount, 'Missing app.version must not evict cache.' );
+        $this->assertSame( '0.2.0', $result->currentVersion );
+    }
+
+    /**
+     * Define environment setup.
+     *
+     * @since 2.5.3
+     *
+     * @param  \Illuminate\Foundation\Application  $app
+     */
+    protected function defineEnvironment( $app ): void
+    {
+        $app['config']->set( 'cms.updates.cache_enabled', true );
+        $app['config']->set( 'cms.updates.cache_ttl', 3600 );
+    }
+}

--- a/tests/Unit/Updates/UpdateInfoTest.php
+++ b/tests/Unit/Updates/UpdateInfoTest.php
@@ -5,6 +5,8 @@ declare( strict_types=1 );
 namespace ArtisanPackUI\CMSFramework\Tests\Unit\Updates;
 
 use ArtisanPackUI\CMSFramework\Modules\Core\Updates\ValueObjects\UpdateInfo;
+use Illuminate\Config\Repository as ConfigRepository;
+use Illuminate\Container\Container;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -14,6 +16,31 @@ use PHPUnit\Framework\TestCase;
  */
 class UpdateInfoTest extends TestCase
 {
+    /**
+     * Snapshot of the global container instance before each test so we can
+     * restore it in tearDown. Without this, a test that calls
+     * `Container::setInstance()` (see the #226 regressions below) can leak the
+     * hand-built container into any subsequent test class that assumes the
+     * container Testbench set up is still current.
+     *
+     * @since 2.5.3
+     */
+    private ?Container $containerSnapshot = null;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->containerSnapshot = Container::getInstance();
+    }
+
+    protected function tearDown(): void
+    {
+        Container::setInstance( $this->containerSnapshot );
+
+        parent::tearDown();
+    }
+
     /**
      * Test UpdateInfo can be instantiated.
      *
@@ -89,6 +116,120 @@ class UpdateInfoTest extends TestCase
         $info = UpdateInfo::fromArray( $data, '2.0.0' );
 
         $this->assertFalse( $info->hasUpdate() );
+    }
+
+    /**
+     * Regression for #226: `hasUpdate()` compares `latestVersion` against
+     * `config('app.version')` at call time when the container is bootstrapped
+     * and the value is set, so an out-of-band version bump (manual composer
+     * install, deploy script) invalidates the stale positive from a cached
+     * `UpdateInfo` snapshot.
+     *
+     * @since 2.5.3
+     */
+    public function test_has_update_reads_current_version_from_config_when_available(): void
+    {
+        $container = new Container;
+        $container->instance( 'config', new ConfigRepository( [
+            'app' => ['version' => '0.2.2'],
+        ] ) );
+        Container::setInstance( $container );
+
+        $stale = new UpdateInfo(
+            currentVersion: '0.2.0',
+            latestVersion: '0.2.2',
+            downloadUrl: 'https://example.com/update.zip',
+        );
+
+        $this->assertFalse(
+            $stale->hasUpdate(),
+            'Expected fresh app.version to override the cached currentVersion snapshot.',
+        );
+    }
+
+    /**
+     * Regression for #226: when the container has no bound `config`,
+     * `hasUpdate()` falls back to the constructor `currentVersion` so
+     * pre-container / non-Laravel callers still see the pre-2.5.3 comparison.
+     *
+     * @since 2.5.3
+     */
+    public function test_has_update_falls_back_to_snapshot_when_config_unbound(): void
+    {
+        Container::setInstance( null );
+
+        $info = new UpdateInfo(
+            currentVersion: '1.0.0',
+            latestVersion: '2.0.0',
+            downloadUrl: 'https://example.com/update.zip',
+        );
+
+        $this->assertTrue( $info->hasUpdate() );
+    }
+
+    /**
+     * Regression for #226: when `app.version` is unset on a host that never
+     * configured it (or set it to an empty string), `hasUpdate()` still falls
+     * back to the constructor snapshot rather than treating the "no fresh
+     * version to compare against" case as a valid comparison. Otherwise the
+     * fresh-read guard silently degrades to the pre-fix behavior when it
+     * matters most.
+     *
+     * @since 2.5.3
+     */
+    public function test_has_update_falls_back_to_snapshot_when_app_version_missing(): void
+    {
+        $container = new Container;
+        $container->instance( 'config', new ConfigRepository( [
+            'app' => [],
+        ] ) );
+        Container::setInstance( $container );
+
+        $info = new UpdateInfo(
+            currentVersion: '1.0.0',
+            latestVersion: '2.0.0',
+            downloadUrl: 'https://example.com/update.zip',
+        );
+
+        $this->assertTrue(
+            $info->hasUpdate(),
+            'Expected snapshot fallback when app.version is unset.',
+        );
+    }
+
+    /**
+     * Test UpdateInfo can be converted to array.
+     *
+     * @since 1.0.0
+     */
+    /**
+     * Regression for #226: `toArray()['current']` must reflect the fresh
+     * `app.version` rather than the frozen constructor snapshot, so JSON
+     * consumers (and the console commands that print it) see a consistent
+     * `{ current, latest, hasUpdate }` triple after an out-of-band version
+     * bump.
+     *
+     * @since 2.5.3
+     */
+    public function test_to_array_uses_fresh_current_version_when_config_available(): void
+    {
+        $container = new Container;
+        $container->instance( 'config', new ConfigRepository( [
+            'app' => ['version' => '0.2.2'],
+        ] ) );
+        Container::setInstance( $container );
+
+        $stale = new UpdateInfo(
+            currentVersion: '0.2.0',
+            latestVersion: '0.2.2',
+            downloadUrl: 'https://example.com/update.zip',
+        );
+
+        $array = $stale->toArray();
+
+        $this->assertSame( '0.2.2', $array['current'] );
+        $this->assertSame( '0.2.2', $array['latest'] );
+        $this->assertFalse( $array['hasUpdate'] );
     }
 
     /**


### PR DESCRIPTION
## Description

\`UpdateChecker::checkForUpdate()\` cached the resolved \`UpdateInfo\` value object for \`cms.updates.cache_ttl\` seconds (default 12h). The cached object froze both \`latestVersion\` (from the feed) **and** \`currentVersion\` (a snapshot of \`config('app.version')\` at cache-populate time). \`hasUpdate()\` then compared those two frozen strings — never re-reading \`config('app.version')\` — so if the host's installed version moved forward *out-of-band* (a manual \`composer install\` on a release zip, an unzip-over-site, a deploy script) between cache-populate and cache-render, the Updates admin page kept saying \"Update available to X\" for a site already on X, up to 12h. Two separate mechanisms, both belt-and-suspenders.

**Closes:** #226

## Type of Change

- [x] Bug fix (fixes an issue)

## Related Issue

**Issue:** #226

## Motivation and Context

Follow-up to #219 / #224 / #225 — the last of the four self-updater paper-cuts that make the whole updater surface feel broken on a real developer's machine. Not a data-safety issue (worst case someone clicks \"update to the same version\" and re-installs), but a first-impression bug that makes the admin surface look stale. Discovered while testing the click-to-update flow end-to-end on a Herd host.

## Changes Made

**Fix A — read-time computation.** \`UpdateInfo::hasUpdate()\` and \`UpdateInfo::toArray()['current']\` now both route through a new \`resolveCurrentVersion()\` helper that reads \`config('app.version')\` fresh at call time when the container is bootstrapped and the value is a non-empty string. Falls back to the constructor \`currentVersion\` for non-Laravel callers, tests, and hosts that never set \`app.version\`. Container check goes through \`Illuminate\\Container\\Container::getInstance()->bound('config')\` so we never touch an unbootstrapped container. The same helper is now used by \`PerformUpdateCommand\`, \`CheckForUpdateCommand\`, and \`CheckForUpdateScheduled\` so console output and log lines stay internally consistent with \`hasUpdate()\`.

**Fix B — cache-invalidation.** \`UpdateChecker::checkForUpdate()\` now calls \`cacheIsStale(\$cached)\`, which reads \`config('app.version')\` **without** a default, treats \`null\`/empty as \"no fresh version to compare against\" (keeps the pre-2.5.3 cache-serving behavior on hosts that never set \`app.version\`), and only evicts the cache when the fresh value genuinely differs from the cached snapshot. Without the null-guard the fix would collapse on any host that never sets \`app.version\` — the default would fill in the cached snapshot itself, equality would always hold, and no cache would ever be invalidated.

**Fix C — documentation.** New \"Cached update info and out-of-band version bumps\" section in \`docs/self-updater.md\` documents both mechanisms.

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS 15.5 with Laravel Herd
- Browser (if applicable): any
- PHP Version: 8.4.23
- Project Version: cms-framework 2.5.3 (host: Keystone CMS)

**Tests Performed:**
1. \`./vendor/bin/pest tests/Unit/Updates tests/Feature/Updates\` — 112 passed
2. Manually reproduced: loaded \`/admin/settings/updates\` on Keystone 0.2.0, bumped to 0.2.2 via out-of-band composer install, reloaded — the stale \"Update available\" badge is gone
3. Confirmed the unset-\`app.version\` case doesn't cause a cache stampede (no source hit on every read)

## Accessibility Tests Run

- [x] N/A — server-side code path, no user-facing markup changed

## Tests Added

- [x] Unit tests added/updated
- [x] All tests passing

**Test details:**

5 new tests:
- \`UpdateInfoTest::test_has_update_reads_current_version_from_config_when_available\` — fresh 0.2.2 \`app.version\` overrides cached 0.2.0 snapshot
- \`UpdateInfoTest::test_has_update_falls_back_to_snapshot_when_config_unbound\` — plain-PHPUnit callers keep pre-2.5.3 behavior
- \`UpdateInfoTest::test_has_update_falls_back_to_snapshot_when_app_version_missing\` — locks in Fix A's null-guard for empty config
- \`UpdateInfoTest::test_to_array_uses_fresh_current_version_when_config_available\` — payload consistency after bump
- \`UpdateCheckerTest\` (new file) — three tests covering (a) stale cache eviction on version divergence, (b) fresh-cache fast path served without source hit, (c) unset \`app.version\` doesn't evict cache (guards against the HIGH regression Fix B was almost re-introducing)

Also added \`setUp\`/\`tearDown\` to \`UpdateInfoTest\` that snapshots and restores \`Container::getInstance()\` so the tests that mutate the global container don't leak state into sibling test classes.

## Documentation

- [x] Inline code documentation added
- [x] Wiki updated (new section in \`docs/self-updater.md\`)

**Documentation details:** New \"Cached update info and out-of-band version bumps\" section in \`docs/self-updater.md\` covers both invalidation mechanisms.

## Pre-Submission Checklist

- [x] Followed contributing guidelines
- [x] Checked for other open PRs for same update
- [x] Code passes all tests
- [x] Code has been linted
- [x] Accessibility tests completed
- [x] Code follows project style guide
- [x] Self-review completed
- [x] Comments added for complex code
- [x] No new warnings generated