### PR TITLE
fix: bypass Http facade for updater metadata GETs to avoid listener hangs

### DIFF
--- a/src/Modules/Core/Updates/Sources/CustomJsonUpdateSource.php
+++ b/src/Modules/Core/Updates/Sources/CustomJsonUpdateSource.php
@@ -6,9 +6,9 @@ namespace ArtisanPackUI\CMSFramework\Modules\Core\Updates\Sources;
 
 use ArtisanPackUI\CMSFramework\Modules\Core\Updates\Contracts\UpdateSourceInterface;
 use ArtisanPackUI\CMSFramework\Modules\Core\Updates\Exceptions\UpdateException;
+use ArtisanPackUI\CMSFramework\Modules\Core\Updates\Support\MetadataClient;
 use ArtisanPackUI\CMSFramework\Modules\Core\Updates\Support\StreamsDownloadsToDisk;
 use ArtisanPackUI\CMSFramework\Modules\Core\Updates\ValueObjects\UpdateInfo;
-use Illuminate\Support\Facades\Http;
 
 /**
  * Custom JSON Update Source
@@ -165,15 +165,14 @@ class CustomJsonUpdateSource implements UpdateSourceInterface
             $url .= ( str_contains( $url, '?' ) ? '&' : '?' ) . http_build_query( $this->queryParams );
         }
 
-        $response = Http::timeout( config( 'cms.updates.http_timeout', 15 ) )
-            ->retry( config( 'cms.updates.http_retries', 3 ), 100, throw: false )
-            ->get( $url );
+        $retries  = max( 0, (int) config( 'cms.updates.http_retries', 3 ) - 1 );
+        $response = MetadataClient::get( $url, retries: $retries );
 
-        if ( ! $response->successful() ) {
-            throw UpdateException::versionCheckFailed( "HTTP {$response->status()}: {$response->body()}" );
+        if ( $response['status'] < 200 || $response['status'] >= 300 ) {
+            throw UpdateException::versionCheckFailed( "HTTP {$response['status']}: {$response['body']}" );
         }
 
-        $data = $response->json();
+        $data = json_decode( $response['body'], true );
 
         if ( ! is_array( $data ) ) {
             throw UpdateException::invalidJsonResponse( $url );

--- a/src/Modules/Core/Updates/Sources/GitHubUpdateSource.php
+++ b/src/Modules/Core/Updates/Sources/GitHubUpdateSource.php
@@ -6,9 +6,9 @@ namespace ArtisanPackUI\CMSFramework\Modules\Core\Updates\Sources;
 
 use ArtisanPackUI\CMSFramework\Modules\Core\Updates\Contracts\UpdateSourceInterface;
 use ArtisanPackUI\CMSFramework\Modules\Core\Updates\Exceptions\UpdateException;
+use ArtisanPackUI\CMSFramework\Modules\Core\Updates\Support\MetadataClient;
 use ArtisanPackUI\CMSFramework\Modules\Core\Updates\Support\StreamsDownloadsToDisk;
 use ArtisanPackUI\CMSFramework\Modules\Core\Updates\ValueObjects\UpdateInfo;
-use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Str;
 use InvalidArgumentException;
 
@@ -221,15 +221,15 @@ class GitHubUpdateSource implements UpdateSourceInterface
             $headers['Authorization'] = "token {$this->accessToken}";
         }
 
-        $response = Http::withHeaders( $headers )
-            ->timeout( config( 'cms.updates.http_timeout', 15 ) )
-            ->get( $apiUrl );
+        $response = MetadataClient::get( $apiUrl, $headers );
 
-        if ( ! $response->successful() ) {
-            throw UpdateException::versionCheckFailed( "GitHub API error: {$response->status()}" );
+        if ( ! $this->responseIsSuccessful( $response['status'] ) ) {
+            throw UpdateException::versionCheckFailed( "GitHub API error: {$response['status']}" );
         }
 
-        return $response->json();
+        $decoded = json_decode( $response['body'], true );
+
+        return is_array( $decoded ) ? $decoded : [];
     }
 
     /**
@@ -255,25 +255,33 @@ class GitHubUpdateSource implements UpdateSourceInterface
             $headers['Authorization'] = "token {$this->accessToken}";
         }
 
-        $response = Http::withHeaders( $headers )
-            ->timeout( config( 'cms.updates.http_timeout', 15 ) )
-            ->get( $apiUrl );
+        $response = MetadataClient::get( $apiUrl, $headers );
 
-        if ( ! $response->successful() ) {
+        if ( ! $this->responseIsSuccessful( $response['status'] ) ) {
             // Try without 'v' prefix
             $tag    = ltrim( $version, 'v' );
             $apiUrl = "https://api.github.com/repos/{$this->owner}/{$this->repo}/releases/tags/{$tag}";
 
-            $response = Http::withHeaders( $headers )
-                ->timeout( config( 'cms.updates.http_timeout', 15 ) )
-                ->get( $apiUrl );
+            $response = MetadataClient::get( $apiUrl, $headers );
 
-            if ( ! $response->successful() ) {
+            if ( ! $this->responseIsSuccessful( $response['status'] ) ) {
                 throw UpdateException::downloadFailed( "Release not found for version: {$version}" );
             }
         }
 
-        return $response->json();
+        $decoded = json_decode( $response['body'], true );
+
+        return is_array( $decoded ) ? $decoded : [];
+    }
+
+    /**
+     * Check if a raw HTTP status code represents a 2xx success.
+     *
+     * @since 2.5.4
+     */
+    protected function responseIsSuccessful( int $status ): bool
+    {
+        return $status >= 200 && $status < 300;
     }
 
     /**

--- a/src/Modules/Core/Updates/Sources/GitLabUpdateSource.php
+++ b/src/Modules/Core/Updates/Sources/GitLabUpdateSource.php
@@ -6,9 +6,9 @@ namespace ArtisanPackUI\CMSFramework\Modules\Core\Updates\Sources;
 
 use ArtisanPackUI\CMSFramework\Modules\Core\Updates\Contracts\UpdateSourceInterface;
 use ArtisanPackUI\CMSFramework\Modules\Core\Updates\Exceptions\UpdateException;
+use ArtisanPackUI\CMSFramework\Modules\Core\Updates\Support\MetadataClient;
 use ArtisanPackUI\CMSFramework\Modules\Core\Updates\Support\StreamsDownloadsToDisk;
 use ArtisanPackUI\CMSFramework\Modules\Core\Updates\ValueObjects\UpdateInfo;
-use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
 use InvalidArgumentException;
 use Throwable;
@@ -219,15 +219,15 @@ class GitLabUpdateSource implements UpdateSourceInterface
             $headers['PRIVATE-TOKEN'] = $this->accessToken;
         }
 
-        $response = Http::withHeaders( $headers )
-            ->timeout( config( 'cms.updates.http_timeout', 15 ) )
-            ->get( $apiUrl );
+        $response = MetadataClient::get( $apiUrl, $headers );
 
-        if ( ! $response->successful() ) {
-            throw UpdateException::versionCheckFailed( "GitLab API error: {$response->status()}" );
+        if ( ! $this->responseIsSuccessful( $response['status'] ) ) {
+            throw UpdateException::versionCheckFailed( "GitLab API error: {$response['status']}" );
         }
 
-        return $response->json();
+        $decoded = json_decode( $response['body'], true );
+
+        return is_array( $decoded ) ? $decoded : [];
     }
 
     /**
@@ -253,25 +253,33 @@ class GitLabUpdateSource implements UpdateSourceInterface
             $headers['PRIVATE-TOKEN'] = $this->accessToken;
         }
 
-        $response = Http::withHeaders( $headers )
-            ->timeout( config( 'cms.updates.http_timeout', 15 ) )
-            ->get( $apiUrl );
+        $response = MetadataClient::get( $apiUrl, $headers );
 
-        if ( ! $response->successful() ) {
+        if ( ! $this->responseIsSuccessful( $response['status'] ) ) {
             // Try without 'v' prefix
             $tag    = ltrim( $version, 'v' );
             $apiUrl = "https://gitlab.com/api/v4/projects/{$this->projectId}/releases/{$tag}";
 
-            $response = Http::withHeaders( $headers )
-                ->timeout( config( 'cms.updates.http_timeout', 15 ) )
-                ->get( $apiUrl );
+            $response = MetadataClient::get( $apiUrl, $headers );
 
-            if ( ! $response->successful() ) {
+            if ( ! $this->responseIsSuccessful( $response['status'] ) ) {
                 throw UpdateException::downloadFailed( "Release not found for version: {$version}" );
             }
         }
 
-        return $response->json();
+        $decoded = json_decode( $response['body'], true );
+
+        return is_array( $decoded ) ? $decoded : [];
+    }
+
+    /**
+     * Check if a raw HTTP status code represents a 2xx success.
+     *
+     * @since 2.5.4
+     */
+    protected function responseIsSuccessful( int $status ): bool
+    {
+        return $status >= 200 && $status < 300;
     }
 
     /**
@@ -508,9 +516,7 @@ class GitLabUpdateSource implements UpdateSourceInterface
         }
 
         try {
-            $response = Http::withHeaders( $headers )
-                ->timeout( config( 'cms.updates.http_timeout', 15 ) )
-                ->get( $url );
+            $response = MetadataClient::get( $url, $headers );
         } catch ( Throwable $e ) {
             Log::warning( 'Failed to fetch GitLab SHA-256 sidecar.', [
                 'url'   => $url,
@@ -520,16 +526,16 @@ class GitLabUpdateSource implements UpdateSourceInterface
             return null;
         }
 
-        if ( ! $response->successful() ) {
+        if ( ! $this->responseIsSuccessful( $response['status'] ) ) {
             Log::warning( 'GitLab SHA-256 sidecar request returned a non-success status.', [
                 'url'    => $url,
-                'status' => $response->status(),
+                'status' => $response['status'],
             ] );
 
             return null;
         }
 
-        if ( preg_match( '/\b([a-f0-9]{64})\b/i', $response->body(), $matches ) ) {
+        if ( preg_match( '/\b([a-f0-9]{64})\b/i', $response['body'], $matches ) ) {
             return strtolower( $matches[1] );
         }
 

--- a/src/Modules/Core/Updates/Support/MetadataClient.php
+++ b/src/Modules/Core/Updates/Support/MetadataClient.php
@@ -1,0 +1,191 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Modules\Core\Updates\Support;
+
+use ArtisanPackUI\CMSFramework\Modules\Core\Updates\Exceptions\UpdateException;
+use Closure;
+use GuzzleHttp\Client;
+use GuzzleHttp\ClientInterface;
+use Illuminate\Support\Facades\Http;
+use Throwable;
+
+/**
+ * Metadata Client
+ *
+ * Performs the updater's small metadata GETs (release feeds, single-release
+ * lookups, SHA-256 sidecars, custom JSON endpoints) through a raw Guzzle
+ * client that bypasses Laravel's HTTP factory event dispatch.
+ *
+ * Laravel dispatches `Illuminate\Http\Client\Events\RequestSending` and
+ * `ResponseReceived` around every `Http::` request. Any userland listener on
+ * those events — Herd Pro's `HttpClientWatcher`, Telescope's HTTP client
+ * watcher, Debugbar, custom monitoring hooks — can block or corrupt the
+ * request lifecycle. When Herd's dump-server socket is stopped or wedged,
+ * the listener blocks for the full `max_execution_time` and the feed check
+ * dies at `phar://.../dump.phar/src/Herd.php:56` instead of the ~200ms it
+ * would take against the real endpoint (see #231). #224 shielded the
+ * download response body against the same class of interaction; this class
+ * extends the invariant to the feed / version / sidecar / JSON metadata
+ * requests, which have no operational value in an observer's timeline.
+ *
+ * Raw Guzzle does not dispatch Laravel's HTTP client events, so no watcher
+ * can inspect or block these requests.
+ *
+ * ### Testing
+ *
+ * Because production traffic bypasses the `Http::` facade, `Http::fake()` no
+ * longer intercepts these calls. For test convenience, {@see useHttpFacadeBridge}
+ * routes them back through `Http::` so existing `Http::fake()` and
+ * `Http::assertSent()` calls continue to work. Regression tests that need to
+ * exercise the raw path (to prove no `RequestSending` listener fires) inject
+ * a mock Guzzle client via {@see setClient}.
+ *
+ * @since 2.5.4
+ */
+final class MetadataClient
+{
+    /**
+     * Optional override that routes calls through a custom responder instead of
+     * the raw Guzzle client. Used by {@see useHttpFacadeBridge} to keep
+     * `Http::fake()` in play for existing tests.
+     *
+     * @var (Closure(string, array<string, string>, int): array{status: int, body: string})|null
+     *
+     * @since 2.5.4
+     */
+    private static ?Closure $responder = null;
+
+    /**
+     * Optional Guzzle client override injected by tests that need to exercise
+     * the raw-Guzzle path without hitting the network.
+     *
+     * @since 2.5.4
+     */
+    private static ?ClientInterface $client = null;
+
+    /**
+     * Perform a GET against the given URL and return the status + body.
+     *
+     * The call bypasses Laravel's HTTP client factory (and therefore its
+     * `RequestSending` / `ResponseReceived` event dispatch) unless a test
+     * bridge or client override is installed.
+     *
+     * @since 2.5.4
+     *
+     * @param  string                 $url             Absolute URL to fetch.
+     * @param  array<string, string>  $headers         Request headers.
+     * @param  int|null               $timeoutSeconds  Per-request timeout. Falls back to
+     *                                                 `cms.updates.http_timeout` (15s).
+     * @param  int                    $retries         Additional retry attempts on transport
+     *                                                 error or 5xx response. Zero means one
+     *                                                 attempt total.
+     *
+     * @throws UpdateException When every attempt fails at the transport layer.
+     *
+     * @return array{status: int, body: string} Response status and raw body.
+     */
+    public static function get(
+        string $url,
+        array $headers = [],
+        ?int $timeoutSeconds = null,
+        int $retries = 0,
+    ): array {
+        $timeout = $timeoutSeconds ?? (int) config( 'cms.updates.http_timeout', 15 );
+
+        if ( null !== self::$responder ) {
+            return ( self::$responder )( $url, $headers, $timeout );
+        }
+
+        $attempts  = max( 1, $retries + 1 );
+        $lastError = null;
+        $last      = null;
+
+        for ( $attempt = 0; $attempt < $attempts; $attempt++ ) {
+            try {
+                $response = self::client()->request( 'GET', $url, [
+                    'headers'         => $headers,
+                    'timeout'         => $timeout,
+                    'connect_timeout' => $timeout,
+                    'http_errors'     => false,
+                ] );
+
+                $last = [
+                    'status' => $response->getStatusCode(),
+                    'body'   => (string) $response->getBody(),
+                ];
+
+                // Retry on 5xx (matches Laravel's `Http::retry()` default), return everything else.
+                if ( $last['status'] < 500 ) {
+                    return $last;
+                }
+            } catch ( Throwable $e ) {
+                $lastError = $e;
+            }
+        }
+
+        if ( null !== $last ) {
+            return $last;
+        }
+
+        throw UpdateException::versionCheckFailed(
+            'HTTP request failed: ' . ( $lastError?->getMessage() ?? 'unknown transport error' ),
+        );
+    }
+
+    /**
+     * Route future calls through Laravel's `Http::` facade so `Http::fake()`
+     * continues to intercept them in tests.
+     *
+     * Production callers must never invoke this — it re-enables the exact
+     * event dispatch this class exists to bypass.
+     *
+     * @since 2.5.4
+     */
+    public static function useHttpFacadeBridge(): void
+    {
+        self::$responder = static function ( string $url, array $headers, int $timeout ): array {
+            $response = Http::withHeaders( $headers )
+                ->timeout( $timeout )
+                ->get( $url );
+
+            return [
+                'status' => $response->status(),
+                'body'   => $response->body(),
+            ];
+        };
+    }
+
+    /**
+     * Inject a Guzzle client (typically backed by `MockHandler`) so tests can
+     * exercise the raw-Guzzle path without hitting the network.
+     *
+     * @since 2.5.4
+     */
+    public static function setClient( ?ClientInterface $client ): void
+    {
+        self::$client = $client;
+    }
+
+    /**
+     * Clear any bridge or injected client. Tests should call this in tearDown.
+     *
+     * @since 2.5.4
+     */
+    public static function reset(): void
+    {
+        self::$responder = null;
+        self::$client    = null;
+    }
+
+    /**
+     * Resolve the Guzzle client to use for the next request.
+     *
+     * @since 2.5.4
+     */
+    private static function client(): ClientInterface
+    {
+        return self::$client ?? new Client();
+    }
+}

--- a/tests/Unit/Updates/CustomJsonUpdateSourceTest.php
+++ b/tests/Unit/Updates/CustomJsonUpdateSourceTest.php
@@ -6,7 +6,13 @@ namespace ArtisanPackUI\CMSFramework\Tests\Unit\Updates;
 
 use ArtisanPackUI\CMSFramework\Modules\Core\Updates\Exceptions\UpdateException;
 use ArtisanPackUI\CMSFramework\Modules\Core\Updates\Sources\CustomJsonUpdateSource;
+use ArtisanPackUI\CMSFramework\Modules\Core\Updates\Support\MetadataClient;
 use ArtisanPackUI\CMSFramework\Modules\Core\Updates\ValueObjects\UpdateInfo;
+use GuzzleHttp\Client as GuzzleClient;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Response as GuzzleResponse;
+use Illuminate\Http\Client\Events\RequestSending;
 use Illuminate\Http\Client\Events\ResponseReceived;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Http;
@@ -19,6 +25,26 @@ use Orchestra\Testbench\TestCase;
  */
 class CustomJsonUpdateSourceTest extends TestCase
 {
+    /**
+     * @since 2.5.4
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        MetadataClient::useHttpFacadeBridge();
+    }
+
+    /**
+     * @since 2.5.4
+     */
+    protected function tearDown(): void
+    {
+        MetadataClient::reset();
+
+        parent::tearDown();
+    }
+
     /**
      * Test custom JSON source supports all URLs (fallback source).
      *
@@ -376,6 +402,49 @@ class CustomJsonUpdateSourceTest extends TestCase
         } finally {
             @unlink( $tempPath );
         }
+    }
+
+    /**
+     * Regression for #231: the JSON feed GET must bypass Laravel's HTTP client
+     * factory so no `RequestSending` / `ResponseReceived` listener (Herd Pro's
+     * `HttpClientWatcher`, Telescope, Debugbar, custom monitoring) can block
+     * or corrupt the request lifecycle.
+     *
+     * @since 2.5.4
+     */
+    public function test_feed_check_bypasses_laravel_http_client_events(): void
+    {
+        MetadataClient::reset();
+
+        $mock = new MockHandler( [
+            new GuzzleResponse( 200, [], json_encode( [
+                'version'      => '2.0.0',
+                'download_url' => 'https://example.com/releases/cms-2.0.0.zip',
+            ] ) ),
+        ] );
+        MetadataClient::setClient( new GuzzleClient( [ 'handler' => HandlerStack::create( $mock ) ] ) );
+
+        $requestSendingFired   = false;
+        $responseReceivedFired = false;
+        Event::listen( RequestSending::class, function () use ( &$requestSendingFired ): void {
+            $requestSendingFired = true;
+        } );
+        Event::listen( ResponseReceived::class, function () use ( &$responseReceivedFired ): void {
+            $responseReceivedFired = true;
+        } );
+
+        $source     = new CustomJsonUpdateSource( 'https://example.com/updates.json', '1.0.0' );
+        $updateInfo = $source->checkForUpdate();
+
+        $this->assertSame( '2.0.0', $updateInfo->latestVersion );
+        $this->assertFalse(
+            $requestSendingFired,
+            'RequestSending must not fire for the feed check — any userland listener would block the request lifecycle (see #231).',
+        );
+        $this->assertFalse(
+            $responseReceivedFired,
+            'ResponseReceived must not fire for the feed check — any userland listener would block the request lifecycle (see #231).',
+        );
     }
 
     /**

--- a/tests/Unit/Updates/GitHubUpdateSourceTest.php
+++ b/tests/Unit/Updates/GitHubUpdateSourceTest.php
@@ -6,7 +6,13 @@ namespace ArtisanPackUI\CMSFramework\Tests\Unit\Updates;
 
 use ArtisanPackUI\CMSFramework\Modules\Core\Updates\Exceptions\UpdateException;
 use ArtisanPackUI\CMSFramework\Modules\Core\Updates\Sources\GitHubUpdateSource;
+use ArtisanPackUI\CMSFramework\Modules\Core\Updates\Support\MetadataClient;
 use ArtisanPackUI\CMSFramework\Modules\Core\Updates\ValueObjects\UpdateInfo;
+use GuzzleHttp\Client as GuzzleClient;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Response as GuzzleResponse;
+use Illuminate\Http\Client\Events\RequestSending;
 use Illuminate\Http\Client\Events\ResponseReceived;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Http;
@@ -20,6 +26,26 @@ use Orchestra\Testbench\TestCase;
  */
 class GitHubUpdateSourceTest extends TestCase
 {
+    /**
+     * @since 2.5.4
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        MetadataClient::useHttpFacadeBridge();
+    }
+
+    /**
+     * @since 2.5.4
+     */
+    protected function tearDown(): void
+    {
+        MetadataClient::reset();
+
+        parent::tearDown();
+    }
+
     /**
      * Test GitHub source supports GitHub URLs.
      *
@@ -412,6 +438,58 @@ class GitHubUpdateSourceTest extends TestCase
         } finally {
             @unlink( $tempPath );
         }
+    }
+
+    /**
+     * Regression for #231: the feed-check GET must bypass Laravel's HTTP
+     * client factory so no `RequestSending` / `ResponseReceived` listener
+     * (Herd Pro's `HttpClientWatcher`, Telescope, Debugbar, custom monitoring)
+     * can block or corrupt the request lifecycle.
+     *
+     * @since 2.5.4
+     */
+    public function test_feed_check_bypasses_laravel_http_client_events(): void
+    {
+        MetadataClient::reset();
+
+        $mock = new MockHandler( [
+            new GuzzleResponse( 200, [], json_encode( [
+                [
+                    'tag_name'     => 'v2.0.0',
+                    'name'         => 'v2.0.0',
+                    'body'         => 'Release',
+                    'html_url'     => 'https://github.com/user/repo/releases/tag/v2.0.0',
+                    'id'           => 1,
+                    'prerelease'   => false,
+                    'published_at' => '2024-12-15T10:00:00Z',
+                    'assets'       => [],
+                    'zipball_url'  => 'https://api.github.com/repos/user/repo/zipball/v2.0.0',
+                ],
+            ] ) ),
+        ] );
+        MetadataClient::setClient( new GuzzleClient( [ 'handler' => HandlerStack::create( $mock ) ] ) );
+
+        $requestSendingFired   = false;
+        $responseReceivedFired = false;
+        Event::listen( RequestSending::class, function () use ( &$requestSendingFired ): void {
+            $requestSendingFired = true;
+        } );
+        Event::listen( ResponseReceived::class, function () use ( &$responseReceivedFired ): void {
+            $responseReceivedFired = true;
+        } );
+
+        $source     = new GitHubUpdateSource( 'https://github.com/user/repo', '1.0.0' );
+        $updateInfo = $source->checkForUpdate();
+
+        $this->assertSame( '2.0.0', $updateInfo->latestVersion );
+        $this->assertFalse(
+            $requestSendingFired,
+            'RequestSending must not fire for the feed check — any userland listener would block the request lifecycle (see #231).',
+        );
+        $this->assertFalse(
+            $responseReceivedFired,
+            'ResponseReceived must not fire for the feed check — any userland listener would block the request lifecycle (see #231).',
+        );
     }
 
     /**

--- a/tests/Unit/Updates/GitLabUpdateSourceTest.php
+++ b/tests/Unit/Updates/GitLabUpdateSourceTest.php
@@ -6,7 +6,13 @@ namespace ArtisanPackUI\CMSFramework\Tests\Unit\Updates;
 
 use ArtisanPackUI\CMSFramework\Modules\Core\Updates\Exceptions\UpdateException;
 use ArtisanPackUI\CMSFramework\Modules\Core\Updates\Sources\GitLabUpdateSource;
+use ArtisanPackUI\CMSFramework\Modules\Core\Updates\Support\MetadataClient;
 use ArtisanPackUI\CMSFramework\Modules\Core\Updates\ValueObjects\UpdateInfo;
+use GuzzleHttp\Client as GuzzleClient;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Response as GuzzleResponse;
+use Illuminate\Http\Client\Events\RequestSending;
 use Illuminate\Http\Client\Events\ResponseReceived;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Http;
@@ -21,6 +27,30 @@ use Orchestra\Testbench\TestCase;
  */
 class GitLabUpdateSourceTest extends TestCase
 {
+    /**
+     * @since 2.5.4
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Route MetadataClient calls through `Http::` so existing `Http::fake()`
+        // stubs continue to intercept feed / sidecar / version requests. The
+        // dedicated regression tests above reset this bridge to exercise the
+        // raw-Guzzle path directly.
+        MetadataClient::useHttpFacadeBridge();
+    }
+
+    /**
+     * @since 2.5.4
+     */
+    protected function tearDown(): void
+    {
+        MetadataClient::reset();
+
+        parent::tearDown();
+    }
+
     /**
      * Test GitLab source supports GitLab URLs.
      *
@@ -964,6 +994,115 @@ class GitLabUpdateSourceTest extends TestCase
         } finally {
             @unlink( $tempPath );
         }
+    }
+
+    /**
+     * Regression for #231: the feed-check GET must bypass Laravel's HTTP
+     * client factory so no `RequestSending` / `ResponseReceived` listener
+     * (Herd Pro's `HttpClientWatcher`, Telescope, Debugbar, custom monitoring)
+     * can block or corrupt the request lifecycle. The feed call is routed
+     * through a raw Guzzle client rather than `Http::`, so no Laravel HTTP
+     * client event fires for the metadata request.
+     *
+     * @since 2.5.4
+     */
+    public function test_feed_check_bypasses_laravel_http_client_events(): void
+    {
+        // Reset the bridge installed in setUp so this test exercises the raw
+        // Guzzle path, then inject a mock Guzzle client so no real network
+        // traffic is issued.
+        MetadataClient::reset();
+
+        $mock = new MockHandler( [
+            new GuzzleResponse( 200, [], json_encode( [
+                [
+                    'tag_name'    => 'v2.0.0',
+                    'description' => 'Release',
+                    'created_at'  => '2024-12-15T10:00:00.000Z',
+                ],
+            ] ) ),
+        ] );
+        MetadataClient::setClient( new GuzzleClient( [ 'handler' => HandlerStack::create( $mock ) ] ) );
+
+        $requestSendingFired   = false;
+        $responseReceivedFired = false;
+        Event::listen( RequestSending::class, function () use ( &$requestSendingFired ): void {
+            $requestSendingFired = true;
+        } );
+        Event::listen( ResponseReceived::class, function () use ( &$responseReceivedFired ): void {
+            $responseReceivedFired = true;
+        } );
+
+        $source     = new GitLabUpdateSource( 'https://gitlab.com/user/repo', '1.0.0' );
+        $updateInfo = $source->checkForUpdate();
+
+        $this->assertSame( '2.0.0', $updateInfo->latestVersion );
+        $this->assertFalse(
+            $requestSendingFired,
+            'RequestSending must not fire for the feed check — any userland listener would block the request lifecycle (see #231).',
+        );
+        $this->assertFalse(
+            $responseReceivedFired,
+            'ResponseReceived must not fire for the feed check — any userland listener would block the request lifecycle (see #231).',
+        );
+    }
+
+    /**
+     * Regression for #231: the SHA-256 sidecar GET must bypass Laravel's HTTP
+     * client factory for the same reason as the feed check.
+     *
+     * @since 2.5.4
+     */
+    public function test_sidecar_fetch_bypasses_laravel_http_client_events(): void
+    {
+        // Sidecars only apply to release-asset downloads.
+        config()->set( 'cms.updates.gitlab_update_strategy', 'release_asset' );
+
+        MetadataClient::reset();
+
+        $expectedHash = str_repeat( 'a', 64 );
+
+        $mock = new MockHandler( [
+            new GuzzleResponse( 200, [], json_encode( [
+                [
+                    'tag_name'    => 'v2.0.0',
+                    'description' => 'Release notes',
+                    'created_at'  => '2024-12-15T10:00:00.000Z',
+                    'assets'      => [
+                        'links' => [
+                            [
+                                'name' => 'source.zip',
+                                'url'  => 'https://example.com/releases/v2.0.0/source.zip',
+                            ],
+                            [
+                                'name' => 'source.zip.sha256',
+                                'url'  => 'https://example.com/releases/v2.0.0/source.zip.sha256',
+                            ],
+                        ],
+                    ],
+                ],
+            ] ) ),
+            new GuzzleResponse( 200, [], $expectedHash . "  source.zip\n" ),
+        ] );
+        MetadataClient::setClient( new GuzzleClient( [ 'handler' => HandlerStack::create( $mock ) ] ) );
+
+        $eventsFired = 0;
+        Event::listen( RequestSending::class, function () use ( &$eventsFired ): void {
+            $eventsFired++;
+        } );
+        Event::listen( ResponseReceived::class, function () use ( &$eventsFired ): void {
+            $eventsFired++;
+        } );
+
+        $source     = new GitLabUpdateSource( 'https://gitlab.com/user/repo', '1.0.0' );
+        $updateInfo = $source->checkForUpdate();
+
+        $this->assertSame( $expectedHash, $updateInfo->sha256 );
+        $this->assertSame(
+            0,
+            $eventsFired,
+            'Sidecar fetch must not go through Laravel HTTP client events (see #231).',
+        );
     }
 
     /**


### PR DESCRIPTION
## Description

The feed check, single-release lookup, SHA-256 sidecar fetch, and custom JSON endpoint all went through Laravel's `Http` facade, which dispatches `RequestSending` and `ResponseReceived` around every request. Any userland listener on those events — Herd Pro's `HttpClientWatcher`, Telescope, Debugbar, custom monitoring — can block or corrupt the request lifecycle. When Herd's dump-server socket is stopped or wedged, the check dies after `max_execution_time` at `phar://.../dump.phar/src/Herd.php:56` instead of the ~200ms round-trip to the endpoint.

#224 shielded the download response body against the same class of interaction; this change extends the invariant to the metadata requests by routing them through a new `MetadataClient` static helper that uses a raw `GuzzleHttp\Client`, bypassing Laravel's HTTP factory event dispatch entirely. The download path still uses `Http::sink()` (already shielded by #224).

**Closes:** #231

## Type of Change

- [x] Bug fix (fixes an issue)

## Related Issue

**Issue:** #231

## Motivation and Context

On any Laravel Herd Pro host (or any host with Telescope / Debugbar / a custom `RequestSending` listener), `/admin/settings/updates` was rendering `Maximum execution time of 30 seconds exceeded` on every page load because the listener blocked on a dead socket for the full `max_execution_time`. Timeouts on `Http::timeout(10)` never fired because the block was inside the *listener*, not inside the outbound cURL call. Click-to-update also timed out mid-pipeline, potentially rolling back a successfully-applied update.

## Changes Made

- New `MetadataClient` helper (`src/Modules/Core/Updates/Support/MetadataClient.php`) that performs metadata GETs via raw Guzzle, bypassing Laravel's HTTP factory event dispatch. Preserves `Http::retry`-style 5xx retry semantics for the custom JSON endpoint.
- Routed `GitLabUpdateSource::fetchReleases()`, `getReleaseByVersion()`, and `fetchSidecarHash()` through `MetadataClient`.
- Routed `GitHubUpdateSource::fetchReleases()` and `getReleaseByVersion()` through `MetadataClient`.
- Routed `CustomJsonUpdateSource::fetchJson()` through `MetadataClient`, preserving the config-driven retry count.
- The download response body is unchanged — it stays on `Http::sink()` behind the `StreamsDownloadsToDisk` trait already shielded by #224.

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS 15+
- PHP Version: 8.4.23
- Project Version: cms-framework 2.5.4

**Tests Performed:**
1. Full `pest` suite (1420 tests, 3573 assertions) — all passing.
2. Updates-specific suites (`tests/Unit/Updates/` + `tests/Feature/Updates/`) — 120 tests, 264 assertions.
3. Three new regression tests (one per source) install real `RequestSending` / `ResponseReceived` listeners via `Event::listen`, inject a mock Guzzle client, and assert the listeners **never fire** during `checkForUpdate()`.

## Accessibility Tests Run

- [x] Not applicable — backend-only change; no UI surface.

## Tests Added

- [x] Unit tests added
- [x] All tests passing

**Test details:**

- `GitLabUpdateSourceTest::test_feed_check_bypasses_laravel_http_client_events` — asserts neither `RequestSending` nor `ResponseReceived` fires for the feed GET.
- `GitLabUpdateSourceTest::test_sidecar_fetch_bypasses_laravel_http_client_events` — same guarantee for the SHA-256 sidecar GET.
- `GitHubUpdateSourceTest::test_feed_check_bypasses_laravel_http_client_events` — same guarantee for the GitHub feed.
- `CustomJsonUpdateSourceTest::test_feed_check_bypasses_laravel_http_client_events` — same guarantee for the custom JSON endpoint.

Existing tests keep using `Http::fake()` via a `MetadataClient::useHttpFacadeBridge()` helper installed in each test class's `setUp`, so no test bodies had to change.

## Documentation

- [x] Inline code documentation added

**Documentation details:**

`MetadataClient` carries a full class-level docblock explaining the bypass, why it exists (linking #231 and #224), and the two test hooks (`useHttpFacadeBridge`, `setClient`).

## Pre-Submission Checklist

- [x] Code passes all tests
- [x] Code follows project style guide
- [x] Self-review completed
- [x] Inline documentation for the new helper class

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved update checks for custom JSON, GitHub, and GitLab sources.
  - Added more reliable handling of temporary server errors and connection failures.
  - Improved support for version tags with and without the `v` prefix.
  - GitLab checksum retrieval now reports failures more clearly.

- **Reliability**
  - Update metadata requests now use consistent timeout and retry handling, reducing failed or incomplete update checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->