### PR TITLE
fix: surface per-candidate stat results when composer discovery fails

### DIFF
--- a/src/Modules/Core/Updates/Exceptions/UpdateException.php
+++ b/src/Modules/Core/Updates/Exceptions/UpdateException.php
@@ -108,15 +108,58 @@ class UpdateException extends CMSFrameworkException
     /**
      * Composer binary could not be located on the host.
      *
+     * Accepts either a flat list of searched paths (legacy 2.5.3 signature)
+     * or a list of per-candidate diagnostic results shaped as
+     * `['path' => string, 'is_file' => bool, 'is_executable' => bool]`. When
+     * diagnostic results are supplied, the rendered message surfaces the
+     * `is_file()` / `is_executable()` outcome for each path so operators can
+     * distinguish a wrong-path failure from a PHP-FPM sandboxed-stat failure
+     * (macOS Herd Pro, chrooted FPM pools, restrictive `open_basedir`).
+     *
      * @since 2.5.3
      *
-     * @param  array<int, string>  $searchedPaths  Absolute paths inspected during discovery.
+     * @param  array<int, array{path: string, is_file: bool, is_executable: bool}>|array<int, string>  $searched
+     *         Either legacy string paths, or per-candidate diagnostic entries.
      */
-    public static function composerBinaryNotFound( array $searchedPaths ): self
+    public static function composerBinaryNotFound( array $searched ): self
     {
-        $paths   = empty( $searchedPaths ) ? '(none)' : implode( ', ', $searchedPaths );
+        if ( empty( $searched ) ) {
+            $rendered = '(none)';
+        } else {
+            $allDiagnostic = true;
+            foreach ( $searched as $entry ) {
+                if ( ! is_array( $entry ) ) {
+                    $allDiagnostic = false;
+                    break;
+                }
+            }
+
+            if ( $allDiagnostic ) {
+                $rendered = implode( ', ', array_map(
+                    static function ( array $entry ): string {
+                        $path = $entry['path'] ?? '(unknown)';
+                        $file = ( $entry['is_file'] ?? false ) ? 'true' : 'false';
+                        $exec = ( $entry['is_file'] ?? false )
+                            ? ( ( $entry['is_executable'] ?? false ) ? 'true' : 'false' )
+                            : 'n/a';
+
+                        return "{$path} (is_file={$file}, is_executable={$exec})";
+                    },
+                    $searched,
+                ) );
+            } else {
+                $rendered = implode( ', ', array_map(
+                    static fn ( $entry ): string => is_array( $entry ) ? (string) ( $entry['path'] ?? '(unknown)' ) : (string) $entry,
+                    $searched,
+                ) );
+            }
+        }
+
         $message = 'Composer binary could not be located on the host. '
-            . "Searched: {$paths}. "
+            . "Searched: {$rendered}. "
+            . 'If `is_file` reports `false` for a path that exists at the OS level, the PHP process '
+            . 'likely cannot stat it (macOS Herd Pro sandboxes `/opt/homebrew/*` from PHP-FPM; chrooted '
+            . 'FPM pools and restrictive `open_basedir` behave the same way). '
             . 'Set `COMPOSER_BINARY` in your Laravel `.env` file (populates '
             . '`cms.updates.composer_binary`) or export it at the OS level '
             . '(PHP-FPM pool env, shell before starting FPM), or override '

--- a/src/Modules/Core/Updates/Managers/ApplicationUpdateManager.php
+++ b/src/Modules/Core/Updates/Managers/ApplicationUpdateManager.php
@@ -722,15 +722,42 @@ class ApplicationUpdateManager
      * Locate a composer binary on disk by walking a curated list of common
      * install paths. Returns the first executable hit or `null`.
      *
+     * When discovery finds nothing, emits a structured `Log::warning` with
+     * per-candidate `is_file()` / `is_executable()` results so operators can
+     * distinguish "the path was wrong" from "PHP-FPM sandboxing hid a path
+     * that exists at the OS level" (common on macOS Herd Pro, chrooted FPM
+     * pools, and containers with restrictive `open_basedir`) without having
+     * to reflect into the framework or diff their environment.
+     *
      * @since 2.5.3
      */
     protected function discoverComposerBinary(): ?string
     {
+        $results = [];
+
         foreach ( $this->composerCandidatePaths() as $path ) {
-            if ( is_file( $path ) && is_executable( $path ) ) {
+            $isFile       = is_file( $path );
+            $isExecutable = $isFile ? is_executable( $path ) : false;
+
+            $results[] = [
+                'path'          => $path,
+                'is_file'       => $isFile,
+                'is_executable' => $isExecutable,
+            ];
+
+            if ( $isFile && $isExecutable ) {
                 return $path;
             }
         }
+
+        \Illuminate\Support\Facades\Log::warning(
+            'cms-framework: composer binary discovery failed; no candidate path was both a file and executable in the current PHP process context.',
+            [
+                'candidates' => $results,
+                'php_sapi'   => PHP_SAPI,
+                'hint'       => 'If a candidate exists at the OS level but reports is_file=false here, the PHP process likely cannot stat it (macOS Herd Pro sandbox, chrooted FPM pool, restrictive open_basedir). Set COMPOSER_BINARY in .env or override cms.updates.composer_install_command with an absolute path.',
+            ],
+        );
 
         return null;
     }

--- a/tests/Unit/Updates/ApplicationUpdateManagerTest.php
+++ b/tests/Unit/Updates/ApplicationUpdateManagerTest.php
@@ -703,12 +703,83 @@ class ApplicationUpdateManagerTest extends TestCase
                 }
             };
 
+            Log::shouldReceive( 'warning' )->never();
+
             $this->assertSame( $executableHit, $manager->callDiscover() );
         } finally {
             @unlink( $missing );
             @unlink( $nonExecutable );
             @unlink( $executableHit );
             @unlink( $laterCandidate );
+            @rmdir( $tempDir );
+        }
+    }
+
+    /**
+     * Regression for #233: when discovery finds nothing, emit a structured
+     * `Log::warning` that reports per-candidate `is_file()` / `is_executable()`
+     * results so operators can distinguish a wrong-path failure from a
+     * PHP-FPM sandboxed-stat failure (macOS Herd Pro, chrooted FPM pools,
+     * restrictive `open_basedir`) without having to reflect into the
+     * framework.
+     *
+     * @since 2.5.4
+     */
+    public function test_discover_composer_binary_logs_per_candidate_diagnostics_on_failure(): void
+    {
+        $tempDir = sys_get_temp_dir() . '/cmsfw-composer-diag-' . bin2hex( random_bytes( 6 ) );
+        mkdir( $tempDir, 0755, true );
+
+        $missing       = $tempDir . '/missing-composer';
+        $nonExecutable = $tempDir . '/non-executable-composer';
+
+        file_put_contents( $nonExecutable, "#!/bin/sh\n" );
+        chmod( $nonExecutable, 0644 );
+
+        $manager = new class( [$missing, $nonExecutable] ) extends ApplicationUpdateManager {
+            public function __construct( protected array $paths )
+            {
+            }
+
+            protected function composerCandidatePaths(): array
+            {
+                return $this->paths;
+            }
+
+            public function callDiscover(): ?string
+            {
+                return $this->discoverComposerBinary();
+            }
+        };
+
+        $captured = [];
+        Log::shouldReceive( 'warning' )
+            ->once()
+            ->andReturnUsing( function ( string $message, array $context ) use ( &$captured ): void {
+                $captured = [
+                    'message' => $message,
+                    'context' => $context,
+                ];
+            } );
+
+        try {
+            $this->assertNull( $manager->callDiscover() );
+
+            $this->assertStringContainsString( 'composer binary discovery failed', $captured['message'] );
+            $this->assertArrayHasKey( 'candidates', $captured['context'] );
+            $this->assertArrayHasKey( 'php_sapi', $captured['context'] );
+            $this->assertArrayHasKey( 'hint', $captured['context'] );
+
+            $this->assertSame(
+                [
+                    ['path' => $missing, 'is_file' => false, 'is_executable' => false],
+                    ['path' => $nonExecutable, 'is_file' => true, 'is_executable' => false],
+                ],
+                $captured['context']['candidates'],
+            );
+        } finally {
+            @unlink( $missing );
+            @unlink( $nonExecutable );
             @rmdir( $tempDir );
         }
     }

--- a/tests/Unit/Updates/UpdateExceptionTest.php
+++ b/tests/Unit/Updates/UpdateExceptionTest.php
@@ -1,0 +1,95 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Tests\Unit\Updates;
+
+use ArtisanPackUI\CMSFramework\Modules\Core\Updates\Exceptions\UpdateException;
+use Orchestra\Testbench\TestCase;
+
+/**
+ * UpdateException factory tests.
+ *
+ * @since 2.5.4
+ */
+class UpdateExceptionTest extends TestCase
+{
+    /**
+     * Regression for #233: `composerBinaryNotFound()` renders per-candidate
+     * `is_file()` / `is_executable()` results when supplied with diagnostic
+     * entries, so operators can see whether a path was missing, unstat-able,
+     * or present-but-not-executable without cross-referencing the log.
+     *
+     * @since 2.5.4
+     */
+    public function test_composer_binary_not_found_renders_diagnostic_entries(): void
+    {
+        $exception = UpdateException::composerBinaryNotFound( [
+            ['path' => '/usr/local/bin/composer', 'is_file' => false, 'is_executable' => false],
+            ['path' => '/opt/homebrew/bin/composer', 'is_file' => true, 'is_executable' => false],
+            ['path' => '/home/x/.composer/vendor/bin/composer', 'is_file' => true, 'is_executable' => true],
+        ] );
+
+        $message = $exception->getMessage();
+
+        $this->assertStringContainsString( '/usr/local/bin/composer (is_file=false, is_executable=n/a)', $message );
+        $this->assertStringContainsString( '/opt/homebrew/bin/composer (is_file=true, is_executable=false)', $message );
+        $this->assertStringContainsString( '/home/x/.composer/vendor/bin/composer (is_file=true, is_executable=true)', $message );
+        $this->assertStringContainsString( 'PHP process', $message );
+        $this->assertStringContainsString( 'COMPOSER_BINARY', $message );
+    }
+
+    /**
+     * Regression for #233: the legacy 2.5.3 signature — a flat list of
+     * absolute paths — must continue to render as before so downstream
+     * consumers that predate the diagnostic upgrade keep working.
+     *
+     * @since 2.5.4
+     */
+    public function test_composer_binary_not_found_still_supports_legacy_string_paths(): void
+    {
+        $exception = UpdateException::composerBinaryNotFound( [
+            '/usr/local/bin/composer',
+            '/opt/homebrew/bin/composer',
+        ] );
+
+        $message = $exception->getMessage();
+
+        $this->assertStringContainsString( 'Searched: /usr/local/bin/composer, /opt/homebrew/bin/composer.', $message );
+        $this->assertStringContainsString( 'COMPOSER_BINARY', $message );
+    }
+
+    /**
+     * Empty candidate list still produces a sensible message rather than
+     * "Searched: ." — guards against a caller passing `[]` after all
+     * candidates were filtered out.
+     *
+     * @since 2.5.4
+     */
+    public function test_composer_binary_not_found_handles_empty_candidate_list(): void
+    {
+        $exception = UpdateException::composerBinaryNotFound( [] );
+
+        $this->assertStringContainsString( 'Searched: (none).', $exception->getMessage() );
+    }
+
+    /**
+     * A mixed array (diagnostic entry at index 0, plain string later) must
+     * not raise a `TypeError` from the diagnostic-branch closure signature.
+     * Guards against a caller half-migrating to the new shape.
+     *
+     * @since 2.5.4
+     */
+    public function test_composer_binary_not_found_tolerates_mixed_input_shapes(): void
+    {
+        $exception = UpdateException::composerBinaryNotFound( [
+            ['path' => '/opt/homebrew/bin/composer', 'is_file' => true, 'is_executable' => false],
+            '/usr/local/bin/composer',
+        ] );
+
+        $message = $exception->getMessage();
+
+        $this->assertStringContainsString( '/opt/homebrew/bin/composer', $message );
+        $this->assertStringContainsString( '/usr/local/bin/composer', $message );
+    }
+}


### PR DESCRIPTION
## Description

When `discoverComposerBinary()` fails to find composer, the operator previously only saw a list of paths that were searched — no signal for *why* each candidate was rejected. On macOS Herd Pro, `/opt/homebrew/bin/composer` exists and is executable from the shell but reports `is_file() === false` in PHP-FPM request context because Herd sandboxes `/opt/homebrew/*`. Same story for chrooted FPM pools and restrictive `open_basedir`. Without per-path diagnostics, operators had no way to distinguish "the framework isn't looking there" from "the framework looked but PHP can't stat it."

**Closes:** #233

## Type of Change

- [x] Bug fix (fixes an issue)

## Related Issue

**Issue:** #233

## Motivation and Context

Follow-up to #225 (which added discovery + the error message). That fix was a real quality-of-life win; this PR makes the *diagnostic* as good as the *behavior*. On the reproduction host, isolating "the framework is wrong about paths" from "PHP-FPM can't see those paths" took multiple rounds of reflection dumps and source-reading. A structured log line closes that gap.

## Changes Made

- `ApplicationUpdateManager::discoverComposerBinary()` collects `path`, `is_file`, `is_executable` for every candidate and emits `Log::warning` on failure with `candidates`, `php_sapi`, and a `hint` pointing at Herd/FPM sandboxing / `open_basedir` as likely root causes when `is_file=false` for paths that exist at the OS level.
- `UpdateException::composerBinaryNotFound()` accepts either the legacy `array<int, string>` or the new per-candidate diagnostic shape. When diagnostic entries are supplied, the message renders each path with its stat outcome and calls out the FPM-sandbox root cause. Legacy callers still work.
- Mixed-shape input (some diagnostic entries, some strings) degrades to path-only rendering rather than raising a `TypeError`.

Fix C from the issue (shell `command -v composer` fallback) was intentionally skipped — the issue calls Fix A alone sufficient, and adding a `Process::run` inside discovery pulls in more surface than the diagnostic gap warrants.

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS 15+
- PHP Version: 8.4.23
- Project Version: cms-framework `release/2.5.4`

**Tests Performed:**
1. Full `tests/Unit/Updates/` suite — 120 passed (268 assertions)
2. Targeted diagnostic test asserts the exact structured log payload shape
3. Legacy-signature test confirms pre-2.5.4 string-array callers still render correctly

## Accessibility Tests Run

- [ ] N/A — backend diagnostic change, no UI surface

## Tests Added

- [x] Unit tests added/updated
- [x] All tests passing

**Test details:**
- `test_discover_composer_binary_logs_per_candidate_diagnostics_on_failure` — verifies the `Log::warning` payload includes per-candidate `path`/`is_file`/`is_executable` triples plus `php_sapi` and `hint`.
- Added `Log::shouldReceive('warning')->never()` to the existing success-path test to guard against future refactors accidentally logging on every discovery call.
- New `UpdateExceptionTest.php` covers: diagnostic entry rendering, legacy string-path rendering, empty-list handling, and mixed-shape defensive rendering.

## Documentation

- [x] Inline code documentation added — updated PHPDoc on `discoverComposerBinary()` and `composerBinaryNotFound()` to describe the diagnostic behavior and the root causes it surfaces.

## Pre-Submission Checklist

- [x] Code passes all tests
- [x] Code has been linted (no new violations introduced; pre-existing baseline violations left as-is)
- [x] Self-review completed
- [x] Comments added for complex code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved diagnostics when the Composer executable cannot be found.
  - Error messages now show whether each candidate path exists and is executable.
  - Added clearer warnings, including runtime details that can help identify path-resolution issues.
  - Preserved compatibility with existing Composer path checks and error handling.

- **Tests**
  - Added coverage for successful discovery, failed discovery, empty results, and mixed path formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->