### PR TITLE
security: fail closed when update source omits sha256 checksum

### DIFF
--- a/src/Modules/Core/Updates/Exceptions/UpdateException.php
+++ b/src/Modules/Core/Updates/Exceptions/UpdateException.php
@@ -86,6 +86,20 @@ class UpdateException extends CMSFrameworkException
     }
 
     /**
+     * Update source did not advertise a SHA-256 checksum and the host has not
+     * opted in to accepting unverified updates.
+     *
+     * @since 2.5.4
+     */
+    public static function checksumRequired( string $targetVersion ): self
+    {
+        return new self(
+            "Refusing to install update {$targetVersion}: the update source did not advertise a SHA-256 checksum. "
+            . 'Set `cms.updates.allow_unverified_updates` to true to opt in to unverified updates on trusted networks.',
+        );
+    }
+
+    /**
      * ZIP extraction failed.
      *
      * @since 1.0.0

--- a/src/Modules/Core/Updates/Managers/ApplicationUpdateManager.php
+++ b/src/Modules/Core/Updates/Managers/ApplicationUpdateManager.php
@@ -417,6 +417,10 @@ class ApplicationUpdateManager
             return;
         }
 
+        if ( ! config( 'cms.updates.allow_unverified_updates', false ) ) {
+            throw UpdateException::checksumRequired( $targetVersion );
+        }
+
         \Illuminate\Support\Facades\Log::warning( 'Skipping update integrity verification: update source did not advertise a SHA-256 checksum.', [
             'target_version' => $targetVersion,
             'source'         => $updateInfo->metadata['source'] ?? null,

--- a/src/Modules/Core/Updates/config/updates.php
+++ b/src/Modules/Core/Updates/config/updates.php
@@ -184,6 +184,27 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Allow Unverified Updates
+    |--------------------------------------------------------------------------
+    |
+    | When `verify_checksum` is enabled and the update source does not
+    | advertise a SHA-256 checksum, the updater fails closed by default and
+    | aborts the update rather than installing arbitrary remote code without
+    | an integrity check.
+    |
+    | Set to `true` only when consuming a trusted update source (e.g. an
+    | air-gapped mirror or an internal feed) that intentionally does not
+    | publish checksums. The updater will log a warning and proceed.
+    |
+    | CAUTION: This weakens the reachability story for extraction-time
+    | vulnerabilities such as zip-slip. Do not enable in production unless
+    | you fully control the source and transport.
+    |
+    */
+    'allow_unverified_updates' => env( 'CMS_UPDATES_ALLOW_UNVERIFIED', false ),
+
+    /*
+    |--------------------------------------------------------------------------
     | GitLab Update Strategy
     |--------------------------------------------------------------------------
     |

--- a/tests/Unit/Updates/ApplicationUpdateManagerTest.php
+++ b/tests/Unit/Updates/ApplicationUpdateManagerTest.php
@@ -230,13 +230,17 @@ class ApplicationUpdateManagerTest extends TestCase
     }
 
     /**
-     * Test maybeVerifyChecksum logs a warning when the source omits a checksum.
+     * Test maybeVerifyChecksum logs a warning when the source omits a checksum
+     * and the host has explicitly opted in to accepting unverified updates.
      *
      * @since 2.0.0
      */
     public function test_maybe_verify_checksum_logs_warning_when_sha256_missing(): void
     {
-        config( ['cms.updates.verify_checksum' => true] );
+        config( [
+            'cms.updates.verify_checksum'          => true,
+            'cms.updates.allow_unverified_updates' => true,
+        ] );
 
         $manager = new ApplicationUpdateManager;
 
@@ -259,6 +263,40 @@ class ApplicationUpdateManagerTest extends TestCase
         $reflection = new ReflectionClass( $manager );
         $method     = $reflection->getMethod( 'maybeVerifyChecksum' );
         $method->setAccessible( true );
+
+        $method->invoke( $manager, '/does/not/matter.zip', $updateInfo, '2.0.0' );
+    }
+
+    /**
+     * Test maybeVerifyChecksum fails closed by default when the source omits a
+     * checksum. The updater must refuse to proceed rather than installing
+     * arbitrary remote code without integrity verification.
+     *
+     * @since 2.5.4
+     */
+    public function test_maybe_verify_checksum_throws_when_sha256_missing_and_not_opted_in(): void
+    {
+        config( [
+            'cms.updates.verify_checksum'          => true,
+            'cms.updates.allow_unverified_updates' => false,
+        ] );
+
+        $manager = new ApplicationUpdateManager;
+
+        $updateInfo = new UpdateInfo(
+            currentVersion: '1.0.0',
+            latestVersion: '2.0.0',
+            downloadUrl: 'https://example.com/update.zip',
+            sha256: null,
+            metadata: ['source' => 'gitlab'],
+        );
+
+        $reflection = new ReflectionClass( $manager );
+        $method     = $reflection->getMethod( 'maybeVerifyChecksum' );
+        $method->setAccessible( true );
+
+        $this->expectException( UpdateException::class );
+        $this->expectExceptionMessage( 'did not advertise a SHA-256 checksum' );
 
         $method->invoke( $manager, '/does/not/matter.zip', $updateInfo, '2.0.0' );
     }


### PR DESCRIPTION
## Description

`ApplicationUpdateManager::maybeVerifyChecksum()` previously logged a warning and returned silently when the update source did not advertise a SHA-256 hash, letting the updater download and execute arbitrary remote code — extraction, `composer install`, migrations — without any integrity check. That fail-open behavior also weakened the reachability story for #234 (zip-slip in extraction).

This PR makes the updater **fail closed by default**: when no checksum is advertised, `checksumRequired()` is thrown and the update aborts. Hosts on trusted networks (air-gapped mirrors, internal feeds) can opt in via `cms.updates.allow_unverified_updates` (env `CMS_UPDATES_ALLOW_UNVERIFIED`, default `false`); those hosts still get the original warning log.

**Closes:** #235

## Type of Change

- [x] Security fix
- [x] Bug fix (fixes an issue)

## Related Issue

**Issue:** #235

## Motivation and Context

The updater fetches and executes arbitrary code from a remote source. Under the previous behavior, any response that omitted `sha256` — whether from a bespoke `CustomJsonUpdateSource`, a compromised release, or a MITM'd feed — proceeded to extraction and composer install with no integrity verification. A compromised source could trivially ship a malicious payload with the checksum field simply omitted.

Failing closed by default aligns the updater with the security expectation the config name (`verify_checksum`, defaulting `true`) implies, and preserves an escape hatch for hosts that intentionally accept the risk.

## Changes Made

- Added `UpdateException::checksumRequired($targetVersion)` factory
- Added `cms.updates.allow_unverified_updates` config (default `false`, env `CMS_UPDATES_ALLOW_UNVERIFIED`), with a caution block in the config docblock about the zip-slip reachability trade-off
- `maybeVerifyChecksum()` now throws when `sha256` is missing and the opt-in is off; when opted in, existing warning log behavior is preserved
- Updated `test_maybe_verify_checksum_logs_warning_when_sha256_missing` to opt in explicitly (previously it validated the fail-open path)
- Added `test_maybe_verify_checksum_throws_when_sha256_missing_and_not_opted_in`

## How Has This Been Tested?

**Testing Environment:**
- PHP Version: 8.5.7
- Project Version: 2.5.4 (branched from `release/2.5.4`)

**Tests Performed:**
1. Full test suite: 1,430 passed, 7 skipped
2. Focused `ApplicationUpdateManagerTest`: 31 passed, including the new fail-closed test and the updated opt-in warning test

## Accessibility Tests Run

- [x] N/A — server-side security fix, no UI surface

## Tests Added

- [x] Unit tests added/updated
- [x] All tests passing

**Test details:**
- `test_maybe_verify_checksum_throws_when_sha256_missing_and_not_opted_in` — asserts `UpdateException` is thrown with the "did not advertise a SHA-256 checksum" message when the source omits the hash and the default (fail-closed) config is in effect
- `test_maybe_verify_checksum_logs_warning_when_sha256_missing` — retooled to set `allow_unverified_updates = true` and re-verify the warning log path still works for opted-in hosts
