### PR TITLE
fix(updates): use CLI PHP interpreter for composer instead of PHP_BINARY

### DIFF
--- a/src/Modules/Core/Updates/Exceptions/UpdateException.php
+++ b/src/Modules/Core/Updates/Exceptions/UpdateException.php
@@ -1,6 +1,6 @@
 <?php
 
-declare( strict_types=1 );
+declare(strict_types=1);
 
 namespace ArtisanPackUI\CMSFramework\Modules\Core\Updates\Exceptions;
 
@@ -20,9 +20,9 @@ class UpdateException extends CMSFrameworkException
      *
      * @since 1.0.0
      */
-    public static function versionCheckFailed( string $reason ): self
+    public static function versionCheckFailed(string $reason): self
     {
-        return new self( "Failed to check for updates: {$reason}" );
+        return new self("Failed to check for updates: {$reason}");
     }
 
     /**
@@ -32,7 +32,7 @@ class UpdateException extends CMSFrameworkException
      */
     public static function noUpdateUrlConfigured(): self
     {
-        return new self( 'Update URL not configured. Please set UPDATE_SOURCE_URL in .env' );
+        return new self('Update URL not configured. Please set UPDATE_SOURCE_URL in .env');
     }
 
     /**
@@ -40,9 +40,9 @@ class UpdateException extends CMSFrameworkException
      *
      * @since 1.0.0
      */
-    public static function invalidJsonResponse( string $url ): self
+    public static function invalidJsonResponse(string $url): self
     {
-        return new self( "Invalid JSON response from update URL: {$url}" );
+        return new self("Invalid JSON response from update URL: {$url}");
     }
 
     /**
@@ -50,9 +50,9 @@ class UpdateException extends CMSFrameworkException
      *
      * @since 1.0.0
      */
-    public static function missingRequiredField( string $field ): self
+    public static function missingRequiredField(string $field): self
     {
-        return new self( "Update JSON missing required field: {$field}" );
+        return new self("Update JSON missing required field: {$field}");
     }
 
     /**
@@ -60,9 +60,9 @@ class UpdateException extends CMSFrameworkException
      *
      * @since 1.0.0
      */
-    public static function backupFailed( string $path ): self
+    public static function backupFailed(string $path): self
     {
-        return new self( "Failed to create backup at: {$path}" );
+        return new self("Failed to create backup at: {$path}");
     }
 
     /**
@@ -70,9 +70,9 @@ class UpdateException extends CMSFrameworkException
      *
      * @since 1.0.0
      */
-    public static function downloadFailed( string $url ): self
+    public static function downloadFailed(string $url): self
     {
-        return new self( "Failed to download update from: {$url}" );
+        return new self("Failed to download update from: {$url}");
     }
 
     /**
@@ -80,9 +80,9 @@ class UpdateException extends CMSFrameworkException
      *
      * @since 1.0.0
      */
-    public static function checksumMismatch( string $expected, string $actual ): self
+    public static function checksumMismatch(string $expected, string $actual): self
     {
-        return new self( "Checksum mismatch. Expected: {$expected}, Got: {$actual}" );
+        return new self("Checksum mismatch. Expected: {$expected}, Got: {$actual}");
     }
 
     /**
@@ -90,9 +90,9 @@ class UpdateException extends CMSFrameworkException
      *
      * @since 1.0.0
      */
-    public static function extractionFailed( string $zipPath ): self
+    public static function extractionFailed(string $zipPath): self
     {
-        return new self( "Failed to extract ZIP archive: {$zipPath}" );
+        return new self("Failed to extract ZIP archive: {$zipPath}");
     }
 
     /**
@@ -100,9 +100,9 @@ class UpdateException extends CMSFrameworkException
      *
      * @since 1.0.0
      */
-    public static function composerInstallFailed( string $output ): self
+    public static function composerInstallFailed(string $output): self
     {
-        return new self( "Composer install failed. Output:\n{$output}" );
+        return new self("Composer install failed. Output:\n{$output}");
     }
 
     /**
@@ -112,15 +112,41 @@ class UpdateException extends CMSFrameworkException
      *
      * @param  array<int, string>  $searchedPaths  Absolute paths inspected during discovery.
      */
-    public static function composerBinaryNotFound( array $searchedPaths ): self
+    public static function composerBinaryNotFound(array $searchedPaths): self
     {
-        $paths   = empty( $searchedPaths ) ? '(none)' : implode( ', ', $searchedPaths );
+        $paths   = empty($searchedPaths) ? '(none)' : implode(', ', $searchedPaths);
         $message = 'Composer binary could not be located on the host. '
-            . "Searched: {$paths}. "
-            . 'Set the COMPOSER_BINARY environment variable or override '
-            . '`cms.updates.composer_install_command` with an absolute path to composer.';
+            ."Searched: {$paths}. "
+            .'Set the COMPOSER_BINARY environment variable or override '
+            .'`cms.updates.composer_install_command` with an absolute path to composer.';
 
-        return new self( $message );
+        return new self($message);
+    }
+
+    /**
+     * Composer binary was located but `--version` execution failed. Surfaces
+     * the resolved binary, the PHP interpreter used to invoke it, the exit
+     * code, and any captured output so operators can distinguish an
+     * unreachable-binary failure from an unusable-interpreter one (e.g. the
+     * FPM daemon binary being handed a PHAR).
+     *
+     * @since 2.5.4
+     */
+    public static function composerVerificationFailed(
+        string $composerBinary,
+        string $phpBinary,
+        int $exitCode,
+        string $detail,
+    ): self {
+        $detail  = '' === $detail ? '(no output captured)' : $detail;
+        $message = 'Composer binary was located but could not be executed. '
+            ."Ran: {$phpBinary} {$composerBinary} --version. "
+            ."Exit code: {$exitCode}. Output: {$detail}. "
+            .'If the PHP path points at an FPM/CGI SAPI binary, set the '
+            .'`CMS_PHP_BINARY` environment variable to an absolute path to a '
+            .'CLI PHP binary.';
+
+        return new self($message);
     }
 
     /**
@@ -130,7 +156,7 @@ class UpdateException extends CMSFrameworkException
      *
      * @since 2.5.3
      */
-    public static function rollbackAfterFailure( string $originalError, string $rollbackError ): self
+    public static function rollbackAfterFailure(string $originalError, string $rollbackError): self
     {
         return new self(
             "Rollback failed: {$rollbackError}. Original update error: {$originalError}. Manual intervention required.",
@@ -142,9 +168,9 @@ class UpdateException extends CMSFrameworkException
      *
      * @since 1.0.0
      */
-    public static function migrationFailed( string $output ): self
+    public static function migrationFailed(string $output): self
     {
-        return new self( "Migration failed. Output:\n{$output}" );
+        return new self("Migration failed. Output:\n{$output}");
     }
 
     /**
@@ -152,9 +178,9 @@ class UpdateException extends CMSFrameworkException
      *
      * @since 1.0.0
      */
-    public static function rollbackFailed( string $reason ): self
+    public static function rollbackFailed(string $reason): self
     {
-        return new self( "Rollback failed: {$reason}. Manual intervention required." );
+        return new self("Rollback failed: {$reason}. Manual intervention required.");
     }
 
     /**
@@ -164,7 +190,7 @@ class UpdateException extends CMSFrameworkException
      */
     public static function noUpdateAvailable(): self
     {
-        return new self( 'No update available. Already running the latest version.' );
+        return new self('No update available. Already running the latest version.');
     }
 
     /**
@@ -174,7 +200,7 @@ class UpdateException extends CMSFrameworkException
      */
     public static function permissionDenied(): self
     {
-        return new self( 'You do not have permission to perform core updates.' );
+        return new self('You do not have permission to perform core updates.');
     }
 
     /**
@@ -182,9 +208,9 @@ class UpdateException extends CMSFrameworkException
      *
      * @since 1.0.0
      */
-    public static function maintenanceModeFailure( string $action ): self
+    public static function maintenanceModeFailure(string $action): self
     {
-        return new self( "Failed to {$action} maintenance mode." );
+        return new self("Failed to {$action} maintenance mode.");
     }
 
     /**
@@ -192,9 +218,9 @@ class UpdateException extends CMSFrameworkException
      *
      * @since 1.0.0
      */
-    public static function incompatiblePhpVersion( string $required, string $current ): self
+    public static function incompatiblePhpVersion(string $required, string $current): self
     {
-        return new self( "Update requires PHP {$required}, but you have {$current}" );
+        return new self("Update requires PHP {$required}, but you have {$current}");
     }
 
     /**
@@ -202,8 +228,8 @@ class UpdateException extends CMSFrameworkException
      *
      * @since 1.0.0
      */
-    public static function incompatibleFrameworkVersion( string $required, string $current ): self
+    public static function incompatibleFrameworkVersion(string $required, string $current): self
     {
-        return new self( "Update requires cms-framework {$required}, but you have {$current}");
+        return new self("Update requires cms-framework {$required}, but you have {$current}");
     }
 }

--- a/src/Modules/Core/Updates/Exceptions/UpdateException.php
+++ b/src/Modules/Core/Updates/Exceptions/UpdateException.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare( strict_types=1 );
 
 namespace ArtisanPackUI\CMSFramework\Modules\Core\Updates\Exceptions;
 
@@ -20,9 +20,9 @@ class UpdateException extends CMSFrameworkException
      *
      * @since 1.0.0
      */
-    public static function versionCheckFailed(string $reason): self
+    public static function versionCheckFailed( string $reason ): self
     {
-        return new self("Failed to check for updates: {$reason}");
+        return new self( "Failed to check for updates: {$reason}" );
     }
 
     /**
@@ -32,7 +32,7 @@ class UpdateException extends CMSFrameworkException
      */
     public static function noUpdateUrlConfigured(): self
     {
-        return new self('Update URL not configured. Please set UPDATE_SOURCE_URL in .env');
+        return new self( 'Update URL not configured. Please set UPDATE_SOURCE_URL in .env' );
     }
 
     /**
@@ -40,9 +40,9 @@ class UpdateException extends CMSFrameworkException
      *
      * @since 1.0.0
      */
-    public static function invalidJsonResponse(string $url): self
+    public static function invalidJsonResponse( string $url ): self
     {
-        return new self("Invalid JSON response from update URL: {$url}");
+        return new self( "Invalid JSON response from update URL: {$url}" );
     }
 
     /**
@@ -50,9 +50,9 @@ class UpdateException extends CMSFrameworkException
      *
      * @since 1.0.0
      */
-    public static function missingRequiredField(string $field): self
+    public static function missingRequiredField( string $field ): self
     {
-        return new self("Update JSON missing required field: {$field}");
+        return new self( "Update JSON missing required field: {$field}" );
     }
 
     /**
@@ -60,9 +60,9 @@ class UpdateException extends CMSFrameworkException
      *
      * @since 1.0.0
      */
-    public static function backupFailed(string $path): self
+    public static function backupFailed( string $path ): self
     {
-        return new self("Failed to create backup at: {$path}");
+        return new self( "Failed to create backup at: {$path}" );
     }
 
     /**
@@ -70,9 +70,9 @@ class UpdateException extends CMSFrameworkException
      *
      * @since 1.0.0
      */
-    public static function downloadFailed(string $url): self
+    public static function downloadFailed( string $url ): self
     {
-        return new self("Failed to download update from: {$url}");
+        return new self( "Failed to download update from: {$url}" );
     }
 
     /**
@@ -80,9 +80,9 @@ class UpdateException extends CMSFrameworkException
      *
      * @since 1.0.0
      */
-    public static function checksumMismatch(string $expected, string $actual): self
+    public static function checksumMismatch( string $expected, string $actual ): self
     {
-        return new self("Checksum mismatch. Expected: {$expected}, Got: {$actual}");
+        return new self( "Checksum mismatch. Expected: {$expected}, Got: {$actual}" );
     }
 
     /**
@@ -90,9 +90,9 @@ class UpdateException extends CMSFrameworkException
      *
      * @since 1.0.0
      */
-    public static function extractionFailed(string $zipPath): self
+    public static function extractionFailed( string $zipPath ): self
     {
-        return new self("Failed to extract ZIP archive: {$zipPath}");
+        return new self( "Failed to extract ZIP archive: {$zipPath}" );
     }
 
     /**
@@ -100,9 +100,9 @@ class UpdateException extends CMSFrameworkException
      *
      * @since 1.0.0
      */
-    public static function composerInstallFailed(string $output): self
+    public static function composerInstallFailed( string $output ): self
     {
-        return new self("Composer install failed. Output:\n{$output}");
+        return new self( "Composer install failed. Output:\n{$output}" );
     }
 
     /**
@@ -112,15 +112,15 @@ class UpdateException extends CMSFrameworkException
      *
      * @param  array<int, string>  $searchedPaths  Absolute paths inspected during discovery.
      */
-    public static function composerBinaryNotFound(array $searchedPaths): self
+    public static function composerBinaryNotFound( array $searchedPaths ): self
     {
-        $paths   = empty($searchedPaths) ? '(none)' : implode(', ', $searchedPaths);
+        $paths   = empty( $searchedPaths ) ? '(none)' : implode( ', ', $searchedPaths );
         $message = 'Composer binary could not be located on the host. '
-            ."Searched: {$paths}. "
-            .'Set the COMPOSER_BINARY environment variable or override '
-            .'`cms.updates.composer_install_command` with an absolute path to composer.';
+            . "Searched: {$paths}. "
+            . 'Set the COMPOSER_BINARY environment variable or override '
+            . '`cms.updates.composer_install_command` with an absolute path to composer.';
 
-        return new self($message);
+        return new self( $message );
     }
 
     /**
@@ -140,13 +140,13 @@ class UpdateException extends CMSFrameworkException
     ): self {
         $detail  = '' === $detail ? '(no output captured)' : $detail;
         $message = 'Composer binary was located but could not be executed. '
-            ."Ran: {$phpBinary} {$composerBinary} --version. "
-            ."Exit code: {$exitCode}. Output: {$detail}. "
-            .'If the PHP path points at an FPM/CGI SAPI binary, set the '
-            .'`CMS_PHP_BINARY` environment variable to an absolute path to a '
-            .'CLI PHP binary.';
+            . "Ran: {$phpBinary} {$composerBinary} --version. "
+            . "Exit code: {$exitCode}. Output: {$detail}. "
+            . 'If the PHP path points at an FPM/CGI SAPI binary, set the '
+            . '`CMS_PHP_BINARY` environment variable to an absolute path to a '
+            . 'CLI PHP binary.';
 
-        return new self($message);
+        return new self( $message );
     }
 
     /**
@@ -156,7 +156,7 @@ class UpdateException extends CMSFrameworkException
      *
      * @since 2.5.3
      */
-    public static function rollbackAfterFailure(string $originalError, string $rollbackError): self
+    public static function rollbackAfterFailure( string $originalError, string $rollbackError ): self
     {
         return new self(
             "Rollback failed: {$rollbackError}. Original update error: {$originalError}. Manual intervention required.",
@@ -168,9 +168,9 @@ class UpdateException extends CMSFrameworkException
      *
      * @since 1.0.0
      */
-    public static function migrationFailed(string $output): self
+    public static function migrationFailed( string $output ): self
     {
-        return new self("Migration failed. Output:\n{$output}");
+        return new self( "Migration failed. Output:\n{$output}" );
     }
 
     /**
@@ -178,9 +178,9 @@ class UpdateException extends CMSFrameworkException
      *
      * @since 1.0.0
      */
-    public static function rollbackFailed(string $reason): self
+    public static function rollbackFailed( string $reason ): self
     {
-        return new self("Rollback failed: {$reason}. Manual intervention required.");
+        return new self( "Rollback failed: {$reason}. Manual intervention required." );
     }
 
     /**
@@ -190,7 +190,7 @@ class UpdateException extends CMSFrameworkException
      */
     public static function noUpdateAvailable(): self
     {
-        return new self('No update available. Already running the latest version.');
+        return new self( 'No update available. Already running the latest version.' );
     }
 
     /**
@@ -200,7 +200,7 @@ class UpdateException extends CMSFrameworkException
      */
     public static function permissionDenied(): self
     {
-        return new self('You do not have permission to perform core updates.');
+        return new self( 'You do not have permission to perform core updates.' );
     }
 
     /**
@@ -208,9 +208,9 @@ class UpdateException extends CMSFrameworkException
      *
      * @since 1.0.0
      */
-    public static function maintenanceModeFailure(string $action): self
+    public static function maintenanceModeFailure( string $action ): self
     {
-        return new self("Failed to {$action} maintenance mode.");
+        return new self( "Failed to {$action} maintenance mode." );
     }
 
     /**
@@ -218,9 +218,9 @@ class UpdateException extends CMSFrameworkException
      *
      * @since 1.0.0
      */
-    public static function incompatiblePhpVersion(string $required, string $current): self
+    public static function incompatiblePhpVersion( string $required, string $current ): self
     {
-        return new self("Update requires PHP {$required}, but you have {$current}");
+        return new self( "Update requires PHP {$required}, but you have {$current}" );
     }
 
     /**
@@ -228,8 +228,8 @@ class UpdateException extends CMSFrameworkException
      *
      * @since 1.0.0
      */
-    public static function incompatibleFrameworkVersion(string $required, string $current): self
+    public static function incompatibleFrameworkVersion( string $required, string $current): self
     {
-        return new self("Update requires cms-framework {$required}, but you have {$current}");
+        return new self( "Update requires cms-framework {$required}, but you have {$current}");
     }
 }

--- a/src/Modules/Core/Updates/Managers/ApplicationUpdateManager.php
+++ b/src/Modules/Core/Updates/Managers/ApplicationUpdateManager.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare( strict_types=1 );
 
 namespace ArtisanPackUI\CMSFramework\Modules\Core\Updates\Managers;
 
@@ -84,11 +84,11 @@ class ApplicationUpdateManager
      *
      * @return bool True if update successful
      */
-    public function performUpdate(?string $version = null): bool
+    public function performUpdate( ?string $version = null ): bool
     {
         $updateInfo = $this->checkForUpdate();
 
-        if (! $updateInfo->hasUpdate()) {
+        if ( ! $updateInfo->hasUpdate() ) {
             throw UpdateException::noUpdateAvailable();
         }
 
@@ -100,18 +100,18 @@ class ApplicationUpdateManager
             $this->enableMaintenanceMode();
 
             // Step 2: Create backup
-            if (config('cms.updates.backup_enabled', true)) {
+            if ( config( 'cms.updates.backup_enabled', true ) ) {
                 $this->createBackup();
             }
 
             // Step 3: Download update
-            $zipPath = $this->getUpdateChecker()->downloadUpdate($targetVersion);
+            $zipPath = $this->getUpdateChecker()->downloadUpdate( $targetVersion );
 
             // Step 4: Verify checksum (or surface the silent skip)
-            $this->maybeVerifyChecksum($zipPath, $updateInfo, $targetVersion);
+            $this->maybeVerifyChecksum( $zipPath, $updateInfo, $targetVersion );
 
             // Step 5: Extract update
-            $this->extractUpdate($zipPath);
+            $this->extractUpdate( $zipPath );
 
             // Step 6: Run composer install
             $this->runComposerInstall();
@@ -123,15 +123,15 @@ class ApplicationUpdateManager
             $this->clearCaches();
 
             // Step 9: Clean up
-            $this->cleanup($zipPath);
+            $this->cleanup( $zipPath );
 
             // Step 10: Disable maintenance mode
             $this->disableMaintenanceMode();
 
             return true;
-        } catch (Throwable $e) {
+        } catch ( Throwable $e ) {
             // Rollback on failure
-            $this->handleUpdateFailure($e);
+            $this->handleUpdateFailure( $e );
 
             throw $e;
         }
@@ -144,7 +144,7 @@ class ApplicationUpdateManager
      *
      * @param  UpdateChecker  $checker  Update checker instance
      */
-    public function setUpdateChecker(UpdateChecker $checker): void
+    public function setUpdateChecker( UpdateChecker $checker ): void
     {
         $this->checker = $checker;
     }
@@ -158,19 +158,19 @@ class ApplicationUpdateManager
      *
      * @throws UpdateException
      */
-    public function rollback(string $backupPath): void
+    public function rollback( string $backupPath ): void
     {
-        if (! File::exists($backupPath)) {
-            throw UpdateException::rollbackFailed("Backup not found: {$backupPath}");
+        if ( ! File::exists( $backupPath ) ) {
+            throw UpdateException::rollbackFailed( "Backup not found: {$backupPath}" );
         }
 
         $zip = new ZipArchive;
 
-        if (true !== $zip->open($backupPath)) {
-            throw UpdateException::rollbackFailed('Could not open backup ZIP');
+        if ( true !== $zip->open( $backupPath ) ) {
+            throw UpdateException::rollbackFailed( 'Could not open backup ZIP' );
         }
 
-        $zip->extractTo(base_path());
+        $zip->extractTo( base_path() );
         $zip->close();
 
         // Before invoking composer install, verify the resolved binary is
@@ -208,13 +208,13 @@ class ApplicationUpdateManager
      */
     protected function getUpdateChecker(): UpdateChecker
     {
-        if ($this->checker) {
+        if ( $this->checker ) {
             return $this->checker;
         }
 
-        $updateUrl = config('cms.updates.update_source_url');
+        $updateUrl = config( 'cms.updates.update_source_url' );
 
-        if (! $updateUrl) {
+        if ( ! $updateUrl ) {
             throw UpdateException::noUpdateUrlConfigured();
         }
 
@@ -236,32 +236,32 @@ class ApplicationUpdateManager
      */
     protected function createBackup(): void
     {
-        $backupDir  = storage_path(config('cms.updates.backup_path', 'backups/application'));
-        $backupName = 'backup-'.date('Y-m-d-His').'.zip';
+        $backupDir  = storage_path( config( 'cms.updates.backup_path', 'backups/application' ) );
+        $backupName = 'backup-' . date( 'Y-m-d-His' ) . '.zip';
         $backupPath = "{$backupDir}/{$backupName}";
 
         // Create backup directory
-        if (! File::exists($backupDir)) {
-            File::makeDirectory($backupDir, 0755, true);
+        if ( ! File::exists( $backupDir ) ) {
+            File::makeDirectory( $backupDir, 0755, true );
         }
 
         // Create backup ZIP
         $zip = new ZipArchive;
 
-        if (true !== $zip->open($backupPath, ZipArchive::CREATE | ZipArchive::OVERWRITE)) {
-            throw UpdateException::backupFailed($backupPath);
+        if ( true !== $zip->open( $backupPath, ZipArchive::CREATE | ZipArchive::OVERWRITE ) ) {
+            throw UpdateException::backupFailed( $backupPath );
         }
 
         // Add all files except excluded paths
-        $excludePaths = config('cms.updates.exclude_from_update', []);
-        $this->addDirectoryToZip($zip, base_path(), '', $excludePaths);
+        $excludePaths = config( 'cms.updates.exclude_from_update', [] );
+        $this->addDirectoryToZip( $zip, base_path(), '', $excludePaths );
 
         $zip->close();
 
         $this->backupPath = $backupPath;
 
         // Clean old backups
-        $this->cleanOldBackups($backupDir);
+        $this->cleanOldBackups( $backupDir );
     }
 
     /**
@@ -274,53 +274,53 @@ class ApplicationUpdateManager
      * @param  string  $localPath  Local path in ZIP
      * @param  array<string>  $excludePaths  Paths to exclude
      */
-    protected function addDirectoryToZip(ZipArchive $zip, string $sourcePath, string $localPath, array $excludePaths): void
+    protected function addDirectoryToZip( ZipArchive $zip, string $sourcePath, string $localPath, array $excludePaths ): void
     {
         $files = new RecursiveIteratorIterator(
-            new RecursiveDirectoryIterator($sourcePath),
+            new RecursiveDirectoryIterator( $sourcePath ),
             RecursiveIteratorIterator::LEAVES_ONLY,
         );
 
         $basePath = base_path();
 
-        foreach ($files as $file) {
-            if ($file->isDir()) {
+        foreach ( $files as $file ) {
+            if ( $file->isDir() ) {
                 continue;
             }
 
             // Get real path and validate it
             $filePath = $file->getRealPath();
 
-            if (false === $filePath) {
+            if ( false === $filePath ) {
                 // getRealPath() failed - log and skip
-                \Illuminate\Support\Facades\Log::warning('Failed to get real path for file during backup', [
+                \Illuminate\Support\Facades\Log::warning( 'Failed to get real path for file during backup', [
                     'file' => $file->getPathname(),
-                ]);
+                ] );
 
                 continue;
             }
 
             // Verify the resolved path starts with base_path() to prevent traversal issues
-            if (! str_starts_with($filePath, $basePath)) {
+            if ( ! str_starts_with( $filePath, $basePath ) ) {
                 // File is outside base path (symlink or external) - log and skip
-                \Illuminate\Support\Facades\Log::warning('Skipping file outside base path during backup', [
+                \Illuminate\Support\Facades\Log::warning( 'Skipping file outside base path during backup', [
                     'file'      => $filePath,
                     'base_path' => $basePath,
-                ]);
+                ] );
 
                 continue;
             }
 
             // Safe to compute relative path
-            $relativePath = substr($filePath, strlen($basePath) + 1);
+            $relativePath = substr( $filePath, strlen( $basePath ) + 1 );
 
             // Skip excluded paths
-            if ($this->isPathExcluded($relativePath, $excludePaths)) {
+            if ( $this->isPathExcluded( $relativePath, $excludePaths ) ) {
                 continue;
             }
 
-            $zipPath = $localPath.DIRECTORY_SEPARATOR.$relativePath;
-            $zip->addFile($filePath, $zipPath);
+            $zipPath = $localPath . DIRECTORY_SEPARATOR . $relativePath;
+            $zip->addFile( $filePath, $zipPath );
         }
     }
 
@@ -334,14 +334,14 @@ class ApplicationUpdateManager
      *
      * @return bool True if excluded
      */
-    protected function isPathExcluded(string $path, array $excludePaths): bool
+    protected function isPathExcluded( string $path, array $excludePaths ): bool
     {
-        foreach ($excludePaths as $exclude) {
-            if (str_starts_with($path, $exclude)) {
+        foreach ( $excludePaths as $exclude ) {
+            if ( str_starts_with( $path, $exclude ) ) {
                 return true;
             }
 
-            if (str_contains($exclude, '*') && fnmatch($exclude, $path)) {
+            if ( str_contains( $exclude, '*' ) && fnmatch( $exclude, $path ) ) {
                 return true;
             }
         }
@@ -356,20 +356,20 @@ class ApplicationUpdateManager
      *
      * @param  string  $backupDir  Backup directory
      */
-    protected function cleanOldBackups(string $backupDir): void
+    protected function cleanOldBackups( string $backupDir ): void
     {
-        $retentionDays = config('cms.updates.backup_retention_days', 30);
-        $cutoffTime    = time() - ($retentionDays * 86400);
+        $retentionDays = config( 'cms.updates.backup_retention_days', 30 );
+        $cutoffTime    = time() - ( $retentionDays * 86400 );
 
-        $backups = glob("{$backupDir}/backup-*.zip");
+        $backups = glob( "{$backupDir}/backup-*.zip" );
 
-        if (false === $backups) {
+        if ( false === $backups ) {
             return;
         }
 
-        foreach ($backups as $backup) {
-            if (filemtime($backup) < $cutoffTime) {
-                File::delete($backup);
+        foreach ( $backups as $backup ) {
+            if ( filemtime( $backup ) < $cutoffTime ) {
+                File::delete( $backup );
             }
         }
     }
@@ -384,12 +384,12 @@ class ApplicationUpdateManager
      *
      * @throws UpdateException
      */
-    protected function verifyChecksum(string $zipPath, string $expectedHash): void
+    protected function verifyChecksum( string $zipPath, string $expectedHash ): void
     {
-        $actualHash = hash_file('sha256', $zipPath);
+        $actualHash = hash_file( 'sha256', $zipPath );
 
-        if ($actualHash !== $expectedHash) {
-            throw UpdateException::checksumMismatch($expectedHash, $actualHash);
+        if ( $actualHash !== $expectedHash ) {
+            throw UpdateException::checksumMismatch( $expectedHash, $actualHash );
         }
     }
 
@@ -405,22 +405,22 @@ class ApplicationUpdateManager
      *
      * @throws UpdateException When the checksum is present but does not match.
      */
-    protected function maybeVerifyChecksum(string $zipPath, UpdateInfo $updateInfo, string $targetVersion): void
+    protected function maybeVerifyChecksum( string $zipPath, UpdateInfo $updateInfo, string $targetVersion ): void
     {
-        if (! config('cms.updates.verify_checksum', true)) {
+        if ( ! config( 'cms.updates.verify_checksum', true ) ) {
             return;
         }
 
-        if ($updateInfo->sha256) {
-            $this->verifyChecksum($zipPath, $updateInfo->sha256);
+        if ( $updateInfo->sha256 ) {
+            $this->verifyChecksum( $zipPath, $updateInfo->sha256 );
 
             return;
         }
 
-        \Illuminate\Support\Facades\Log::warning('Skipping update integrity verification: update source did not advertise a SHA-256 checksum.', [
+        \Illuminate\Support\Facades\Log::warning( 'Skipping update integrity verification: update source did not advertise a SHA-256 checksum.', [
             'target_version' => $targetVersion,
             'source'         => $updateInfo->metadata['source'] ?? null,
-        ]);
+        ] );
     }
 
     /**
@@ -432,95 +432,95 @@ class ApplicationUpdateManager
      *
      * @throws UpdateException
      */
-    protected function extractUpdate(string $zipPath): void
+    protected function extractUpdate( string $zipPath ): void
     {
         $zip = new ZipArchive;
 
-        if (true !== $zip->open($zipPath)) {
-            throw UpdateException::extractionFailed($zipPath);
+        if ( true !== $zip->open( $zipPath ) ) {
+            throw UpdateException::extractionFailed( $zipPath );
         }
 
         $extractPath  = base_path();
-        $excludePaths = config('cms.updates.exclude_from_update', []);
+        $excludePaths = config( 'cms.updates.exclude_from_update', [] );
 
         // Detect common root prefix by scanning all entry names
-        $commonPrefix = $this->detectCommonRootPrefix($zip, $excludePaths);
+        $commonPrefix = $this->detectCommonRootPrefix( $zip, $excludePaths );
 
         // Extract files (except excluded paths), stripping common prefix
-        for ($i = 0; $i < $zip->numFiles; $i++) {
-            $filename = $zip->getNameIndex($i);
+        for ( $i = 0; $i < $zip->numFiles; $i++ ) {
+            $filename = $zip->getNameIndex( $i );
 
             // Strip common prefix if detected
-            $targetPath = $commonPrefix ? substr($filename, strlen($commonPrefix)) : $filename;
+            $targetPath = $commonPrefix ? substr( $filename, strlen( $commonPrefix ) ) : $filename;
 
             // Skip excluded paths (check both original and stripped paths)
-            if ($this->isPathExcluded($filename, $excludePaths) || $this->isPathExcluded($targetPath, $excludePaths)) {
+            if ( $this->isPathExcluded( $filename, $excludePaths ) || $this->isPathExcluded( $targetPath, $excludePaths ) ) {
                 continue;
             }
 
             // Skip empty paths (directories become empty after prefix stripping)
-            if (empty($targetPath)) {
+            if ( empty( $targetPath ) ) {
                 continue;
             }
 
             // Get file info
-            $stat = $zip->statIndex($i);
-            if (false === $stat) {
+            $stat = $zip->statIndex( $i );
+            if ( false === $stat ) {
                 continue;
             }
 
-            $fullTargetPath = $extractPath.DIRECTORY_SEPARATOR.$targetPath;
+            $fullTargetPath = $extractPath . DIRECTORY_SEPARATOR . $targetPath;
 
             // Handle directories
-            if (str_ends_with($filename, '/')) {
-                if (! File::exists($fullTargetPath)) {
-                    File::makeDirectory($fullTargetPath, 0755, true);
+            if ( str_ends_with( $filename, '/' ) ) {
+                if ( ! File::exists( $fullTargetPath ) ) {
+                    File::makeDirectory( $fullTargetPath, 0755, true );
                 }
 
                 continue;
             }
 
             // Handle files - ensure parent directory exists
-            $targetDir = dirname($fullTargetPath);
-            if (! File::exists($targetDir)) {
-                File::makeDirectory($targetDir, 0755, true);
+            $targetDir = dirname( $fullTargetPath );
+            if ( ! File::exists( $targetDir ) ) {
+                File::makeDirectory( $targetDir, 0755, true );
             }
 
             // Stream the entry to disk rather than materializing it as a PHP
             // string via `getFromIndex()`. On a 128M host, a single large file
             // inside the release (bundled JS/CSS, images) can otherwise OOM in
             // the middle of extraction.
-            $entryStream = $zip->getStream($filename);
-            if (false === $entryStream) {
+            $entryStream = $zip->getStream( $filename );
+            if ( false === $entryStream ) {
                 continue;
             }
 
-            $out = @fopen($fullTargetPath, 'wb');
-            if (false === $out) {
-                fclose($entryStream);
+            $out = @fopen( $fullTargetPath, 'wb' );
+            if ( false === $out ) {
+                fclose( $entryStream );
 
                 continue;
             }
 
             try {
-                while (! feof($entryStream)) {
-                    $chunk = fread($entryStream, 1024 * 1024);
-                    if (false === $chunk || '' === $chunk) {
+                while ( ! feof( $entryStream ) ) {
+                    $chunk = fread( $entryStream, 1024 * 1024 );
+                    if ( false === $chunk || '' === $chunk ) {
                         break;
                     }
 
-                    fwrite($out, $chunk);
+                    fwrite( $out, $chunk );
                 }
             } finally {
-                fclose($entryStream);
-                fclose($out);
+                fclose( $entryStream );
+                fclose( $out );
             }
 
             // Preserve file permissions if available
-            if (isset($stat['external_attributes'])) {
-                $permissions = ($stat['external_attributes'] >> 16) & 0777;
-                if ($permissions > 0) {
-                    @chmod($fullTargetPath, $permissions);
+            if ( isset( $stat['external_attributes'] ) ) {
+                $permissions = ( $stat['external_attributes'] >> 16 ) & 0777;
+                if ( $permissions > 0 ) {
+                    @chmod( $fullTargetPath, $permissions );
                 }
             }
         }
@@ -538,34 +538,34 @@ class ApplicationUpdateManager
      *
      * @return string|null Common root prefix, or null if none detected
      */
-    protected function detectCommonRootPrefix(ZipArchive $zip, array $excludePaths): ?string
+    protected function detectCommonRootPrefix( ZipArchive $zip, array $excludePaths ): ?string
     {
         $firstSegments = [];
 
         // Scan all non-excluded entries to find first path segment
-        for ($i = 0; $i < $zip->numFiles; $i++) {
-            $filename = $zip->getNameIndex($i);
+        for ( $i = 0; $i < $zip->numFiles; $i++ ) {
+            $filename = $zip->getNameIndex( $i );
 
             // Skip excluded paths
-            if ($this->isPathExcluded($filename, $excludePaths)) {
+            if ( $this->isPathExcluded( $filename, $excludePaths ) ) {
                 continue;
             }
 
             // Get first path segment
-            $parts = explode('/', $filename);
-            if (! empty($parts[0])) {
+            $parts = explode( '/', $filename );
+            if ( ! empty( $parts[0] ) ) {
                 $firstSegments[] = $parts[0];
             }
         }
 
         // If all entries share the same first segment, that's our common prefix
-        if (empty($firstSegments)) {
+        if ( empty( $firstSegments ) ) {
             return null;
         }
 
-        $uniqueSegments = array_unique($firstSegments);
-        if (1 === count($uniqueSegments)) {
-            return reset($uniqueSegments).'/';
+        $uniqueSegments = array_unique( $firstSegments );
+        if ( 1 === count( $uniqueSegments ) ) {
+            return reset( $uniqueSegments ) . '/';
         }
 
         return null;
@@ -581,14 +581,14 @@ class ApplicationUpdateManager
     protected function runComposerInstall(): void
     {
         $command = $this->resolveComposerCommand();
-        $timeout = config('cms.updates.composer_timeout', 600);
+        $timeout = config( 'cms.updates.composer_timeout', 600 );
 
-        $result = Process::timeout($timeout)
-            ->path(base_path())
-            ->run($command);
+        $result = Process::timeout( $timeout )
+            ->path( base_path() )
+            ->run( $command );
 
-        if (! $result->successful()) {
-            throw UpdateException::composerInstallFailed($result->errorOutput());
+        if ( ! $result->successful() ) {
+            throw UpdateException::composerInstallFailed( $result->errorOutput() );
         }
     }
 
@@ -613,21 +613,21 @@ class ApplicationUpdateManager
     protected function resolveComposerCommand(): string
     {
         $envBinary = $this->envComposerBinary();
-        if (null !== $envBinary) {
-            return $this->buildComposerCommand($envBinary);
+        if ( null !== $envBinary ) {
+            return $this->buildComposerCommand( $envBinary );
         }
 
-        $configured = config('cms.updates.composer_install_command');
-        if (is_string($configured) && self::DEFAULT_COMPOSER_INSTALL_COMMAND !== $configured) {
+        $configured = config( 'cms.updates.composer_install_command' );
+        if ( is_string( $configured ) && self::DEFAULT_COMPOSER_INSTALL_COMMAND !== $configured ) {
             return $configured;
         }
 
         $discovered = $this->discoverComposerBinary();
-        if (null !== $discovered) {
-            return $this->buildComposerCommand($discovered);
+        if ( null !== $discovered ) {
+            return $this->buildComposerCommand( $discovered );
         }
 
-        return is_string($configured) ? $configured : self::DEFAULT_COMPOSER_INSTALL_COMMAND;
+        return is_string( $configured ) ? $configured : self::DEFAULT_COMPOSER_INSTALL_COMMAND;
     }
 
     /**
@@ -644,20 +644,20 @@ class ApplicationUpdateManager
     protected function verifyComposerBinaryAvailable(): void
     {
         $binary = $this->resolveComposerBinaryForVerification();
-        if (null === $binary) {
+        if ( null === $binary ) {
             return;
         }
 
         $php     = $this->resolvePhpBinary();
-        $command = escapeshellarg($php).' '.escapeshellarg($binary).' --version';
+        $command = escapeshellarg( $php ) . ' ' . escapeshellarg( $binary ) . ' --version';
 
-        $result = Process::timeout(10)
-            ->path(base_path())
-            ->run($command);
+        $result = Process::timeout( 10 )
+            ->path( base_path() )
+            ->run( $command );
 
-        if (! $result->successful()) {
-            $stderr = trim((string) $result->errorOutput());
-            $stdout = trim((string) $result->output());
+        if ( ! $result->successful() ) {
+            $stderr = trim( (string) $result->errorOutput() );
+            $stdout = trim( (string) $result->output() );
             $detail = '' !== $stderr ? $stderr : $stdout;
 
             throw UpdateException::composerVerificationFailed(
@@ -680,12 +680,12 @@ class ApplicationUpdateManager
     protected function resolveComposerBinaryForVerification(): ?string
     {
         $envBinary = $this->envComposerBinary();
-        if (null !== $envBinary) {
+        if ( null !== $envBinary ) {
             return $envBinary;
         }
 
-        $configured = config('cms.updates.composer_install_command');
-        if (is_string($configured) && self::DEFAULT_COMPOSER_INSTALL_COMMAND !== $configured) {
+        $configured = config( 'cms.updates.composer_install_command' );
+        if ( is_string( $configured ) && self::DEFAULT_COMPOSER_INSTALL_COMMAND !== $configured ) {
             return null;
         }
 
@@ -700,9 +700,9 @@ class ApplicationUpdateManager
      */
     protected function envComposerBinary(): ?string
     {
-        $envBinary = getenv('COMPOSER_BINARY');
+        $envBinary = getenv( 'COMPOSER_BINARY' );
 
-        if (false === $envBinary || '' === $envBinary) {
+        if ( false === $envBinary || '' === $envBinary ) {
             return null;
         }
 
@@ -717,8 +717,8 @@ class ApplicationUpdateManager
      */
     protected function discoverComposerBinary(): ?string
     {
-        foreach ($this->composerCandidatePaths() as $path) {
-            if (is_file($path) && is_executable($path)) {
+        foreach ( $this->composerCandidatePaths() as $path ) {
+            if ( is_file( $path ) && is_executable( $path ) ) {
                 return $path;
             }
         }
@@ -736,16 +736,16 @@ class ApplicationUpdateManager
      */
     protected function composerCandidatePaths(): array
     {
-        $home = getenv('HOME');
+        $home = getenv( 'HOME' );
 
         $candidates = [
             '/usr/local/bin/composer',
             '/opt/homebrew/bin/composer',
         ];
 
-        if (is_string($home) && '' !== $home) {
-            $candidates[] = $home.'/.composer/vendor/bin/composer';
-            $candidates[] = $home.'/.config/composer/vendor/bin/composer';
+        if ( is_string( $home ) && '' !== $home ) {
+            $candidates[] = $home . '/.composer/vendor/bin/composer';
+            $candidates[] = $home . '/.config/composer/vendor/bin/composer';
         }
 
         $candidates[] = '/usr/bin/composer';
@@ -761,9 +761,9 @@ class ApplicationUpdateManager
      *
      * @since 2.5.3
      */
-    protected function buildComposerCommand(string $binary): string
+    protected function buildComposerCommand( string $binary ): string
     {
-        return escapeshellarg($this->resolvePhpBinary()).' '.escapeshellarg($binary).' '.self::DEFAULT_COMPOSER_INSTALL_ARGS;
+        return escapeshellarg( $this->resolvePhpBinary() ) . ' ' . escapeshellarg( $binary ) . ' ' . self::DEFAULT_COMPOSER_INSTALL_ARGS;
     }
 
     /**
@@ -790,17 +790,17 @@ class ApplicationUpdateManager
      */
     protected function resolvePhpBinary(): string
     {
-        $override = getenv('CMS_PHP_BINARY');
-        if (is_string($override) && '' !== $override) {
+        $override = getenv( 'CMS_PHP_BINARY' );
+        if ( is_string( $override ) && '' !== $override ) {
             return $override;
         }
 
-        if ('cli' === PHP_SAPI) {
+        if ( 'cli' === PHP_SAPI ) {
             return PHP_BINARY;
         }
 
-        foreach ($this->phpCandidatePaths() as $candidate) {
-            if ($this->isCliPhpBinary($candidate)) {
+        foreach ( $this->phpCandidatePaths() as $candidate ) {
+            if ( $this->isCliPhpBinary( $candidate ) ) {
                 return $candidate;
             }
         }
@@ -818,15 +818,15 @@ class ApplicationUpdateManager
      */
     protected function phpCandidatePaths(): array
     {
-        $home = getenv('HOME');
+        $home = getenv( 'HOME' );
 
         $candidates = [];
 
-        if (is_string($home) && '' !== $home) {
+        if ( is_string( $home ) && '' !== $home ) {
             // Laravel Herd on macOS ships a `php` symlink pointing at the
             // currently-active CLI binary (e.g. `php84`). Prefer it so hosts
             // that use Herd for both FPM and CLI stay on a single toolchain.
-            $candidates[] = $home.'/Library/Application Support/Herd/bin/php';
+            $candidates[] = $home . '/Library/Application Support/Herd/bin/php';
         }
 
         $candidates[] = '/opt/homebrew/bin/php';
@@ -845,15 +845,15 @@ class ApplicationUpdateManager
      *
      * @since 2.5.4
      */
-    protected function isCliPhpBinary(string $path): bool
+    protected function isCliPhpBinary( string $path ): bool
     {
-        if (! is_file($path) || ! is_executable($path)) {
+        if ( ! is_file( $path ) || ! is_executable( $path ) ) {
             return false;
         }
 
-        $basename = strtolower(basename($path));
+        $basename = strtolower( basename( $path ) );
 
-        return ! str_contains($basename, 'fpm') && ! str_contains($basename, 'cgi');
+        return ! str_contains( $basename, 'fpm' ) && ! str_contains( $basename, 'cgi' );
     }
 
     /**
@@ -866,9 +866,9 @@ class ApplicationUpdateManager
     protected function runMigrations(): void
     {
         try {
-            Artisan::call('migrate', ['--force' => true]);
-        } catch (Throwable $e) {
-            throw UpdateException::migrationFailed($e->getMessage());
+            Artisan::call( 'migrate', ['--force' => true] );
+        } catch ( Throwable $e ) {
+            throw UpdateException::migrationFailed( $e->getMessage() );
         }
     }
 
@@ -879,10 +879,10 @@ class ApplicationUpdateManager
      */
     protected function clearCaches(): void
     {
-        Artisan::call('config:clear');
-        Artisan::call('cache:clear');
-        Artisan::call('route:clear');
-        Artisan::call('view:clear');
+        Artisan::call( 'config:clear' );
+        Artisan::call( 'cache:clear' );
+        Artisan::call( 'route:clear' );
+        Artisan::call( 'view:clear' );
     }
 
     /**
@@ -892,10 +892,10 @@ class ApplicationUpdateManager
      *
      * @param  string  $zipPath  Path to ZIP file
      */
-    protected function cleanup(string $zipPath): void
+    protected function cleanup( string $zipPath ): void
     {
-        if (File::exists($zipPath)) {
-            File::delete($zipPath);
+        if ( File::exists( $zipPath ) ) {
+            File::delete( $zipPath );
         }
     }
 
@@ -909,9 +909,9 @@ class ApplicationUpdateManager
     protected function enableMaintenanceMode(): void
     {
         try {
-            Artisan::call('down', ['--render' => 'errors::503']);
-        } catch (Throwable $e) {
-            throw UpdateException::maintenanceModeFailure('enable');
+            Artisan::call( 'down', ['--render' => 'errors::503'] );
+        } catch ( Throwable $e ) {
+            throw UpdateException::maintenanceModeFailure( 'enable' );
         }
     }
 
@@ -925,9 +925,9 @@ class ApplicationUpdateManager
     protected function disableMaintenanceMode(): void
     {
         try {
-            Artisan::call('up');
-        } catch (Throwable $e) {
-            throw UpdateException::maintenanceModeFailure('disable');
+            Artisan::call( 'up' );
+        } catch ( Throwable $e ) {
+            throw UpdateException::maintenanceModeFailure( 'disable' );
         }
     }
 
@@ -938,10 +938,10 @@ class ApplicationUpdateManager
      *
      * @param  Throwable  $exception  The throwable that caused failure
      */
-    protected function handleUpdateFailure(Throwable $exception): void
+    protected function handleUpdateFailure( Throwable $exception ): void
     {
         // Log the original exception for debugging
-        \Illuminate\Support\Facades\Log::error('Update failed, beginning rollback', [
+        \Illuminate\Support\Facades\Log::error( 'Update failed, beginning rollback', [
             'exception' => $exception->getMessage(),
             'trace'     => $exception->getTraceAsString(),
             'file'      => $exception->getFile(),
@@ -951,7 +951,7 @@ class ApplicationUpdateManager
         // Attempt to disable maintenance mode
         try {
             $this->disableMaintenanceMode();
-        } catch (Throwable $e) {
+        } catch ( Throwable $e) {
             \Illuminate\Support\Facades\Log::error(
                 'Failed to disable maintenance mode during update rollback; host may remain in maintenance mode.',
                 ['exception' => $e->getMessage()],
@@ -959,15 +959,15 @@ class ApplicationUpdateManager
         }
 
         // If we have a backup, attempt rollback
-        if ($this->backupPath && File::exists($this->backupPath)) {
+        if ( $this->backupPath && File::exists( $this->backupPath)) {
             try {
-                $this->rollback($this->backupPath);
-            } catch (Throwable $e) {
+                $this->rollback( $this->backupPath);
+            } catch ( Throwable $e) {
                 // Rollback failed - this is critical. Preserve the original
                 // update-failure message alongside the rollback message so the
                 // operator can see both failures rather than only the trailing
                 // one.
-                throw UpdateException::rollbackAfterFailure($exception->getMessage(), $e->getMessage());
+                throw UpdateException::rollbackAfterFailure( $exception->getMessage(), $e->getMessage());
             }
         }
     }

--- a/src/Modules/Core/Updates/Managers/ApplicationUpdateManager.php
+++ b/src/Modules/Core/Updates/Managers/ApplicationUpdateManager.php
@@ -1,6 +1,6 @@
 <?php
 
-declare( strict_types=1 );
+declare(strict_types=1);
 
 namespace ArtisanPackUI\CMSFramework\Modules\Core\Updates\Managers;
 
@@ -84,11 +84,11 @@ class ApplicationUpdateManager
      *
      * @return bool True if update successful
      */
-    public function performUpdate( ?string $version = null ): bool
+    public function performUpdate(?string $version = null): bool
     {
         $updateInfo = $this->checkForUpdate();
 
-        if ( ! $updateInfo->hasUpdate() ) {
+        if (! $updateInfo->hasUpdate()) {
             throw UpdateException::noUpdateAvailable();
         }
 
@@ -100,18 +100,18 @@ class ApplicationUpdateManager
             $this->enableMaintenanceMode();
 
             // Step 2: Create backup
-            if ( config( 'cms.updates.backup_enabled', true ) ) {
+            if (config('cms.updates.backup_enabled', true)) {
                 $this->createBackup();
             }
 
             // Step 3: Download update
-            $zipPath = $this->getUpdateChecker()->downloadUpdate( $targetVersion );
+            $zipPath = $this->getUpdateChecker()->downloadUpdate($targetVersion);
 
             // Step 4: Verify checksum (or surface the silent skip)
-            $this->maybeVerifyChecksum( $zipPath, $updateInfo, $targetVersion );
+            $this->maybeVerifyChecksum($zipPath, $updateInfo, $targetVersion);
 
             // Step 5: Extract update
-            $this->extractUpdate( $zipPath );
+            $this->extractUpdate($zipPath);
 
             // Step 6: Run composer install
             $this->runComposerInstall();
@@ -123,15 +123,15 @@ class ApplicationUpdateManager
             $this->clearCaches();
 
             // Step 9: Clean up
-            $this->cleanup( $zipPath );
+            $this->cleanup($zipPath);
 
             // Step 10: Disable maintenance mode
             $this->disableMaintenanceMode();
 
             return true;
-        } catch ( Throwable $e ) {
+        } catch (Throwable $e) {
             // Rollback on failure
-            $this->handleUpdateFailure( $e );
+            $this->handleUpdateFailure($e);
 
             throw $e;
         }
@@ -144,7 +144,7 @@ class ApplicationUpdateManager
      *
      * @param  UpdateChecker  $checker  Update checker instance
      */
-    public function setUpdateChecker( UpdateChecker $checker ): void
+    public function setUpdateChecker(UpdateChecker $checker): void
     {
         $this->checker = $checker;
     }
@@ -158,19 +158,19 @@ class ApplicationUpdateManager
      *
      * @throws UpdateException
      */
-    public function rollback( string $backupPath ): void
+    public function rollback(string $backupPath): void
     {
-        if ( ! File::exists( $backupPath ) ) {
-            throw UpdateException::rollbackFailed( "Backup not found: {$backupPath}" );
+        if (! File::exists($backupPath)) {
+            throw UpdateException::rollbackFailed("Backup not found: {$backupPath}");
         }
 
         $zip = new ZipArchive;
 
-        if ( true !== $zip->open( $backupPath ) ) {
-            throw UpdateException::rollbackFailed( 'Could not open backup ZIP' );
+        if (true !== $zip->open($backupPath)) {
+            throw UpdateException::rollbackFailed('Could not open backup ZIP');
         }
 
-        $zip->extractTo( base_path() );
+        $zip->extractTo(base_path());
         $zip->close();
 
         // Before invoking composer install, verify the resolved binary is
@@ -208,13 +208,13 @@ class ApplicationUpdateManager
      */
     protected function getUpdateChecker(): UpdateChecker
     {
-        if ( $this->checker ) {
+        if ($this->checker) {
             return $this->checker;
         }
 
-        $updateUrl = config( 'cms.updates.update_source_url' );
+        $updateUrl = config('cms.updates.update_source_url');
 
-        if ( ! $updateUrl ) {
+        if (! $updateUrl) {
             throw UpdateException::noUpdateUrlConfigured();
         }
 
@@ -236,32 +236,32 @@ class ApplicationUpdateManager
      */
     protected function createBackup(): void
     {
-        $backupDir  = storage_path( config( 'cms.updates.backup_path', 'backups/application' ) );
-        $backupName = 'backup-' . date( 'Y-m-d-His' ) . '.zip';
+        $backupDir  = storage_path(config('cms.updates.backup_path', 'backups/application'));
+        $backupName = 'backup-'.date('Y-m-d-His').'.zip';
         $backupPath = "{$backupDir}/{$backupName}";
 
         // Create backup directory
-        if ( ! File::exists( $backupDir ) ) {
-            File::makeDirectory( $backupDir, 0755, true );
+        if (! File::exists($backupDir)) {
+            File::makeDirectory($backupDir, 0755, true);
         }
 
         // Create backup ZIP
         $zip = new ZipArchive;
 
-        if ( true !== $zip->open( $backupPath, ZipArchive::CREATE | ZipArchive::OVERWRITE ) ) {
-            throw UpdateException::backupFailed( $backupPath );
+        if (true !== $zip->open($backupPath, ZipArchive::CREATE | ZipArchive::OVERWRITE)) {
+            throw UpdateException::backupFailed($backupPath);
         }
 
         // Add all files except excluded paths
-        $excludePaths = config( 'cms.updates.exclude_from_update', [] );
-        $this->addDirectoryToZip( $zip, base_path(), '', $excludePaths );
+        $excludePaths = config('cms.updates.exclude_from_update', []);
+        $this->addDirectoryToZip($zip, base_path(), '', $excludePaths);
 
         $zip->close();
 
         $this->backupPath = $backupPath;
 
         // Clean old backups
-        $this->cleanOldBackups( $backupDir );
+        $this->cleanOldBackups($backupDir);
     }
 
     /**
@@ -274,53 +274,53 @@ class ApplicationUpdateManager
      * @param  string  $localPath  Local path in ZIP
      * @param  array<string>  $excludePaths  Paths to exclude
      */
-    protected function addDirectoryToZip( ZipArchive $zip, string $sourcePath, string $localPath, array $excludePaths ): void
+    protected function addDirectoryToZip(ZipArchive $zip, string $sourcePath, string $localPath, array $excludePaths): void
     {
         $files = new RecursiveIteratorIterator(
-            new RecursiveDirectoryIterator( $sourcePath ),
+            new RecursiveDirectoryIterator($sourcePath),
             RecursiveIteratorIterator::LEAVES_ONLY,
         );
 
         $basePath = base_path();
 
-        foreach ( $files as $file ) {
-            if ( $file->isDir() ) {
+        foreach ($files as $file) {
+            if ($file->isDir()) {
                 continue;
             }
 
             // Get real path and validate it
             $filePath = $file->getRealPath();
 
-            if ( false === $filePath ) {
+            if (false === $filePath) {
                 // getRealPath() failed - log and skip
-                \Illuminate\Support\Facades\Log::warning( 'Failed to get real path for file during backup', [
+                \Illuminate\Support\Facades\Log::warning('Failed to get real path for file during backup', [
                     'file' => $file->getPathname(),
-                ] );
+                ]);
 
                 continue;
             }
 
             // Verify the resolved path starts with base_path() to prevent traversal issues
-            if ( ! str_starts_with( $filePath, $basePath ) ) {
+            if (! str_starts_with($filePath, $basePath)) {
                 // File is outside base path (symlink or external) - log and skip
-                \Illuminate\Support\Facades\Log::warning( 'Skipping file outside base path during backup', [
+                \Illuminate\Support\Facades\Log::warning('Skipping file outside base path during backup', [
                     'file'      => $filePath,
                     'base_path' => $basePath,
-                ] );
+                ]);
 
                 continue;
             }
 
             // Safe to compute relative path
-            $relativePath = substr( $filePath, strlen( $basePath ) + 1 );
+            $relativePath = substr($filePath, strlen($basePath) + 1);
 
             // Skip excluded paths
-            if ( $this->isPathExcluded( $relativePath, $excludePaths ) ) {
+            if ($this->isPathExcluded($relativePath, $excludePaths)) {
                 continue;
             }
 
-            $zipPath = $localPath . DIRECTORY_SEPARATOR . $relativePath;
-            $zip->addFile( $filePath, $zipPath );
+            $zipPath = $localPath.DIRECTORY_SEPARATOR.$relativePath;
+            $zip->addFile($filePath, $zipPath);
         }
     }
 
@@ -334,14 +334,14 @@ class ApplicationUpdateManager
      *
      * @return bool True if excluded
      */
-    protected function isPathExcluded( string $path, array $excludePaths ): bool
+    protected function isPathExcluded(string $path, array $excludePaths): bool
     {
-        foreach ( $excludePaths as $exclude ) {
-            if ( str_starts_with( $path, $exclude ) ) {
+        foreach ($excludePaths as $exclude) {
+            if (str_starts_with($path, $exclude)) {
                 return true;
             }
 
-            if ( str_contains( $exclude, '*' ) && fnmatch( $exclude, $path ) ) {
+            if (str_contains($exclude, '*') && fnmatch($exclude, $path)) {
                 return true;
             }
         }
@@ -356,20 +356,20 @@ class ApplicationUpdateManager
      *
      * @param  string  $backupDir  Backup directory
      */
-    protected function cleanOldBackups( string $backupDir ): void
+    protected function cleanOldBackups(string $backupDir): void
     {
-        $retentionDays = config( 'cms.updates.backup_retention_days', 30 );
-        $cutoffTime    = time() - ( $retentionDays * 86400 );
+        $retentionDays = config('cms.updates.backup_retention_days', 30);
+        $cutoffTime    = time() - ($retentionDays * 86400);
 
-        $backups = glob( "{$backupDir}/backup-*.zip" );
+        $backups = glob("{$backupDir}/backup-*.zip");
 
-        if ( false === $backups ) {
+        if (false === $backups) {
             return;
         }
 
-        foreach ( $backups as $backup ) {
-            if ( filemtime( $backup ) < $cutoffTime ) {
-                File::delete( $backup );
+        foreach ($backups as $backup) {
+            if (filemtime($backup) < $cutoffTime) {
+                File::delete($backup);
             }
         }
     }
@@ -384,12 +384,12 @@ class ApplicationUpdateManager
      *
      * @throws UpdateException
      */
-    protected function verifyChecksum( string $zipPath, string $expectedHash ): void
+    protected function verifyChecksum(string $zipPath, string $expectedHash): void
     {
-        $actualHash = hash_file( 'sha256', $zipPath );
+        $actualHash = hash_file('sha256', $zipPath);
 
-        if ( $actualHash !== $expectedHash ) {
-            throw UpdateException::checksumMismatch( $expectedHash, $actualHash );
+        if ($actualHash !== $expectedHash) {
+            throw UpdateException::checksumMismatch($expectedHash, $actualHash);
         }
     }
 
@@ -405,22 +405,22 @@ class ApplicationUpdateManager
      *
      * @throws UpdateException When the checksum is present but does not match.
      */
-    protected function maybeVerifyChecksum( string $zipPath, UpdateInfo $updateInfo, string $targetVersion ): void
+    protected function maybeVerifyChecksum(string $zipPath, UpdateInfo $updateInfo, string $targetVersion): void
     {
-        if ( ! config( 'cms.updates.verify_checksum', true ) ) {
+        if (! config('cms.updates.verify_checksum', true)) {
             return;
         }
 
-        if ( $updateInfo->sha256 ) {
-            $this->verifyChecksum( $zipPath, $updateInfo->sha256 );
+        if ($updateInfo->sha256) {
+            $this->verifyChecksum($zipPath, $updateInfo->sha256);
 
             return;
         }
 
-        \Illuminate\Support\Facades\Log::warning( 'Skipping update integrity verification: update source did not advertise a SHA-256 checksum.', [
+        \Illuminate\Support\Facades\Log::warning('Skipping update integrity verification: update source did not advertise a SHA-256 checksum.', [
             'target_version' => $targetVersion,
             'source'         => $updateInfo->metadata['source'] ?? null,
-        ] );
+        ]);
     }
 
     /**
@@ -432,95 +432,95 @@ class ApplicationUpdateManager
      *
      * @throws UpdateException
      */
-    protected function extractUpdate( string $zipPath ): void
+    protected function extractUpdate(string $zipPath): void
     {
         $zip = new ZipArchive;
 
-        if ( true !== $zip->open( $zipPath ) ) {
-            throw UpdateException::extractionFailed( $zipPath );
+        if (true !== $zip->open($zipPath)) {
+            throw UpdateException::extractionFailed($zipPath);
         }
 
         $extractPath  = base_path();
-        $excludePaths = config( 'cms.updates.exclude_from_update', [] );
+        $excludePaths = config('cms.updates.exclude_from_update', []);
 
         // Detect common root prefix by scanning all entry names
-        $commonPrefix = $this->detectCommonRootPrefix( $zip, $excludePaths );
+        $commonPrefix = $this->detectCommonRootPrefix($zip, $excludePaths);
 
         // Extract files (except excluded paths), stripping common prefix
-        for ( $i = 0; $i < $zip->numFiles; $i++ ) {
-            $filename = $zip->getNameIndex( $i );
+        for ($i = 0; $i < $zip->numFiles; $i++) {
+            $filename = $zip->getNameIndex($i);
 
             // Strip common prefix if detected
-            $targetPath = $commonPrefix ? substr( $filename, strlen( $commonPrefix ) ) : $filename;
+            $targetPath = $commonPrefix ? substr($filename, strlen($commonPrefix)) : $filename;
 
             // Skip excluded paths (check both original and stripped paths)
-            if ( $this->isPathExcluded( $filename, $excludePaths ) || $this->isPathExcluded( $targetPath, $excludePaths ) ) {
+            if ($this->isPathExcluded($filename, $excludePaths) || $this->isPathExcluded($targetPath, $excludePaths)) {
                 continue;
             }
 
             // Skip empty paths (directories become empty after prefix stripping)
-            if ( empty( $targetPath ) ) {
+            if (empty($targetPath)) {
                 continue;
             }
 
             // Get file info
-            $stat = $zip->statIndex( $i );
-            if ( false === $stat ) {
+            $stat = $zip->statIndex($i);
+            if (false === $stat) {
                 continue;
             }
 
-            $fullTargetPath = $extractPath . DIRECTORY_SEPARATOR . $targetPath;
+            $fullTargetPath = $extractPath.DIRECTORY_SEPARATOR.$targetPath;
 
             // Handle directories
-            if ( str_ends_with( $filename, '/' ) ) {
-                if ( ! File::exists( $fullTargetPath ) ) {
-                    File::makeDirectory( $fullTargetPath, 0755, true );
+            if (str_ends_with($filename, '/')) {
+                if (! File::exists($fullTargetPath)) {
+                    File::makeDirectory($fullTargetPath, 0755, true);
                 }
 
                 continue;
             }
 
             // Handle files - ensure parent directory exists
-            $targetDir = dirname( $fullTargetPath );
-            if ( ! File::exists( $targetDir ) ) {
-                File::makeDirectory( $targetDir, 0755, true );
+            $targetDir = dirname($fullTargetPath);
+            if (! File::exists($targetDir)) {
+                File::makeDirectory($targetDir, 0755, true);
             }
 
             // Stream the entry to disk rather than materializing it as a PHP
             // string via `getFromIndex()`. On a 128M host, a single large file
             // inside the release (bundled JS/CSS, images) can otherwise OOM in
             // the middle of extraction.
-            $entryStream = $zip->getStream( $filename );
-            if ( false === $entryStream ) {
+            $entryStream = $zip->getStream($filename);
+            if (false === $entryStream) {
                 continue;
             }
 
-            $out = @fopen( $fullTargetPath, 'wb' );
-            if ( false === $out ) {
-                fclose( $entryStream );
+            $out = @fopen($fullTargetPath, 'wb');
+            if (false === $out) {
+                fclose($entryStream);
 
                 continue;
             }
 
             try {
-                while ( ! feof( $entryStream ) ) {
-                    $chunk = fread( $entryStream, 1024 * 1024 );
-                    if ( false === $chunk || '' === $chunk ) {
+                while (! feof($entryStream)) {
+                    $chunk = fread($entryStream, 1024 * 1024);
+                    if (false === $chunk || '' === $chunk) {
                         break;
                     }
 
-                    fwrite( $out, $chunk );
+                    fwrite($out, $chunk);
                 }
             } finally {
-                fclose( $entryStream );
-                fclose( $out );
+                fclose($entryStream);
+                fclose($out);
             }
 
             // Preserve file permissions if available
-            if ( isset( $stat['external_attributes'] ) ) {
-                $permissions = ( $stat['external_attributes'] >> 16 ) & 0777;
-                if ( $permissions > 0 ) {
-                    @chmod( $fullTargetPath, $permissions );
+            if (isset($stat['external_attributes'])) {
+                $permissions = ($stat['external_attributes'] >> 16) & 0777;
+                if ($permissions > 0) {
+                    @chmod($fullTargetPath, $permissions);
                 }
             }
         }
@@ -538,34 +538,34 @@ class ApplicationUpdateManager
      *
      * @return string|null Common root prefix, or null if none detected
      */
-    protected function detectCommonRootPrefix( ZipArchive $zip, array $excludePaths ): ?string
+    protected function detectCommonRootPrefix(ZipArchive $zip, array $excludePaths): ?string
     {
         $firstSegments = [];
 
         // Scan all non-excluded entries to find first path segment
-        for ( $i = 0; $i < $zip->numFiles; $i++ ) {
-            $filename = $zip->getNameIndex( $i );
+        for ($i = 0; $i < $zip->numFiles; $i++) {
+            $filename = $zip->getNameIndex($i);
 
             // Skip excluded paths
-            if ( $this->isPathExcluded( $filename, $excludePaths ) ) {
+            if ($this->isPathExcluded($filename, $excludePaths)) {
                 continue;
             }
 
             // Get first path segment
-            $parts = explode( '/', $filename );
-            if ( ! empty( $parts[0] ) ) {
+            $parts = explode('/', $filename);
+            if (! empty($parts[0])) {
                 $firstSegments[] = $parts[0];
             }
         }
 
         // If all entries share the same first segment, that's our common prefix
-        if ( empty( $firstSegments ) ) {
+        if (empty($firstSegments)) {
             return null;
         }
 
-        $uniqueSegments = array_unique( $firstSegments );
-        if ( 1 === count( $uniqueSegments ) ) {
-            return reset( $uniqueSegments ) . '/';
+        $uniqueSegments = array_unique($firstSegments);
+        if (1 === count($uniqueSegments)) {
+            return reset($uniqueSegments).'/';
         }
 
         return null;
@@ -581,14 +581,14 @@ class ApplicationUpdateManager
     protected function runComposerInstall(): void
     {
         $command = $this->resolveComposerCommand();
-        $timeout = config( 'cms.updates.composer_timeout', 600 );
+        $timeout = config('cms.updates.composer_timeout', 600);
 
-        $result = Process::timeout( $timeout )
-            ->path( base_path() )
-            ->run( $command );
+        $result = Process::timeout($timeout)
+            ->path(base_path())
+            ->run($command);
 
-        if ( ! $result->successful() ) {
-            throw UpdateException::composerInstallFailed( $result->errorOutput() );
+        if (! $result->successful()) {
+            throw UpdateException::composerInstallFailed($result->errorOutput());
         }
     }
 
@@ -613,21 +613,21 @@ class ApplicationUpdateManager
     protected function resolveComposerCommand(): string
     {
         $envBinary = $this->envComposerBinary();
-        if ( null !== $envBinary ) {
-            return $this->buildComposerCommand( $envBinary );
+        if (null !== $envBinary) {
+            return $this->buildComposerCommand($envBinary);
         }
 
-        $configured = config( 'cms.updates.composer_install_command' );
-        if ( is_string( $configured ) && self::DEFAULT_COMPOSER_INSTALL_COMMAND !== $configured ) {
+        $configured = config('cms.updates.composer_install_command');
+        if (is_string($configured) && self::DEFAULT_COMPOSER_INSTALL_COMMAND !== $configured) {
             return $configured;
         }
 
         $discovered = $this->discoverComposerBinary();
-        if ( null !== $discovered ) {
-            return $this->buildComposerCommand( $discovered );
+        if (null !== $discovered) {
+            return $this->buildComposerCommand($discovered);
         }
 
-        return is_string( $configured ) ? $configured : self::DEFAULT_COMPOSER_INSTALL_COMMAND;
+        return is_string($configured) ? $configured : self::DEFAULT_COMPOSER_INSTALL_COMMAND;
     }
 
     /**
@@ -644,18 +644,28 @@ class ApplicationUpdateManager
     protected function verifyComposerBinaryAvailable(): void
     {
         $binary = $this->resolveComposerBinaryForVerification();
-        if ( null === $binary ) {
+        if (null === $binary) {
             return;
         }
 
-        $command = escapeshellarg( PHP_BINARY ) . ' ' . escapeshellarg( $binary ) . ' --version';
+        $php     = $this->resolvePhpBinary();
+        $command = escapeshellarg($php).' '.escapeshellarg($binary).' --version';
 
-        $result = Process::timeout( 10 )
-            ->path( base_path() )
-            ->run( $command );
+        $result = Process::timeout(10)
+            ->path(base_path())
+            ->run($command);
 
-        if ( ! $result->successful() ) {
-            throw UpdateException::composerBinaryNotFound( $this->composerCandidatePaths() );
+        if (! $result->successful()) {
+            $stderr = trim((string) $result->errorOutput());
+            $stdout = trim((string) $result->output());
+            $detail = '' !== $stderr ? $stderr : $stdout;
+
+            throw UpdateException::composerVerificationFailed(
+                $binary,
+                $php,
+                (int) $result->exitCode(),
+                $detail,
+            );
         }
     }
 
@@ -670,12 +680,12 @@ class ApplicationUpdateManager
     protected function resolveComposerBinaryForVerification(): ?string
     {
         $envBinary = $this->envComposerBinary();
-        if ( null !== $envBinary ) {
+        if (null !== $envBinary) {
             return $envBinary;
         }
 
-        $configured = config( 'cms.updates.composer_install_command' );
-        if ( is_string( $configured ) && self::DEFAULT_COMPOSER_INSTALL_COMMAND !== $configured ) {
+        $configured = config('cms.updates.composer_install_command');
+        if (is_string($configured) && self::DEFAULT_COMPOSER_INSTALL_COMMAND !== $configured) {
             return null;
         }
 
@@ -690,9 +700,9 @@ class ApplicationUpdateManager
      */
     protected function envComposerBinary(): ?string
     {
-        $envBinary = getenv( 'COMPOSER_BINARY' );
+        $envBinary = getenv('COMPOSER_BINARY');
 
-        if ( false === $envBinary || '' === $envBinary ) {
+        if (false === $envBinary || '' === $envBinary) {
             return null;
         }
 
@@ -707,8 +717,8 @@ class ApplicationUpdateManager
      */
     protected function discoverComposerBinary(): ?string
     {
-        foreach ( $this->composerCandidatePaths() as $path ) {
-            if ( is_file( $path ) && is_executable( $path ) ) {
+        foreach ($this->composerCandidatePaths() as $path) {
+            if (is_file($path) && is_executable($path)) {
                 return $path;
             }
         }
@@ -726,16 +736,16 @@ class ApplicationUpdateManager
      */
     protected function composerCandidatePaths(): array
     {
-        $home = getenv( 'HOME' );
+        $home = getenv('HOME');
 
         $candidates = [
             '/usr/local/bin/composer',
             '/opt/homebrew/bin/composer',
         ];
 
-        if ( is_string( $home ) && '' !== $home ) {
-            $candidates[] = $home . '/.composer/vendor/bin/composer';
-            $candidates[] = $home . '/.config/composer/vendor/bin/composer';
+        if (is_string($home) && '' !== $home) {
+            $candidates[] = $home.'/.composer/vendor/bin/composer';
+            $candidates[] = $home.'/.config/composer/vendor/bin/composer';
         }
 
         $candidates[] = '/usr/bin/composer';
@@ -744,14 +754,106 @@ class ApplicationUpdateManager
     }
 
     /**
-     * Build the composer command line from a binary path. Uses `PHP_BINARY`
-     * so PHP-FPM's `PATH` never needs to resolve `php` for composer's shebang.
+     * Build the composer command line from a binary path. Invokes composer via
+     * a resolved CLI PHP interpreter so PHP-FPM's `PATH` never needs to
+     * resolve `php` for composer's shebang, and so we never hand the PHAR to
+     * an FPM daemon binary (which prints usage and exits 64).
      *
      * @since 2.5.3
      */
-    protected function buildComposerCommand( string $binary ): string
+    protected function buildComposerCommand(string $binary): string
     {
-        return escapeshellarg( PHP_BINARY ) . ' ' . escapeshellarg( $binary ) . ' ' . self::DEFAULT_COMPOSER_INSTALL_ARGS;
+        return escapeshellarg($this->resolvePhpBinary()).' '.escapeshellarg($binary).' '.self::DEFAULT_COMPOSER_INSTALL_ARGS;
+    }
+
+    /**
+     * Resolve a CLI PHP binary suitable for executing composer's PHAR.
+     *
+     * `PHP_BINARY` is only trustworthy when the current SAPI is `cli` — under
+     * PHP-FPM (which is where the self-updater actually runs from the admin
+     * UI) it resolves to the FPM daemon binary, which cannot execute scripts.
+     * Handing composer to it produces the classic "prints usage, exits 64,
+     * empty stderr" failure that led to #225 and reappeared under Herd.
+     *
+     * Resolution order:
+     * 1. `CMS_PHP_BINARY` environment variable — absolute path, wins.
+     * 2. `PHP_BINARY` when `PHP_SAPI === 'cli'` — the CLI-invoked update
+     *    command path (artisan, workers) hits this and gets the same
+     *    interpreter as the parent process.
+     * 3. A curated candidate list of CLI installs, filtering out anything
+     *    whose basename smells like an FPM/CGI SAPI binary.
+     * 4. `PHP_BINARY` as a last-resort fallback so callers still get *a*
+     *    command to execute; the surrounding diagnostic will surface the
+     *    real failure.
+     *
+     * @since 2.5.4
+     */
+    protected function resolvePhpBinary(): string
+    {
+        $override = getenv('CMS_PHP_BINARY');
+        if (is_string($override) && '' !== $override) {
+            return $override;
+        }
+
+        if ('cli' === PHP_SAPI) {
+            return PHP_BINARY;
+        }
+
+        foreach ($this->phpCandidatePaths() as $candidate) {
+            if ($this->isCliPhpBinary($candidate)) {
+                return $candidate;
+            }
+        }
+
+        return PHP_BINARY;
+    }
+
+    /**
+     * Common CLI PHP install paths, in preference order. Extracted so tests
+     * and the `composerVerificationFailed` diagnostic can share the same list.
+     *
+     * @since 2.5.4
+     *
+     * @return array<int, string>
+     */
+    protected function phpCandidatePaths(): array
+    {
+        $home = getenv('HOME');
+
+        $candidates = [];
+
+        if (is_string($home) && '' !== $home) {
+            // Laravel Herd on macOS ships a `php` symlink pointing at the
+            // currently-active CLI binary (e.g. `php84`). Prefer it so hosts
+            // that use Herd for both FPM and CLI stay on a single toolchain.
+            $candidates[] = $home.'/Library/Application Support/Herd/bin/php';
+        }
+
+        $candidates[] = '/opt/homebrew/bin/php';
+        $candidates[] = '/usr/local/bin/php';
+        $candidates[] = '/usr/bin/php';
+
+        return $candidates;
+    }
+
+    /**
+     * Return true when the path points at what looks like a CLI PHP binary —
+     * executable, and whose basename does not smell like an FPM or CGI SAPI
+     * binary (`php-fpm`, `php84-fpm`, `php-cgi`, …). Cheap heuristic; the
+     * only real cost of a false-positive is the caller falling through to
+     * `PHP_BINARY` and surfacing the resulting diagnostic.
+     *
+     * @since 2.5.4
+     */
+    protected function isCliPhpBinary(string $path): bool
+    {
+        if (! is_file($path) || ! is_executable($path)) {
+            return false;
+        }
+
+        $basename = strtolower(basename($path));
+
+        return ! str_contains($basename, 'fpm') && ! str_contains($basename, 'cgi');
     }
 
     /**
@@ -764,9 +866,9 @@ class ApplicationUpdateManager
     protected function runMigrations(): void
     {
         try {
-            Artisan::call( 'migrate', ['--force' => true] );
-        } catch ( Throwable $e ) {
-            throw UpdateException::migrationFailed( $e->getMessage() );
+            Artisan::call('migrate', ['--force' => true]);
+        } catch (Throwable $e) {
+            throw UpdateException::migrationFailed($e->getMessage());
         }
     }
 
@@ -777,10 +879,10 @@ class ApplicationUpdateManager
      */
     protected function clearCaches(): void
     {
-        Artisan::call( 'config:clear' );
-        Artisan::call( 'cache:clear' );
-        Artisan::call( 'route:clear' );
-        Artisan::call( 'view:clear' );
+        Artisan::call('config:clear');
+        Artisan::call('cache:clear');
+        Artisan::call('route:clear');
+        Artisan::call('view:clear');
     }
 
     /**
@@ -790,10 +892,10 @@ class ApplicationUpdateManager
      *
      * @param  string  $zipPath  Path to ZIP file
      */
-    protected function cleanup( string $zipPath ): void
+    protected function cleanup(string $zipPath): void
     {
-        if ( File::exists( $zipPath ) ) {
-            File::delete( $zipPath );
+        if (File::exists($zipPath)) {
+            File::delete($zipPath);
         }
     }
 
@@ -807,9 +909,9 @@ class ApplicationUpdateManager
     protected function enableMaintenanceMode(): void
     {
         try {
-            Artisan::call( 'down', ['--render' => 'errors::503'] );
-        } catch ( Throwable $e ) {
-            throw UpdateException::maintenanceModeFailure( 'enable' );
+            Artisan::call('down', ['--render' => 'errors::503']);
+        } catch (Throwable $e) {
+            throw UpdateException::maintenanceModeFailure('enable');
         }
     }
 
@@ -823,9 +925,9 @@ class ApplicationUpdateManager
     protected function disableMaintenanceMode(): void
     {
         try {
-            Artisan::call( 'up' );
-        } catch ( Throwable $e ) {
-            throw UpdateException::maintenanceModeFailure( 'disable' );
+            Artisan::call('up');
+        } catch (Throwable $e) {
+            throw UpdateException::maintenanceModeFailure('disable');
         }
     }
 
@@ -836,20 +938,20 @@ class ApplicationUpdateManager
      *
      * @param  Throwable  $exception  The throwable that caused failure
      */
-    protected function handleUpdateFailure( Throwable $exception ): void
+    protected function handleUpdateFailure(Throwable $exception): void
     {
         // Log the original exception for debugging
-        \Illuminate\Support\Facades\Log::error( 'Update failed, beginning rollback', [
+        \Illuminate\Support\Facades\Log::error('Update failed, beginning rollback', [
             'exception' => $exception->getMessage(),
             'trace'     => $exception->getTraceAsString(),
             'file'      => $exception->getFile(),
             'line'      => $exception->getLine(),
-        ] );
+        ]);
 
         // Attempt to disable maintenance mode
         try {
             $this->disableMaintenanceMode();
-        } catch ( Throwable $e ) {
+        } catch (Throwable $e) {
             \Illuminate\Support\Facades\Log::error(
                 'Failed to disable maintenance mode during update rollback; host may remain in maintenance mode.',
                 ['exception' => $e->getMessage()],
@@ -857,15 +959,15 @@ class ApplicationUpdateManager
         }
 
         // If we have a backup, attempt rollback
-        if ( $this->backupPath && File::exists( $this->backupPath ) ) {
+        if ($this->backupPath && File::exists($this->backupPath)) {
             try {
-                $this->rollback( $this->backupPath );
-            } catch ( Throwable $e ) {
+                $this->rollback($this->backupPath);
+            } catch (Throwable $e) {
                 // Rollback failed - this is critical. Preserve the original
                 // update-failure message alongside the rollback message so the
                 // operator can see both failures rather than only the trailing
                 // one.
-                throw UpdateException::rollbackAfterFailure( $exception->getMessage(), $e->getMessage() );
+                throw UpdateException::rollbackAfterFailure($exception->getMessage(), $e->getMessage());
             }
         }
     }

--- a/src/Modules/Core/Updates/config/updates.php
+++ b/src/Modules/Core/Updates/config/updates.php
@@ -53,7 +53,7 @@ return [
     |
     | 1. `COMPOSER_BINARY` environment variable — set this to an absolute path
     |    if you know where composer lives (e.g. `/opt/homebrew/bin/composer`)
-    |    and want the framework to build the command as `{PHP_BINARY} {binary}
+    |    and want the framework to build the command as `{CLI PHP} {binary}
     |    install --no-dev --no-interaction --optimize-autoloader`.
     | 2. A non-default value for this config key — set this to a bespoke shell
     |    string if you need full control (custom flags, prepended PATH, etc.).
@@ -61,6 +61,12 @@ return [
     |    `/opt/homebrew/bin/composer`, `~/.composer/vendor/bin/composer`,
     |    `~/.config/composer/vendor/bin/composer`, `/usr/bin/composer`).
     | 4. This default command (bare `composer`).
+    |
+    | The PHP interpreter used to invoke composer is resolved from a CLI SAPI
+    | binary — never from `PHP_BINARY` when the caller is PHP-FPM, because
+    | `PHP_BINARY` under FPM points at the daemon and cannot execute PHARs.
+    | Set `CMS_PHP_BINARY` if the framework picks the wrong CLI PHP on your
+    | host.
     |
     */
     'composer_install_command' => 'composer install --no-dev --no-interaction --optimize-autoloader',

--- a/tests/Unit/Updates/ApplicationUpdateManagerTest.php
+++ b/tests/Unit/Updates/ApplicationUpdateManagerTest.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare( strict_types=1 );
 
 namespace ArtisanPackUI\CMSFramework\Tests\Unit\Updates;
 
@@ -39,16 +39,16 @@ class ApplicationUpdateManagerTest extends TestCase
             downloadUrl: 'https://example.com/update.zip',
         );
 
-        $checker = $this->createMock(UpdateChecker::class);
-        $checker->method('checkForUpdate')->willReturn($updateInfo);
+        $checker = $this->createMock( UpdateChecker::class );
+        $checker->method( 'checkForUpdate' )->willReturn( $updateInfo );
 
-        $manager->setUpdateChecker($checker);
+        $manager->setUpdateChecker( $checker );
 
         $result = $manager->checkForUpdate();
 
-        $this->assertInstanceOf(UpdateInfo::class, $result);
-        $this->assertTrue($result->hasUpdate());
-        $this->assertEquals('2.0.0', $result->latestVersion);
+        $this->assertInstanceOf( UpdateInfo::class, $result );
+        $this->assertTrue( $result->hasUpdate() );
+        $this->assertEquals( '2.0.0', $result->latestVersion );
     }
 
     /**
@@ -58,12 +58,12 @@ class ApplicationUpdateManagerTest extends TestCase
      */
     public function test_throws_exception_when_no_update_url(): void
     {
-        config(['cms.updates.update_source_url' => null]);
+        config( ['cms.updates.update_source_url' => null] );
 
         $manager = new ApplicationUpdateManager;
 
-        $this->expectException(UpdateException::class);
-        $this->expectExceptionMessage('Update URL not configured');
+        $this->expectException( UpdateException::class );
+        $this->expectExceptionMessage( 'Update URL not configured' );
 
         $manager->checkForUpdate();
     }
@@ -83,13 +83,13 @@ class ApplicationUpdateManagerTest extends TestCase
             downloadUrl: 'https://example.com/update.zip',
         );
 
-        $checker = $this->createMock(UpdateChecker::class);
-        $checker->method('checkForUpdate')->willReturn($updateInfo);
+        $checker = $this->createMock( UpdateChecker::class );
+        $checker->method( 'checkForUpdate' )->willReturn( $updateInfo );
 
-        $manager->setUpdateChecker($checker);
+        $manager->setUpdateChecker( $checker );
 
-        $this->expectException(UpdateException::class);
-        $this->expectExceptionMessage('No update available');
+        $this->expectException( UpdateException::class );
+        $this->expectExceptionMessage( 'No update available' );
 
         $manager->performUpdate();
     }
@@ -103,13 +103,13 @@ class ApplicationUpdateManagerTest extends TestCase
     {
         $manager = new ApplicationUpdateManager;
 
-        $checker = $this->createMock(UpdateChecker::class);
-        $checker->expects($this->once())->method('clearCache');
+        $checker = $this->createMock( UpdateChecker::class );
+        $checker->expects( $this->once() )->method( 'clearCache' );
 
-        $manager->setUpdateChecker($checker);
+        $manager->setUpdateChecker( $checker );
         $manager->clearCache();
 
-        $this->assertTrue(true); // If we get here, the test passed
+        $this->assertTrue( true ); // If we get here, the test passed
     }
 
     /**
@@ -121,21 +121,21 @@ class ApplicationUpdateManagerTest extends TestCase
     {
         $manager = new ApplicationUpdateManager;
 
-        $reflection = new ReflectionClass($manager);
-        $method     = $reflection->getMethod('isPathExcluded');
-        $method->setAccessible(true);
+        $reflection = new ReflectionClass( $manager );
+        $method     = $reflection->getMethod( 'isPathExcluded' );
+        $method->setAccessible( true );
 
         // Test exact match
-        $this->assertTrue($method->invoke($manager, 'storage/logs/test.log', ['storage']));
+        $this->assertTrue( $method->invoke( $manager, 'storage/logs/test.log', ['storage'] ) );
 
         // Test non-match
-        $this->assertFalse($method->invoke($manager, 'app/Models/User.php', ['storage']));
+        $this->assertFalse( $method->invoke( $manager, 'app/Models/User.php', ['storage'] ) );
 
         // Test wildcard match
-        $this->assertTrue($method->invoke($manager, 'bootstrap/cache/config.php', ['bootstrap/cache/*.php']));
+        $this->assertTrue( $method->invoke( $manager, 'bootstrap/cache/config.php', ['bootstrap/cache/*.php'] ) );
 
         // Test no match with wildcard
-        $this->assertFalse($method->invoke($manager, 'bootstrap/app.php', ['bootstrap/cache/*.php']));
+        $this->assertFalse( $method->invoke( $manager, 'bootstrap/app.php', ['bootstrap/cache/*.php'] ) );
     }
 
     /**
@@ -147,10 +147,10 @@ class ApplicationUpdateManagerTest extends TestCase
     {
         $manager = new ApplicationUpdateManager;
 
-        $this->expectException(UpdateException::class);
-        $this->expectExceptionMessage('Backup not found');
+        $this->expectException( UpdateException::class );
+        $this->expectExceptionMessage( 'Backup not found' );
 
-        $manager->rollback('/nonexistent/backup.zip');
+        $manager->rollback( '/nonexistent/backup.zip' );
     }
 
     /**
@@ -168,14 +168,14 @@ class ApplicationUpdateManagerTest extends TestCase
             downloadUrl: 'https://example.com/update.zip',
         );
 
-        $checker = $this->createMock(UpdateChecker::class);
-        $checker->method('checkForUpdate')->willReturn($updateInfo);
+        $checker = $this->createMock( UpdateChecker::class );
+        $checker->method( 'checkForUpdate' )->willReturn( $updateInfo );
 
-        $manager->setUpdateChecker($checker);
+        $manager->setUpdateChecker( $checker );
 
         $result = $manager->checkForUpdate();
 
-        $this->assertEquals('2.0.0', $result->latestVersion);
+        $this->assertEquals( '2.0.0', $result->latestVersion );
     }
 
     /**
@@ -187,20 +187,20 @@ class ApplicationUpdateManagerTest extends TestCase
     {
         $manager = new ApplicationUpdateManager;
 
-        $zipPath = tempnam(sys_get_temp_dir(), 'cmsfw-update-');
-        file_put_contents($zipPath, 'fake zip contents');
+        $zipPath = tempnam( sys_get_temp_dir(), 'cmsfw-update-' );
+        file_put_contents( $zipPath, 'fake zip contents' );
 
         try {
-            $reflection = new ReflectionClass($manager);
-            $method     = $reflection->getMethod('verifyChecksum');
-            $method->setAccessible(true);
+            $reflection = new ReflectionClass( $manager );
+            $method     = $reflection->getMethod( 'verifyChecksum' );
+            $method->setAccessible( true );
 
-            $this->expectException(UpdateException::class);
-            $this->expectExceptionMessage('Checksum mismatch');
+            $this->expectException( UpdateException::class );
+            $this->expectExceptionMessage( 'Checksum mismatch' );
 
-            $method->invoke($manager, $zipPath, str_repeat('0', 64));
+            $method->invoke( $manager, $zipPath, str_repeat( '0', 64 ) );
         } finally {
-            @unlink($zipPath);
+            @unlink( $zipPath );
         }
     }
 
@@ -213,19 +213,19 @@ class ApplicationUpdateManagerTest extends TestCase
     {
         $manager = new ApplicationUpdateManager;
 
-        $zipPath = tempnam(sys_get_temp_dir(), 'cmsfw-update-');
-        file_put_contents($zipPath, 'matching zip contents');
+        $zipPath = tempnam( sys_get_temp_dir(), 'cmsfw-update-' );
+        file_put_contents( $zipPath, 'matching zip contents' );
 
         try {
-            $reflection = new ReflectionClass($manager);
-            $method     = $reflection->getMethod('verifyChecksum');
-            $method->setAccessible(true);
+            $reflection = new ReflectionClass( $manager );
+            $method     = $reflection->getMethod( 'verifyChecksum' );
+            $method->setAccessible( true );
 
-            $method->invoke($manager, $zipPath, hash_file('sha256', $zipPath));
+            $method->invoke( $manager, $zipPath, hash_file( 'sha256', $zipPath ) );
 
-            $this->assertTrue(true); // No exception means success.
+            $this->assertTrue( true ); // No exception means success.
         } finally {
-            @unlink($zipPath);
+            @unlink( $zipPath );
         }
     }
 
@@ -236,7 +236,7 @@ class ApplicationUpdateManagerTest extends TestCase
      */
     public function test_maybe_verify_checksum_logs_warning_when_sha256_missing(): void
     {
-        config(['cms.updates.verify_checksum' => true]);
+        config( ['cms.updates.verify_checksum' => true] );
 
         $manager = new ApplicationUpdateManager;
 
@@ -248,19 +248,19 @@ class ApplicationUpdateManagerTest extends TestCase
             metadata: ['source' => 'gitlab'],
         );
 
-        Log::shouldReceive('warning')
+        Log::shouldReceive( 'warning' )
             ->once()
-            ->withArgs(function (string $message, array $context): bool {
-                return str_contains($message, 'Skipping update integrity verification')
-                    && '2.0.0' === ($context['target_version'] ?? null)
-                    && 'gitlab' === ($context['source'] ?? null);
-            });
+            ->withArgs( function ( string $message, array $context ): bool {
+                return str_contains( $message, 'Skipping update integrity verification' )
+                    && '2.0.0' === ( $context['target_version'] ?? null )
+                    && 'gitlab' === ( $context['source'] ?? null );
+            } );
 
-        $reflection = new ReflectionClass($manager);
-        $method     = $reflection->getMethod('maybeVerifyChecksum');
-        $method->setAccessible(true);
+        $reflection = new ReflectionClass( $manager );
+        $method     = $reflection->getMethod( 'maybeVerifyChecksum' );
+        $method->setAccessible( true );
 
-        $method->invoke($manager, '/does/not/matter.zip', $updateInfo, '2.0.0');
+        $method->invoke( $manager, '/does/not/matter.zip', $updateInfo, '2.0.0' );
     }
 
     /**
@@ -270,7 +270,7 @@ class ApplicationUpdateManagerTest extends TestCase
      */
     public function test_maybe_verify_checksum_is_silent_when_disabled(): void
     {
-        config(['cms.updates.verify_checksum' => false]);
+        config( ['cms.updates.verify_checksum' => false] );
 
         $manager = new ApplicationUpdateManager;
 
@@ -281,13 +281,13 @@ class ApplicationUpdateManagerTest extends TestCase
             sha256: null,
         );
 
-        Log::shouldReceive('warning')->never();
+        Log::shouldReceive( 'warning' )->never();
 
-        $reflection = new ReflectionClass($manager);
-        $method     = $reflection->getMethod('maybeVerifyChecksum');
-        $method->setAccessible(true);
+        $reflection = new ReflectionClass( $manager );
+        $method     = $reflection->getMethod( 'maybeVerifyChecksum' );
+        $method->setAccessible( true );
 
-        $method->invoke($manager, '/does/not/matter.zip', $updateInfo, '2.0.0');
+        $method->invoke( $manager, '/does/not/matter.zip', $updateInfo, '2.0.0' );
     }
 
     /**
@@ -298,7 +298,7 @@ class ApplicationUpdateManagerTest extends TestCase
      */
     public function test_perform_update_disables_maintenance_mode_on_fatal_error(): void
     {
-        config(['cms.updates.backup_enabled' => false]);
+        config( ['cms.updates.backup_enabled' => false] );
 
         $manager = new class extends ApplicationUpdateManager {
             public array $modeCalls = [];
@@ -320,20 +320,20 @@ class ApplicationUpdateManagerTest extends TestCase
             downloadUrl: 'https://example.com/update.zip',
         );
 
-        $checker = $this->createMock(UpdateChecker::class);
-        $checker->method('checkForUpdate')->willReturn($updateInfo);
-        $checker->method('downloadUpdate')->willThrowException(new Error('Simulated fatal error'));
+        $checker = $this->createMock( UpdateChecker::class );
+        $checker->method( 'checkForUpdate' )->willReturn( $updateInfo );
+        $checker->method( 'downloadUpdate' )->willThrowException( new Error( 'Simulated fatal error' ) );
 
-        $manager->setUpdateChecker($checker);
+        $manager->setUpdateChecker( $checker );
 
         try {
             $manager->performUpdate();
-            $this->fail('Expected Error to be thrown.');
-        } catch (Error $e) {
-            $this->assertSame('Simulated fatal error', $e->getMessage());
+            $this->fail( 'Expected Error to be thrown.' );
+        } catch ( Error $e ) {
+            $this->assertSame( 'Simulated fatal error', $e->getMessage() );
         }
 
-        $this->assertSame(['enable', 'disable'], $manager->modeCalls);
+        $this->assertSame( ['enable', 'disable'], $manager->modeCalls );
     }
 
     /**
@@ -346,25 +346,27 @@ class ApplicationUpdateManagerTest extends TestCase
      */
     public function test_extract_update_streams_entries_to_disk(): void
     {
-        $tempRoot = sys_get_temp_dir().'/cmsfw-extract-'.bin2hex(random_bytes(6));
-        $target   = $tempRoot.'/target';
-        mkdir($target, 0755, true);
+        $tempRoot = sys_get_temp_dir() . '/cmsfw-extract-' . bin2hex( random_bytes( 6 ) );
+        $target   = $tempRoot . '/target';
+        mkdir( $target, 0755, true );
 
-        $zipPath  = $tempRoot.'/update.zip';
-        $largeBig = str_repeat('x', 65536);
+        $zipPath  = $tempRoot . '/update.zip';
+        $largeBig = str_repeat( 'x', 65536 );
 
         $zip = new ZipArchive;
-        $this->assertTrue(true === $zip->open($zipPath, ZipArchive::CREATE | ZipArchive::OVERWRITE));
-        $zip->addFromString('release-root/app/Model.php', "<?php\n".$largeBig);
-        $zip->addFromString('release-root/routes/web.php', "<?php\nRoute::get('/', fn () => 'ok');\n");
+        $this->assertTrue( true === $zip->open( $zipPath, ZipArchive::CREATE | ZipArchive::OVERWRITE ) );
+        $zip->addFromString( 'release-root/app/Model.php', "<?php\n" . $largeBig );
+        $zip->addFromString( 'release-root/routes/web.php', "<?php\nRoute::get('/', fn () => 'ok');\n" );
         $zip->close();
 
-        $manager = new class($target) extends ApplicationUpdateManager {
-            public function __construct(protected string $extractRoot) {}
-
-            public function extractInto(string $zipPath): void
+        $manager = new class( $target ) extends ApplicationUpdateManager {
+            public function __construct( protected string $extractRoot )
             {
-                $this->extractUpdate($zipPath);
+            }
+
+            public function extractInto( string $zipPath ): void
+            {
+                $this->extractUpdate( $zipPath );
             }
         };
 
@@ -372,23 +374,23 @@ class ApplicationUpdateManagerTest extends TestCase
         // inside extractUpdate resolves to a scratch directory instead of the
         // testbench root.
         $originalBase = base_path();
-        app()->setBasePath($target);
+        app()->setBasePath( $target );
 
         try {
-            $manager->extractInto($zipPath);
+            $manager->extractInto( $zipPath );
 
-            $this->assertFileExists($target.'/app/Model.php');
-            $this->assertFileExists($target.'/routes/web.php');
+            $this->assertFileExists( $target . '/app/Model.php' );
+            $this->assertFileExists( $target . '/routes/web.php' );
             $this->assertSame(
-                strlen("<?php\n".$largeBig),
-                filesize($target.'/app/Model.php'),
+                strlen( "<?php\n" . $largeBig ),
+                filesize( $target . '/app/Model.php' ),
                 'Streamed extraction should produce a byte-for-byte copy of the ZIP entry.',
             );
         } finally {
-            app()->setBasePath($originalBase);
-            @unlink($zipPath);
-            $this->removeDirectory($target);
-            @rmdir($tempRoot);
+            app()->setBasePath( $originalBase );
+            @unlink( $zipPath );
+            $this->removeDirectory( $target );
+            @rmdir( $tempRoot );
         }
     }
 
@@ -401,25 +403,25 @@ class ApplicationUpdateManagerTest extends TestCase
      */
     public function test_resolve_composer_command_prefers_env_binary(): void
     {
-        config(['cms.updates.composer_install_command' => ApplicationUpdateManager::DEFAULT_COMPOSER_INSTALL_COMMAND]);
+        config( ['cms.updates.composer_install_command' => ApplicationUpdateManager::DEFAULT_COMPOSER_INSTALL_COMMAND] );
 
-        $original = getenv('COMPOSER_BINARY');
-        putenv('COMPOSER_BINARY=/opt/homebrew/bin/composer');
+        $original = getenv( 'COMPOSER_BINARY' );
+        putenv( 'COMPOSER_BINARY=/opt/homebrew/bin/composer' );
 
         try {
             $manager = new ApplicationUpdateManager;
 
-            $reflection = new ReflectionClass($manager);
-            $method     = $reflection->getMethod('resolveComposerCommand');
-            $method->setAccessible(true);
+            $reflection = new ReflectionClass( $manager );
+            $method     = $reflection->getMethod( 'resolveComposerCommand' );
+            $method->setAccessible( true );
 
-            $command = $method->invoke($manager);
+            $command = $method->invoke( $manager );
 
-            $this->assertStringStartsWith(escapeshellarg(PHP_BINARY).' ', $command);
-            $this->assertStringContainsString(escapeshellarg('/opt/homebrew/bin/composer'), $command);
-            $this->assertStringEndsWith(' '.ApplicationUpdateManager::DEFAULT_COMPOSER_INSTALL_ARGS, $command);
+            $this->assertStringStartsWith( escapeshellarg( PHP_BINARY ) . ' ', $command );
+            $this->assertStringContainsString( escapeshellarg( '/opt/homebrew/bin/composer' ), $command );
+            $this->assertStringEndsWith( ' ' . ApplicationUpdateManager::DEFAULT_COMPOSER_INSTALL_ARGS, $command );
         } finally {
-            putenv(false === $original ? 'COMPOSER_BINARY' : 'COMPOSER_BINARY='.$original);
+            putenv( false === $original ? 'COMPOSER_BINARY' : 'COMPOSER_BINARY=' . $original );
         }
     }
 
@@ -433,21 +435,21 @@ class ApplicationUpdateManagerTest extends TestCase
     public function test_resolve_composer_command_respects_non_default_config_override(): void
     {
         $override = 'PATH=/opt/homebrew/bin:/usr/bin /opt/homebrew/bin/composer install --no-dev --no-interaction --optimize-autoloader';
-        config(['cms.updates.composer_install_command' => $override]);
+        config( ['cms.updates.composer_install_command' => $override] );
 
-        $original = getenv('COMPOSER_BINARY');
-        putenv('COMPOSER_BINARY');
+        $original = getenv( 'COMPOSER_BINARY' );
+        putenv( 'COMPOSER_BINARY' );
 
         try {
             $manager = new ApplicationUpdateManager;
 
-            $reflection = new ReflectionClass($manager);
-            $method     = $reflection->getMethod('resolveComposerCommand');
-            $method->setAccessible(true);
+            $reflection = new ReflectionClass( $manager );
+            $method     = $reflection->getMethod( 'resolveComposerCommand' );
+            $method->setAccessible( true );
 
-            $this->assertSame($override, $method->invoke($manager));
+            $this->assertSame( $override, $method->invoke( $manager ) );
         } finally {
-            putenv(false === $original ? 'COMPOSER_BINARY' : 'COMPOSER_BINARY='.$original);
+            putenv( false === $original ? 'COMPOSER_BINARY' : 'COMPOSER_BINARY=' . $original );
         }
     }
 
@@ -459,10 +461,10 @@ class ApplicationUpdateManagerTest extends TestCase
      */
     public function test_resolve_composer_command_uses_discovered_binary(): void
     {
-        config(['cms.updates.composer_install_command' => ApplicationUpdateManager::DEFAULT_COMPOSER_INSTALL_COMMAND]);
+        config( ['cms.updates.composer_install_command' => ApplicationUpdateManager::DEFAULT_COMPOSER_INSTALL_COMMAND] );
 
-        $original = getenv('COMPOSER_BINARY');
-        putenv('COMPOSER_BINARY');
+        $original = getenv( 'COMPOSER_BINARY' );
+        putenv( 'COMPOSER_BINARY' );
 
         try {
             $manager = new class extends ApplicationUpdateManager {
@@ -472,17 +474,17 @@ class ApplicationUpdateManagerTest extends TestCase
                 }
             };
 
-            $reflection = new ReflectionClass($manager);
-            $method     = $reflection->getMethod('resolveComposerCommand');
-            $method->setAccessible(true);
+            $reflection = new ReflectionClass( $manager );
+            $method     = $reflection->getMethod( 'resolveComposerCommand' );
+            $method->setAccessible( true );
 
-            $command = $method->invoke($manager);
+            $command = $method->invoke( $manager );
 
-            $this->assertStringStartsWith(escapeshellarg(PHP_BINARY).' ', $command);
-            $this->assertStringContainsString(escapeshellarg('/discovered/path/composer'), $command);
-            $this->assertStringEndsWith(' '.ApplicationUpdateManager::DEFAULT_COMPOSER_INSTALL_ARGS, $command);
+            $this->assertStringStartsWith( escapeshellarg( PHP_BINARY ) . ' ', $command );
+            $this->assertStringContainsString( escapeshellarg( '/discovered/path/composer' ), $command );
+            $this->assertStringEndsWith( ' ' . ApplicationUpdateManager::DEFAULT_COMPOSER_INSTALL_ARGS, $command );
         } finally {
-            putenv(false === $original ? 'COMPOSER_BINARY' : 'COMPOSER_BINARY='.$original);
+            putenv( false === $original ? 'COMPOSER_BINARY' : 'COMPOSER_BINARY=' . $original );
         }
     }
 
@@ -494,10 +496,10 @@ class ApplicationUpdateManagerTest extends TestCase
      */
     public function test_resolve_composer_command_falls_back_to_default(): void
     {
-        config(['cms.updates.composer_install_command' => ApplicationUpdateManager::DEFAULT_COMPOSER_INSTALL_COMMAND]);
+        config( ['cms.updates.composer_install_command' => ApplicationUpdateManager::DEFAULT_COMPOSER_INSTALL_COMMAND] );
 
-        $original = getenv('COMPOSER_BINARY');
-        putenv('COMPOSER_BINARY');
+        $original = getenv( 'COMPOSER_BINARY' );
+        putenv( 'COMPOSER_BINARY' );
 
         try {
             $manager = new class extends ApplicationUpdateManager {
@@ -507,16 +509,16 @@ class ApplicationUpdateManagerTest extends TestCase
                 }
             };
 
-            $reflection = new ReflectionClass($manager);
-            $method     = $reflection->getMethod('resolveComposerCommand');
-            $method->setAccessible(true);
+            $reflection = new ReflectionClass( $manager );
+            $method     = $reflection->getMethod( 'resolveComposerCommand' );
+            $method->setAccessible( true );
 
             $this->assertSame(
                 ApplicationUpdateManager::DEFAULT_COMPOSER_INSTALL_COMMAND,
-                $method->invoke($manager),
+                $method->invoke( $manager ),
             );
         } finally {
-            putenv(false === $original ? 'COMPOSER_BINARY' : 'COMPOSER_BINARY='.$original);
+            putenv( false === $original ? 'COMPOSER_BINARY' : 'COMPOSER_BINARY=' . $original );
         }
     }
 
@@ -529,17 +531,17 @@ class ApplicationUpdateManagerTest extends TestCase
      */
     public function test_composer_candidate_paths_covers_documented_locations(): void
     {
-        $original = getenv('HOME');
-        putenv('HOME=/home/tester');
+        $original = getenv( 'HOME' );
+        putenv( 'HOME=/home/tester' );
 
         try {
             $manager = new ApplicationUpdateManager;
 
-            $reflection = new ReflectionClass($manager);
-            $method     = $reflection->getMethod('composerCandidatePaths');
-            $method->setAccessible(true);
+            $reflection = new ReflectionClass( $manager );
+            $method     = $reflection->getMethod( 'composerCandidatePaths' );
+            $method->setAccessible( true );
 
-            $candidates = $method->invoke($manager);
+            $candidates = $method->invoke( $manager );
 
             $this->assertSame(
                 [
@@ -552,7 +554,7 @@ class ApplicationUpdateManagerTest extends TestCase
                 $candidates,
             );
         } finally {
-            putenv(false === $original ? 'HOME' : 'HOME='.$original);
+            putenv( false === $original ? 'HOME' : 'HOME=' . $original );
         }
     }
 
@@ -566,26 +568,28 @@ class ApplicationUpdateManagerTest extends TestCase
      */
     public function test_discover_composer_binary_returns_first_executable_hit(): void
     {
-        $tempDir = sys_get_temp_dir().'/cmsfw-composer-'.bin2hex(random_bytes(6));
-        mkdir($tempDir, 0755, true);
+        $tempDir = sys_get_temp_dir() . '/cmsfw-composer-' . bin2hex( random_bytes( 6 ) );
+        mkdir( $tempDir, 0755, true );
 
-        $missing        = $tempDir.'/missing-composer';
-        $nonExecutable  = $tempDir.'/non-executable-composer';
-        $executableHit  = $tempDir.'/executable-composer';
-        $laterCandidate = $tempDir.'/never-reached-composer';
+        $missing        = $tempDir . '/missing-composer';
+        $nonExecutable  = $tempDir . '/non-executable-composer';
+        $executableHit  = $tempDir . '/executable-composer';
+        $laterCandidate = $tempDir . '/never-reached-composer';
 
-        file_put_contents($nonExecutable, "#!/bin/sh\n");
-        chmod($nonExecutable, 0644);
+        file_put_contents( $nonExecutable, "#!/bin/sh\n" );
+        chmod( $nonExecutable, 0644 );
 
-        file_put_contents($executableHit, "#!/bin/sh\n");
-        chmod($executableHit, 0755);
+        file_put_contents( $executableHit, "#!/bin/sh\n" );
+        chmod( $executableHit, 0755 );
 
-        file_put_contents($laterCandidate, "#!/bin/sh\n");
-        chmod($laterCandidate, 0755);
+        file_put_contents( $laterCandidate, "#!/bin/sh\n" );
+        chmod( $laterCandidate, 0755 );
 
         try {
-            $manager = new class([$missing, $nonExecutable, $executableHit, $laterCandidate]) extends ApplicationUpdateManager {
-                public function __construct(protected array $paths) {}
+            $manager = new class( [$missing, $nonExecutable, $executableHit, $laterCandidate] ) extends ApplicationUpdateManager {
+                public function __construct( protected array $paths )
+                {
+                }
 
                 protected function composerCandidatePaths(): array
                 {
@@ -598,13 +602,13 @@ class ApplicationUpdateManagerTest extends TestCase
                 }
             };
 
-            $this->assertSame($executableHit, $manager->callDiscover());
+            $this->assertSame( $executableHit, $manager->callDiscover() );
         } finally {
-            @unlink($missing);
-            @unlink($nonExecutable);
-            @unlink($executableHit);
-            @unlink($laterCandidate);
-            @rmdir($tempDir);
+            @unlink( $missing );
+            @unlink( $nonExecutable );
+            @unlink( $executableHit );
+            @unlink( $laterCandidate );
+            @rmdir( $tempDir );
         }
     }
 
@@ -623,9 +627,9 @@ class ApplicationUpdateManagerTest extends TestCase
      */
     public function test_rollback_throws_composer_verification_failed_when_version_check_fails(): void
     {
-        Process::fake([
-            '*--version*' => Process::result('', 'command not found', 127),
-        ]);
+        Process::fake( [
+            '*--version*' => Process::result( '', 'command not found', 127 ),
+        ] );
 
         $manager = new class extends ApplicationUpdateManager {
             protected function resolveComposerBinaryForVerification(): ?string
@@ -634,19 +638,19 @@ class ApplicationUpdateManagerTest extends TestCase
             }
         };
 
-        $backupPath = tempnam(sys_get_temp_dir(), 'cmsfw-backup-').'.zip';
+        $backupPath = tempnam( sys_get_temp_dir(), 'cmsfw-backup-' ) . '.zip';
         $zip        = new ZipArchive;
-        $this->assertTrue(true === $zip->open($backupPath, ZipArchive::CREATE | ZipArchive::OVERWRITE));
-        $zip->addFromString('placeholder.txt', 'ok');
+        $this->assertTrue( true === $zip->open( $backupPath, ZipArchive::CREATE | ZipArchive::OVERWRITE ) );
+        $zip->addFromString( 'placeholder.txt', 'ok' );
         $zip->close();
 
         try {
-            $this->expectException(UpdateException::class);
-            $this->expectExceptionMessage('could not be executed');
+            $this->expectException( UpdateException::class );
+            $this->expectExceptionMessage( 'could not be executed' );
 
-            $manager->rollback($backupPath);
+            $manager->rollback( $backupPath );
         } finally {
-            @unlink($backupPath);
+            @unlink( $backupPath );
         }
     }
 
@@ -662,10 +666,10 @@ class ApplicationUpdateManagerTest extends TestCase
         $manager = new class extends ApplicationUpdateManager {
             public function __construct()
             {
-                $stub = tempnam(sys_get_temp_dir(), 'cmsfw-backup-');
-                @unlink($stub);
-                $this->backupPath = $stub.'.zip';
-                file_put_contents($this->backupPath, 'not-a-zip');
+                $stub = tempnam( sys_get_temp_dir(), 'cmsfw-backup-' );
+                @unlink( $stub );
+                $this->backupPath = $stub . '.zip';
+                file_put_contents( $this->backupPath, 'not-a-zip' );
             }
 
             protected function disableMaintenanceMode(): void
@@ -673,30 +677,30 @@ class ApplicationUpdateManagerTest extends TestCase
                 // No-op; nothing to disable in this unit context.
             }
 
-            public function callHandleFailure(Throwable $e): void
+            public function callHandleFailure( Throwable $e ): void
             {
-                $this->handleUpdateFailure($e);
+                $this->handleUpdateFailure( $e );
             }
         };
 
         try {
-            $original = new RuntimeException('composer install failed because it ran out of memory');
+            $original = new RuntimeException( 'composer install failed because it ran out of memory' );
 
             try {
-                $manager->callHandleFailure($original);
-                $this->fail('Expected UpdateException from rollback.');
-            } catch (UpdateException $e) {
-                $this->assertStringContainsString('Rollback failed', $e->getMessage());
-                $this->assertStringContainsString('ran out of memory', $e->getMessage());
-                $this->assertStringContainsString('Manual intervention required', $e->getMessage());
+                $manager->callHandleFailure( $original );
+                $this->fail( 'Expected UpdateException from rollback.' );
+            } catch ( UpdateException $e ) {
+                $this->assertStringContainsString( 'Rollback failed', $e->getMessage() );
+                $this->assertStringContainsString( 'ran out of memory', $e->getMessage() );
+                $this->assertStringContainsString( 'Manual intervention required', $e->getMessage() );
             }
         } finally {
-            $reflection = new ReflectionClass($manager);
-            $property   = $reflection->getProperty('backupPath');
-            $property->setAccessible(true);
-            $path = $property->getValue($manager);
-            if (is_string($path)) {
-                @unlink($path);
+            $reflection = new ReflectionClass( $manager );
+            $property   = $reflection->getProperty( 'backupPath' );
+            $property->setAccessible( true );
+            $path = $property->getValue( $manager );
+            if ( is_string( $path ) ) {
+                @unlink( $path );
             }
         }
     }
@@ -712,23 +716,25 @@ class ApplicationUpdateManagerTest extends TestCase
      */
     public function test_resolve_php_binary_skips_fpm_candidates_and_prefers_cli(): void
     {
-        $tempDir = sys_get_temp_dir().'/cmsfw-php-'.bin2hex(random_bytes(6));
-        mkdir($tempDir, 0755, true);
+        $tempDir = sys_get_temp_dir() . '/cmsfw-php-' . bin2hex( random_bytes( 6 ) );
+        mkdir( $tempDir, 0755, true );
 
-        $fpm = $tempDir.'/php84-fpm';
-        $cli = $tempDir.'/php';
+        $fpm = $tempDir . '/php84-fpm';
+        $cli = $tempDir . '/php';
 
-        file_put_contents($fpm, "#!/bin/sh\n");
-        chmod($fpm, 0755);
-        file_put_contents($cli, "#!/bin/sh\n");
-        chmod($cli, 0755);
+        file_put_contents( $fpm, "#!/bin/sh\n" );
+        chmod( $fpm, 0755 );
+        file_put_contents( $cli, "#!/bin/sh\n" );
+        chmod( $cli, 0755 );
 
-        $original = getenv('CMS_PHP_BINARY');
-        putenv('CMS_PHP_BINARY');
+        $original = getenv( 'CMS_PHP_BINARY' );
+        putenv( 'CMS_PHP_BINARY' );
 
         try {
-            $manager = new class([$fpm, $cli], 'fpm-fcgi') extends ApplicationUpdateManager {
-                public function __construct(protected array $paths, protected string $sapi) {}
+            $manager = new class( [$fpm, $cli], 'fpm-fcgi' ) extends ApplicationUpdateManager {
+                public function __construct( protected array $paths, protected string $sapi )
+                {
+                }
 
                 protected function phpCandidatePaths(): array
                 {
@@ -740,8 +746,8 @@ class ApplicationUpdateManagerTest extends TestCase
                     // Bypass the PHP_SAPI short-circuit by shadowing the
                     // condition — we can't mutate the runtime SAPI constant,
                     // so we run the discovery path directly.
-                    foreach ($this->phpCandidatePaths() as $candidate) {
-                        if ($this->isCliPhpBinary($candidate)) {
+                    foreach ( $this->phpCandidatePaths() as $candidate ) {
+                        if ( $this->isCliPhpBinary( $candidate ) ) {
                             return $candidate;
                         }
                     }
@@ -750,12 +756,12 @@ class ApplicationUpdateManagerTest extends TestCase
                 }
             };
 
-            $this->assertSame($cli, $manager->callResolvePhpBinary());
+            $this->assertSame( $cli, $manager->callResolvePhpBinary() );
         } finally {
-            @unlink($fpm);
-            @unlink($cli);
-            @rmdir($tempDir);
-            putenv(false === $original ? 'CMS_PHP_BINARY' : 'CMS_PHP_BINARY='.$original);
+            @unlink( $fpm );
+            @unlink( $cli );
+            @rmdir( $tempDir );
+            putenv( false === $original ? 'CMS_PHP_BINARY' : 'CMS_PHP_BINARY=' . $original );
         }
     }
 
@@ -768,19 +774,19 @@ class ApplicationUpdateManagerTest extends TestCase
      */
     public function test_resolve_php_binary_respects_env_override(): void
     {
-        $original = getenv('CMS_PHP_BINARY');
-        putenv('CMS_PHP_BINARY=/custom/path/to/php');
+        $original = getenv( 'CMS_PHP_BINARY' );
+        putenv( 'CMS_PHP_BINARY=/custom/path/to/php' );
 
         try {
             $manager = new ApplicationUpdateManager;
 
-            $reflection = new ReflectionClass($manager);
-            $method     = $reflection->getMethod('resolvePhpBinary');
-            $method->setAccessible(true);
+            $reflection = new ReflectionClass( $manager );
+            $method     = $reflection->getMethod( 'resolvePhpBinary' );
+            $method->setAccessible( true );
 
-            $this->assertSame('/custom/path/to/php', $method->invoke($manager));
+            $this->assertSame( '/custom/path/to/php', $method->invoke( $manager ) );
         } finally {
-            putenv(false === $original ? 'CMS_PHP_BINARY' : 'CMS_PHP_BINARY='.$original);
+            putenv( false === $original ? 'CMS_PHP_BINARY' : 'CMS_PHP_BINARY=' . $original );
         }
     }
 
@@ -794,15 +800,15 @@ class ApplicationUpdateManagerTest extends TestCase
      */
     public function test_php_candidate_paths_covers_documented_locations(): void
     {
-        $original = getenv('HOME');
-        putenv('HOME=/home/tester');
+        $original = getenv( 'HOME' );
+        putenv( 'HOME=/home/tester' );
 
         try {
             $manager = new ApplicationUpdateManager;
 
-            $reflection = new ReflectionClass($manager);
-            $method     = $reflection->getMethod('phpCandidatePaths');
-            $method->setAccessible(true);
+            $reflection = new ReflectionClass( $manager );
+            $method     = $reflection->getMethod( 'phpCandidatePaths' );
+            $method->setAccessible( true );
 
             $this->assertSame(
                 [
@@ -811,10 +817,10 @@ class ApplicationUpdateManagerTest extends TestCase
                     '/usr/local/bin/php',
                     '/usr/bin/php',
                 ],
-                $method->invoke($manager),
+                $method->invoke( $manager ),
             );
         } finally {
-            putenv(false === $original ? 'HOME' : 'HOME='.$original);
+            putenv( false === $original ? 'HOME' : 'HOME=' . $original );
         }
     }
 
@@ -838,11 +844,11 @@ class ApplicationUpdateManagerTest extends TestCase
 
         $message = $exception->getMessage();
 
-        $this->assertStringContainsString('/opt/homebrew/bin/composer', $message);
-        $this->assertStringContainsString('/Users/tester/Herd/bin/php84-fpm', $message);
-        $this->assertStringContainsString('Exit code: 64', $message);
-        $this->assertStringContainsString('Usage: php84-fpm', $message);
-        $this->assertStringContainsString('CMS_PHP_BINARY', $message);
+        $this->assertStringContainsString( '/opt/homebrew/bin/composer', $message );
+        $this->assertStringContainsString( '/Users/tester/Herd/bin/php84-fpm', $message );
+        $this->assertStringContainsString( 'Exit code: 64', $message );
+        $this->assertStringContainsString( 'Usage: php84-fpm', $message );
+        $this->assertStringContainsString( 'CMS_PHP_BINARY', $message );
     }
 
     /**
@@ -850,33 +856,33 @@ class ApplicationUpdateManagerTest extends TestCase
      *
      * @since 2.5.2
      */
-    protected function removeDirectory(string $path): void
+    protected function removeDirectory( string $path ): void
     {
-        if (! is_dir($path)) {
+        if ( ! is_dir( $path ) ) {
             return;
         }
 
-        $items = scandir($path);
+        $items = scandir( $path );
 
-        if (false === $items) {
+        if ( false === $items ) {
             return;
         }
 
-        foreach ($items as $item) {
-            if ('.' === $item || '..' === $item) {
+        foreach ( $items as $item) {
+            if ( '.' === $item || '..' === $item) {
                 continue;
             }
 
-            $full = $path.DIRECTORY_SEPARATOR.$item;
+            $full = $path . DIRECTORY_SEPARATOR . $item;
 
-            if (is_dir($full)) {
-                $this->removeDirectory($full);
+            if ( is_dir( $full)) {
+                $this->removeDirectory( $full);
             } else {
-                @unlink($full);
+                @unlink( $full);
             }
         }
 
-        @rmdir($path);
+        @rmdir( $path);
     }
 
     /**
@@ -886,15 +892,15 @@ class ApplicationUpdateManagerTest extends TestCase
      *
      * @param  \Illuminate\Foundation\Application  $app
      */
-    protected function defineEnvironment($app): void
+    protected function defineEnvironment( $app): void
     {
-        $app['config']->set('cms.updates.update_source_url', 'https://github.com/test/repo');
-        $app['config']->set('cms.updates.backup_enabled', true);
-        $app['config']->set('cms.updates.backup_path', 'backups/application');
-        $app['config']->set('cms.updates.backup_retention_days', 30);
-        $app['config']->set('cms.updates.verify_checksum', false); // Disable for tests
-        $app['config']->set('cms.updates.composer_install_command', 'composer install --no-dev');
-        $app['config']->set('cms.updates.composer_timeout', 600);
-        $app['config']->set('cms.updates.exclude_from_update', ['.env', 'storage', 'vendor']);
+        $app['config']->set( 'cms.updates.update_source_url', 'https://github.com/test/repo');
+        $app['config']->set( 'cms.updates.backup_enabled', true);
+        $app['config']->set( 'cms.updates.backup_path', 'backups/application');
+        $app['config']->set( 'cms.updates.backup_retention_days', 30);
+        $app['config']->set( 'cms.updates.verify_checksum', false); // Disable for tests
+        $app['config']->set( 'cms.updates.composer_install_command', 'composer install --no-dev');
+        $app['config']->set( 'cms.updates.composer_timeout', 600);
+        $app['config']->set( 'cms.updates.exclude_from_update', ['.env', 'storage', 'vendor']);
     }
 }

--- a/tests/Unit/Updates/ApplicationUpdateManagerTest.php
+++ b/tests/Unit/Updates/ApplicationUpdateManagerTest.php
@@ -1,6 +1,6 @@
 <?php
 
-declare( strict_types=1 );
+declare(strict_types=1);
 
 namespace ArtisanPackUI\CMSFramework\Tests\Unit\Updates;
 
@@ -39,16 +39,16 @@ class ApplicationUpdateManagerTest extends TestCase
             downloadUrl: 'https://example.com/update.zip',
         );
 
-        $checker = $this->createMock( UpdateChecker::class );
-        $checker->method( 'checkForUpdate' )->willReturn( $updateInfo );
+        $checker = $this->createMock(UpdateChecker::class);
+        $checker->method('checkForUpdate')->willReturn($updateInfo);
 
-        $manager->setUpdateChecker( $checker );
+        $manager->setUpdateChecker($checker);
 
         $result = $manager->checkForUpdate();
 
-        $this->assertInstanceOf( UpdateInfo::class, $result );
-        $this->assertTrue( $result->hasUpdate() );
-        $this->assertEquals( '2.0.0', $result->latestVersion );
+        $this->assertInstanceOf(UpdateInfo::class, $result);
+        $this->assertTrue($result->hasUpdate());
+        $this->assertEquals('2.0.0', $result->latestVersion);
     }
 
     /**
@@ -58,12 +58,12 @@ class ApplicationUpdateManagerTest extends TestCase
      */
     public function test_throws_exception_when_no_update_url(): void
     {
-        config( ['cms.updates.update_source_url' => null] );
+        config(['cms.updates.update_source_url' => null]);
 
         $manager = new ApplicationUpdateManager;
 
-        $this->expectException( UpdateException::class );
-        $this->expectExceptionMessage( 'Update URL not configured' );
+        $this->expectException(UpdateException::class);
+        $this->expectExceptionMessage('Update URL not configured');
 
         $manager->checkForUpdate();
     }
@@ -83,13 +83,13 @@ class ApplicationUpdateManagerTest extends TestCase
             downloadUrl: 'https://example.com/update.zip',
         );
 
-        $checker = $this->createMock( UpdateChecker::class );
-        $checker->method( 'checkForUpdate' )->willReturn( $updateInfo );
+        $checker = $this->createMock(UpdateChecker::class);
+        $checker->method('checkForUpdate')->willReturn($updateInfo);
 
-        $manager->setUpdateChecker( $checker );
+        $manager->setUpdateChecker($checker);
 
-        $this->expectException( UpdateException::class );
-        $this->expectExceptionMessage( 'No update available' );
+        $this->expectException(UpdateException::class);
+        $this->expectExceptionMessage('No update available');
 
         $manager->performUpdate();
     }
@@ -103,13 +103,13 @@ class ApplicationUpdateManagerTest extends TestCase
     {
         $manager = new ApplicationUpdateManager;
 
-        $checker = $this->createMock( UpdateChecker::class );
-        $checker->expects( $this->once() )->method( 'clearCache' );
+        $checker = $this->createMock(UpdateChecker::class);
+        $checker->expects($this->once())->method('clearCache');
 
-        $manager->setUpdateChecker( $checker );
+        $manager->setUpdateChecker($checker);
         $manager->clearCache();
 
-        $this->assertTrue( true ); // If we get here, the test passed
+        $this->assertTrue(true); // If we get here, the test passed
     }
 
     /**
@@ -121,21 +121,21 @@ class ApplicationUpdateManagerTest extends TestCase
     {
         $manager = new ApplicationUpdateManager;
 
-        $reflection = new ReflectionClass( $manager );
-        $method     = $reflection->getMethod( 'isPathExcluded' );
-        $method->setAccessible( true );
+        $reflection = new ReflectionClass($manager);
+        $method     = $reflection->getMethod('isPathExcluded');
+        $method->setAccessible(true);
 
         // Test exact match
-        $this->assertTrue( $method->invoke( $manager, 'storage/logs/test.log', ['storage'] ) );
+        $this->assertTrue($method->invoke($manager, 'storage/logs/test.log', ['storage']));
 
         // Test non-match
-        $this->assertFalse( $method->invoke( $manager, 'app/Models/User.php', ['storage'] ) );
+        $this->assertFalse($method->invoke($manager, 'app/Models/User.php', ['storage']));
 
         // Test wildcard match
-        $this->assertTrue( $method->invoke( $manager, 'bootstrap/cache/config.php', ['bootstrap/cache/*.php'] ) );
+        $this->assertTrue($method->invoke($manager, 'bootstrap/cache/config.php', ['bootstrap/cache/*.php']));
 
         // Test no match with wildcard
-        $this->assertFalse( $method->invoke( $manager, 'bootstrap/app.php', ['bootstrap/cache/*.php'] ) );
+        $this->assertFalse($method->invoke($manager, 'bootstrap/app.php', ['bootstrap/cache/*.php']));
     }
 
     /**
@@ -147,10 +147,10 @@ class ApplicationUpdateManagerTest extends TestCase
     {
         $manager = new ApplicationUpdateManager;
 
-        $this->expectException( UpdateException::class );
-        $this->expectExceptionMessage( 'Backup not found' );
+        $this->expectException(UpdateException::class);
+        $this->expectExceptionMessage('Backup not found');
 
-        $manager->rollback( '/nonexistent/backup.zip' );
+        $manager->rollback('/nonexistent/backup.zip');
     }
 
     /**
@@ -168,14 +168,14 @@ class ApplicationUpdateManagerTest extends TestCase
             downloadUrl: 'https://example.com/update.zip',
         );
 
-        $checker = $this->createMock( UpdateChecker::class );
-        $checker->method( 'checkForUpdate' )->willReturn( $updateInfo );
+        $checker = $this->createMock(UpdateChecker::class);
+        $checker->method('checkForUpdate')->willReturn($updateInfo);
 
-        $manager->setUpdateChecker( $checker );
+        $manager->setUpdateChecker($checker);
 
         $result = $manager->checkForUpdate();
 
-        $this->assertEquals( '2.0.0', $result->latestVersion );
+        $this->assertEquals('2.0.0', $result->latestVersion);
     }
 
     /**
@@ -187,20 +187,20 @@ class ApplicationUpdateManagerTest extends TestCase
     {
         $manager = new ApplicationUpdateManager;
 
-        $zipPath = tempnam( sys_get_temp_dir(), 'cmsfw-update-' );
-        file_put_contents( $zipPath, 'fake zip contents' );
+        $zipPath = tempnam(sys_get_temp_dir(), 'cmsfw-update-');
+        file_put_contents($zipPath, 'fake zip contents');
 
         try {
-            $reflection = new ReflectionClass( $manager );
-            $method     = $reflection->getMethod( 'verifyChecksum' );
-            $method->setAccessible( true );
+            $reflection = new ReflectionClass($manager);
+            $method     = $reflection->getMethod('verifyChecksum');
+            $method->setAccessible(true);
 
-            $this->expectException( UpdateException::class );
-            $this->expectExceptionMessage( 'Checksum mismatch' );
+            $this->expectException(UpdateException::class);
+            $this->expectExceptionMessage('Checksum mismatch');
 
-            $method->invoke( $manager, $zipPath, str_repeat( '0', 64 ) );
+            $method->invoke($manager, $zipPath, str_repeat('0', 64));
         } finally {
-            @unlink( $zipPath );
+            @unlink($zipPath);
         }
     }
 
@@ -213,19 +213,19 @@ class ApplicationUpdateManagerTest extends TestCase
     {
         $manager = new ApplicationUpdateManager;
 
-        $zipPath = tempnam( sys_get_temp_dir(), 'cmsfw-update-' );
-        file_put_contents( $zipPath, 'matching zip contents' );
+        $zipPath = tempnam(sys_get_temp_dir(), 'cmsfw-update-');
+        file_put_contents($zipPath, 'matching zip contents');
 
         try {
-            $reflection = new ReflectionClass( $manager );
-            $method     = $reflection->getMethod( 'verifyChecksum' );
-            $method->setAccessible( true );
+            $reflection = new ReflectionClass($manager);
+            $method     = $reflection->getMethod('verifyChecksum');
+            $method->setAccessible(true);
 
-            $method->invoke( $manager, $zipPath, hash_file( 'sha256', $zipPath ) );
+            $method->invoke($manager, $zipPath, hash_file('sha256', $zipPath));
 
-            $this->assertTrue( true ); // No exception means success.
+            $this->assertTrue(true); // No exception means success.
         } finally {
-            @unlink( $zipPath );
+            @unlink($zipPath);
         }
     }
 
@@ -236,7 +236,7 @@ class ApplicationUpdateManagerTest extends TestCase
      */
     public function test_maybe_verify_checksum_logs_warning_when_sha256_missing(): void
     {
-        config( ['cms.updates.verify_checksum' => true] );
+        config(['cms.updates.verify_checksum' => true]);
 
         $manager = new ApplicationUpdateManager;
 
@@ -248,19 +248,19 @@ class ApplicationUpdateManagerTest extends TestCase
             metadata: ['source' => 'gitlab'],
         );
 
-        Log::shouldReceive( 'warning' )
+        Log::shouldReceive('warning')
             ->once()
-            ->withArgs( function ( string $message, array $context ): bool {
-                return str_contains( $message, 'Skipping update integrity verification' )
-                    && '2.0.0' === ( $context['target_version'] ?? null )
-                    && 'gitlab' === ( $context['source'] ?? null );
-            } );
+            ->withArgs(function (string $message, array $context): bool {
+                return str_contains($message, 'Skipping update integrity verification')
+                    && '2.0.0' === ($context['target_version'] ?? null)
+                    && 'gitlab' === ($context['source'] ?? null);
+            });
 
-        $reflection = new ReflectionClass( $manager );
-        $method     = $reflection->getMethod( 'maybeVerifyChecksum' );
-        $method->setAccessible( true );
+        $reflection = new ReflectionClass($manager);
+        $method     = $reflection->getMethod('maybeVerifyChecksum');
+        $method->setAccessible(true);
 
-        $method->invoke( $manager, '/does/not/matter.zip', $updateInfo, '2.0.0' );
+        $method->invoke($manager, '/does/not/matter.zip', $updateInfo, '2.0.0');
     }
 
     /**
@@ -270,7 +270,7 @@ class ApplicationUpdateManagerTest extends TestCase
      */
     public function test_maybe_verify_checksum_is_silent_when_disabled(): void
     {
-        config( ['cms.updates.verify_checksum' => false] );
+        config(['cms.updates.verify_checksum' => false]);
 
         $manager = new ApplicationUpdateManager;
 
@@ -281,13 +281,13 @@ class ApplicationUpdateManagerTest extends TestCase
             sha256: null,
         );
 
-        Log::shouldReceive( 'warning' )->never();
+        Log::shouldReceive('warning')->never();
 
-        $reflection = new ReflectionClass( $manager );
-        $method     = $reflection->getMethod( 'maybeVerifyChecksum' );
-        $method->setAccessible( true );
+        $reflection = new ReflectionClass($manager);
+        $method     = $reflection->getMethod('maybeVerifyChecksum');
+        $method->setAccessible(true);
 
-        $method->invoke( $manager, '/does/not/matter.zip', $updateInfo, '2.0.0' );
+        $method->invoke($manager, '/does/not/matter.zip', $updateInfo, '2.0.0');
     }
 
     /**
@@ -298,7 +298,7 @@ class ApplicationUpdateManagerTest extends TestCase
      */
     public function test_perform_update_disables_maintenance_mode_on_fatal_error(): void
     {
-        config( ['cms.updates.backup_enabled' => false] );
+        config(['cms.updates.backup_enabled' => false]);
 
         $manager = new class extends ApplicationUpdateManager {
             public array $modeCalls = [];
@@ -320,20 +320,20 @@ class ApplicationUpdateManagerTest extends TestCase
             downloadUrl: 'https://example.com/update.zip',
         );
 
-        $checker = $this->createMock( UpdateChecker::class );
-        $checker->method( 'checkForUpdate' )->willReturn( $updateInfo );
-        $checker->method( 'downloadUpdate' )->willThrowException( new Error( 'Simulated fatal error' ) );
+        $checker = $this->createMock(UpdateChecker::class);
+        $checker->method('checkForUpdate')->willReturn($updateInfo);
+        $checker->method('downloadUpdate')->willThrowException(new Error('Simulated fatal error'));
 
-        $manager->setUpdateChecker( $checker );
+        $manager->setUpdateChecker($checker);
 
         try {
             $manager->performUpdate();
-            $this->fail( 'Expected Error to be thrown.' );
-        } catch ( Error $e ) {
-            $this->assertSame( 'Simulated fatal error', $e->getMessage() );
+            $this->fail('Expected Error to be thrown.');
+        } catch (Error $e) {
+            $this->assertSame('Simulated fatal error', $e->getMessage());
         }
 
-        $this->assertSame( ['enable', 'disable'], $manager->modeCalls );
+        $this->assertSame(['enable', 'disable'], $manager->modeCalls);
     }
 
     /**
@@ -346,27 +346,25 @@ class ApplicationUpdateManagerTest extends TestCase
      */
     public function test_extract_update_streams_entries_to_disk(): void
     {
-        $tempRoot = sys_get_temp_dir() . '/cmsfw-extract-' . bin2hex( random_bytes( 6 ) );
-        $target   = $tempRoot . '/target';
-        mkdir( $target, 0755, true );
+        $tempRoot = sys_get_temp_dir().'/cmsfw-extract-'.bin2hex(random_bytes(6));
+        $target   = $tempRoot.'/target';
+        mkdir($target, 0755, true);
 
-        $zipPath  = $tempRoot . '/update.zip';
-        $largeBig = str_repeat( 'x', 65536 );
+        $zipPath  = $tempRoot.'/update.zip';
+        $largeBig = str_repeat('x', 65536);
 
         $zip = new ZipArchive;
-        $this->assertTrue( true === $zip->open( $zipPath, ZipArchive::CREATE | ZipArchive::OVERWRITE ) );
-        $zip->addFromString( 'release-root/app/Model.php', "<?php\n" . $largeBig );
-        $zip->addFromString( 'release-root/routes/web.php', "<?php\nRoute::get('/', fn () => 'ok');\n" );
+        $this->assertTrue(true === $zip->open($zipPath, ZipArchive::CREATE | ZipArchive::OVERWRITE));
+        $zip->addFromString('release-root/app/Model.php', "<?php\n".$largeBig);
+        $zip->addFromString('release-root/routes/web.php', "<?php\nRoute::get('/', fn () => 'ok');\n");
         $zip->close();
 
-        $manager = new class( $target ) extends ApplicationUpdateManager {
-            public function __construct( protected string $extractRoot )
-            {
-            }
+        $manager = new class($target) extends ApplicationUpdateManager {
+            public function __construct(protected string $extractRoot) {}
 
-            public function extractInto( string $zipPath ): void
+            public function extractInto(string $zipPath): void
             {
-                $this->extractUpdate( $zipPath );
+                $this->extractUpdate($zipPath);
             }
         };
 
@@ -374,23 +372,23 @@ class ApplicationUpdateManagerTest extends TestCase
         // inside extractUpdate resolves to a scratch directory instead of the
         // testbench root.
         $originalBase = base_path();
-        app()->setBasePath( $target );
+        app()->setBasePath($target);
 
         try {
-            $manager->extractInto( $zipPath );
+            $manager->extractInto($zipPath);
 
-            $this->assertFileExists( $target . '/app/Model.php' );
-            $this->assertFileExists( $target . '/routes/web.php' );
+            $this->assertFileExists($target.'/app/Model.php');
+            $this->assertFileExists($target.'/routes/web.php');
             $this->assertSame(
-                strlen( "<?php\n" . $largeBig ),
-                filesize( $target . '/app/Model.php' ),
+                strlen("<?php\n".$largeBig),
+                filesize($target.'/app/Model.php'),
                 'Streamed extraction should produce a byte-for-byte copy of the ZIP entry.',
             );
         } finally {
-            app()->setBasePath( $originalBase );
-            @unlink( $zipPath );
-            $this->removeDirectory( $target );
-            @rmdir( $tempRoot );
+            app()->setBasePath($originalBase);
+            @unlink($zipPath);
+            $this->removeDirectory($target);
+            @rmdir($tempRoot);
         }
     }
 
@@ -403,25 +401,25 @@ class ApplicationUpdateManagerTest extends TestCase
      */
     public function test_resolve_composer_command_prefers_env_binary(): void
     {
-        config( ['cms.updates.composer_install_command' => ApplicationUpdateManager::DEFAULT_COMPOSER_INSTALL_COMMAND] );
+        config(['cms.updates.composer_install_command' => ApplicationUpdateManager::DEFAULT_COMPOSER_INSTALL_COMMAND]);
 
-        $original = getenv( 'COMPOSER_BINARY' );
-        putenv( 'COMPOSER_BINARY=/opt/homebrew/bin/composer' );
+        $original = getenv('COMPOSER_BINARY');
+        putenv('COMPOSER_BINARY=/opt/homebrew/bin/composer');
 
         try {
             $manager = new ApplicationUpdateManager;
 
-            $reflection = new ReflectionClass( $manager );
-            $method     = $reflection->getMethod( 'resolveComposerCommand' );
-            $method->setAccessible( true );
+            $reflection = new ReflectionClass($manager);
+            $method     = $reflection->getMethod('resolveComposerCommand');
+            $method->setAccessible(true);
 
-            $command = $method->invoke( $manager );
+            $command = $method->invoke($manager);
 
-            $this->assertStringStartsWith( escapeshellarg( PHP_BINARY ) . ' ', $command );
-            $this->assertStringContainsString( escapeshellarg( '/opt/homebrew/bin/composer' ), $command );
-            $this->assertStringEndsWith( ' ' . ApplicationUpdateManager::DEFAULT_COMPOSER_INSTALL_ARGS, $command );
+            $this->assertStringStartsWith(escapeshellarg(PHP_BINARY).' ', $command);
+            $this->assertStringContainsString(escapeshellarg('/opt/homebrew/bin/composer'), $command);
+            $this->assertStringEndsWith(' '.ApplicationUpdateManager::DEFAULT_COMPOSER_INSTALL_ARGS, $command);
         } finally {
-            putenv( false === $original ? 'COMPOSER_BINARY' : 'COMPOSER_BINARY=' . $original );
+            putenv(false === $original ? 'COMPOSER_BINARY' : 'COMPOSER_BINARY='.$original);
         }
     }
 
@@ -435,21 +433,21 @@ class ApplicationUpdateManagerTest extends TestCase
     public function test_resolve_composer_command_respects_non_default_config_override(): void
     {
         $override = 'PATH=/opt/homebrew/bin:/usr/bin /opt/homebrew/bin/composer install --no-dev --no-interaction --optimize-autoloader';
-        config( ['cms.updates.composer_install_command' => $override] );
+        config(['cms.updates.composer_install_command' => $override]);
 
-        $original = getenv( 'COMPOSER_BINARY' );
-        putenv( 'COMPOSER_BINARY' );
+        $original = getenv('COMPOSER_BINARY');
+        putenv('COMPOSER_BINARY');
 
         try {
             $manager = new ApplicationUpdateManager;
 
-            $reflection = new ReflectionClass( $manager );
-            $method     = $reflection->getMethod( 'resolveComposerCommand' );
-            $method->setAccessible( true );
+            $reflection = new ReflectionClass($manager);
+            $method     = $reflection->getMethod('resolveComposerCommand');
+            $method->setAccessible(true);
 
-            $this->assertSame( $override, $method->invoke( $manager ) );
+            $this->assertSame($override, $method->invoke($manager));
         } finally {
-            putenv( false === $original ? 'COMPOSER_BINARY' : 'COMPOSER_BINARY=' . $original );
+            putenv(false === $original ? 'COMPOSER_BINARY' : 'COMPOSER_BINARY='.$original);
         }
     }
 
@@ -461,10 +459,10 @@ class ApplicationUpdateManagerTest extends TestCase
      */
     public function test_resolve_composer_command_uses_discovered_binary(): void
     {
-        config( ['cms.updates.composer_install_command' => ApplicationUpdateManager::DEFAULT_COMPOSER_INSTALL_COMMAND] );
+        config(['cms.updates.composer_install_command' => ApplicationUpdateManager::DEFAULT_COMPOSER_INSTALL_COMMAND]);
 
-        $original = getenv( 'COMPOSER_BINARY' );
-        putenv( 'COMPOSER_BINARY' );
+        $original = getenv('COMPOSER_BINARY');
+        putenv('COMPOSER_BINARY');
 
         try {
             $manager = new class extends ApplicationUpdateManager {
@@ -474,17 +472,17 @@ class ApplicationUpdateManagerTest extends TestCase
                 }
             };
 
-            $reflection = new ReflectionClass( $manager );
-            $method     = $reflection->getMethod( 'resolveComposerCommand' );
-            $method->setAccessible( true );
+            $reflection = new ReflectionClass($manager);
+            $method     = $reflection->getMethod('resolveComposerCommand');
+            $method->setAccessible(true);
 
-            $command = $method->invoke( $manager );
+            $command = $method->invoke($manager);
 
-            $this->assertStringStartsWith( escapeshellarg( PHP_BINARY ) . ' ', $command );
-            $this->assertStringContainsString( escapeshellarg( '/discovered/path/composer' ), $command );
-            $this->assertStringEndsWith( ' ' . ApplicationUpdateManager::DEFAULT_COMPOSER_INSTALL_ARGS, $command );
+            $this->assertStringStartsWith(escapeshellarg(PHP_BINARY).' ', $command);
+            $this->assertStringContainsString(escapeshellarg('/discovered/path/composer'), $command);
+            $this->assertStringEndsWith(' '.ApplicationUpdateManager::DEFAULT_COMPOSER_INSTALL_ARGS, $command);
         } finally {
-            putenv( false === $original ? 'COMPOSER_BINARY' : 'COMPOSER_BINARY=' . $original );
+            putenv(false === $original ? 'COMPOSER_BINARY' : 'COMPOSER_BINARY='.$original);
         }
     }
 
@@ -496,10 +494,10 @@ class ApplicationUpdateManagerTest extends TestCase
      */
     public function test_resolve_composer_command_falls_back_to_default(): void
     {
-        config( ['cms.updates.composer_install_command' => ApplicationUpdateManager::DEFAULT_COMPOSER_INSTALL_COMMAND] );
+        config(['cms.updates.composer_install_command' => ApplicationUpdateManager::DEFAULT_COMPOSER_INSTALL_COMMAND]);
 
-        $original = getenv( 'COMPOSER_BINARY' );
-        putenv( 'COMPOSER_BINARY' );
+        $original = getenv('COMPOSER_BINARY');
+        putenv('COMPOSER_BINARY');
 
         try {
             $manager = new class extends ApplicationUpdateManager {
@@ -509,16 +507,16 @@ class ApplicationUpdateManagerTest extends TestCase
                 }
             };
 
-            $reflection = new ReflectionClass( $manager );
-            $method     = $reflection->getMethod( 'resolveComposerCommand' );
-            $method->setAccessible( true );
+            $reflection = new ReflectionClass($manager);
+            $method     = $reflection->getMethod('resolveComposerCommand');
+            $method->setAccessible(true);
 
             $this->assertSame(
                 ApplicationUpdateManager::DEFAULT_COMPOSER_INSTALL_COMMAND,
-                $method->invoke( $manager ),
+                $method->invoke($manager),
             );
         } finally {
-            putenv( false === $original ? 'COMPOSER_BINARY' : 'COMPOSER_BINARY=' . $original );
+            putenv(false === $original ? 'COMPOSER_BINARY' : 'COMPOSER_BINARY='.$original);
         }
     }
 
@@ -531,17 +529,17 @@ class ApplicationUpdateManagerTest extends TestCase
      */
     public function test_composer_candidate_paths_covers_documented_locations(): void
     {
-        $original = getenv( 'HOME' );
-        putenv( 'HOME=/home/tester' );
+        $original = getenv('HOME');
+        putenv('HOME=/home/tester');
 
         try {
             $manager = new ApplicationUpdateManager;
 
-            $reflection = new ReflectionClass( $manager );
-            $method     = $reflection->getMethod( 'composerCandidatePaths' );
-            $method->setAccessible( true );
+            $reflection = new ReflectionClass($manager);
+            $method     = $reflection->getMethod('composerCandidatePaths');
+            $method->setAccessible(true);
 
-            $candidates = $method->invoke( $manager );
+            $candidates = $method->invoke($manager);
 
             $this->assertSame(
                 [
@@ -554,7 +552,7 @@ class ApplicationUpdateManagerTest extends TestCase
                 $candidates,
             );
         } finally {
-            putenv( false === $original ? 'HOME' : 'HOME=' . $original );
+            putenv(false === $original ? 'HOME' : 'HOME='.$original);
         }
     }
 
@@ -568,33 +566,26 @@ class ApplicationUpdateManagerTest extends TestCase
      */
     public function test_discover_composer_binary_returns_first_executable_hit(): void
     {
-        $tempDir = sys_get_temp_dir() . '/cmsfw-composer-' . bin2hex( random_bytes( 6 ) );
-        mkdir( $tempDir, 0755, true );
+        $tempDir = sys_get_temp_dir().'/cmsfw-composer-'.bin2hex(random_bytes(6));
+        mkdir($tempDir, 0755, true);
 
-        $missing        = $tempDir . '/missing-composer';
-        $nonExecutable  = $tempDir . '/non-executable-composer';
-        $executableHit  = $tempDir . '/executable-composer';
-        $laterCandidate = $tempDir . '/never-reached-composer';
+        $missing        = $tempDir.'/missing-composer';
+        $nonExecutable  = $tempDir.'/non-executable-composer';
+        $executableHit  = $tempDir.'/executable-composer';
+        $laterCandidate = $tempDir.'/never-reached-composer';
 
-        file_put_contents( $nonExecutable, "#!/bin/sh\n" );
-        chmod( $nonExecutable, 0644 );
+        file_put_contents($nonExecutable, "#!/bin/sh\n");
+        chmod($nonExecutable, 0644);
 
-        file_put_contents( $executableHit, "#!/bin/sh\n" );
-        chmod( $executableHit, 0755 );
+        file_put_contents($executableHit, "#!/bin/sh\n");
+        chmod($executableHit, 0755);
 
-        file_put_contents( $laterCandidate, "#!/bin/sh\n" );
-        chmod( $laterCandidate, 0755 );
+        file_put_contents($laterCandidate, "#!/bin/sh\n");
+        chmod($laterCandidate, 0755);
 
         try {
-            $manager = new class( [
-                $missing,
-                $nonExecutable,
-                $executableHit,
-                $laterCandidate,
-            ] ) extends ApplicationUpdateManager {
-                public function __construct( protected array $paths )
-                {
-                }
+            $manager = new class([$missing, $nonExecutable, $executableHit, $laterCandidate]) extends ApplicationUpdateManager {
+                public function __construct(protected array $paths) {}
 
                 protected function composerCandidatePaths(): array
                 {
@@ -607,29 +598,34 @@ class ApplicationUpdateManagerTest extends TestCase
                 }
             };
 
-            $this->assertSame( $executableHit, $manager->callDiscover() );
+            $this->assertSame($executableHit, $manager->callDiscover());
         } finally {
-            @unlink( $missing );
-            @unlink( $nonExecutable );
-            @unlink( $executableHit );
-            @unlink( $laterCandidate );
-            @rmdir( $tempDir );
+            @unlink($missing);
+            @unlink($nonExecutable);
+            @unlink($executableHit);
+            @unlink($laterCandidate);
+            @rmdir($tempDir);
         }
     }
 
     /**
      * Regression for #225: rollback pre-checks the resolved composer binary
      * with `--version` before invoking install, and surfaces a specific
-     * `composerBinaryNotFound` error rather than the generic "Manual
-     * intervention required" when the binary can't be reached.
+     * error rather than the generic "Manual intervention required" when the
+     * binary can't be reached.
+     *
+     * As of 2.5.4 the pre-check throws `composerVerificationFailed` (which
+     * captures exit code + output) rather than `composerBinaryNotFound` —
+     * the binary *was* located, so the misleading "not found" wording was
+     * masking real interpreter mismatches on PHP-FPM hosts.
      *
      * @since 2.5.3
      */
-    public function test_rollback_throws_composer_binary_not_found_when_version_check_fails(): void
+    public function test_rollback_throws_composer_verification_failed_when_version_check_fails(): void
     {
-        Process::fake( [
-            '*--version*' => Process::result( '', 'command not found', 127 ),
-        ] );
+        Process::fake([
+            '*--version*' => Process::result('', 'command not found', 127),
+        ]);
 
         $manager = new class extends ApplicationUpdateManager {
             protected function resolveComposerBinaryForVerification(): ?string
@@ -638,19 +634,19 @@ class ApplicationUpdateManagerTest extends TestCase
             }
         };
 
-        $backupPath = tempnam( sys_get_temp_dir(), 'cmsfw-backup-' ) . '.zip';
+        $backupPath = tempnam(sys_get_temp_dir(), 'cmsfw-backup-').'.zip';
         $zip        = new ZipArchive;
-        $this->assertTrue( true === $zip->open( $backupPath, ZipArchive::CREATE | ZipArchive::OVERWRITE ) );
-        $zip->addFromString( 'placeholder.txt', 'ok' );
+        $this->assertTrue(true === $zip->open($backupPath, ZipArchive::CREATE | ZipArchive::OVERWRITE));
+        $zip->addFromString('placeholder.txt', 'ok');
         $zip->close();
 
         try {
-            $this->expectException( UpdateException::class );
-            $this->expectExceptionMessage( 'Composer binary could not be located' );
+            $this->expectException(UpdateException::class);
+            $this->expectExceptionMessage('could not be executed');
 
-            $manager->rollback( $backupPath );
+            $manager->rollback($backupPath);
         } finally {
-            @unlink( $backupPath );
+            @unlink($backupPath);
         }
     }
 
@@ -666,10 +662,10 @@ class ApplicationUpdateManagerTest extends TestCase
         $manager = new class extends ApplicationUpdateManager {
             public function __construct()
             {
-                $stub = tempnam( sys_get_temp_dir(), 'cmsfw-backup-' );
-                @unlink( $stub );
-                $this->backupPath = $stub . '.zip';
-                file_put_contents( $this->backupPath, 'not-a-zip' );
+                $stub = tempnam(sys_get_temp_dir(), 'cmsfw-backup-');
+                @unlink($stub);
+                $this->backupPath = $stub.'.zip';
+                file_put_contents($this->backupPath, 'not-a-zip');
             }
 
             protected function disableMaintenanceMode(): void
@@ -677,32 +673,176 @@ class ApplicationUpdateManagerTest extends TestCase
                 // No-op; nothing to disable in this unit context.
             }
 
-            public function callHandleFailure( Throwable $e ): void
+            public function callHandleFailure(Throwable $e): void
             {
-                $this->handleUpdateFailure( $e );
+                $this->handleUpdateFailure($e);
             }
         };
 
         try {
-            $original = new RuntimeException( 'composer install failed because it ran out of memory' );
+            $original = new RuntimeException('composer install failed because it ran out of memory');
 
             try {
-                $manager->callHandleFailure( $original );
-                $this->fail( 'Expected UpdateException from rollback.' );
-            } catch ( UpdateException $e ) {
-                $this->assertStringContainsString( 'Rollback failed', $e->getMessage() );
-                $this->assertStringContainsString( 'ran out of memory', $e->getMessage() );
-                $this->assertStringContainsString( 'Manual intervention required', $e->getMessage() );
+                $manager->callHandleFailure($original);
+                $this->fail('Expected UpdateException from rollback.');
+            } catch (UpdateException $e) {
+                $this->assertStringContainsString('Rollback failed', $e->getMessage());
+                $this->assertStringContainsString('ran out of memory', $e->getMessage());
+                $this->assertStringContainsString('Manual intervention required', $e->getMessage());
             }
         } finally {
-            $reflection = new ReflectionClass( $manager );
-            $property   = $reflection->getProperty( 'backupPath' );
-            $property->setAccessible( true );
-            $path = $property->getValue( $manager );
-            if ( is_string( $path ) ) {
-                @unlink( $path );
+            $reflection = new ReflectionClass($manager);
+            $property   = $reflection->getProperty('backupPath');
+            $property->setAccessible(true);
+            $path = $property->getValue($manager);
+            if (is_string($path)) {
+                @unlink($path);
             }
         }
+    }
+
+    /**
+     * The PHP interpreter used to run composer must be a *CLI* SAPI binary.
+     * Under PHP-FPM `PHP_BINARY` points at the FPM daemon, which prints usage
+     * and exits 64 when handed a PHAR — the root cause of the "Composer
+     * install failed. Output: ." symptom observed on Herd hosts. Regression
+     * guard: an FPM-shaped candidate must be rejected in favor of a CLI one.
+     *
+     * @since 2.5.4
+     */
+    public function test_resolve_php_binary_skips_fpm_candidates_and_prefers_cli(): void
+    {
+        $tempDir = sys_get_temp_dir().'/cmsfw-php-'.bin2hex(random_bytes(6));
+        mkdir($tempDir, 0755, true);
+
+        $fpm = $tempDir.'/php84-fpm';
+        $cli = $tempDir.'/php';
+
+        file_put_contents($fpm, "#!/bin/sh\n");
+        chmod($fpm, 0755);
+        file_put_contents($cli, "#!/bin/sh\n");
+        chmod($cli, 0755);
+
+        $original = getenv('CMS_PHP_BINARY');
+        putenv('CMS_PHP_BINARY');
+
+        try {
+            $manager = new class([$fpm, $cli], 'fpm-fcgi') extends ApplicationUpdateManager {
+                public function __construct(protected array $paths, protected string $sapi) {}
+
+                protected function phpCandidatePaths(): array
+                {
+                    return $this->paths;
+                }
+
+                public function callResolvePhpBinary(): string
+                {
+                    // Bypass the PHP_SAPI short-circuit by shadowing the
+                    // condition — we can't mutate the runtime SAPI constant,
+                    // so we run the discovery path directly.
+                    foreach ($this->phpCandidatePaths() as $candidate) {
+                        if ($this->isCliPhpBinary($candidate)) {
+                            return $candidate;
+                        }
+                    }
+
+                    return PHP_BINARY;
+                }
+            };
+
+            $this->assertSame($cli, $manager->callResolvePhpBinary());
+        } finally {
+            @unlink($fpm);
+            @unlink($cli);
+            @rmdir($tempDir);
+            putenv(false === $original ? 'CMS_PHP_BINARY' : 'CMS_PHP_BINARY='.$original);
+        }
+    }
+
+    /**
+     * `CMS_PHP_BINARY` is the operator escape hatch — when set it wins over
+     * SAPI detection and candidate discovery so hosts with an unusual layout
+     * can point the updater at a known-good CLI PHP.
+     *
+     * @since 2.5.4
+     */
+    public function test_resolve_php_binary_respects_env_override(): void
+    {
+        $original = getenv('CMS_PHP_BINARY');
+        putenv('CMS_PHP_BINARY=/custom/path/to/php');
+
+        try {
+            $manager = new ApplicationUpdateManager;
+
+            $reflection = new ReflectionClass($manager);
+            $method     = $reflection->getMethod('resolvePhpBinary');
+            $method->setAccessible(true);
+
+            $this->assertSame('/custom/path/to/php', $method->invoke($manager));
+        } finally {
+            putenv(false === $original ? 'CMS_PHP_BINARY' : 'CMS_PHP_BINARY='.$original);
+        }
+    }
+
+    /**
+     * The candidate list must include Herd's macOS install path and the
+     * common Homebrew/system locations in preference order. Cross-checked
+     * with the diagnostic in `composerVerificationFailed` so operators see
+     * the same list the framework tried.
+     *
+     * @since 2.5.4
+     */
+    public function test_php_candidate_paths_covers_documented_locations(): void
+    {
+        $original = getenv('HOME');
+        putenv('HOME=/home/tester');
+
+        try {
+            $manager = new ApplicationUpdateManager;
+
+            $reflection = new ReflectionClass($manager);
+            $method     = $reflection->getMethod('phpCandidatePaths');
+            $method->setAccessible(true);
+
+            $this->assertSame(
+                [
+                    '/home/tester/Library/Application Support/Herd/bin/php',
+                    '/opt/homebrew/bin/php',
+                    '/usr/local/bin/php',
+                    '/usr/bin/php',
+                ],
+                $method->invoke($manager),
+            );
+        } finally {
+            putenv(false === $original ? 'HOME' : 'HOME='.$original);
+        }
+    }
+
+    /**
+     * `composerVerificationFailed` must surface the actual exit code and
+     * captured output so operators can distinguish an interpreter-mismatch
+     * (usage/64) failure from a genuine unreachable-binary case. Without
+     * this the previous "not found" wording sent operators chasing PATH
+     * issues that weren't there.
+     *
+     * @since 2.5.4
+     */
+    public function test_composer_verification_failed_message_includes_diagnostic_context(): void
+    {
+        $exception = UpdateException::composerVerificationFailed(
+            composerBinary: '/opt/homebrew/bin/composer',
+            phpBinary: '/Users/tester/Herd/bin/php84-fpm',
+            exitCode: 64,
+            detail: 'Usage: php84-fpm ...',
+        );
+
+        $message = $exception->getMessage();
+
+        $this->assertStringContainsString('/opt/homebrew/bin/composer', $message);
+        $this->assertStringContainsString('/Users/tester/Herd/bin/php84-fpm', $message);
+        $this->assertStringContainsString('Exit code: 64', $message);
+        $this->assertStringContainsString('Usage: php84-fpm', $message);
+        $this->assertStringContainsString('CMS_PHP_BINARY', $message);
     }
 
     /**
@@ -710,33 +850,33 @@ class ApplicationUpdateManagerTest extends TestCase
      *
      * @since 2.5.2
      */
-    protected function removeDirectory( string $path ): void
+    protected function removeDirectory(string $path): void
     {
-        if ( ! is_dir( $path ) ) {
+        if (! is_dir($path)) {
             return;
         }
 
-        $items = scandir( $path );
+        $items = scandir($path);
 
-        if ( false === $items ) {
+        if (false === $items) {
             return;
         }
 
-        foreach ( $items as $item ) {
-            if ( '.' === $item || '..' === $item ) {
+        foreach ($items as $item) {
+            if ('.' === $item || '..' === $item) {
                 continue;
             }
 
-            $full = $path . DIRECTORY_SEPARATOR . $item;
+            $full = $path.DIRECTORY_SEPARATOR.$item;
 
-            if ( is_dir( $full ) ) {
-                $this->removeDirectory( $full );
+            if (is_dir($full)) {
+                $this->removeDirectory($full);
             } else {
-                @unlink( $full );
+                @unlink($full);
             }
         }
 
-        @rmdir( $path );
+        @rmdir($path);
     }
 
     /**
@@ -746,15 +886,15 @@ class ApplicationUpdateManagerTest extends TestCase
      *
      * @param  \Illuminate\Foundation\Application  $app
      */
-    protected function defineEnvironment( $app ): void
+    protected function defineEnvironment($app): void
     {
-        $app['config']->set( 'cms.updates.update_source_url', 'https://github.com/test/repo' );
-        $app['config']->set( 'cms.updates.backup_enabled', true );
-        $app['config']->set( 'cms.updates.backup_path', 'backups/application' );
-        $app['config']->set( 'cms.updates.backup_retention_days', 30 );
-        $app['config']->set( 'cms.updates.verify_checksum', false ); // Disable for tests
-        $app['config']->set( 'cms.updates.composer_install_command', 'composer install --no-dev' );
-        $app['config']->set( 'cms.updates.composer_timeout', 600 );
-        $app['config']->set( 'cms.updates.exclude_from_update', ['.env', 'storage', 'vendor'] );
+        $app['config']->set('cms.updates.update_source_url', 'https://github.com/test/repo');
+        $app['config']->set('cms.updates.backup_enabled', true);
+        $app['config']->set('cms.updates.backup_path', 'backups/application');
+        $app['config']->set('cms.updates.backup_retention_days', 30);
+        $app['config']->set('cms.updates.verify_checksum', false); // Disable for tests
+        $app['config']->set('cms.updates.composer_install_command', 'composer install --no-dev');
+        $app['config']->set('cms.updates.composer_timeout', 600);
+        $app['config']->set('cms.updates.exclude_from_update', ['.env', 'storage', 'vendor']);
     }
 }


### PR DESCRIPTION
## Description

Under PHP-FPM `PHP_BINARY` points at the FPM daemon binary, which prints its own CLI-help text and exits 64 when handed the composer PHAR. That produced the misleading `Composer install failed. Output: .` symptom on Herd hosts — composer was discovered fine, but the interpreter used to invoke it was the wrong SAPI. Rollback then wrongly reported *"Composer binary could not be located"* because `verifyComposerBinaryAvailable()` reused the same broken interpreter and its `--version` check also failed.

Follow-up to #225 — the resolver added there was correct about *what* composer binary to run; this fixes *how* to run it.

**Closes:** _(none — surfaced by dogfooding the artisanpack-ui trial site trying to update 0.2.3 → 0.2.4)_

## Type of Change

- [x] Bug fix (fixes an issue)

## Related Issue

**Issue:** _n/a — reproduced live on the artisanpack-ui trial site; diagnosed via a temp FPM diagnostic route. Companion issues filed on pre-existing extraction/checksum weaknesses surfaced by the same review:_

- #234 (critical) — zip-slip in `extractUpdate`
- #235 (high) — fail-open checksum verification in `maybeVerifyChecksum`
- #236 (medium) — silent skip on stream/write failures during extraction

## Motivation and Context

Reproducer, confirmed via a temporary `/__diag_composer` route on the trial site under Herd's PHP-FPM pool:

```
PHP_BINARY=/Users/…/Herd/bin/php84-fpm     (fpm-fcgi SAPI)
cmd: '…/php84-fpm' '/opt/homebrew/bin/composer' --version 2>&1
exit=64
out=[Usage: php84-fpm [-n] [-e] [-h] [-i] [-m] [-v] [-t] …]
err=[]
```

Swap the interpreter for a CLI PHP on the same host and the same command exits 0 with composer's normal version banner. That's this PR.

## Changes Made

- New `ApplicationUpdateManager::resolvePhpBinary()`:
  1. `CMS_PHP_BINARY` env var (absolute path) — operator escape hatch.
  2. `PHP_BINARY` when `PHP_SAPI === 'cli'` — artisan/worker path stays on the parent interpreter.
  3. Candidate walk: `~/Library/Application Support/Herd/bin/php`, `/opt/homebrew/bin/php`, `/usr/local/bin/php`, `/usr/bin/php`; reject anything whose basename contains `fpm` or `cgi`.
  4. `PHP_BINARY` last-resort fallback so the diagnostic still surfaces.
- `buildComposerCommand()` and the rollback pre-check now use the resolved CLI PHP.
- New `UpdateException::composerVerificationFailed(...)` factory reports the resolved composer path, PHP interpreter, exit code, and captured output when `--version` fails. Rollback throws this (not the misleading `composerBinaryNotFound`) when the binary was found but couldn't be executed.
- Config doc-comment updated to explain the CLI-PHP requirement and `CMS_PHP_BINARY` override.

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS 27.0.0
- PHP Version: 8.5.7
- Project Version: 2.5.3 (target 2.5.4)

**Tests Performed:**
1. Live diagnostic on the artisanpack-ui trial site (Herd PHP-FPM) — reproduced the empty-output failure with `PHP_BINARY`, confirmed exit-0 with `/opt/homebrew/bin/php` as interpreter. Temp diag route removed post-diagnosis.
2. `vendor/bin/pest tests/Unit/Updates tests/Feature/Updates --compact` → **116 passed** (253 assertions).
3. `vendor/bin/pint --dirty --format agent` — clean.

**Not yet performed:** end-to-end live update round-trip through admin UI on the trial site with this branch installed via `composer require` path repository. Holding PR in **draft** until that manual verification passes (per team rule: don't ready-for-review until the branch is confirmed working end-to-end).

## Accessibility Tests Run

- [x] N/A — server-side change, no UI surface

## Tests Added

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] All tests passing

**Test details:**

- `test_resolve_php_binary_skips_fpm_candidates_and_prefers_cli` — regression guard for the exact FPM-shaped candidate that triggered the bug.
- `test_resolve_php_binary_respects_env_override` — `CMS_PHP_BINARY` escape hatch.
- `test_php_candidate_paths_covers_documented_locations` — parity with the diagnostic in `composerVerificationFailed`.
- `test_composer_verification_failed_message_includes_diagnostic_context` — confirms operators see binary, interpreter, exit code, and output.
- `test_rollback_throws_composer_verification_failed_when_version_check_fails` — updated from the old `composer_binary_not_found` assertion (renamed to reflect the new, more accurate exception).

## Documentation

- [x] Inline code documentation added
- [x] Config doc-comment updated (`src/Modules/Core/Updates/config/updates.php`)

## Pre-Submission Checklist

- [x] Code passes all tests (Updates suites)
- [x] Code has been linted (`pint --dirty --format agent`)
- [x] CodeRabbit CLI reviewed pre-push (3 pre-existing findings filed as #234, #235, #236 — none against this PR's changes)
- [x] Self-review completed
- [x] Comments added for the non-obvious SAPI reasoning in `resolvePhpBinary()` and `buildComposerCommand()`
- [ ] Manual end-to-end verification on trial site (blocker for moving out of draft)

## Notes for reviewers

The diff looks larger than it is: `pint --dirty` reformatted the entire touched files. The *logical* change is confined to `resolvePhpBinary()` / `phpCandidatePaths()` / `isCliPhpBinary()` in `ApplicationUpdateManager.php`, the `composerVerificationFailed()` factory in `UpdateException.php`, and the two callers (`buildComposerCommand()`, `verifyComposerBinaryAvailable()`). Everything else in the diff is whitespace/style normalization.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved update and rollback reliability, including safer archive handling and recovery after failed updates.
  - Added clearer diagnostics for Composer, PHP, checksum, and permission-related failures.
  - Update verification now warns when a source does not provide a checksum.

- **Improvements**
  - Composer and PHP executable detection now better supports hosting environments using PHP-FPM.
  - Updates preserve file permissions and provide more informative maintenance-mode failure handling.

- **Documentation**
  - Clarified configuration guidance for selecting the correct command-line PHP executable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->