### PR TITLE
feat(blog,pages): manager write APIs — autoDraft/create/update/delete/duplicate (#250)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+## [2.7.0] - 2026-07-30
+
+### Added
+
+- **`BlogManager` write API** ([#250](https://github.com/ArtisanPack-UI/cms-framework/issues/250), Keystone [#183](https://gitlab.com/jacob-martella-web-design/jacob-martella-web-design/jmwd-keystone-cms/jmwd-keystone-cms/-/issues/183)) — new methods `autoDraft()`, `create()`, `update()`, `delete()`, `duplicate()`, `syncCategories()`, `syncTags()`, `uniqueSlug()` on `Modules\Blog\Managers\BlogManager`. All writes wrapped in a DB transaction. Unique-slug allocation skips soft-deleted rows so a restored draft can't collide. `create()`/`update()` route filter-registered custom-field values through the `HasCustomFields` magic setter before save so a single INSERT/UPDATE captures both hardcoded columns and metadata JSON. `update()` stamps `published_at = now()` exactly once on the first draft→published transition — subsequent republishes preserve the original stamp.
+- **`PageManager` write API** ([#250](https://github.com/ArtisanPack-UI/cms-framework/issues/250)) — same seven methods on `Modules\Pages\Managers\PageManager` plus support for the hierarchical `parent_id`, `order`, and `template` attributes. `duplicate()` preserves `template` but resets status to Draft and clears `published_at`. Coexists with the existing hierarchy helpers (`getPageTree`, `movePage`, `reorderPages`) which stay unchanged.
+
+### Changed
+
 ## [2.6.0] - 2026-07-30
 
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "description": "Adds in the back end support for building a CMS with any front end framework.",
   "type": "library",
   "license": "MIT",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "autoload": {
     "psr-4": {
       "ArtisanPackUI\\CMSFramework\\": "src/",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "48a5194f50408318b1424e63fdcff210",
+    "content-hash": "83d8a72fdf994aee9683cc84df1ae217",
     "packages": [
         {
             "name": "artisanpack-ui/accessibility",

--- a/src/Modules/Blog/Managers/BlogManager.php
+++ b/src/Modules/Blog/Managers/BlogManager.php
@@ -16,6 +16,7 @@ use ArtisanPackUI\CMSFramework\Modules\Blog\Models\Post;
 use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Enums\ContentStatus;
 use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Managers\Concerns\HasContentFilters;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\QueryException;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
@@ -202,12 +203,16 @@ class BlogManager
      */
     public function autoDraft( ?int $authorId = null, string $baseSlug = 'untitled-post' ): Post
     {
-        return Post::create( [
+        $post = new Post( [
             'title'     => 'Untitled post',
             'slug'      => $this->uniqueSlug( $baseSlug ),
             'status'    => ContentStatus::Draft,
             'author_id' => $authorId,
         ] );
+
+        $this->saveWithSlugRetry( $post );
+
+        return $post;
     }
 
     /**
@@ -248,7 +253,7 @@ class BlogManager
 
             $post = new Post( $this->fillableSubset( $attributes ) );
             $this->applyCustomFields( $post, $customFields );
-            $post->save();
+            $this->saveWithSlugRetry( $post );
 
             return $post;
         } );
@@ -270,6 +275,14 @@ class BlogManager
     public function update( Post $post, array $attributes, ?array $customFields = null ): Post
     {
         return DB::transaction( function () use ( $post, $attributes, $customFields ): Post {
+            // A caller passing `slug => ''` on update would otherwise
+            // overwrite an existing unique slug with an empty string,
+            // bypassing the allocator. Drop the key when blank so the
+            // fill() below leaves the record's current slug intact.
+            if ( array_key_exists( 'slug', $attributes ) && '' === trim( ( string ) $attributes['slug'] ) ) {
+                unset( $attributes['slug'] );
+            }
+
             $wasPublished = ContentStatus::Published === $post->status;
 
             $post->fill( $this->fillableSubset( $attributes ) );
@@ -281,7 +294,7 @@ class BlogManager
             }
 
             $this->applyCustomFields( $post, $customFields );
-            $post->save();
+            $this->saveWithSlugRetry( $post );
 
             return $post;
         } );
@@ -320,7 +333,7 @@ class BlogManager
             $copy->slug      = $this->uniqueSlug( $post->slug . '-copy' );
             $copy->status    = ContentStatus::Draft;
             $copy->author_id = $authorId ?? $post->author_id;
-            $copy->save();
+            $this->saveWithSlugRetry( $copy );
 
             $copy->categories()->sync( $post->categories->pluck( 'id' )->all() );
             $copy->tags()->sync( $post->tags->pluck( 'id' )->all() );
@@ -339,7 +352,9 @@ class BlogManager
      */
     public function syncCategories( Post $post, array $categoryIds ): void
     {
-        $post->categories()->sync( $categoryIds );
+        // Wrapped so a mid-sync constraint violation on the attach
+        // half doesn't leave the pivot with the detach half applied.
+        DB::transaction( fn () => $post->categories()->sync( $categoryIds ) );
     }
 
     /**
@@ -352,7 +367,7 @@ class BlogManager
      */
     public function syncTags( Post $post, array $tagIds ): void
     {
-        $post->tags()->sync( $tagIds );
+        DB::transaction( fn () => $post->tags()->sync( $tagIds ) );
     }
 
     /**
@@ -454,5 +469,48 @@ class BlogManager
         foreach ( $customFields as $key => $value ) {
             $post->{$key} = $value;
         }
+    }
+
+    /**
+     * Save a post, catching the tiny race where two writers each pass
+     * {@see uniqueSlug()}'s pre-check with the same candidate ( two
+     * simultaneous "New Post" clicks both probing `untitled-post` )
+     * and then collide on the DB-level unique index. Reallocates the
+     * slug once from its own value as a fresh base and retries. If the
+     * retry also collides — genuine sustained contention, not a race —
+     * the second exception surfaces to the caller.
+     *
+     * @throws QueryException on non-slug-unique errors, or on a second
+     *                        slug-unique collision after the retry.
+     */
+    protected function saveWithSlugRetry( Post $post ): void
+    {
+        try {
+            $post->save();
+        } catch ( QueryException $e ) {
+            if ( ! $this->isUniqueSlugViolation( $e ) ) {
+                throw $e;
+            }
+
+            $post->slug = $this->uniqueSlug( $post->slug );
+            $post->save();
+        }
+    }
+
+    /**
+     * Whether a QueryException reports an integrity-constraint violation
+     * on the slug column. Uses the SQLSTATE class ( `23`, integrity
+     * constraint violation ) rather than a driver-specific errno so the
+     * check works uniformly across MySQL, SQLite, and PostgreSQL.
+     */
+    protected function isUniqueSlugViolation( QueryException $e ): bool
+    {
+        $sqlState = ( string ) $e->getCode();
+
+        if ( ! str_starts_with( $sqlState, '23' ) ) {
+            return false;
+        }
+
+        return str_contains( strtolower( $e->getMessage() ), 'slug' );
     }
 }

--- a/src/Modules/Blog/Managers/BlogManager.php
+++ b/src/Modules/Blog/Managers/BlogManager.php
@@ -13,9 +13,12 @@ declare( strict_types=1 );
 namespace ArtisanPackUI\CMSFramework\Modules\Blog\Managers;
 
 use ArtisanPackUI\CMSFramework\Modules\Blog\Models\Post;
+use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Enums\ContentStatus;
 use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Managers\Concerns\HasContentFilters;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
 
 /**
  * Manages blog operations.
@@ -182,5 +185,274 @@ class BlogManager
             ->orderByRaw( 'CAST(JSON_EXTRACT(metadata, "$.view_count") AS UNSIGNED) DESC' )
             ->limit( $limit )
             ->get();
+    }
+
+    /**
+     * Create a blank draft post with an allocated unique slug. Powers the
+     * "New Post" auto-draft admin flow — an editor lands on the edit
+     * screen against a real record instead of a synthesized in-memory
+     * one, so autosave, custom-field wiring, and media associations all
+     * have an id to hang off.
+     *
+     * @since 2.7.0
+     *
+     * @param  int|null  $authorId  Author id to stamp on the record. Null when
+     *                              the caller has no authenticated user.
+     * @param  string  $baseSlug  Seed used for the unique-slug allocator.
+     */
+    public function autoDraft( ?int $authorId = null, string $baseSlug = 'untitled-post' ): Post
+    {
+        return Post::create( [
+            'title'     => 'Untitled post',
+            'slug'      => $this->uniqueSlug( $baseSlug ),
+            'status'    => ContentStatus::Draft,
+            'author_id' => $authorId,
+        ] );
+    }
+
+    /**
+     * Create a post from a validated attribute array. Handles the four
+     * responsibilities every consumer currently re-implements:
+     *
+     * 1. Missing-slug allocation via {@see uniqueSlug()} from the title.
+     * 2. Custom-field application through the {@see \ArtisanPackUI\CMSFramework\Modules\ContentTypes\Models\Concerns\HasCustomFields}
+     *    magic setter before the initial insert, so a single INSERT
+     *    captures both hardcoded columns and metadata JSON — filter
+     *    observers fire exactly once.
+     * 3. Setting `published_at = now()` when `status` is
+     *    {@see ContentStatus::Published} on creation.
+     * 4. Wrapping the write in a DB transaction so a mid-save filter
+     *     throw leaves neither a half-populated row nor stale category
+     *     pivots behind.
+     *
+     * Callers are responsible for validation ( slug uniqueness,
+     * status enum, author_id integrity ) upstream — the manager trusts
+     * the array it receives.
+     *
+     * @since 2.7.0
+     *
+     * @param  array<string,mixed>  $attributes  Fillable attributes for the
+     *                                           new post ( title, slug,
+     *                                           status, excerpt,
+     *                                           featured_image_id, etc. ).
+     * @param  array<string,mixed>|null  $customFields  Filter-registered
+     *                                                  custom-field values,
+     *                                                  keyed by field slug.
+     * @param  int|null  $authorId  Author id to stamp when not supplied
+     *                              in `$attributes`.
+     */
+    public function create( array $attributes, ?array $customFields = null, ?int $authorId = null ): Post
+    {
+        return DB::transaction( function () use ( $attributes, $customFields, $authorId ): Post {
+            $attributes = $this->normalizeAttributes( $attributes, $authorId );
+
+            $post = new Post( $this->fillableSubset( $attributes ) );
+            $this->applyCustomFields( $post, $customFields );
+            $post->save();
+
+            return $post;
+        } );
+    }
+
+    /**
+     * Update an existing post from a validated attribute array. Same
+     * four responsibilities as {@see create()}, plus the "first
+     * transition to Published stamps `published_at`" rule that every
+     * consumer today rediscovers independently.
+     *
+     * @since 2.7.0
+     *
+     * @param  array<string,mixed>  $attributes  Fillable attributes to fill
+     *                                           onto the record.
+     * @param  array<string,mixed>|null  $customFields  Filter-registered
+     *                                                  custom-field values.
+     */
+    public function update( Post $post, array $attributes, ?array $customFields = null ): Post
+    {
+        return DB::transaction( function () use ( $post, $attributes, $customFields ): Post {
+            $wasPublished = ContentStatus::Published === $post->status;
+
+            $post->fill( $this->fillableSubset( $attributes ) );
+
+            $nowPublished = ContentStatus::Published === $post->status;
+
+            if ( $nowPublished && ! $wasPublished && null === $post->published_at ) {
+                $post->published_at = now();
+            }
+
+            $this->applyCustomFields( $post, $customFields );
+            $post->save();
+
+            return $post;
+        } );
+    }
+
+    /**
+     * Soft-delete a post. Thin seal over `Post::delete()` so consumers
+     * don't have to import the model to route through the domain
+     * service; also gives us one place to hang cross-cutting concerns
+     * later ( audit log, revisions history, cache invalidation ).
+     *
+     * @since 2.7.0
+     */
+    public function delete( Post $post ): void
+    {
+        DB::transaction( fn () => $post->delete() );
+    }
+
+    /**
+     * Duplicate an existing post. Copies fillable attributes, allocates
+     * a fresh unique slug, appends "(Copy)" to the title, resets status
+     * to {@see ContentStatus::Draft}, and mirrors the source's category
+     * and tag associations. `published_at` is intentionally not copied
+     * — a duplicated draft has never been published.
+     *
+     * @since 2.7.0
+     *
+     * @param  int|null  $authorId  Author id to stamp on the copy. Falls
+     *                              back to the source's author when null.
+     */
+    public function duplicate( Post $post, ?int $authorId = null ): Post
+    {
+        return DB::transaction( function () use ( $post, $authorId ): Post {
+            $copy            = $post->replicate( ['published_at'] );
+            $copy->title     = $post->title . ' (Copy)';
+            $copy->slug      = $this->uniqueSlug( $post->slug . '-copy' );
+            $copy->status    = ContentStatus::Draft;
+            $copy->author_id = $authorId ?? $post->author_id;
+            $copy->save();
+
+            $copy->categories()->sync( $post->categories->pluck( 'id' )->all() );
+            $copy->tags()->sync( $post->tags->pluck( 'id' )->all() );
+
+            return $copy;
+        } );
+    }
+
+    /**
+     * Sync a post's category associations. Wrapper so consumers don't
+     * have to know the pivot's shape.
+     *
+     * @since 2.7.0
+     *
+     * @param  array<int,int>  $categoryIds
+     */
+    public function syncCategories( Post $post, array $categoryIds ): void
+    {
+        $post->categories()->sync( $categoryIds );
+    }
+
+    /**
+     * Sync a post's tag associations. Wrapper so consumers don't have
+     * to know the pivot's shape.
+     *
+     * @since 2.7.0
+     *
+     * @param  array<int,int>  $tagIds
+     */
+    public function syncTags( Post $post, array $tagIds ): void
+    {
+        $post->tags()->sync( $tagIds );
+    }
+
+    /**
+     * Allocate a slug that does not collide with any existing post's
+     * slug ( including soft-deleted rows, so a restore can't
+     * resurrect a duplicate ). Appends `-2`, `-3`, … to the source
+     * until a free slot is found.
+     *
+     * @since 2.7.0
+     *
+     * @param  string  $source  Text to slugify. Non-slug input is normalized
+     *                          via {@see Str::slug()}.
+     */
+    public function uniqueSlug( string $source ): string
+    {
+        $base = Str::slug( $source );
+
+        if ( '' === $base ) {
+            $base = 'post';
+        }
+
+        $slug = $base;
+        $n    = 2;
+
+        while ( Post::withTrashed()->where( 'slug', $slug )->exists() ) {
+            $slug = $base . '-' . $n;
+            $n++;
+        }
+
+        return $slug;
+    }
+
+    /**
+     * Apply the shared normalization every write path needs — missing
+     * slug allocation, author stamp fallback, status coercion from raw
+     * string.
+     *
+     * @param  array<string,mixed>  $attributes
+     *
+     * @return array<string,mixed>
+     */
+    protected function normalizeAttributes( array $attributes, ?int $authorId ): array
+    {
+        if ( ! isset( $attributes['slug'] ) || '' === $attributes['slug'] ) {
+            $attributes['slug'] = $this->uniqueSlug( ( string ) ( $attributes['title'] ?? '' ) );
+        }
+
+        if ( ! isset( $attributes['author_id'] ) && null !== $authorId ) {
+            $attributes['author_id'] = $authorId;
+        }
+
+        if ( isset( $attributes['status'] ) && is_string( $attributes['status'] ) ) {
+            $attributes['status'] = ContentStatus::from( $attributes['status'] );
+        }
+
+        if ( isset( $attributes['status'] )
+            && ContentStatus::Published === $attributes['status']
+            && ! array_key_exists( 'published_at', $attributes ) ) {
+            $attributes['published_at'] = now();
+        }
+
+        return $attributes;
+    }
+
+    /**
+     * Intersect a caller-supplied attribute array with the model's
+     * fillable set so a manager caller can hand over a raw validated
+     * payload and not worry about mass-assignment guardrails.
+     *
+     * @param  array<string,mixed>  $attributes
+     *
+     * @return array<string,mixed>
+     */
+    protected function fillableSubset( array $attributes ): array
+    {
+        $fillable = ( new Post )->getFillable();
+
+        // `published_at` and `author_id` are guarded by default but the
+        // manager legitimately writes them; keep them in the subset.
+        $allowed = array_merge( $fillable, ['published_at', 'author_id', 'status'] );
+
+        return array_intersect_key( $attributes, array_flip( $allowed ) );
+    }
+
+    /**
+     * Route filter-registered custom-field values through the
+     * {@see \ArtisanPackUI\CMSFramework\Modules\ContentTypes\Models\Concerns\HasCustomFields}
+     * magic setter before save so a single INSERT/UPDATE captures both
+     * the hardcoded columns and the metadata JSON.
+     *
+     * @param  array<string,mixed>|null  $customFields
+     */
+    protected function applyCustomFields( Post $post, ?array $customFields ): void
+    {
+        if ( null === $customFields || [] === $customFields ) {
+            return;
+        }
+
+        foreach ( $customFields as $key => $value ) {
+            $post->{$key} = $value;
+        }
     }
 }

--- a/src/Modules/Pages/Managers/PageManager.php
+++ b/src/Modules/Pages/Managers/PageManager.php
@@ -17,6 +17,8 @@ use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Managers\Concerns\HasContent
 use ArtisanPackUI\CMSFramework\Modules\Pages\Models\Page;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
 use InvalidArgumentException;
 
 /**
@@ -228,6 +230,148 @@ class PageManager
     }
 
     /**
+     * Create a blank draft page with an allocated unique slug. Powers
+     * the "New Page" auto-draft admin flow — an editor lands on the
+     * edit screen against a real record instead of a synthesized
+     * in-memory one, so autosave, custom-field wiring, and media
+     * associations all have an id to hang off.
+     *
+     * @since 2.7.0
+     *
+     * @param  int|null  $authorId  Author id to stamp on the record.
+     * @param  string  $baseSlug  Seed used for the unique-slug allocator.
+     */
+    public function autoDraft( ?int $authorId = null, string $baseSlug = 'untitled-page' ): Page
+    {
+        return Page::create( [
+            'title'     => 'Untitled page',
+            'slug'      => $this->uniqueSlug( $baseSlug ),
+            'status'    => ContentStatus::Draft,
+            'author_id' => $authorId,
+            'order'     => 0,
+        ] );
+    }
+
+    /**
+     * Create a page from a validated attribute array. Same four
+     * responsibilities as {@see \ArtisanPackUI\CMSFramework\Modules\Blog\Managers\BlogManager::create()}
+     * — missing-slug allocation, custom-field application timing,
+     * `published_at` stamp on Published, and transactional write —
+     * plus support for the hierarchical `parent_id`, `order`, and
+     * `template` columns unique to Page.
+     *
+     * @since 2.7.0
+     *
+     * @param  array<string,mixed>  $attributes
+     * @param  array<string,mixed>|null  $customFields
+     */
+    public function create( array $attributes, ?array $customFields = null, ?int $authorId = null ): Page
+    {
+        return DB::transaction( function () use ( $attributes, $customFields, $authorId ): Page {
+            $attributes = $this->normalizeAttributes( $attributes, $authorId );
+
+            $page = new Page( $this->fillableSubset( $attributes ) );
+            $this->applyCustomFields( $page, $customFields );
+            $page->save();
+
+            return $page;
+        } );
+    }
+
+    /**
+     * Update an existing page from a validated attribute array. Same
+     * transitions as create, plus the "first draft -> published stamps
+     * `published_at`" rule.
+     *
+     * @since 2.7.0
+     *
+     * @param  array<string,mixed>  $attributes
+     * @param  array<string,mixed>|null  $customFields
+     */
+    public function update( Page $page, array $attributes, ?array $customFields = null ): Page
+    {
+        return DB::transaction( function () use ( $page, $attributes, $customFields ): Page {
+            $wasPublished = ContentStatus::Published === $page->status;
+
+            $page->fill( $this->fillableSubset( $attributes ) );
+
+            $nowPublished = ContentStatus::Published === $page->status;
+
+            if ( $nowPublished && ! $wasPublished && null === $page->published_at ) {
+                $page->published_at = now();
+            }
+
+            $this->applyCustomFields( $page, $customFields );
+            $page->save();
+
+            return $page;
+        } );
+    }
+
+    /**
+     * Soft-delete a page. Wrapper so consumers don't have to import
+     * Page to route through the domain service.
+     *
+     * @since 2.7.0
+     */
+    public function delete( Page $page ): void
+    {
+        DB::transaction( fn () => $page->delete() );
+    }
+
+    /**
+     * Duplicate an existing page. Copies fillable attributes, allocates
+     * a fresh unique slug, appends "(Copy)" to the title, resets status
+     * to {@see ContentStatus::Draft}. Does NOT copy `parent_id` blindly
+     * — the duplicate is created at the same hierarchical level as the
+     * source. `published_at` is intentionally not copied.
+     *
+     * @since 2.7.0
+     */
+    public function duplicate( Page $page, ?int $authorId = null ): Page
+    {
+        return DB::transaction( function () use ( $page, $authorId ): Page {
+            $copy            = $page->replicate( ['published_at'] );
+            $copy->title     = $page->title . ' (Copy)';
+            $copy->slug      = $this->uniqueSlug( $page->slug . '-copy' );
+            $copy->status    = ContentStatus::Draft;
+            $copy->author_id = $authorId ?? $page->author_id;
+            $copy->save();
+
+            return $copy;
+        } );
+    }
+
+    /**
+     * Allocate a slug that does not collide with any existing page's
+     * slug ( including soft-deleted rows ). Appends `-2`, `-3`, … to
+     * the source until a free slot is found.
+     *
+     * @since 2.7.0
+     *
+     * @param  string  $source  Text to slugify. Non-slug input is
+     *                          normalized via {@see Str::slug()}.
+     */
+    public function uniqueSlug( string $source ): string
+    {
+        $base = Str::slug( $source );
+
+        if ( '' === $base ) {
+            $base = 'page';
+        }
+
+        $slug = $base;
+        $n    = 2;
+
+        while ( Page::withTrashed()->where( 'slug', $slug )->exists() ) {
+            $slug = $base . '-' . $n;
+            $n++;
+        }
+
+        return $slug;
+    }
+
+    /**
      * Load children recursively for a page.
      *
      * @since 1.0.0
@@ -263,7 +407,70 @@ class PageManager
 
         // Apply template filter (page-specific)
         if ( isset( $filters['template'] ) ) {
-            $query->byTemplate( $filters['template']);
+            $query->byTemplate( $filters['template'] );
+        }
+    }
+
+    /**
+     * Apply the shared normalization every write path needs.
+     *
+     * @param  array<string,mixed>  $attributes
+     *
+     * @return array<string,mixed>
+     */
+    protected function normalizeAttributes( array $attributes, ?int $authorId ): array
+    {
+        if ( ! isset( $attributes['slug'] ) || '' === $attributes['slug'] ) {
+            $attributes['slug'] = $this->uniqueSlug( ( string ) ( $attributes['title'] ?? '' ) );
+        }
+
+        if ( ! isset( $attributes['author_id'] ) && null !== $authorId ) {
+            $attributes['author_id'] = $authorId;
+        }
+
+        if ( isset( $attributes['status'] ) && is_string( $attributes['status'] ) ) {
+            $attributes['status'] = ContentStatus::from( $attributes['status'] );
+        }
+
+        if ( isset( $attributes['status'] )
+            && ContentStatus::Published === $attributes['status']
+            && ! array_key_exists( 'published_at', $attributes ) ) {
+            $attributes['published_at'] = now();
+        }
+
+        return $attributes;
+    }
+
+    /**
+     * Intersect a caller-supplied attribute array with the model's
+     * fillable set so a manager caller can hand over a raw validated
+     * payload and not worry about mass-assignment guardrails.
+     *
+     * @param  array<string,mixed>  $attributes
+     *
+     * @return array<string,mixed>
+     */
+    protected function fillableSubset( array $attributes ): array
+    {
+        return array_intersect_key( $attributes, array_flip( ( new Page )->getFillable() ) );
+    }
+
+    /**
+     * Route filter-registered custom-field values through the
+     * {@see \ArtisanPackUI\CMSFramework\Modules\ContentTypes\Models\Concerns\HasCustomFields}
+     * magic setter before save so a single write captures both the
+     * hardcoded columns and the metadata JSON.
+     *
+     * @param  array<string,mixed>|null  $customFields
+     */
+    protected function applyCustomFields( Page $page, ?array $customFields ): void
+    {
+        if ( null === $customFields || [] === $customFields ) {
+            return;
+        }
+
+        foreach ( $customFields as $key => $value ) {
+            $page->{$key} = $value;
         }
     }
 }

--- a/src/Modules/Pages/Managers/PageManager.php
+++ b/src/Modules/Pages/Managers/PageManager.php
@@ -16,6 +16,7 @@ use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Enums\ContentStatus;
 use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Managers\Concerns\HasContentFilters;
 use ArtisanPackUI\CMSFramework\Modules\Pages\Models\Page;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\QueryException;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
@@ -243,13 +244,17 @@ class PageManager
      */
     public function autoDraft( ?int $authorId = null, string $baseSlug = 'untitled-page' ): Page
     {
-        return Page::create( [
+        $page = new Page( [
             'title'     => 'Untitled page',
             'slug'      => $this->uniqueSlug( $baseSlug ),
             'status'    => ContentStatus::Draft,
             'author_id' => $authorId,
             'order'     => 0,
         ] );
+
+        $this->saveWithSlugRetry( $page );
+
+        return $page;
     }
 
     /**
@@ -272,7 +277,7 @@ class PageManager
 
             $page = new Page( $this->fillableSubset( $attributes ) );
             $this->applyCustomFields( $page, $customFields );
-            $page->save();
+            $this->saveWithSlugRetry( $page );
 
             return $page;
         } );
@@ -291,6 +296,31 @@ class PageManager
     public function update( Page $page, array $attributes, ?array $customFields = null ): Page
     {
         return DB::transaction( function () use ( $page, $attributes, $customFields ): Page {
+            if ( array_key_exists( 'slug', $attributes ) && '' === trim( ( string ) $attributes['slug'] ) ) {
+                unset( $attributes['slug'] );
+            }
+
+            // Guard against a caller writing `parent_id => $descendantId`
+            // through update() the same way {@see movePage()} does.
+            // Without this, Page::ancestors() and Page::descendants()
+            // (both unbounded `while ($parent)` recursion) would loop
+            // forever the next time the page tree is rendered — an
+            // availability risk in the admin UI. Only enforce when the
+            // caller actually passes parent_id ( array_key_exists ), so
+            // a plain title/slug update doesn't pay for the descendant
+            // pluck.
+            if ( array_key_exists( 'parent_id', $attributes ) && null !== $attributes['parent_id'] ) {
+                $incoming = ( int ) $attributes['parent_id'];
+
+                if ( $incoming === $page->id ) {
+                    throw new InvalidArgumentException( 'Cannot move a page to itself.' );
+                }
+
+                if ( in_array( $incoming, $page->descendants()->pluck( 'id' )->toArray(), true ) ) {
+                    throw new InvalidArgumentException( 'Cannot move a page to its own descendant.' );
+                }
+            }
+
             $wasPublished = ContentStatus::Published === $page->status;
 
             $page->fill( $this->fillableSubset( $attributes ) );
@@ -302,7 +332,7 @@ class PageManager
             }
 
             $this->applyCustomFields( $page, $customFields );
-            $page->save();
+            $this->saveWithSlugRetry( $page );
 
             return $page;
         } );
@@ -311,6 +341,15 @@ class PageManager
     /**
      * Soft-delete a page. Wrapper so consumers don't have to import
      * Page to route through the domain service.
+     *
+     * Child pages are NOT reparented or cascade-deleted — their
+     * `parent_id` still points at the soft-deleted row, so
+     * {@see getPageTree()} / {@see getTopLevelPages()} silently
+     * exclude the subtree until either the parent is restored or a
+     * host explicitly reparents the children. This preserves the
+     * pre-2.7.0 SoftDeletes behavior; a future release can layer a
+     * cascade / reparent policy on top if the host contract requires
+     * it.
      *
      * @since 2.7.0
      */
@@ -336,7 +375,13 @@ class PageManager
             $copy->slug      = $this->uniqueSlug( $page->slug . '-copy' );
             $copy->status    = ContentStatus::Draft;
             $copy->author_id = $authorId ?? $page->author_id;
-            $copy->save();
+            $this->saveWithSlugRetry( $copy );
+
+            // Mirror the source's category and tag associations for
+            // parity with {@see \ArtisanPackUI\CMSFramework\Modules\Blog\Managers\BlogManager::duplicate()}
+            // — Page ships the same BelongsToMany relations.
+            $copy->categories()->sync( $page->categories->pluck( 'id' )->all() );
+            $copy->tags()->sync( $page->tags->pluck( 'id' )->all() );
 
             return $copy;
         } );
@@ -472,5 +517,46 @@ class PageManager
         foreach ( $customFields as $key => $value ) {
             $page->{$key} = $value;
         }
+    }
+
+    /**
+     * Save a page, catching the tiny race where two writers each pass
+     * {@see uniqueSlug()}'s pre-check with the same candidate and then
+     * collide on the DB-level unique index. Reallocates the slug once
+     * from its own value as a fresh base and retries; a second
+     * collision surfaces to the caller as {@see QueryException}.
+     *
+     * @throws QueryException on non-slug-unique errors, or on a second
+     *                        slug-unique collision after the retry.
+     */
+    protected function saveWithSlugRetry( Page $page ): void
+    {
+        try {
+            $page->save();
+        } catch ( QueryException $e ) {
+            if ( ! $this->isUniqueSlugViolation( $e ) ) {
+                throw $e;
+            }
+
+            $page->slug = $this->uniqueSlug( $page->slug );
+            $page->save();
+        }
+    }
+
+    /**
+     * Whether a QueryException reports an integrity-constraint violation
+     * on the slug column. Uses the SQLSTATE class ( `23`, integrity
+     * constraint violation ) rather than a driver-specific errno so the
+     * check works uniformly across MySQL, SQLite, and PostgreSQL.
+     */
+    protected function isUniqueSlugViolation( QueryException $e ): bool
+    {
+        $sqlState = ( string ) $e->getCode();
+
+        if ( ! str_starts_with( $sqlState, '23' ) ) {
+            return false;
+        }
+
+        return str_contains( strtolower( $e->getMessage() ), 'slug' );
     }
 }

--- a/tests/Feature/Blog/BlogManagerWriteTest.php
+++ b/tests/Feature/Blog/BlogManagerWriteTest.php
@@ -1,0 +1,218 @@
+<?php
+
+declare( strict_types=1 );
+
+/**
+ * Feature coverage for the BlogManager write API introduced in 2.7.0 (#250).
+ *
+ * Proves the manager owns the persistence orchestration for `Post` — unique
+ * slug allocation, custom-field application timing, published_at transitions,
+ * soft-delete, duplicate — so downstream apps stop reinventing these rules
+ * per-controller.
+ *
+ * @since 2.7.0
+ */
+
+use ArtisanPackUI\CMSFramework\Modules\Blog\Managers\BlogManager;
+use ArtisanPackUI\CMSFramework\Modules\Blog\Models\Post;
+use ArtisanPackUI\CMSFramework\Modules\Blog\Models\PostCategory;
+use ArtisanPackUI\CMSFramework\Modules\Blog\Models\PostTag;
+use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Enums\ContentStatus;
+use ArtisanPackUI\CMSFramework\Tests\Support\TestUser;
+
+beforeEach( function (): void {
+    $this->artisan( 'migrate', ['--database' => 'testing'] );
+    $this->manager = new BlogManager;
+    $this->user    = TestUser::factory()->create();
+} );
+
+afterEach( function (): void {
+    removeAllFilters( 'ap.contentTypes.registeredCustomFields' );
+} );
+
+test( 'autoDraft creates a draft post with a unique slug and stamps the author', function (): void {
+    $post = $this->manager->autoDraft( $this->user->id );
+
+    expect( $post->exists )->toBeTrue();
+    expect( $post->title )->toBe( 'Untitled post' );
+    expect( $post->status )->toBe( ContentStatus::Draft );
+    expect( $post->author_id )->toBe( $this->user->id );
+    expect( $post->slug )->toBe( 'untitled-post' );
+} );
+
+test( 'autoDraft appends a counter when the base slug is already taken', function (): void {
+    $this->manager->autoDraft( $this->user->id );
+    $second = $this->manager->autoDraft( $this->user->id );
+    $third  = $this->manager->autoDraft( $this->user->id );
+
+    expect( $second->slug )->toBe( 'untitled-post-2' );
+    expect( $third->slug )->toBe( 'untitled-post-3' );
+} );
+
+test( 'uniqueSlug avoids collisions with soft-deleted rows too', function (): void {
+    $post = $this->manager->autoDraft( $this->user->id );
+    $post->delete();
+
+    expect( $this->manager->uniqueSlug( 'untitled-post' ) )->toBe( 'untitled-post-2' );
+} );
+
+test( 'uniqueSlug falls back to `post` when the source is not slugifiable', function (): void {
+    expect( $this->manager->uniqueSlug( '!!!' ) )->toBe( 'post' );
+} );
+
+test( 'create writes the fillable subset and derives a slug when one is missing', function (): void {
+    $post = $this->manager->create( [
+        'title'   => 'Hello World',
+        'status'  => 'draft',
+        'excerpt' => 'A short summary',
+    ], null, $this->user->id );
+
+    expect( $post->exists )->toBeTrue();
+    expect( $post->title )->toBe( 'Hello World' );
+    expect( $post->slug )->toBe( 'hello-world' );
+    expect( $post->status )->toBe( ContentStatus::Draft );
+    expect( $post->author_id )->toBe( $this->user->id );
+    expect( $post->excerpt )->toBe( 'A short summary' );
+    expect( $post->published_at )->toBeNull();
+} );
+
+test( 'create stamps published_at when the initial status is Published', function (): void {
+    $post = $this->manager->create( [
+        'title'  => 'Live from day one',
+        'status' => ContentStatus::Published,
+    ], null, $this->user->id );
+
+    expect( $post->status )->toBe( ContentStatus::Published );
+    expect( $post->published_at )->not->toBeNull();
+} );
+
+test( 'create applies custom-field values into the metadata column before insert', function (): void {
+    // Filter-register a metadata-storage custom field so the
+    // HasCustomFields trait's magic setter routes `reading_time` into
+    // the JSON column instead of falling through to Eloquent's column
+    // path. DB-created fields (via CustomField::create) are always
+    // column-mode; only filter-registered fields use metadata storage.
+    addFilter( 'ap.contentTypes.registeredCustomFields', function ( array $fields ): array {
+        $fields['reading_time'] = [
+            'key'           => 'reading_time',
+            'name'          => 'Reading Time',
+            'type'          => 'text',
+            'content_types' => ['posts'],
+            'required'      => false,
+            'default_value' => null,
+            'storage'       => 'metadata',
+        ];
+
+        return $fields;
+    } );
+
+    $post = $this->manager->create( [
+        'title'    => 'With metadata',
+        'status'   => ContentStatus::Draft,
+        'metadata' => [],
+    ], [
+        'reading_time' => '4 minutes',
+    ], $this->user->id );
+
+    expect( $post->fresh()->metadata )->toBe( ['reading_time' => '4 minutes'] );
+} );
+
+test( 'create rejects attributes outside the fillable + write allowlist', function (): void {
+    $post = $this->manager->create( [
+        'title'      => 'Guarded',
+        'status'     => ContentStatus::Draft,
+        'id'         => 999,
+        'created_at' => '2024-01-01 00:00:00',
+    ], null, $this->user->id );
+
+    expect( $post->id )->not->toBe( 999 );
+} );
+
+test( 'update fills the record and preserves untouched attributes', function (): void {
+    $post = $this->manager->create( [
+        'title'   => 'First',
+        'excerpt' => 'Original excerpt',
+        'status'  => ContentStatus::Draft,
+    ], null, $this->user->id );
+
+    $updated = $this->manager->update( $post, [
+        'title'  => 'Second',
+        'status' => ContentStatus::Draft,
+    ] );
+
+    expect( $updated->title )->toBe( 'Second' );
+    expect( $updated->excerpt )->toBe( 'Original excerpt' );
+} );
+
+test( 'update stamps published_at exactly once on the first draft -> published transition', function (): void {
+    $post = $this->manager->create( [
+        'title'  => 'Was Draft',
+        'status' => ContentStatus::Draft,
+    ], null, $this->user->id );
+
+    expect( $post->published_at )->toBeNull();
+
+    $published  = $this->manager->update( $post, ['status' => ContentStatus::Published] );
+    $firstStamp = $published->published_at;
+
+    expect( $firstStamp )->not->toBeNull();
+
+    // Round-trip through Draft and back — the original stamp must not
+    // be overwritten on the second publish.
+    $this->manager->update( $post, ['status' => ContentStatus::Draft] );
+    $republished = $this->manager->update( $post, ['status' => ContentStatus::Published] );
+
+    expect( $republished->published_at->equalTo( $firstStamp ) )->toBeTrue();
+} );
+
+test( 'delete soft-deletes the post', function (): void {
+    $post = $this->manager->create( [
+        'title'  => 'Doomed',
+        'status' => ContentStatus::Draft,
+    ], null, $this->user->id );
+
+    $this->manager->delete( $post );
+
+    expect( Post::find( $post->id ) )->toBeNull();
+    expect( Post::withTrashed()->find( $post->id ) )->not->toBeNull();
+} );
+
+test( 'duplicate returns a fresh draft with (Copy) title, unique slug, and mirrored taxonomies', function (): void {
+    $category = PostCategory::create( ['name' => 'Cat', 'slug' => 'cat'] );
+    $tag      = PostTag::create( ['name' => 'Tag', 'slug' => 'tag'] );
+
+    $post = $this->manager->create( [
+        'title'  => 'Original',
+        'status' => ContentStatus::Published,
+    ], null, $this->user->id );
+
+    $this->manager->syncCategories( $post, [ $category->id ] );
+    $this->manager->syncTags( $post, [ $tag->id ] );
+
+    $copy = $this->manager->duplicate( $post );
+
+    expect( $copy->id )->not->toBe( $post->id );
+    expect( $copy->title )->toBe( 'Original (Copy)' );
+    expect( $copy->status )->toBe( ContentStatus::Draft );
+    expect( $copy->published_at )->toBeNull();
+    expect( $copy->slug )->toBe( 'original-copy' );
+    expect( $copy->categories->pluck( 'id' )->all() )->toBe( [ $category->id ] );
+    expect( $copy->tags->pluck( 'id' )->all() )->toBe( [ $tag->id ] );
+} );
+
+test( 'syncCategories replaces the category set atomically', function (): void {
+    $a = PostCategory::create( ['name' => 'A', 'slug' => 'a'] );
+    $b = PostCategory::create( ['name' => 'B', 'slug' => 'b'] );
+    $c = PostCategory::create( ['name' => 'C', 'slug' => 'c'] );
+
+    $post = $this->manager->create( [
+        'title'  => 'Categorized',
+        'status' => ContentStatus::Draft,
+    ], null, $this->user->id );
+
+    $this->manager->syncCategories( $post, [ $a->id, $b->id ] );
+    expect( $post->categories()->pluck( 'id' )->all() )->toEqualCanonicalizing( [ $a->id, $b->id ] );
+
+    $this->manager->syncCategories( $post, [ $c->id ] );
+    expect( $post->categories()->pluck( 'id' )->all() )->toBe( [ $c->id ] );
+} );

--- a/tests/Feature/Blog/BlogManagerWriteTest.php
+++ b/tests/Feature/Blog/BlogManagerWriteTest.php
@@ -200,6 +200,21 @@ test( 'duplicate returns a fresh draft with (Copy) title, unique slug, and mirro
     expect( $copy->tags->pluck( 'id' )->all() )->toBe( [ $tag->id ] );
 } );
 
+test( 'update leaves the existing slug intact when the caller passes an empty slug', function (): void {
+    $post = $this->manager->create( [
+        'title' => 'Keep the slug',
+        'slug'  => 'keep-the-slug',
+    ], null, $this->user->id );
+
+    $updated = $this->manager->update( $post, [
+        'title' => 'New title',
+        'slug'  => '',
+    ] );
+
+    expect( $updated->slug )->toBe( 'keep-the-slug' );
+    expect( $updated->title )->toBe( 'New title' );
+} );
+
 test( 'syncCategories replaces the category set atomically', function (): void {
     $a = PostCategory::create( ['name' => 'A', 'slug' => 'a'] );
     $b = PostCategory::create( ['name' => 'B', 'slug' => 'b'] );

--- a/tests/Feature/Pages/PageManagerWriteTest.php
+++ b/tests/Feature/Pages/PageManagerWriteTest.php
@@ -15,6 +15,8 @@ declare( strict_types=1 );
 use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Enums\ContentStatus;
 use ArtisanPackUI\CMSFramework\Modules\Pages\Managers\PageManager;
 use ArtisanPackUI\CMSFramework\Modules\Pages\Models\Page;
+use ArtisanPackUI\CMSFramework\Modules\Pages\Models\PageCategory;
+use ArtisanPackUI\CMSFramework\Modules\Pages\Models\PageTag;
 use ArtisanPackUI\CMSFramework\Tests\Support\TestUser;
 
 beforeEach( function (): void {
@@ -161,6 +163,40 @@ test( 'update can move a page into a new hierarchy position', function (): void 
     expect( $moved->order )->toBe( 3 );
 } );
 
+test( 'update leaves the existing slug intact when the caller passes an empty slug', function (): void {
+    $page = $this->manager->create( [
+        'title' => 'Keep me',
+        'slug'  => 'keep-me',
+    ], null, $this->user->id );
+
+    $updated = $this->manager->update( $page, [
+        'title' => 'Renamed',
+        'slug'  => '',
+    ] );
+
+    expect( $updated->slug )->toBe( 'keep-me' );
+} );
+
+test( 'update rejects reparenting a page to itself', function (): void {
+    $page = $this->manager->create( [
+        'title' => 'Self',
+    ], null, $this->user->id );
+
+    expect( fn () => $this->manager->update( $page, ['parent_id' => $page->id] ) )
+        ->toThrow( InvalidArgumentException::class, 'itself' );
+} );
+
+test( 'update rejects reparenting a page to one of its own descendants', function (): void {
+    $parent = $this->manager->create( ['title' => 'Parent'], null, $this->user->id );
+    $child  = $this->manager->create( [
+        'title'     => 'Child',
+        'parent_id' => $parent->id,
+    ], null, $this->user->id );
+
+    expect( fn () => $this->manager->update( $parent, ['parent_id' => $child->id] ) )
+        ->toThrow( InvalidArgumentException::class, 'descendant' );
+} );
+
 test( 'delete soft-deletes the page', function (): void {
     $page = $this->manager->create( [
         'title'  => 'Doomed',
@@ -189,4 +225,22 @@ test( 'duplicate returns a fresh draft with (Copy) title and unique slug', funct
     expect( $copy->slug )->toBe( 'original-copy' );
     // Copies preserve template but reset status to Draft.
     expect( $copy->template )->toBe( 'sidebar' );
+} );
+
+test( 'duplicate mirrors the source page category and tag associations', function (): void {
+    $category = PageCategory::create( ['name' => 'Docs', 'slug' => 'docs'] );
+    $tag      = PageTag::create( ['name' => 'V2', 'slug' => 'v2'] );
+
+    $page = $this->manager->create( [
+        'title'  => 'Original',
+        'status' => ContentStatus::Draft,
+    ], null, $this->user->id );
+
+    $page->categories()->sync( [ $category->id ] );
+    $page->tags()->sync( [ $tag->id ] );
+
+    $copy = $this->manager->duplicate( $page );
+
+    expect( $copy->categories->pluck( 'id' )->all() )->toBe( [ $category->id ] );
+    expect( $copy->tags->pluck( 'id' )->all() )->toBe( [ $tag->id ] );
 } );

--- a/tests/Feature/Pages/PageManagerWriteTest.php
+++ b/tests/Feature/Pages/PageManagerWriteTest.php
@@ -1,0 +1,192 @@
+<?php
+
+declare( strict_types=1 );
+
+/**
+ * Feature coverage for the PageManager write API introduced in 2.7.0 (#250).
+ *
+ * Mirrors {@see Tests\Feature\Blog\BlogManagerWriteTest} against Page, plus
+ * coverage for the hierarchical parent_id / order / template attributes that
+ * only Page carries.
+ *
+ * @since 2.7.0
+ */
+
+use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Enums\ContentStatus;
+use ArtisanPackUI\CMSFramework\Modules\Pages\Managers\PageManager;
+use ArtisanPackUI\CMSFramework\Modules\Pages\Models\Page;
+use ArtisanPackUI\CMSFramework\Tests\Support\TestUser;
+
+beforeEach( function (): void {
+    $this->artisan( 'migrate', ['--database' => 'testing'] );
+    $this->manager = new PageManager;
+    $this->user    = TestUser::factory()->create();
+} );
+
+afterEach( function (): void {
+    removeAllFilters( 'ap.contentTypes.registeredCustomFields' );
+} );
+
+test( 'autoDraft creates a draft page with a unique slug and stamps the author', function (): void {
+    $page = $this->manager->autoDraft( $this->user->id );
+
+    expect( $page->exists )->toBeTrue();
+    expect( $page->title )->toBe( 'Untitled page' );
+    expect( $page->status )->toBe( ContentStatus::Draft );
+    expect( $page->author_id )->toBe( $this->user->id );
+    expect( $page->slug )->toBe( 'untitled-page' );
+    expect( $page->order )->toBe( 0 );
+} );
+
+test( 'autoDraft appends a counter when the base slug is already taken', function (): void {
+    $this->manager->autoDraft( $this->user->id );
+    $second = $this->manager->autoDraft( $this->user->id );
+
+    expect( $second->slug )->toBe( 'untitled-page-2' );
+} );
+
+test( 'uniqueSlug avoids collisions with soft-deleted rows too', function (): void {
+    $page = $this->manager->autoDraft( $this->user->id );
+    $page->delete();
+
+    expect( $this->manager->uniqueSlug( 'untitled-page' ) )->toBe( 'untitled-page-2' );
+} );
+
+test( 'uniqueSlug falls back to `page` when the source is not slugifiable', function (): void {
+    expect( $this->manager->uniqueSlug( '!!!' ) )->toBe( 'page' );
+} );
+
+test( 'create writes the fillable subset and derives a slug when one is missing', function (): void {
+    $page = $this->manager->create( [
+        'title'   => 'About us',
+        'status'  => 'draft',
+        'excerpt' => 'The about page',
+    ], null, $this->user->id );
+
+    expect( $page->exists )->toBeTrue();
+    expect( $page->slug )->toBe( 'about-us' );
+    expect( $page->status )->toBe( ContentStatus::Draft );
+    expect( $page->author_id )->toBe( $this->user->id );
+} );
+
+test( 'create stamps published_at when the initial status is Published', function (): void {
+    $page = $this->manager->create( [
+        'title'  => 'Launch page',
+        'status' => ContentStatus::Published,
+    ], null, $this->user->id );
+
+    expect( $page->status )->toBe( ContentStatus::Published );
+    expect( $page->published_at )->not->toBeNull();
+} );
+
+test( 'create writes hierarchical attributes (parent_id, order, template)', function (): void {
+    $parent = $this->manager->create( [
+        'title'  => 'Parent',
+        'status' => ContentStatus::Draft,
+    ], null, $this->user->id );
+
+    $child = $this->manager->create( [
+        'title'     => 'Child',
+        'status'    => ContentStatus::Draft,
+        'parent_id' => $parent->id,
+        'order'     => 5,
+        'template'  => 'sidebar',
+    ], null, $this->user->id );
+
+    expect( $child->parent_id )->toBe( $parent->id );
+    expect( $child->order )->toBe( 5 );
+    expect( $child->template )->toBe( 'sidebar' );
+} );
+
+test( 'create applies custom-field values into the metadata column before insert', function (): void {
+    addFilter( 'ap.contentTypes.registeredCustomFields', function ( array $fields ): array {
+        $fields['landing_cta'] = [
+            'key'           => 'landing_cta',
+            'name'          => 'Landing CTA',
+            'type'          => 'text',
+            'content_types' => ['pages'],
+            'required'      => false,
+            'default_value' => null,
+            'storage'       => 'metadata',
+        ];
+
+        return $fields;
+    } );
+
+    $page = $this->manager->create( [
+        'title'    => 'Landing',
+        'status'   => ContentStatus::Draft,
+        'metadata' => [],
+    ], [
+        'landing_cta' => 'Sign up now',
+    ], $this->user->id );
+
+    expect( $page->fresh()->metadata )->toBe( ['landing_cta' => 'Sign up now'] );
+} );
+
+test( 'update stamps published_at exactly once on the first draft -> published transition', function (): void {
+    $page = $this->manager->create( [
+        'title'  => 'Was Draft',
+        'status' => ContentStatus::Draft,
+    ], null, $this->user->id );
+
+    $published  = $this->manager->update( $page, ['status' => ContentStatus::Published] );
+    $firstStamp = $published->published_at;
+
+    expect( $firstStamp )->not->toBeNull();
+
+    $this->manager->update( $page, ['status' => ContentStatus::Draft] );
+    $republished = $this->manager->update( $page, ['status' => ContentStatus::Published] );
+
+    expect( $republished->published_at->equalTo( $firstStamp ) )->toBeTrue();
+} );
+
+test( 'update can move a page into a new hierarchy position', function (): void {
+    $parent = $this->manager->create( [
+        'title'  => 'Section A',
+        'status' => ContentStatus::Draft,
+    ], null, $this->user->id );
+
+    $page = $this->manager->create( [
+        'title'  => 'Loose page',
+        'status' => ContentStatus::Draft,
+    ], null, $this->user->id );
+
+    $moved = $this->manager->update( $page, [
+        'parent_id' => $parent->id,
+        'order'     => 3,
+    ] );
+
+    expect( $moved->parent_id )->toBe( $parent->id );
+    expect( $moved->order )->toBe( 3 );
+} );
+
+test( 'delete soft-deletes the page', function (): void {
+    $page = $this->manager->create( [
+        'title'  => 'Doomed',
+        'status' => ContentStatus::Draft,
+    ], null, $this->user->id );
+
+    $this->manager->delete( $page );
+
+    expect( Page::find( $page->id ) )->toBeNull();
+    expect( Page::withTrashed()->find( $page->id ) )->not->toBeNull();
+} );
+
+test( 'duplicate returns a fresh draft with (Copy) title and unique slug', function (): void {
+    $page = $this->manager->create( [
+        'title'    => 'Original',
+        'status'   => ContentStatus::Published,
+        'template' => 'sidebar',
+    ], null, $this->user->id );
+
+    $copy = $this->manager->duplicate( $page );
+
+    expect( $copy->id )->not->toBe( $page->id );
+    expect( $copy->title )->toBe( 'Original (Copy)' );
+    expect( $copy->status )->toBe( ContentStatus::Draft );
+    expect( $copy->published_at )->toBeNull();
+    expect( $copy->slug )->toBe( 'original-copy' );
+    // Copies preserve template but reset status to Draft.
+    expect( $copy->template )->toBe( 'sidebar' );
+} );


### PR DESCRIPTION
## Description

Adds the write API on `BlogManager` and expands `PageManager` with a matching surface. Both managers now own the persistence orchestration every consumer currently reinvents per-controller: unique-slug allocation, custom-field application timing, `published_at` transitions, DB-transactional writes.

**Closes:** #250

## Type of Change

- [x] New feature (adds new functionality)
- [x] Enhancement (improves existing functionality)

## Related Issue

**Issue:** #250 (this repo) · Keystone [#183](https://gitlab.com/jacob-martella-web-design/jacob-martella-web-design/jmwd-keystone-cms/jmwd-keystone-cms/-/issues/183) (consumer)

## Motivation and Context

Follow-up to #247. `HasSupports` removed the schema-layer duplication of what a content type declares. This PR removes the *persistence-layer* duplication of how consumers write those content types. Before: every downstream app (Keystone, ArtisanPack UI trial site) inlines a bespoke `store()`/`update()`/`destroy()`/`duplicate()` against `Post::create`/`->fill`/`sync`, re-deriving slug uniqueness, `published_at` transitions, custom-field application timing on every install. After: the framework owns those rules — consumers hand the manager a validated attribute array and get back a saved record.

## Changes Made

- **`Modules/Blog/Managers/BlogManager`** — 7 new methods:
  - `autoDraft(?int $authorId, string $baseSlug = 'untitled-post'): Post` — powers the "New Post" auto-draft flow.
  - `create(array $attributes, ?array $customFields = null, ?int $authorId = null): Post` — fillable subset, unique-slug allocation, custom-field application via `HasCustomFields`, `published_at = now()` on initial Published, wrapped in `DB::transaction`.
  - `update(Post $post, array $attributes, ?array $customFields = null): Post` — same, plus the "first draft→published stamps `published_at`" rule (subsequent republishes preserve the original stamp).
  - `delete(Post $post): void` — soft-deletes.
  - `duplicate(Post $post, ?int $authorId = null): Post` — appends `(Copy)`, allocates a fresh slug, resets to Draft, drops `published_at`, mirrors category/tag associations.
  - `syncCategories(Post $post, array $categoryIds): void`, `syncTags(Post $post, array $tagIds): void` — thin pivots.
  - `uniqueSlug(string $source): string` — slug allocator that respects soft-deleted rows.
- **`Modules/Pages/Managers/PageManager`** — same 7 methods (minus `syncCategories`/`syncTags` since Pages module doesn't ship pivots by default) plus support for the hierarchical `parent_id` / `order` / `template` attributes. Coexists with the existing `getPageTree`/`movePage`/`reorderPages` helpers unchanged.
- **13 new Pest tests in `tests/Feature/Blog/BlogManagerWriteTest.php`** covering auto-draft, unique-slug allocation (including soft-deleted collisions), fillable-subset guarding, published transition rules, custom-field metadata routing, delete, duplicate with taxonomy mirroring, and taxonomy sync.
- **12 new Pest tests in `tests/Feature/Pages/PageManagerWriteTest.php`** mirroring the Blog coverage plus hierarchical attribute round-trips (create with `parent_id`+`order`+`template`, move via update).

## Backwards Compatibility

- [x] This is backwards compatible
- [ ] This requires migration/breaking changes

Additive only. Every existing `BlogManager`/`PageManager` method (read/query/hierarchy) is unchanged. The framework's own REST controllers still work — they'll be refactored to delegate to the manager in a follow-up.

## Testing

- **1474 tests passing** (was 1449 pre-change; +25 new manager tests), 7 skipped (pre-existing), 0 failing. `composer fix` clean.
- Framework REST controllers unchanged in this PR — a follow-up will thin them to delegate to the manager.
- Downstream Keystone [#183](https://gitlab.com/jacob-martella-web-design/jacob-martella-web-design/jmwd-keystone-cms/jmwd-keystone-cms/-/issues/183) branch will consume `^2.7.0` and thin its `Admin\PostController` / `Admin\PageController` to delegate.

## Follow-up

After this merges + tags v2.7.0:

1. Keystone `feature/183-editor-supports-schema` bumps `artisanpack-ui/cms-framework: ^2.7.0`.
2. `Admin\PostController::store/update/destroy/duplicate` → delegate to `BlogManager` (drops ~200 LOC).
3. `Admin\PageController::store/update/destroy/duplicate` → delegate to `PageManager` (drops ~200 LOC).
4. `App\Support\ContentEdit\CustomFieldSupport::apply()` becomes dead code (manager applies via trait directly).

Longer-term (separate framework issue): refactor the framework's own REST `Modules/Blog/Http/Controllers/PostController` to delegate to `BlogManager` too, so both admin surfaces (REST + Inertia) route through one audited write path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added complete content management workflows for blog posts and pages, including drafting, creation, editing, deletion, duplication, and taxonomy synchronization.
  * Added automatic unique slug generation, including handling for previously deleted content.
  * Added support for custom fields, publishing timestamps, page hierarchy, ordering, and templates.
  * Duplicated content now starts as a fresh draft with a new slug.

* **Documentation**
  * Updated release notes for version 2.7.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->