### PR TITLE
fix: guard extractUpdate against zip-slip archive entries

### DIFF
--- a/src/Modules/Core/Updates/Managers/ApplicationUpdateManager.php
+++ b/src/Modules/Core/Updates/Managers/ApplicationUpdateManager.php
@@ -469,12 +469,39 @@ class ApplicationUpdateManager
                 continue;
             }
 
+            // Reject archive entries whose path would escape the extraction root
+            // (Zip Slip). Because extraction here bypasses ZipArchive::extractTo(),
+            // PHP's own traversal mitigations do not apply, so every entry must be
+            // validated against the base directory before any write.
+            $normalizedTarget = str_replace( '\\', '/', $targetPath );
+            if (
+                str_starts_with( $normalizedTarget, '/' )
+                || '..' === $normalizedTarget
+                || str_starts_with( $normalizedTarget, '../' )
+                || str_contains( $normalizedTarget, '/../' )
+                || str_ends_with( $normalizedTarget, '/..' )
+            ) {
+                \Illuminate\Support\Facades\Log::warning( 'Skipping update ZIP entry with unsafe path', [
+                    'entry' => $filename,
+                ] );
+
+                continue;
+            }
+
             $fullTargetPath = $extractPath . DIRECTORY_SEPARATOR . $targetPath;
 
             // Handle directories
             if ( str_ends_with( $filename, '/' ) ) {
                 if ( ! File::exists( $fullTargetPath ) ) {
                     File::makeDirectory( $fullTargetPath, 0755, true );
+                }
+
+                if ( ! $this->isPathWithinExtractRoot( $fullTargetPath, $extractPath ) ) {
+                    \Illuminate\Support\Facades\Log::warning( 'Skipping update ZIP entry that resolved outside extract root', [
+                        'entry' => $filename,
+                    ] );
+
+                    continue;
                 }
 
                 continue;
@@ -484,6 +511,16 @@ class ApplicationUpdateManager
             $targetDir = dirname( $fullTargetPath );
             if ( ! File::exists( $targetDir ) ) {
                 File::makeDirectory( $targetDir, 0755, true );
+            }
+
+            // Defense-in-depth: after the parent exists, resolve it and confirm
+            // it still sits under the extract root before opening the write stream.
+            if ( ! $this->isPathWithinExtractRoot( $targetDir, $extractPath ) ) {
+                \Illuminate\Support\Facades\Log::warning( 'Skipping update ZIP entry that resolved outside extract root', [
+                    'entry' => $filename,
+                ] );
+
+                continue;
             }
 
             // Stream the entry to disk rather than materializing it as a PHP
@@ -526,6 +563,31 @@ class ApplicationUpdateManager
         }
 
         $zip->close();
+    }
+
+    /**
+     * Determine whether a resolved path sits within the extraction root.
+     *
+     * Uses `realpath()` on both sides so that any `..` traversal or symlink is
+     * resolved before the comparison. Callers must ensure the target directory
+     * has been created first — `realpath()` returns false for missing paths.
+     *
+     * @since 2.5.4
+     *
+     * @param  string  $path  Absolute path to validate.
+     * @param  string  $extractPath  Extraction root the path must sit within.
+     */
+    protected function isPathWithinExtractRoot( string $path, string $extractPath ): bool
+    {
+        $realExtractPath = realpath( $extractPath );
+        $realPath        = realpath( $path );
+
+        if ( false === $realExtractPath || false === $realPath ) {
+            return false;
+        }
+
+        return $realPath === $realExtractPath
+            || str_starts_with( $realPath, $realExtractPath . DIRECTORY_SEPARATOR );
     }
 
     /**

--- a/tests/Unit/Updates/ApplicationUpdateManagerTest.php
+++ b/tests/Unit/Updates/ApplicationUpdateManagerTest.php
@@ -395,6 +395,61 @@ class ApplicationUpdateManagerTest extends TestCase
     }
 
     /**
+     * Regression for #234: `extractUpdate` must reject ZIP entries that resolve
+     * outside the extraction root (Zip Slip). Because extraction bypasses
+     * `ZipArchive::extractTo()` and streams entries manually, PHP's own
+     * traversal mitigations don't apply — the guard has to live in the manager.
+     *
+     * @since 2.5.4
+     */
+    public function test_extract_update_rejects_zip_slip_entries(): void
+    {
+        $tempRoot = sys_get_temp_dir() . '/cmsfw-zipslip-' . bin2hex( random_bytes( 6 ) );
+        $target   = $tempRoot . '/target';
+        $outside  = $tempRoot . '/outside';
+        mkdir( $target, 0755, true );
+        mkdir( $outside, 0755, true );
+
+        $zipPath = $tempRoot . '/update.zip';
+
+        $zip = new ZipArchive;
+        $this->assertTrue( true === $zip->open( $zipPath, ZipArchive::CREATE | ZipArchive::OVERWRITE ) );
+        // Benign entry under the common prefix — should extract normally.
+        $zip->addFromString( 'release-root/app/Model.php', "<?php\n" );
+        // Malicious entry: after the common prefix is stripped, the remaining
+        // path traverses out of the extract root.
+        $zip->addFromString( 'release-root/../../../outside/pwn.php', "<?php // pwned\n" );
+        // Malicious entry with absolute path.
+        $zip->addFromString( '/absolute/etc/cron.d/x', "pwn\n" );
+        $zip->close();
+
+        $manager = new class extends ApplicationUpdateManager {
+            public function extractInto( string $zipPath ): void
+            {
+                $this->extractUpdate( $zipPath );
+            }
+        };
+
+        $originalBase = base_path();
+        app()->setBasePath( $target );
+
+        try {
+            $manager->extractInto( $zipPath );
+
+            $this->assertFileExists( $target . '/app/Model.php' );
+            $this->assertFileDoesNotExist( $outside . '/pwn.php' );
+            $this->assertFileDoesNotExist( $tempRoot . '/outside/pwn.php' );
+            $this->assertFileDoesNotExist( '/absolute/etc/cron.d/x' );
+        } finally {
+            app()->setBasePath( $originalBase );
+            @unlink( $zipPath );
+            $this->removeDirectory( $target );
+            $this->removeDirectory( $outside );
+            @rmdir( $tempRoot );
+        }
+    }
+
+    /**
      * Regression for #225: `COMPOSER_BINARY` env var wins over both config and
      * discovery and is invoked via `PHP_BINARY` so the PHP-FPM pool's `PATH`
      * never has to resolve composer's shebang.


### PR DESCRIPTION
## Description

`ApplicationUpdateManager::extractUpdate()` builds the write target by concatenating `base_path()` with an unvalidated entry name from the ZIP, then streams via `fopen()`/`fwrite()`. Because this bypasses `ZipArchive::extractTo()`, PHP's own traversal mitigations do not apply, so a crafted archive entry like `release-root/../../../etc/cron.d/x` would write outside the install root once `detectCommonRootPrefix()` stripped the common prefix.

**Closes:** #234

## Type of Change

- [x] Bug fix (fixes an issue)
- [x] Security fix

## Related Issue

**Issue:** #234

## Motivation and Context

Manual streaming extraction bypasses `ZipArchive::extractTo()`'s built-in traversal handling. The companion issue (fail-open checksum verification when `sha256` is missing) means archive integrity does not necessarily guard this path, so the extractor itself needs to enforce path safety.

## Changes Made

- Reject archive entries whose normalized target path starts with `/`, equals `..`, or contains `../` segments — logged and skipped before any `mkdir` runs, so a malicious entry can't even create attacker-chosen directories.
- Add `isPathWithinExtractRoot()` helper that uses `realpath()` on both the resolved parent and the extract root as defense-in-depth against symlink-based traversal.
- Apply the `realpath()` check on both directory entries and file entries before opening the write stream.

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS (Darwin 27.0.0)
- PHP Version: 8.5.7
- Project Version: 2.5.4

**Tests Performed:**
1. `./vendor/bin/pest tests/Unit/Updates/ApplicationUpdateManagerTest.php` — 30 passed
2. `./vendor/bin/pest tests/Unit/Updates tests/Feature/Updates` — 129 passed
3. `./vendor/bin/php-cs-fixer fix` — no changes required

## Accessibility Tests Run

N/A — no user-facing UI changes.

## Tests Added

- [x] Unit tests added/updated
- [x] All tests passing

**Test details:**

`test_extract_update_rejects_zip_slip_entries` crafts an archive containing:
- A benign `release-root/app/Model.php` entry (must extract).
- A `release-root/../../../outside/pwn.php` entry that defeats the common-prefix strip (must be rejected).
- An absolute-path `/absolute/etc/cron.d/x` entry (must be rejected).

The test asserts the benign entry is written and none of the malicious ones land outside the extract root.

## Documentation

- [x] Inline code documentation added

**Documentation details:** PHPDoc on the new `isPathWithinExtractRoot()` helper, plus inline comments explaining why the string-level guard runs before any `mkdir` and why the `realpath()` check is used as defense-in-depth.

## Pre-Submission Checklist

- [x] Code passes all tests
- [x] Code has been linted
- [x] Code follows project style guide
- [x] Self-review completed
- [x] Comments added for complex code
- [x] No new warnings generated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved update package extraction security by blocking unsafe archive paths that could write files outside the intended installation directory.
  * Validates directory and file locations before creating or writing them, while logging skipped unsafe entries.

* **Tests**
  * Added regression coverage for relative traversal and absolute-path archive entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->