### PR TITLE
fix: honor COMPOSER_BINARY from Laravel .env in HTTP-request context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`cms.updates.composer_binary` config key** ([#232](https://github.com/ArtisanPack-UI/cms-framework/issues/232)) — priority-1 override for the self-updater's composer binary path, populated by default from `env('COMPOSER_BINARY')`. Setting `COMPOSER_BINARY=/opt/homebrew/bin/composer` in a Laravel `.env` file now works from HTTP-request context, matching the advice the `composerBinaryNotFound` error message gives.
+
 ### Changed
 
 ### Deprecated
@@ -16,6 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 ### Fixed
+
+- **`COMPOSER_BINARY` in `.env` didn't take effect under PHP-FPM** ([#232](https://github.com/ArtisanPack-UI/cms-framework/issues/232)) — `ApplicationUpdateManager::envComposerBinary()` read via `getenv('COMPOSER_BINARY')`, but Laravel 11+'s default dotenv adapter populates `env()`/`$_ENV` without calling `putenv()`, so `getenv()` returned `false` from HTTP-request context and the priority-1 override was silently skipped. `envComposerBinary()` now reads `cms.updates.composer_binary` (populated from `env('COMPOSER_BINARY')` in the shipped config) first, then falls back to `getenv()` for hosts that export `COMPOSER_BINARY` at the OS level. The `composerBinaryNotFound` error message now names both the `.env`/config path and the OS-level path so operators aren't sent down a broken workaround.
 
 ### Security
 

--- a/src/Modules/Core/Updates/Exceptions/UpdateException.php
+++ b/src/Modules/Core/Updates/Exceptions/UpdateException.php
@@ -117,7 +117,9 @@ class UpdateException extends CMSFrameworkException
         $paths   = empty( $searchedPaths ) ? '(none)' : implode( ', ', $searchedPaths );
         $message = 'Composer binary could not be located on the host. '
             . "Searched: {$paths}. "
-            . 'Set the COMPOSER_BINARY environment variable or override '
+            . 'Set `COMPOSER_BINARY` in your Laravel `.env` file (populates '
+            . '`cms.updates.composer_binary`) or export it at the OS level '
+            . '(PHP-FPM pool env, shell before starting FPM), or override '
             . '`cms.updates.composer_install_command` with an absolute path to composer.';
 
         return new self( $message );
@@ -228,7 +230,7 @@ class UpdateException extends CMSFrameworkException
      *
      * @since 1.0.0
      */
-    public static function incompatibleFrameworkVersion( string $required, string $current): self
+    public static function incompatibleFrameworkVersion( string $required, string $current ): self
     {
         return new self( "Update requires cms-framework {$required}, but you have {$current}");
     }

--- a/src/Modules/Core/Updates/Managers/ApplicationUpdateManager.php
+++ b/src/Modules/Core/Updates/Managers/ApplicationUpdateManager.php
@@ -694,14 +694,23 @@ class ApplicationUpdateManager
 
     /**
      * Absolute path from the `COMPOSER_BINARY` environment variable, or `null`
-     * when not set.
+     * when not set. Reads `cms.updates.composer_binary` first — which is
+     * populated from `env('COMPOSER_BINARY')` in the shipped config and
+     * therefore sees values placed in the Laravel `.env` file under both CLI
+     * and HTTP-request contexts — then falls back to `getenv()` for hosts that
+     * export `COMPOSER_BINARY` at the OS level (PHP-FPM pool env, shell before
+     * starting FPM, container ENV, etc.).
      *
      * @since 2.5.3
      */
     protected function envComposerBinary(): ?string
     {
-        $envBinary = getenv( 'COMPOSER_BINARY' );
+        $configured = config( 'cms.updates.composer_binary' );
+        if ( is_string( $configured ) && '' !== $configured ) {
+            return $configured;
+        }
 
+        $envBinary = getenv( 'COMPOSER_BINARY' );
         if ( false === $envBinary || '' === $envBinary ) {
             return null;
         }
@@ -946,12 +955,12 @@ class ApplicationUpdateManager
             'trace'     => $exception->getTraceAsString(),
             'file'      => $exception->getFile(),
             'line'      => $exception->getLine(),
-        ]);
+        ] );
 
         // Attempt to disable maintenance mode
         try {
             $this->disableMaintenanceMode();
-        } catch ( Throwable $e) {
+        } catch ( Throwable $e ) {
             \Illuminate\Support\Facades\Log::error(
                 'Failed to disable maintenance mode during update rollback; host may remain in maintenance mode.',
                 ['exception' => $e->getMessage()],
@@ -959,10 +968,10 @@ class ApplicationUpdateManager
         }
 
         // If we have a backup, attempt rollback
-        if ( $this->backupPath && File::exists( $this->backupPath)) {
+        if ( $this->backupPath && File::exists( $this->backupPath ) ) {
             try {
-                $this->rollback( $this->backupPath);
-            } catch ( Throwable $e) {
+                $this->rollback( $this->backupPath );
+            } catch ( Throwable $e ) {
                 // Rollback failed - this is critical. Preserve the original
                 // update-failure message alongside the rollback message so the
                 // operator can see both failures rather than only the trailing

--- a/src/Modules/Core/Updates/config/updates.php
+++ b/src/Modules/Core/Updates/config/updates.php
@@ -54,7 +54,9 @@ return [
     | 1. `COMPOSER_BINARY` environment variable — set this to an absolute path
     |    if you know where composer lives (e.g. `/opt/homebrew/bin/composer`)
     |    and want the framework to build the command as `{CLI PHP} {binary}
-    |    install --no-dev --no-interaction --optimize-autoloader`.
+    |    install --no-dev --no-interaction --optimize-autoloader`. Set it in
+    |    your Laravel `.env` (populated via `composer_binary` below) or as an
+    |    OS-level env var visible to `getenv()` in the PHP-FPM pool.
     | 2. A non-default value for this config key — set this to a bespoke shell
     |    string if you need full control (custom flags, prepended PATH, etc.).
     | 3. Auto-discovery across common install paths (`/usr/local/bin/composer`,
@@ -70,6 +72,25 @@ return [
     |
     */
     'composer_install_command' => 'composer install --no-dev --no-interaction --optimize-autoloader',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Composer Binary Path (priority-1 override)
+    |--------------------------------------------------------------------------
+    |
+    | Absolute path to the composer binary the self-updater should invoke,
+    | resolved via Laravel's `env()` so setting `COMPOSER_BINARY` in your
+    | `.env` file works — which is the natural first move for a Laravel
+    | operator and what the `composerBinaryNotFound` error message advertises.
+    |
+    | Laravel 11+'s default dotenv adapter populates `env()` and `$_ENV` but
+    | does not `putenv()`, so `getenv('COMPOSER_BINARY')` returns `false` from
+    | HTTP-request context under PHP-FPM even when `.env` has the value. This
+    | config key bridges the gap: the framework reads this key first, then
+    | falls back to `getenv()` for hosts that set the value at the OS level.
+    |
+    */
+    'composer_binary' => env( 'COMPOSER_BINARY' ),
 
     'composer_timeout' => 600, // 10 minutes
 

--- a/tests/Unit/Updates/ApplicationUpdateManagerTest.php
+++ b/tests/Unit/Updates/ApplicationUpdateManagerTest.php
@@ -426,6 +426,107 @@ class ApplicationUpdateManagerTest extends TestCase
     }
 
     /**
+     * Regression for #232: the shipped `cms.updates.composer_binary` config
+     * key (populated from `env('COMPOSER_BINARY')`) is honored as priority-1
+     * so operators who set `COMPOSER_BINARY` in Laravel `.env` — the natural
+     * first move — actually get picked up under HTTP-request context, where
+     * `getenv()` would otherwise return `false` under Laravel 11+.
+     *
+     * @since 2.5.4
+     */
+    public function test_resolve_composer_command_prefers_config_composer_binary(): void
+    {
+        config( [
+            'cms.updates.composer_install_command' => ApplicationUpdateManager::DEFAULT_COMPOSER_INSTALL_COMMAND,
+            'cms.updates.composer_binary'          => '/opt/homebrew/bin/composer',
+        ] );
+
+        $original = getenv( 'COMPOSER_BINARY' );
+        putenv( 'COMPOSER_BINARY' );
+
+        try {
+            $manager = new ApplicationUpdateManager;
+
+            $reflection = new ReflectionClass( $manager );
+            $method     = $reflection->getMethod( 'resolveComposerCommand' );
+            $method->setAccessible( true );
+
+            $command = $method->invoke( $manager );
+
+            $this->assertStringStartsWith( escapeshellarg( PHP_BINARY ) . ' ', $command );
+            $this->assertStringContainsString( escapeshellarg( '/opt/homebrew/bin/composer' ), $command );
+            $this->assertStringEndsWith( ' ' . ApplicationUpdateManager::DEFAULT_COMPOSER_INSTALL_ARGS, $command );
+        } finally {
+            putenv( false === $original ? 'COMPOSER_BINARY' : 'COMPOSER_BINARY=' . $original );
+        }
+    }
+
+    /**
+     * Regression for #232: `cms.updates.composer_binary` wins over
+     * `getenv('COMPOSER_BINARY')` when both are set — the `.env`-populated
+     * config value is the documented priority-1 source.
+     *
+     * @since 2.5.4
+     */
+    public function test_resolve_composer_command_config_binary_wins_over_getenv(): void
+    {
+        config( [
+            'cms.updates.composer_install_command' => ApplicationUpdateManager::DEFAULT_COMPOSER_INSTALL_COMMAND,
+            'cms.updates.composer_binary'          => '/from/config/composer',
+        ] );
+
+        $original = getenv( 'COMPOSER_BINARY' );
+        putenv( 'COMPOSER_BINARY=/from/getenv/composer' );
+
+        try {
+            $manager = new ApplicationUpdateManager;
+
+            $reflection = new ReflectionClass( $manager );
+            $method     = $reflection->getMethod( 'resolveComposerCommand' );
+            $method->setAccessible( true );
+
+            $command = $method->invoke( $manager );
+
+            $this->assertStringContainsString( escapeshellarg( '/from/config/composer' ), $command );
+            $this->assertStringNotContainsString( '/from/getenv/composer', $command );
+        } finally {
+            putenv( false === $original ? 'COMPOSER_BINARY' : 'COMPOSER_BINARY=' . $original );
+        }
+    }
+
+    /**
+     * Regression for #232: when the config key is unset (empty string, null),
+     * fall back to `getenv('COMPOSER_BINARY')` so OS-level exports (PHP-FPM
+     * pool env, container ENV) keep working exactly as before.
+     *
+     * @since 2.5.4
+     */
+    public function test_resolve_composer_command_falls_back_to_getenv_when_config_empty(): void
+    {
+        config( [
+            'cms.updates.composer_install_command' => ApplicationUpdateManager::DEFAULT_COMPOSER_INSTALL_COMMAND,
+            'cms.updates.composer_binary'          => null,
+        ] );
+
+        $original = getenv( 'COMPOSER_BINARY' );
+        putenv( 'COMPOSER_BINARY=/opt/homebrew/bin/composer' );
+
+        try {
+            $manager = new ApplicationUpdateManager;
+
+            $reflection = new ReflectionClass( $manager );
+            $method     = $reflection->getMethod( 'resolveComposerCommand' );
+            $method->setAccessible( true );
+
+            $command = $method->invoke( $manager );
+
+            $this->assertStringContainsString( escapeshellarg( '/opt/homebrew/bin/composer' ), $command );
+        } finally {
+            putenv( false === $original ? 'COMPOSER_BINARY' : 'COMPOSER_BINARY=' . $original );
+        }
+    }
+
+    /**
      * Regression for #225: when the config value differs from the shipped
      * default, treat it as an explicit operator override and leave it alone —
      * no PHP_BINARY wrapping, no shell escaping.
@@ -868,21 +969,21 @@ class ApplicationUpdateManagerTest extends TestCase
             return;
         }
 
-        foreach ( $items as $item) {
-            if ( '.' === $item || '..' === $item) {
+        foreach ( $items as $item ) {
+            if ( '.' === $item || '..' === $item ) {
                 continue;
             }
 
             $full = $path . DIRECTORY_SEPARATOR . $item;
 
-            if ( is_dir( $full)) {
-                $this->removeDirectory( $full);
+            if ( is_dir( $full ) ) {
+                $this->removeDirectory( $full );
             } else {
-                @unlink( $full);
+                @unlink( $full );
             }
         }
 
-        @rmdir( $path);
+        @rmdir( $path );
     }
 
     /**
@@ -892,15 +993,15 @@ class ApplicationUpdateManagerTest extends TestCase
      *
      * @param  \Illuminate\Foundation\Application  $app
      */
-    protected function defineEnvironment( $app): void
+    protected function defineEnvironment( $app ): void
     {
-        $app['config']->set( 'cms.updates.update_source_url', 'https://github.com/test/repo');
-        $app['config']->set( 'cms.updates.backup_enabled', true);
-        $app['config']->set( 'cms.updates.backup_path', 'backups/application');
-        $app['config']->set( 'cms.updates.backup_retention_days', 30);
-        $app['config']->set( 'cms.updates.verify_checksum', false); // Disable for tests
-        $app['config']->set( 'cms.updates.composer_install_command', 'composer install --no-dev');
-        $app['config']->set( 'cms.updates.composer_timeout', 600);
+        $app['config']->set( 'cms.updates.update_source_url', 'https://github.com/test/repo' );
+        $app['config']->set( 'cms.updates.backup_enabled', true );
+        $app['config']->set( 'cms.updates.backup_path', 'backups/application' );
+        $app['config']->set( 'cms.updates.backup_retention_days', 30 );
+        $app['config']->set( 'cms.updates.verify_checksum', false ); // Disable for tests
+        $app['config']->set( 'cms.updates.composer_install_command', 'composer install --no-dev' );
+        $app['config']->set( 'cms.updates.composer_timeout', 600 );
         $app['config']->set( 'cms.updates.exclude_from_update', ['.env', 'storage', 'vendor']);
     }
 }


### PR DESCRIPTION
## Description

`ApplicationUpdateManager::envComposerBinary()` read via `getenv('COMPOSER_BINARY')`, but Laravel 11+'s default dotenv adapter populates `env()`/`$_ENV` without calling `putenv()`, so `getenv()` returned `false` from HTTP-request context under PHP-FPM even when `.env` had the value. The `composerBinaryNotFound` diagnostic's own advice — "Set the COMPOSER_BINARY environment variable" — was therefore a broken lead for the exact operators who needed it (the natural first move for any Laravel operator is to add the value to `.env`).

Add a shipped `cms.updates.composer_binary` config key populated from `env('COMPOSER_BINARY')`. `envComposerBinary()` now reads config first (works from any context), then falls back to `getenv()` for hosts that export the value at the OS level (PHP-FPM pool env, shell before starting FPM, container ENV). Error message updated to name both paths explicitly.

**Closes:** #232

## Type of Change

- [x] Bug fix (fixes an issue)

## Related Issue

**Issue:** #232

## Motivation and Context

Operators hitting `composerBinaryNotFound` on Herd Pro / any PHP-FPM host followed the error's advice, added `COMPOSER_BINARY=/opt/homebrew/bin/composer` to `.env`, cleared config, retried — and got the same error, because `getenv()` and `env()` diverge under HTTP-request context in Laravel 11+. This bug turned the priority-1 escape hatch into a false lead. Fix restores the contract the error message advertises.

## Changes Made

- Add `cms.updates.composer_binary` config key populated from `env('COMPOSER_BINARY')` — the Laravel-native way to expose an env value under both CLI and HTTP contexts.
- `envComposerBinary()` reads config first (with `is_string() && '' !== $configured` type check), falls back to `getenv()` for OS-level exports (no BC break).
- `UpdateException::composerBinaryNotFound()` now names both the `.env`/config path and the OS-level path so operators aren't sent down a broken workaround.
- 3 regression tests: config wins as priority-1; config beats `getenv()` when both are set; empty config falls back to `getenv()`.
- CHANGELOG entries under Unreleased (Added + Fixed).

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS (Laravel Herd)
- Browser (if applicable): n/a
- PHP Version: 8.4
- Project Version: cms-framework 2.5.4-dev

**Tests Performed:**
1. `./vendor/bin/pest tests/Unit/Updates/ApplicationUpdateManagerTest.php --filter=composer` — 11/11 passing (8 pre-existing + 3 new regression tests)
2. `./vendor/bin/pest tests/Unit/Updates/ tests/Feature/Updates/` — 123/123 passing
3. Manual verification on trial site: added `COMPOSER_BINARY=/opt/homebrew/bin/composer` to `.env`, ran `php artisan config:clear`, confirmed self-updater now picks up the value from HTTP-request context.

## Accessibility Tests Run

n/a — backend/config change with no UI surface.

- [ ] Keyboard navigation tested
- [ ] Screen reader tested
- [ ] Color contrast verified
- [ ] ARIA labels checked

## Tests Added

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] All tests passing

**Test details:** 3 new tests in `ApplicationUpdateManagerTest.php` locking in the config → getenv priority chain: `test_resolve_composer_command_prefers_config_composer_binary`, `test_resolve_composer_command_config_binary_wins_over_getenv`, `test_resolve_composer_command_falls_back_to_getenv_when_config_empty`.

## Documentation

- [x] Inline code documentation added
- [ ] README updated
- [ ] Wiki updated
- [ ] API documentation updated

**Documentation details:** Docblock on `envComposerBinary()` explains the config-first / getenv-fallback rationale. Config file comment on `composer_install_command` updated to describe the two env sources. `composer_binary` config key ships with its own comment block explaining the Laravel 11+ dotenv behavior gap.

## Pre-Submission Checklist

- [x] Followed contributing guidelines
- [x] Checked for other open PRs for same update
- [x] Code passes all tests
- [x] Code has been linted
- [x] Accessibility tests completed (n/a — backend)
- [x] Code follows project style guide
- [x] Self-review completed
- [x] Comments added for complex code
- [x] No new warnings generated