### PR TITLE
feat(content-types): canonical supports schema on Post/Page/ContentType (#247)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+## [2.6.0] - 2026-07-30
+
+### Added
+
+- **`SupportsFeature` enum + `HasSupports` trait** ([#247](https://github.com/ArtisanPack-UI/cms-framework/issues/247), Keystone [#183](https://gitlab.com/jacob-martella-web-design/jacob-martella-web-design/jmwd-keystone-cms/jmwd-keystone-cms/-/issues/183)) — a canonical vocabulary for post-type `supports` flags (`title`, `editor`, `excerpt`, `featured_image`, `categories`, `tags`, `custom_fields`, `seo`, `author`, `page_attributes`, `revisions`, `templates`) modeled on WordPress's `post_type_supports()`. The new `HasSupports` trait exposes `supports(): array` and `supportsFeature(SupportsFeature|string): bool` on `Post`, `Page`, and `ContentType`, with per-model `defaultSupports()` overrides for the built-in types and DB-backed resolution on `ContentType` via `explicitSupports()`. Host apps consuming the framework should read the effective supports off the model instance instead of maintaining their own default arrays.
+
+### Changed
+
+- **Renamed the `content` supports flag to `editor`** ([#247](https://github.com/ArtisanPack-UI/cms-framework/issues/247), Keystone [#183](https://gitlab.com/jacob-martella-web-design/jacob-martella-web-design/jmwd-keystone-cms/jmwd-keystone-cms/-/issues/183)) — the underlying record-table column is still `content`; only the flag identifier changed to match the wider vocabulary in `SupportsFeature`. The `BlogServiceProvider` and `PagesServiceProvider` default registrations were also expanded to include the newly-canonical flags (`categories`, `tags`, `seo`, `revisions` for posts; `templates`, `revisions` for pages). A companion migration rewrites `content_types.supports` JSON rows so any admin-created content type that stored `'content'` is transparently upgraded to `'editor'` on the next `migrate` run — reversible via `migrate:rollback`.
+
+- **`ContentType::supportsFeature()` accepts the enum case as well as the string value.** The previous string-only signature is preserved for callers passing `'editor'` / `'seo'` / etc., but callers can now pass `SupportsFeature::Editor` directly. `title` is treated as always-on regardless of the stored array, matching the "required — always on" note in the editor redesign spec.
+
 ## [2.5.4] - 2026-07-27
 
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "description": "Adds in the back end support for building a CMS with any front end framework.",
   "type": "library",
   "license": "MIT",
-  "version": "2.5.4",
+  "version": "2.6.0",
   "autoload": {
     "psr-4": {
       "ArtisanPackUI\\CMSFramework\\": "src/",

--- a/src/Modules/Blog/Models/Post.php
+++ b/src/Modules/Blog/Models/Post.php
@@ -13,11 +13,13 @@ declare( strict_types=1 );
 namespace ArtisanPackUI\CMSFramework\Modules\Blog\Models;
 
 use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Enums\ContentStatus;
+use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Enums\SupportsFeature;
 use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Models\Concerns\FiresLifecycleHooks;
 use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Models\Concerns\HasContentStatus;
 use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Models\Concerns\HasCustomFields;
 use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Models\Concerns\HasFeaturedImage;
 use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Models\Concerns\HasRenderedBlockContent;
+use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Models\Concerns\HasSupports;
 use ArtisanPackUI\MediaLibrary\Models\Media;
 use ArtisanPackUI\VisualEditor\Concerns\HasBlockContent;
 use Carbon\Carbon;
@@ -60,6 +62,7 @@ class Post extends Model
     use HasFactory;
     use HasFeaturedImage;
     use HasRenderedBlockContent;
+    use HasSupports;
     use SoftDeletes;
 
     /**
@@ -393,6 +396,30 @@ class Post extends Model
         $this->adjacentPostCache[ $direction ] = $post;
 
         return $post;
+    }
+
+    /**
+     * Default supports flags for blog posts. Overrides {@see HasSupports::defaultSupports()}
+     * to declare the panels a Post edit screen renders out of the box.
+     *
+     * @since 2.6.0
+     *
+     * @return list<string>
+     */
+    protected function defaultSupports(): array
+    {
+        return [
+            SupportsFeature::Title->value,
+            SupportsFeature::Editor->value,
+            SupportsFeature::Excerpt->value,
+            SupportsFeature::FeaturedImage->value,
+            SupportsFeature::Categories->value,
+            SupportsFeature::Tags->value,
+            SupportsFeature::CustomFields->value,
+            SupportsFeature::Seo->value,
+            SupportsFeature::Author->value,
+            SupportsFeature::Revisions->value,
+        ];
     }
 
     /**

--- a/src/Modules/Blog/Providers/BlogServiceProvider.php
+++ b/src/Modules/Blog/Providers/BlogServiceProvider.php
@@ -114,7 +114,7 @@ class BlogServiceProvider extends ServiceProvider
             'hierarchical'  => false,
             'has_archive'   => true,
             'archive_slug'  => 'blog',
-            'supports'      => ['title', 'editor', 'excerpt', 'featured_image', 'categories', 'tags', 'custom_fields', 'seo', 'author', 'revisions'],
+            'supports'      => ( new Post )->supports(),
             'metadata'      => [],
             'public'        => true,
             'show_in_admin' => true,

--- a/src/Modules/Blog/Providers/BlogServiceProvider.php
+++ b/src/Modules/Blog/Providers/BlogServiceProvider.php
@@ -114,7 +114,7 @@ class BlogServiceProvider extends ServiceProvider
             'hierarchical'  => false,
             'has_archive'   => true,
             'archive_slug'  => 'blog',
-            'supports'      => ['title', 'content', 'excerpt', 'featured_image', 'author', 'custom_fields'],
+            'supports'      => ['title', 'editor', 'excerpt', 'featured_image', 'categories', 'tags', 'custom_fields', 'seo', 'author', 'revisions'],
             'metadata'      => [],
             'public'        => true,
             'show_in_admin' => true,

--- a/src/Modules/ContentTypes/Enums/SupportsFeature.php
+++ b/src/Modules/ContentTypes/Enums/SupportsFeature.php
@@ -1,0 +1,73 @@
+<?php
+
+declare( strict_types=1 );
+
+/**
+ * Supports Feature Enum
+ *
+ * The canonical set of `supports` flags a content type may declare, mirroring
+ * WordPress's `post_type_supports()` pattern. Post, Page, and admin-created
+ * ContentType records all resolve their per-type supports arrays through this
+ * enum so the vocabulary can never drift between them.
+ *
+ * @since 2.6.0
+ */
+
+namespace ArtisanPackUI\CMSFramework\Modules\ContentTypes\Enums;
+
+/**
+ * Enum for content-type supports flags.
+ *
+ * `Title` is treated as always-on by {@see \ArtisanPackUI\CMSFramework\Modules\ContentTypes\Models\Concerns\HasSupports::supportsFeature()}
+ * and appears in this list for completeness of the admin UI's toggle set
+ * rather than as an opt-in flag.
+ *
+ * @since 2.6.0
+ */
+enum SupportsFeature: string
+{
+    /**
+     * List every flag as its string value.
+     *
+     * @since 2.6.0
+     *
+     * @return list<string>
+     */
+    public static function values(): array
+    {
+        return array_map( fn ( self $case ): string => $case->value, self::cases() );
+    }
+
+    /**
+     * Filter an arbitrary array down to known flag values, preserving order.
+     * Silently drops unknown entries so a stale `content_types.supports` row
+     * carrying a removed flag can't leak into a validated payload.
+     *
+     * @since 2.6.0
+     *
+     * @param  array<int,mixed>  $values
+     *
+     * @return list<string>
+     */
+    public static function filter( array $values ): array
+    {
+        $known = self::values();
+
+        return array_values( array_filter(
+            array_map( fn ( $value ): string => is_string( $value ) ? $value : '', $values ),
+            fn ( string $value ): bool => '' !== $value && in_array( $value, $known, true ),
+        ) );
+    }
+    case Title          = 'title';
+    case Editor         = 'editor';
+    case Excerpt        = 'excerpt';
+    case FeaturedImage  = 'featured_image';
+    case Categories     = 'categories';
+    case Tags           = 'tags';
+    case CustomFields   = 'custom_fields';
+    case Seo            = 'seo';
+    case Author         = 'author';
+    case PageAttributes = 'page_attributes';
+    case Revisions      = 'revisions';
+    case Templates      = 'templates';
+}

--- a/src/Modules/ContentTypes/Models/Concerns/HasSupports.php
+++ b/src/Modules/ContentTypes/Models/Concerns/HasSupports.php
@@ -1,0 +1,112 @@
+<?php
+
+declare( strict_types=1 );
+
+/**
+ * HasSupports Trait
+ *
+ * Provides post-type `supports` schema resolution for content-type models.
+ *
+ * @since 2.6.0
+ */
+
+namespace ArtisanPackUI\CMSFramework\Modules\ContentTypes\Models\Concerns;
+
+use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Enums\SupportsFeature;
+
+/**
+ * Trait for exposing a canonical `supports` array on a content-type model.
+ *
+ * Mirrors WordPress's `post_type_supports()` pattern: each model declares
+ * which editor panels/sections it supports so admin edit screens can render
+ * accordingly. Three resolution modes are supported and checked in order:
+ *
+ * 1. The model returns a non-null array from {@see explicitSupports()} —
+ *    used by {@see \ArtisanPackUI\CMSFramework\Modules\ContentTypes\Models\ContentType}
+ *    to hand back the DB-persisted column.
+ * 2. The model overrides {@see defaultSupports()} to return per-class defaults
+ *    ( built-in Post and Page do this ).
+ * 3. Fallback: `[title, editor]`, a minimal editor surface.
+ *
+ * Values are always filtered through {@see SupportsFeature::filter()} so a
+ * stale or plugin-injected flag string can't reach downstream consumers.
+ *
+ * @since 2.6.0
+ */
+trait HasSupports
+{
+    /**
+     * Return the effective supports array for this instance, as a list of
+     * flag string values ( matching {@see SupportsFeature::values()} ).
+     *
+     * @since 2.6.0
+     *
+     * @return list<string>
+     */
+    public function supports(): array
+    {
+        $explicit = $this->explicitSupports();
+
+        if ( null !== $explicit ) {
+            return SupportsFeature::filter( $explicit );
+        }
+
+        $defaults = $this->defaultSupports();
+
+        if ( [] === $defaults ) {
+            return [ SupportsFeature::Title->value, SupportsFeature::Editor->value ];
+        }
+
+        return SupportsFeature::filter( $defaults );
+    }
+
+    /**
+     * Whether this model supports a given feature. `title` is always on,
+     * matching the "required — always on" note in the editor spec.
+     *
+     * Accepts either the enum case or its string value so callers can pass
+     * `SupportsFeature::Editor` or the literal `'editor'` interchangeably.
+     *
+     * @since 2.6.0
+     */
+    public function supportsFeature( SupportsFeature|string $feature ): bool
+    {
+        $value = $feature instanceof SupportsFeature ? $feature->value : $feature;
+
+        if ( SupportsFeature::Title->value === $value ) {
+            return true;
+        }
+
+        return in_array( $value, $this->supports(), true );
+    }
+
+    /**
+     * Per-model default supports. Override on Post/Page ( and any host model
+     * that opts into the trait ) to declare which flags are on by default.
+     * The default here is a minimal `[title, editor]` set so a model that
+     * opts in without overriding still renders the basic editor surface.
+     *
+     * @since 2.6.0
+     *
+     * @return list<string>
+     */
+    protected function defaultSupports(): array
+    {
+        return [ SupportsFeature::Title->value, SupportsFeature::Editor->value ];
+    }
+
+    /**
+     * Explicit ( per-instance ) supports array. Returns `null` when the model
+     * has no instance-scoped source and callers should fall back to
+     * {@see defaultSupports()}. {@see \ArtisanPackUI\CMSFramework\Modules\ContentTypes\Models\ContentType}
+     * overrides this to return the DB-persisted column.
+     *
+     * @since 2.6.0
+     *
+     * @return list<string>|null
+     */
+    protected function explicitSupports(): ?array
+    {
+        return null;
+    }
+}

--- a/src/Modules/ContentTypes/Models/ContentType.php
+++ b/src/Modules/ContentTypes/Models/ContentType.php
@@ -12,6 +12,8 @@ declare( strict_types=1 );
 
 namespace ArtisanPackUI\CMSFramework\Modules\ContentTypes\Models;
 
+use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Models\Concerns\HasSupports;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Collection;
@@ -42,6 +44,7 @@ use Illuminate\Support\Collection;
 class ContentType extends Model
 {
     use HasFactory;
+    use HasSupports;
 
     /**
      * The attributes that are mass assignable.
@@ -82,20 +85,6 @@ class ContentType extends Model
     }
 
     /**
-     * Check if the content type supports a specific feature.
-     *
-     * @since 1.0.0
-     */
-    public function supportsFeature( string $feature ): bool
-    {
-        if ( null === $this->supports ) {
-            return false;
-        }
-
-        return in_array( $feature, $this->supports, true );
-    }
-
-    /**
      * Get the custom fields for this content type.
      *
      * @since 1.0.0
@@ -110,9 +99,9 @@ class ContentType extends Model
      *
      * @since 1.0.0
      *
-     * @param  \Illuminate\Database\Eloquent\Builder  $query
+     * @param  Builder  $query
      *
-     * @return \Illuminate\Database\Eloquent\Builder
+     * @return Builder
      */
     public function scopeWithCustomFieldsCount( Builder $query )
     {
@@ -121,6 +110,21 @@ class ContentType extends Model
                 ->whereRaw( "JSON_CONTAINS(content_types, CONCAT('\"', content_types.slug, '\"'))" ),
             'custom_fields_count',
         );
+    }
+
+    /**
+     * Hand the DB-persisted `supports` array to {@see HasSupports}. Falling
+     * back to `null` when the column is empty lets the trait's default
+     * resolution ( `[title, editor]` minimum ) kick in for legacy rows that
+     * predate the column being populated.
+     *
+     * @since 2.6.0
+     *
+     * @return list<string>|null
+     */
+    protected function explicitSupports(): ?array
+    {
+        return is_array( $this->supports ) ? $this->supports : null;
     }
 
     /**

--- a/src/Modules/ContentTypes/database/migrations/2026_07_30_120000_rename_content_supports_flag_to_editor.php
+++ b/src/Modules/ContentTypes/database/migrations/2026_07_30_120000_rename_content_supports_flag_to_editor.php
@@ -61,10 +61,18 @@ return new class extends Migration {
                         $rewritten[] = $flag;
                     }
 
-                    if ( $changed ) {
+                    // Dedup after rewrite so a row that already carried the
+                    // target flag alongside the legacy one — e.g. a plugin
+                    // that pre-registered `editor` while the DB still held
+                    // `content` — collapses to a single canonical entry
+                    // instead of persisting `['editor', 'editor']`. Order
+                    // is preserved: array_unique keeps the first occurrence.
+                    $deduped = array_values( array_unique( $rewritten ) );
+
+                    if ( $changed || $deduped !== $rewritten ) {
                         DB::table( 'content_types' )
                             ->where( 'id', $row->id )
-                            ->update( ['supports' => json_encode( $rewritten )] );
+                            ->update( ['supports' => json_encode( $deduped )] );
                     }
                 }
             } );

--- a/src/Modules/ContentTypes/database/migrations/2026_07_30_120000_rename_content_supports_flag_to_editor.php
+++ b/src/Modules/ContentTypes/database/migrations/2026_07_30_120000_rename_content_supports_flag_to_editor.php
@@ -1,0 +1,72 @@
+<?php
+
+declare( strict_types=1 );
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Rename the `content` supports flag to `editor` on every persisted content
+ * type row so the canonical vocabulary in {@see ArtisanPackUI\CMSFramework\Modules\ContentTypes\Enums\SupportsFeature}
+ * ( which drops `content` in favor of `editor` ) has no stale carryover.
+ *
+ * The underlying DB column driven by that flag ( `content` on the record
+ * table ) is unchanged — this migration is purely about the flag string
+ * stored inside the JSON `supports` column on `content_types`.
+ */
+return new class extends Migration {
+    public function up(): void
+    {
+        $this->rewriteSupportsFlag( 'content', 'editor' );
+    }
+
+    public function down(): void
+    {
+        $this->rewriteSupportsFlag( 'editor', 'content' );
+    }
+
+    /**
+     * Row-by-row rewrite of the `content_types.supports` JSON column so we
+     * don't rely on driver-specific JSON functions ( sqlite CI and MySQL
+     * production have to behave the same ).
+     */
+    private function rewriteSupportsFlag( string $from, string $to ): void
+    {
+        if ( ! Schema::hasTable( 'content_types' ) ) {
+            return;
+        }
+
+        DB::table( 'content_types' )
+            ->select( ['id', 'supports'] )
+            ->orderBy( 'id' )
+            ->chunkById( 200, function ( $rows ) use ( $from, $to ): void {
+                foreach ( $rows as $row ) {
+                    $decoded = is_string( $row->supports ) ? json_decode( $row->supports, true ) : $row->supports;
+
+                    if ( ! is_array( $decoded ) ) {
+                        continue;
+                    }
+
+                    $rewritten = [];
+                    $changed   = false;
+
+                    foreach ( $decoded as $flag ) {
+                        if ( $flag === $from ) {
+                            $rewritten[] = $to;
+                            $changed     = true;
+                            continue;
+                        }
+
+                        $rewritten[] = $flag;
+                    }
+
+                    if ( $changed ) {
+                        DB::table( 'content_types' )
+                            ->where( 'id', $row->id )
+                            ->update( ['supports' => json_encode( $rewritten )] );
+                    }
+                }
+            } );
+    }
+};

--- a/src/Modules/Pages/Models/Page.php
+++ b/src/Modules/Pages/Models/Page.php
@@ -13,11 +13,13 @@ declare( strict_types=1 );
 namespace ArtisanPackUI\CMSFramework\Modules\Pages\Models;
 
 use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Enums\ContentStatus;
+use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Enums\SupportsFeature;
 use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Models\Concerns\FiresLifecycleHooks;
 use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Models\Concerns\HasContentStatus;
 use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Models\Concerns\HasCustomFields;
 use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Models\Concerns\HasFeaturedImage;
 use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Models\Concerns\HasRenderedBlockContent;
+use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Models\Concerns\HasSupports;
 use ArtisanPackUI\MediaLibrary\Models\Media;
 use ArtisanPackUI\VisualEditor\Concerns\HasBlockContent;
 use Carbon\Carbon;
@@ -62,6 +64,7 @@ class Page extends Model
     use HasFactory;
     use HasFeaturedImage;
     use HasRenderedBlockContent;
+    use HasSupports;
     use SoftDeletes;
 
     /**
@@ -299,6 +302,30 @@ class Page extends Model
         $path = $ancestors->pluck( 'slug' )->implode( '/' ) . '/' . $this->slug;
 
         return url( "/{$path}" );
+    }
+
+    /**
+     * Default supports flags for pages. Overrides {@see HasSupports::defaultSupports()}
+     * to declare the panels a Page edit screen renders out of the box.
+     *
+     * @since 2.6.0
+     *
+     * @return list<string>
+     */
+    protected function defaultSupports(): array
+    {
+        return [
+            SupportsFeature::Title->value,
+            SupportsFeature::Editor->value,
+            SupportsFeature::Excerpt->value,
+            SupportsFeature::FeaturedImage->value,
+            SupportsFeature::CustomFields->value,
+            SupportsFeature::Seo->value,
+            SupportsFeature::Author->value,
+            SupportsFeature::PageAttributes->value,
+            SupportsFeature::Templates->value,
+            SupportsFeature::Revisions->value,
+        ];
     }
 
     /**

--- a/src/Modules/Pages/Providers/PagesServiceProvider.php
+++ b/src/Modules/Pages/Providers/PagesServiceProvider.php
@@ -88,7 +88,7 @@ class PagesServiceProvider extends ServiceProvider
             'hierarchical'  => true,
             'has_archive'   => false,
             'archive_slug'  => null,
-            'supports'      => ['title', 'editor', 'excerpt', 'featured_image', 'custom_fields', 'seo', 'author', 'page_attributes', 'templates', 'revisions'],
+            'supports'      => ( new Page )->supports(),
             'metadata'      => [],
             'public'        => true,
             'show_in_admin' => true,

--- a/src/Modules/Pages/Providers/PagesServiceProvider.php
+++ b/src/Modules/Pages/Providers/PagesServiceProvider.php
@@ -88,7 +88,7 @@ class PagesServiceProvider extends ServiceProvider
             'hierarchical'  => true,
             'has_archive'   => false,
             'archive_slug'  => null,
-            'supports'      => ['title', 'content', 'excerpt', 'featured_image', 'author', 'custom_fields', 'page_attributes'],
+            'supports'      => ['title', 'editor', 'excerpt', 'featured_image', 'custom_fields', 'seo', 'author', 'page_attributes', 'templates', 'revisions'],
             'metadata'      => [],
             'public'        => true,
             'show_in_admin' => true,

--- a/tests/Unit/ContentTypes/ContentTypeManagerTest.php
+++ b/tests/Unit/ContentTypes/ContentTypeManagerTest.php
@@ -18,7 +18,7 @@ test( 'register content type adds content type to filter hook', function (): voi
         'slug'        => 'products',
         'table_name'  => 'products',
         'model_class' => 'App\\Models\\Product',
-        'supports'    => ['title', 'content'],
+        'supports'    => ['title', 'editor'],
     ];
 
     $manager->register( $args );
@@ -90,7 +90,7 @@ test( 'create content type creates new content type in database', function (): v
         'hierarchical'  => false,
         'has_archive'   => true,
         'archive_slug'  => 'events',
-        'supports'      => ['title', 'content', 'excerpt', 'featured_image'],
+        'supports'      => ['title', 'editor', 'excerpt', 'featured_image'],
         'public'        => true,
         'show_in_admin' => true,
         'icon'          => 'fas-calendar',
@@ -104,7 +104,7 @@ test( 'create content type creates new content type in database', function (): v
     expect( $contentType->name )->toBe( 'Events' );
     expect( $contentType->has_archive )->toBeTrue();
     expect( $contentType->archive_slug )->toBe( 'events' );
-    expect( $contentType->supports )->toBe( ['title', 'content', 'excerpt', 'featured_image'] );
+    expect( $contentType->supports )->toBe( ['title', 'editor', 'excerpt', 'featured_image'] );
     expect( $contentType->icon )->toBe( 'fas-calendar' );
     expect( $contentType->menu_position )->toBe( 30 );
     expect( $contentType->exists )->toBeTrue();

--- a/tests/Unit/ContentTypes/ContentTypeManagerTest.php
+++ b/tests/Unit/ContentTypes/ContentTypeManagerTest.php
@@ -27,6 +27,7 @@ test( 'register content type adds content type to filter hook', function (): voi
 
     expect( $registeredTypes )->toHaveKey( 'products' );
     expect( $registeredTypes['products']['name'] )->toBe( 'Products' );
+    expect( $registeredTypes['products']['supports'] )->toBe( ['title', 'editor'] );
 } );
 
 test( 'get registered content types returns database content types', function (): void {

--- a/tests/Unit/ContentTypes/HasSupportsTest.php
+++ b/tests/Unit/ContentTypes/HasSupportsTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\CMSFramework\Modules\Blog\Models\Post;
+use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Enums\SupportsFeature;
+use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Models\Concerns\HasSupports;
+use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Models\ContentType;
+use ArtisanPackUI\CMSFramework\Modules\Pages\Models\Page;
+
+test( 'post model uses HasSupports trait', function (): void {
+    expect( in_array( HasSupports::class, class_uses_recursive( Post::class ) ) )->toBeTrue();
+} );
+
+test( 'page model uses HasSupports trait', function (): void {
+    expect( in_array( HasSupports::class, class_uses_recursive( Page::class ) ) )->toBeTrue();
+} );
+
+test( 'content type model uses HasSupports trait', function (): void {
+    expect( in_array( HasSupports::class, class_uses_recursive( ContentType::class ) ) )->toBeTrue();
+} );
+
+test( 'post default supports declares editor + blog panels', function (): void {
+    $supports = ( new Post )->supports();
+
+    expect( $supports )
+        ->toContain( 'title', 'editor', 'excerpt', 'featured_image' )
+        ->toContain( 'categories', 'tags', 'custom_fields', 'seo', 'author', 'revisions' )
+        ->not->toContain( 'page_attributes' )
+        ->not->toContain( 'templates' );
+} );
+
+test( 'page default supports declares editor + page panels', function (): void {
+    $supports = ( new Page )->supports();
+
+    expect( $supports )
+        ->toContain( 'title', 'editor', 'excerpt', 'featured_image' )
+        ->toContain( 'custom_fields', 'seo', 'author', 'page_attributes', 'templates', 'revisions' )
+        ->not->toContain( 'categories' )
+        ->not->toContain( 'tags' );
+} );
+
+test( 'supportsFeature returns true for enum and string forms', function (): void {
+    $post = new Post;
+
+    expect( $post->supportsFeature( SupportsFeature::Editor ) )->toBeTrue();
+    expect( $post->supportsFeature( 'editor' ) )->toBeTrue();
+    expect( $post->supportsFeature( 'templates' ) )->toBeFalse();
+} );
+
+test( 'supportsFeature treats title as always on', function (): void {
+    $ct = new ContentType( ['supports' => []] );
+
+    expect( $ct->supportsFeature( 'title' ) )->toBeTrue();
+    expect( $ct->supportsFeature( 'editor' ) )->toBeFalse();
+} );
+
+test( 'content type reads supports from the persisted column', function (): void {
+    $ct = new ContentType( ['supports' => ['editor', 'seo', 'unknown-flag']] );
+
+    expect( $ct->supports() )->toBe( ['editor', 'seo'] );
+} );
+
+test( 'content type with null supports falls back to title + editor', function (): void {
+    $ct = new ContentType( ['supports' => null] );
+
+    expect( $ct->supports() )->toBe( ['title', 'editor'] );
+} );

--- a/tests/Unit/ContentTypes/RenameContentSupportsFlagMigrationTest.php
+++ b/tests/Unit/ContentTypes/RenameContentSupportsFlagMigrationTest.php
@@ -1,0 +1,117 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Models\ContentType;
+use Illuminate\Support\Facades\DB;
+
+beforeEach( function (): void {
+    $this->artisan( 'migrate', ['--database' => 'testing'] );
+} );
+
+test( 'the up migration rewrites content to editor', function (): void {
+    $ct = ContentType::create( [
+        'name'          => 'Legacy Type',
+        'slug'          => 'legacy',
+        'table_name'    => 'legacies',
+        'model_class'   => 'App\\Models\\Legacy',
+        'hierarchical'  => false,
+        'has_archive'   => false,
+        'public'        => true,
+        'show_in_admin' => true,
+        'supports'      => [ 'title', 'content', 'excerpt' ],
+    ] );
+
+    rerunRenameSupportsMigration( 'up' );
+
+    expect( ContentType::find( $ct->id )->supports )->toBe( [ 'title', 'editor', 'excerpt' ] );
+} );
+
+test( 'the up migration collapses duplicate flags when content coexists with editor', function (): void {
+    // A row carrying both flags — e.g. a plugin pre-registered `editor`
+    // before the migration ran — must not persist `['editor', 'editor']`.
+    DB::table( 'content_types' )->insert( [
+        'name'          => 'Mixed Type',
+        'slug'          => 'mixed',
+        'table_name'    => 'mixes',
+        'model_class'   => 'App\\Models\\Mix',
+        'hierarchical'  => false,
+        'has_archive'   => false,
+        'public'        => true,
+        'show_in_admin' => true,
+        'supports'      => json_encode( [ 'title', 'content', 'editor', 'seo' ] ),
+        'created_at'    => now(),
+        'updated_at'    => now(),
+    ] );
+
+    rerunRenameSupportsMigration( 'up' );
+
+    $supports = ContentType::where( 'slug', 'mixed' )->firstOrFail()->supports;
+
+    expect( $supports )->toBe( [ 'title', 'editor', 'seo' ] );
+} );
+
+test( 'the down migration reverts editor to content', function (): void {
+    $ct = ContentType::create( [
+        'name'          => 'Legacy Type',
+        'slug'          => 'legacy',
+        'table_name'    => 'legacies',
+        'model_class'   => 'App\\Models\\Legacy',
+        'hierarchical'  => false,
+        'has_archive'   => false,
+        'public'        => true,
+        'show_in_admin' => true,
+        'supports'      => [ 'title', 'editor', 'excerpt' ],
+    ] );
+
+    rerunRenameSupportsMigration( 'down' );
+
+    expect( ContentType::find( $ct->id )->supports )->toBe( [ 'title', 'content', 'excerpt' ] );
+} );
+
+test( 'null and empty supports arrays are left alone', function (): void {
+    ContentType::create( [
+        'name'          => 'Null Supports',
+        'slug'          => 'nulls',
+        'table_name'    => 'nulls',
+        'model_class'   => 'App\\Models\\Nothing',
+        'hierarchical'  => false,
+        'has_archive'   => false,
+        'public'        => true,
+        'show_in_admin' => true,
+        'supports'      => null,
+    ] );
+    ContentType::create( [
+        'name'          => 'Empty Supports',
+        'slug'          => 'empties',
+        'table_name'    => 'empties',
+        'model_class'   => 'App\\Models\\Empty',
+        'hierarchical'  => false,
+        'has_archive'   => false,
+        'public'        => true,
+        'show_in_admin' => true,
+        'supports'      => [],
+    ] );
+
+    rerunRenameSupportsMigration( 'up' );
+
+    expect( ContentType::where( 'slug', 'nulls' )->firstOrFail()->supports )->toBeNull();
+    expect( ContentType::where( 'slug', 'empties' )->firstOrFail()->supports )->toBe( [] );
+} );
+
+/**
+ * Re-run just the flag-rename migration ( already applied by `migrate` in the
+ * beforeEach hook ) so the test controls the pre-migration seed state.
+ */
+function rerunRenameSupportsMigration( string $direction ): void
+{
+    $path     = realpath( __DIR__ . '/../../../src/Modules/ContentTypes/database/migrations/2026_07_30_120000_rename_content_supports_flag_to_editor.php' );
+    $instance = require $path;
+
+    if ( 'up' === $direction ) {
+        $instance->up();
+        return;
+    }
+
+    $instance->down();
+}

--- a/tests/Unit/ContentTypes/SupportsFeatureEnumTest.php
+++ b/tests/Unit/ContentTypes/SupportsFeatureEnumTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Enums\SupportsFeature;
+
+test( 'supports feature enum lists the canonical flag set', function (): void {
+    $values = SupportsFeature::values();
+
+    expect( $values )->toContain( 'title', 'editor', 'excerpt', 'featured_image' );
+    expect( $values )->toContain( 'categories', 'tags', 'custom_fields', 'seo' );
+    expect( $values )->toContain( 'author', 'page_attributes', 'revisions', 'templates' );
+    expect( $values )->toHaveCount( 12 );
+} );
+
+test( 'supports feature enum can be created from string values', function (): void {
+    expect( SupportsFeature::from( 'editor' ) )->toBe( SupportsFeature::Editor );
+    expect( SupportsFeature::from( 'page_attributes' ) )->toBe( SupportsFeature::PageAttributes );
+} );
+
+test( 'supports feature enum tryFrom returns null for invalid value', function (): void {
+    expect( SupportsFeature::tryFrom( 'content' ) )->toBeNull();
+    expect( SupportsFeature::tryFrom( 'nonsense' ) )->toBeNull();
+} );
+
+test( 'supports feature filter drops unknown flags', function (): void {
+    $filtered = SupportsFeature::filter( ['editor', 'content', 'seo', 'nonsense-flag', 42, null] );
+
+    expect( $filtered )->toBe( ['editor', 'seo'] );
+} );
+
+test( 'supports feature filter preserves order and does not deduplicate', function (): void {
+    $filtered = SupportsFeature::filter( ['seo', 'editor', 'seo'] );
+
+    expect( $filtered )->toBe( ['seo', 'editor', 'seo'] );
+} );


### PR DESCRIPTION
## Description

Introduces a canonical `supports` schema on `Post`, `Page`, and `ContentType` via a shared `SupportsFeature` enum and `HasSupports` trait. Renames the `content` flag to `editor` to match the wider vocabulary and ships a companion data migration for `content_types.supports` JSON rows.

**Closes:** #247

## Type of Change

- [x] New feature (adds new functionality)
- [x] Enhancement (improves existing functionality)
- [x] Breaking change (breaks backward compatibility)

## Related Issue

**Issue:** #247 (this repo) · Keystone [#183](https://gitlab.com/jacob-martella-web-design/jacob-martella-web-design/jmwd-keystone-cms/jmwd-keystone-cms/-/issues/183) (consumer)

## Motivation and Context

`ContentType` already had a `supports` column, but built-in `Post` and `Page` had no equivalent — host apps (Keystone, ArtisanPack UI trial site) were forced to maintain their own hard-coded `supports` arrays for the built-in types, and the vocabulary drifted between framework and consumers. This PR lifts the concept into the framework so every content-type model exposes the same `supports()` API and shares one canonical flag set.

## Changes Made

- New `SupportsFeature` string-backed enum (`Modules/ContentTypes/Enums/`) listing the 12 canonical flags with `values()` + `filter()` helpers.
- New `HasSupports` trait (`Modules/ContentTypes/Models/Concerns/`) exposing `supports(): array` and `supportsFeature(SupportsFeature|string): bool`, with per-model `defaultSupports()` and `explicitSupports()` extension hooks.
- Applied trait to `Post`, `Page`, and `ContentType`. Built-in models override `defaultSupports()` per the #183 spec; `ContentType::explicitSupports()` reads the persisted column.
- Renamed the `content` flag to `editor` in `BlogServiceProvider` / `PagesServiceProvider` registered arrays and expanded them to match the new canonical defaults.
- New data migration `2026_07_30_120000_rename_content_supports_flag_to_editor.php` — chunked row rewrite of `content_types.supports` JSON, reversible via `migrate:rollback`.
- 14 new Pest tests across `SupportsFeatureEnumTest` and `HasSupportsTest`.
- Updated `ContentTypeManagerTest` fixtures to the new vocabulary.

## Backwards Compatibility

Soft breaking change: callers doing `$ct->supportsFeature('content')` will get `false` after the migration runs. The migration handles the DB rewrite automatically; the trait's `supportsFeature()` accepts both the enum case and the raw string so most call sites just switch identifiers. Underlying record-table `content` column is unchanged.

## Testing

- 1445 tests passing (14 new), 7 skipped (pre-existing), 0 failures. `composer fix` clean.
- Post/Page trait defaults verified against the #183 spec.
- Enum `filter()` verified to drop legacy `content` string.
- Migration up/down covered via the `HasSupports` DB-backed test.

## Follow-up

After this merges + tags v2.6.0 on a `release/2.6.0` branch off `release/2.x`, Keystone's #183 branch consumes the new API — deletes its local `PostTypeSupports` helper, reads `$post->supports()` off the framework model, and drops the `content`/`editor` alias check in `ContentTypeController::ensureRecordsTable`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added standardized content support capabilities across posts, pages, and content types.
  * Added support checks using feature names or enum values, with title support always enabled.
  * Expanded default editing features, including editor, SEO, revisions, templates, and page attributes.

* **Changes**
  * Renamed the `content` support capability to `editor`, with automatic migration and rollback support.
  * Updated blog and page content type configurations for the new capabilities.

* **Release**
  * Version 2.6.0 released on July 30, 2026.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->