### PR TITLE
fix: surface fopen/fread failures during update extraction

### DIFF
--- a/src/Modules/Core/Updates/Exceptions/UpdateException.php
+++ b/src/Modules/Core/Updates/Exceptions/UpdateException.php
@@ -110,6 +110,22 @@ class UpdateException extends CMSFrameworkException
     }
 
     /**
+     * A single entry in the update ZIP could not be written to disk.
+     *
+     * Distinct from {@see self::extractionFailed()} because the archive itself
+     * opened successfully — the failure is per-entry (fopen/fread on the target
+     * file), and the streaming loop must surface it so that `performUpdate()`
+     * can roll back to the pre-update snapshot instead of leaving a partial
+     * install on disk.
+     *
+     * @since 2.5.4
+     */
+    public static function extractionEntryFailed( string $entry, string $reason ): self
+    {
+        return new self( "Failed to extract update entry '{$entry}': {$reason}" );
+    }
+
+    /**
      * Composer install failed.
      *
      * @since 1.0.0

--- a/src/Modules/Core/Updates/Managers/ApplicationUpdateManager.php
+++ b/src/Modules/Core/Updates/Managers/ApplicationUpdateManager.php
@@ -533,20 +533,44 @@ class ApplicationUpdateManager
             // the middle of extraction.
             $entryStream = $zip->getStream( $filename );
             if ( false === $entryStream ) {
-                continue;
+                \Illuminate\Support\Facades\Log::error( 'Failed to open ZIP entry stream during update extraction', [
+                    'entry' => $filename,
+                ] );
+
+                throw UpdateException::extractionEntryFailed( $filename, 'could not open entry stream from archive' );
             }
 
             $out = @fopen( $fullTargetPath, 'wb' );
             if ( false === $out ) {
                 fclose( $entryStream );
 
-                continue;
+                $error = error_get_last();
+                \Illuminate\Support\Facades\Log::error( 'Failed to open update target for writing', [
+                    'entry'  => $filename,
+                    'target' => $fullTargetPath,
+                    'errno'  => $error['type'] ?? null,
+                    'reason' => $error['message'] ?? null,
+                ] );
+
+                throw UpdateException::extractionEntryFailed(
+                    $filename,
+                    "could not open target for writing: {$fullTargetPath}",
+                );
             }
 
             try {
                 while ( ! feof( $entryStream ) ) {
                     $chunk = fread( $entryStream, 1024 * 1024 );
-                    if ( false === $chunk || '' === $chunk ) {
+                    if ( false === $chunk ) {
+                        \Illuminate\Support\Facades\Log::error( 'Read failure while streaming update entry', [
+                            'entry'  => $filename,
+                            'target' => $fullTargetPath,
+                        ] );
+
+                        throw UpdateException::extractionEntryFailed( $filename, 'read failure while streaming entry from archive' );
+                    }
+
+                    if ( '' === $chunk ) {
                         break;
                     }
 

--- a/tests/Unit/Updates/ApplicationUpdateManagerTest.php
+++ b/tests/Unit/Updates/ApplicationUpdateManagerTest.php
@@ -488,6 +488,69 @@ class ApplicationUpdateManagerTest extends TestCase
     }
 
     /**
+     * Regression for #236: `extractUpdate` must surface a per-entry write
+     * failure (fopen/fread on the target file) as an `UpdateException` so
+     * `performUpdate()`'s catch block can roll back to the pre-update snapshot
+     * instead of leaving a partial install on disk.
+     *
+     * @since 2.5.4
+     */
+    public function test_extract_update_throws_when_entry_target_cannot_be_opened(): void
+    {
+        if ( 0 === posix_geteuid() ) {
+            $this->markTestSkipped( 'Cannot exercise fopen failure as root — the read-only parent guard is bypassed.' );
+        }
+
+        $tempRoot = sys_get_temp_dir() . '/cmsfw-fopen-fail-' . bin2hex( random_bytes( 6 ) );
+        $target   = $tempRoot . '/target';
+        mkdir( $target, 0755, true );
+
+        // Pre-create the entry's parent directory as read-only so the manager
+        // reuses it (skipping the makeDirectory branch) and the subsequent
+        // fopen('wb') on a new file inside it fails.
+        $lockedDir = $target . '/locked';
+        mkdir( $lockedDir, 0555, true );
+
+        $zipPath = $tempRoot . '/update.zip';
+
+        $zip = new ZipArchive;
+        $this->assertTrue( true === $zip->open( $zipPath, ZipArchive::CREATE | ZipArchive::OVERWRITE ) );
+        $zip->addFromString( 'release-root/locked/file.php', "<?php\n// payload\n" );
+        $zip->close();
+
+        $manager = new class extends ApplicationUpdateManager {
+            public function extractInto( string $zipPath ): void
+            {
+                $this->extractUpdate( $zipPath );
+            }
+        };
+
+        $originalBase = base_path();
+        app()->setBasePath( $target );
+
+        try {
+            $threw = false;
+
+            try {
+                $manager->extractInto( $zipPath );
+            } catch ( UpdateException $e ) {
+                $threw = true;
+                $this->assertStringContainsString( 'release-root/locked/file.php', $e->getMessage() );
+                $this->assertStringContainsString( 'could not open target for writing', $e->getMessage() );
+            }
+
+            $this->assertTrue( $threw, 'extractUpdate must throw UpdateException when a target file cannot be opened for writing.' );
+            $this->assertFileDoesNotExist( $lockedDir . '/file.php' );
+        } finally {
+            app()->setBasePath( $originalBase );
+            @chmod( $lockedDir, 0755 );
+            @unlink( $zipPath );
+            $this->removeDirectory( $target );
+            @rmdir( $tempRoot );
+        }
+    }
+
+    /**
      * Regression for #225: `COMPOSER_BINARY` env var wins over both config and
      * discovery and is invoked via `PHP_BINARY` so the PHP-FPM pool's `PATH`
      * never has to resolve composer's shebang.


### PR DESCRIPTION
## Description

Inside `ApplicationUpdateManager::extractUpdate()`'s per-entry loop, a failed `fopen('wb')` or `fread()` on the target file previously did `continue`/`break` without logging or throwing. Extraction of that entry was silently abandoned, nothing propagated to `performUpdate()`'s catch block, and `handleUpdateFailure()`/rollback never triggered — leaving a partial install on disk that failed to boot on the next request with no obvious cause.

**Closes:** #236

## Type of Change

- [x] Bug fix (fixes an issue)

## Related Issue

**Issue:** #236

## Motivation and Context

A failed write during extraction is an update failure. The previous silent `continue`/`break` meant a permission-locked directory or mid-stream disk quota event produced no error surfaced to the operator, no rollback, and a broken install that only manifested on the next request. Surfacing this as an `UpdateException` lets `performUpdate()`'s catch block roll back to the pre-update snapshot the same way any other update failure does.

## Changes Made

- Added `UpdateException::extractionEntryFailed(entry, reason)` factory — distinct from `extractionFailed()` (archive-open failure) so log/message context makes clear which stage failed.
- `ApplicationUpdateManager::extractUpdate()`:
  - `getStream` false → log entry + throw.
  - `fopen('wb')` false → log entry, target, errno, and PHP error message → throw.
  - `fread` false → log entry + target → throw (still `break` on the legitimate empty-string end-of-stream case).
  - Existing `try/finally` closes both handles on the throw path.
- Added Pest regression `test_extract_update_throws_when_entry_target_cannot_be_opened` that pre-creates a read-only parent dir, extracts a ZIP entry into it, and asserts the exception propagates + no partial file lands on disk. Skips when run as root.

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS
- PHP Version: 8.5
- Project Version: 2.5.4

**Tests Performed:**
1. `./vendor/bin/pest --filter=ApplicationUpdateManagerTest` — all 32 tests pass, including the new regression and the existing streaming happy-path test (`test_extract_update_streams_entries_to_disk`).
2. Manual review of `extractUpdate` diff to confirm Zip Slip / `isPathWithinExtractRoot` guards still run before any throw path.

## Accessibility Tests Run

- N/A — backend updater code, no UI surface.

## Tests Added

- [x] Unit tests added/updated
- [x] All tests passing

**Test details:**

`test_extract_update_throws_when_entry_target_cannot_be_opened` — regression covering the fopen-failure path. The existing streaming test continues to cover the happy path.

## Documentation

- [x] Inline code documentation added

**Documentation details:**

New exception factory has a PHPDoc block explaining why it's distinct from `extractionFailed()`. Test has a `@since 2.5.4` docblock referencing #236.

## Pre-Submission Checklist

- [x] Code passes all tests
- [x] Code has been linted (`php-cs-fixer` — no changes)
- [x] Code follows project style guide
- [x] Self-review completed