### PR TITLE
fix: guard performUpdate() against PHP execution-time death (#256)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`php artisan update:status`** ([#256](https://github.com/ArtisanPack-UI/cms-framework/issues/256)) — reports the most recent `performUpdate()` run from a persisted step marker: the step it reached, the versions involved, the recorded error, and — for a run that died mid-flight — the outstanding steps with the command to run for each. Exits non-zero when the last run failed or was interrupted, so it composes with health checks. `--json` emits the raw record for an admin UI; `--clear` discards it after reporting. Host applications can read the same record programmatically via the new `ApplicationUpdateManager::updateState()` / `clearUpdateState()`.
+- **`cms.updates.state_path` and `cms.updates.lift_maintenance_on_interrupt` config keys** ([#256](https://github.com/ArtisanPack-UI/cms-framework/issues/256)) — where the step marker is written (relative paths resolve against `storage_path()`), and whether the new shutdown guard lifts maintenance mode when an update dies mid-flight. The latter defaults to `true`; set `CMS_UPDATES_LIFT_MAINTENANCE_ON_INTERRUPT=false` to fail closed and keep the site down until an operator has verified a possibly half-applied install.
+
 ### Changed
 
 ### Deprecated
@@ -16,6 +19,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 ### Fixed
+
+- **`performUpdate()` had no execution-time guard, so a PHP timeout killed it mid-flight and left the site stuck in maintenance mode** ([#256](https://github.com/ArtisanPack-UI/cms-framework/issues/256)) — `runComposerInstall()` gave the composer child a `cms.updates.composer_timeout` budget (default 600s), but the parent PHP request was still governed by `max_execution_time`, which defaults to **30 seconds** under PHP-FPM — the path the admin UI uses. Composer was given ten minutes and the request was killed after thirty seconds. Worse, an execution-time fatal is raised at shutdown rather than thrown, so `performUpdate()`'s `catch` block never ran: no rollback, and step 10's `disableMaintenanceMode()` never executed. The operator was left with a site returning 503 to every visitor, no error in the UI (the request died before rendering a response), and no automatic way back. Every other failure in this module to date failed *safely*; this one failed open. Three guards now cover it:
+
+  - `performUpdate()` and `rollback()` call `set_time_limit( 0 )` and `ignore_user_abort( true )` up front, so neither PHP's execution ceiling nor the operator closing the browser tab can kill the request mid-update. Hosts that put `set_time_limit` in `disable_functions` get a warning log naming `php artisan update:perform` as the supported path instead.
+  - `enableMaintenanceMode()` registers a shutdown guard that lifts maintenance mode if the process dies before step 10 — covering out-of-memory fatals and FPM's `request_terminate_timeout`, neither of which `set_time_limit()` can override. It logs a `critical` entry naming the step it died on, and if `artisan up` itself fails (likely when shutting down after an OOM fatal) it removes `storage/framework/down` directly.
+  - Each of the ten steps is persisted to a state file as it is entered, so a killed update is *detectable*. Previously there was no way to distinguish "update in progress", "update died at step 6", and "the site was manually put into maintenance mode". A flat file rather than a cache entry on purpose: step 8 runs `cache:clear`, and the database cache driver is unavailable while step 7's migrations are mid-flight.
+
+  Nothing here makes an HTTP request a *good* place to run a multi-minute job — `php artisan update:perform` from the CLI remains the supported path, and moving the HTTP endpoint to a queued job is tracked separately. These guards make the HTTP path fail safely instead of taking the site down and leaving it there.
 
 ### Security
 

--- a/docs/self-updater.md
+++ b/docs/self-updater.md
@@ -84,6 +84,59 @@ When an update fails, the framework rolls back to the pre-update backup. Two beh
 - **Zip-slip protection.** Entries whose normalized path starts with `/` or contains `..` segments are rejected before the target directory is created. After path assembly, `realpath()` verifies the resolved parent still sits under the extraction root before opening the write stream. Rejected entries are logged and skipped — a crafted `release-root/../../../etc/cron.d/x` can no longer escape the install root.
 - **fopen/fread failures surface as rollback triggers.** A failed `fopen('wb')` or `fread()` used to `continue`/`break` silently, leaving a partial install on disk that failed to boot on the next request with no obvious cause. Failures are now logged with the entry + errno and thrown via `UpdateException::extractionEntryFailed()`, so `performUpdate()`'s catch block rolls back to the pre-update snapshot.
 
+## Long-running updates and interrupted processes
+
+A full update — download, extract, `composer install` across a real dependency tree, migrate — routinely runs for several minutes. PHP's `max_execution_time` defaults to **30 seconds** under PHP-FPM, which is the path the admin UI uses. Three guards keep that survivable:
+
+- **`performUpdate()` and `rollback()` call `set_time_limit( 0 )` and `ignore_user_abort( true )` up front.** The `Process::timeout()` in `runComposerInstall()` only bounds the composer *child*; without this the parent request was killed roughly twenty times sooner than composer's own budget allowed for. `ignore_user_abort()` covers the operator closing the browser tab. When a host has `set_time_limit` in `disable_functions`, the framework logs a warning naming `php artisan update:perform` as the supported path instead.
+
+- **Maintenance mode is lifted by a shutdown handler when the process dies anyway.** An execution-time or out-of-memory fatal is raised at shutdown, not thrown, so `performUpdate()`'s `catch` never runs — no rollback, and step 10 (`disableMaintenanceMode()`) never executes. The site then serves 503 to every visitor with no error in the UI and no automatic way back. `enableMaintenanceMode()` now registers a shutdown guard that lifts maintenance mode in that case and logs a `critical` entry naming the step it died on. If `artisan up` itself fails (common when shutting down after an OOM fatal), the guard removes `storage/framework/down` directly.
+
+  Leaving the site up on a possibly half-applied install is a real trade-off. Set `cms.updates.lift_maintenance_on_interrupt` to `false` to fail closed and keep the site down until an operator has verified it by hand.
+
+  This cannot help against `kill -9`, which runs no shutdown handlers. The persisted state marker below covers that case.
+
+- **Each step is persisted to a state file, so a killed update is diagnosable.** Before this there was no way to distinguish "update in progress", "update died at step 6", and "the site was manually put into maintenance mode".
+
+### `php artisan update:status`
+
+Reports the most recent run — the step it reached, the versions involved, the recorded error, and, for an interrupted run, the outstanding steps with the command for each:
+
+```console
+$ php artisan update:status
+✗ Interrupted (process died mid-update)
+
+  From version    0.2.4
+  To version      0.3.0
+  Last step       7/10 — Run database migrations
+  ...
+
+The update process died before finishing. The install may be half-applied.
+
+These steps had not completed. Run them in order to finish the update:
+
+  7. Run database migrations
+     php artisan migrate --force
+  8. Clear application caches
+     php artisan config:clear && php artisan cache:clear && php artisan route:clear && php artisan view:clear
+  10. Disable maintenance mode
+     php artisan up
+```
+
+It exits non-zero when the last run failed or was interrupted, so it composes with health checks. `--json` emits the raw record for an admin UI; `--clear` discards it after reporting. Host applications can read the same record programmatically via `ApplicationUpdateManager::updateState()`.
+
+A run interrupted during download or extraction is not resumable — the application tree may be partially overwritten — so the command points at the pre-update snapshot in `storage/backups/application/` instead of a resume checklist.
+
+The marker is a flat JSON file rather than a cache entry on purpose: step 8 runs `cache:clear`, and the database cache driver is unavailable while step 7's migrations are mid-flight. `storage/` is in `exclude_from_update`, so it survives extraction of the new release.
+
+> **Note:** the supported path for a slow host remains `php artisan update:perform` from the CLI, where `max_execution_time` is `0` and there is no gateway timeout to hit. The guards above make the HTTP path safe to *fail*; they don't make it a good place to run a multi-minute job.
+
+### Two consequences worth knowing about
+
+**Keep `performUpdate()` behind admin authorization.** Lifting `max_execution_time` and setting `ignore_user_abort( true )` means an HTTP-triggered update now occupies a PHP-FPM worker for as long as the update takes, and keeps occupying it even if the caller disconnects. The individual phases stay bounded (`download_timeout`, `composer_timeout`), so the total is bounded in practice — but an update endpoint reachable without authorization would be a much cheaper way to exhaust the worker pool than it was at 30 seconds. This has always been an operator responsibility; the guards raise the cost of getting it wrong.
+
+**Nothing serializes concurrent updates.** Two overlapping `performUpdate()` calls will fight over the same application tree and the same state marker; the second `begin()` overwrites the first. That was true before this change too, but the longer window makes an overlap easier to hit. If your admin UI can dispatch an update more than once, gate it — disable the button while `updateState()` reports `in_progress`, or take a lock around the call.
+
 ## Cached update info and out-of-band version bumps
 
 `UpdateChecker::checkForUpdate()` caches the resolved `UpdateInfo` value object under `cms.{type}.{slug}.update_check` for `cms.updates.cache_ttl` seconds (default 43,200s / 12h). The cached object contains both the feed's `latestVersion` and a snapshot of `config('app.version')` taken when the cache was populated.
@@ -103,6 +156,8 @@ When the host's installed version changes *out-of-band* (a manual `composer inst
 | `cms.updates.allow_unverified_updates` | Opt-in to warn-and-continue when the source omits a SHA-256 checksum. Default `false`. Env: `CMS_UPDATES_ALLOW_UNVERIFIED`. |
 | `cms.updates.backup_enabled` | Whether to snapshot before updating. |
 | `cms.updates.exclude_from_update` | Paths preserved during extraction. |
+| `cms.updates.state_path` | Where the step marker is written. Relative paths resolve against `storage_path()`. Default `framework/cms-update-state.json`. |
+| `cms.updates.lift_maintenance_on_interrupt` | Whether the shutdown guard lifts maintenance mode when an update dies mid-flight. Default `true`. Env: `CMS_UPDATES_LIFT_MAINTENANCE_ON_INTERRUPT`. |
 
 Environment variables:
 
@@ -111,3 +166,4 @@ Environment variables:
 | `COMPOSER_BINARY` | Absolute path to composer, exposed to `cms.updates.composer_binary` via `env()`. |
 | `CMS_PHP_BINARY` | Absolute path to a CLI PHP binary; overrides `PHP_BINARY` when the updater invokes composer. |
 | `CMS_UPDATES_ALLOW_UNVERIFIED` | Boolean; opts into warn-and-continue when the source omits a SHA-256 checksum. |
+| `CMS_UPDATES_LIFT_MAINTENANCE_ON_INTERRUPT` | Boolean; set `false` to leave the site in maintenance mode when an update dies mid-flight. |

--- a/src/Modules/Core/Providers/CoreServiceProvider.php
+++ b/src/Modules/Core/Providers/CoreServiceProvider.php
@@ -17,6 +17,7 @@ use ArtisanPackUI\CMSFramework\Modules\Core\Updates\Console\CheckForUpdateComman
 use ArtisanPackUI\CMSFramework\Modules\Core\Updates\Console\CheckForUpdateScheduled;
 use ArtisanPackUI\CMSFramework\Modules\Core\Updates\Console\PerformUpdateCommand;
 use ArtisanPackUI\CMSFramework\Modules\Core\Updates\Console\RollbackUpdateCommand;
+use ArtisanPackUI\CMSFramework\Modules\Core\Updates\Console\UpdateStatusCommand;
 use Illuminate\Support\ServiceProvider;
 
 /**
@@ -62,6 +63,7 @@ class CoreServiceProvider extends ServiceProvider
                 CheckForUpdateCommand::class,
                 PerformUpdateCommand::class,
                 RollbackUpdateCommand::class,
+                UpdateStatusCommand::class,
                 CheckForUpdateScheduled::class,
             ] );
         }

--- a/src/Modules/Core/Updates/Console/UpdateStatusCommand.php
+++ b/src/Modules/Core/Updates/Console/UpdateStatusCommand.php
@@ -1,0 +1,232 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Modules\Core\Updates\Console;
+
+use ArtisanPackUI\CMSFramework\Modules\Core\Updates\Enums\UpdateRunStatus;
+use ArtisanPackUI\CMSFramework\Modules\Core\Updates\Enums\UpdateStep;
+use ArtisanPackUI\CMSFramework\Modules\Core\Updates\Managers\ApplicationUpdateManager;
+use Illuminate\Console\Command;
+
+/**
+ * Update Status Command
+ *
+ * Reports the outcome of the most recent `performUpdate()` run from the
+ * persisted state marker. Exists so that an update killed mid-flight is
+ * diagnosable — before this, "update in progress", "update died at step 6",
+ * and "the site was manually put into maintenance mode" were
+ * indistinguishable without reading framework source.
+ *
+ * @since 2.7.1
+ */
+class UpdateStatusCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @since 2.7.1
+     *
+     * @var string
+     */
+    protected $signature = 'update:status
+                            {--json : Output the raw persisted state as JSON}
+                            {--clear : Discard the recorded state after reporting it}';
+
+    /**
+     * The console command description.
+     *
+     * @since 2.7.1
+     *
+     * @var string
+     */
+    protected $description = 'Report the status of the most recent application update';
+
+    /**
+     * Execute the console command.
+     *
+     * @since 2.7.1
+     *
+     * @param  ApplicationUpdateManager  $manager  Update manager.
+     *
+     * @return int Command exit code.
+     */
+    public function handle( ApplicationUpdateManager $manager ): int
+    {
+        $state = $manager->updateState();
+
+        if ( null === $state ) {
+            if ( $this->option( 'json' ) ) {
+                $this->line( (string) json_encode( null ) );
+            } else {
+                $this->info( __( 'No application update has been recorded.' ) );
+            }
+
+            return self::SUCCESS;
+        }
+
+        if ( $this->option( 'json' ) ) {
+            $this->line( (string) json_encode( $state, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) );
+
+            $this->maybeClear( $manager );
+
+            return self::SUCCESS;
+        }
+
+        // The record is read after a crash by definition, so treat every field
+        // as untrusted rather than casting a half-written value.
+        $status = UpdateRunStatus::tryFrom( $this->stringField( $state, 'status' ) );
+        $step   = UpdateStep::tryFrom( $this->stringField( $state, 'step' ) );
+
+        $this->renderSummary( $state, $status, $step );
+
+        if ( UpdateRunStatus::Interrupted === $status ) {
+            $this->renderRecovery( $step );
+        }
+
+        $this->maybeClear( $manager );
+
+        return null !== $status && $status->needsAttention() ? self::FAILURE : self::SUCCESS;
+    }
+
+    /**
+     * Render the headline status block.
+     *
+     * @since 2.7.1
+     *
+     * @param  array<string, mixed>  $state  Persisted state.
+     * @param  UpdateRunStatus|null  $status  Parsed status, when recognised.
+     * @param  UpdateStep|null  $step  Parsed step, when recognised.
+     */
+    protected function renderSummary( array $state, ?UpdateRunStatus $status, ?UpdateStep $step ): void
+    {
+        $label = $status?->label() ?? ( $this->stringField( $state, 'status' ) ?: __( 'Unknown' ) );
+
+        $this->newLine();
+
+        match ( $status ) {
+            UpdateRunStatus::Completed   => $this->info( '✓ ' . $label ),
+            UpdateRunStatus::InProgress  => $this->warn( '… ' . $label ),
+            UpdateRunStatus::Failed,
+            UpdateRunStatus::Interrupted => $this->error( '✗ ' . $label ),
+            default                      => $this->line( $label ),
+        };
+
+        $this->newLine();
+
+        $totalSteps = count( UpdateStep::cases() );
+
+        $rows = [
+            [__( 'From version' ), $this->stringField( $state, 'current_version' ) ?: '—'],
+            [__( 'To version' ), $this->stringField( $state, 'target_version' ) ?: '—'],
+            [
+                __( 'Last step' ),
+                null !== $step
+                    ? "{$step->number()}/{$totalSteps} — {$step->label()}"
+                    : ( $this->stringField( $state, 'step_label' ) ?: '—' ),
+            ],
+            [__( 'Started' ), $this->stringField( $state, 'started_at' ) ?: '—'],
+            [__( 'Last updated' ), $this->stringField( $state, 'updated_at' ) ?: '—'],
+            [__( 'PHP SAPI' ), $this->stringField( $state, 'php_sapi' ) ?: '—'],
+        ];
+
+        $this->table( [__( 'Field' ), __( 'Value' )], $rows );
+
+        $error = $this->stringField( $state, 'error' );
+
+        if ( '' !== $error ) {
+            $this->newLine();
+            $this->line( __( 'Error:' ) );
+            $this->error( $error );
+        }
+
+        if ( UpdateRunStatus::InProgress === $status ) {
+            $this->newLine();
+            $this->comment( __( 'An update is either still running or died without triggering its shutdown handler (e.g. `kill -9`). Check whether the recorded PID is still alive before intervening.' ) );
+        }
+    }
+
+    /**
+     * Render the manual recovery checklist for an interrupted update.
+     *
+     * @since 2.7.1
+     *
+     * @param  UpdateStep|null  $step  Step the update died on.
+     */
+    protected function renderRecovery( ?UpdateStep $step ): void
+    {
+        $this->newLine();
+        $this->warn( __( 'The update process died before finishing. The install may be half-applied.' ) );
+        $this->newLine();
+
+        if ( null === $step ) {
+            $this->line( __( 'The step in flight was not recorded. Restore the pre-update snapshot from storage/backups/application/ before continuing.' ) );
+
+            return;
+        }
+
+        if ( $step->number() < UpdateStep::ComposerInstall->number() ) {
+            $this->line( __( 'It died during download or extraction, which is not resumable — the application tree may be partially overwritten. Restore the pre-update snapshot from storage/backups/application/ instead of finishing by hand.' ) );
+
+            return;
+        }
+
+        $this->line( __( 'These steps had not completed. Run them in order to finish the update:' ) );
+        $this->newLine();
+
+        foreach ( $step->outstandingSteps() as $outstanding ) {
+            $command = $outstanding->recoveryCommand();
+
+            if ( null === $command ) {
+                continue;
+            }
+
+            $this->line( "  {$outstanding->number()}. {$outstanding->label()}" );
+            $this->comment( "     {$command}" );
+        }
+
+        $this->newLine();
+        $this->line( __( 'If you would rather not finish by hand, restore the pre-update snapshot from storage/backups/application/.' ) );
+    }
+
+    /**
+     * Read a field from the persisted record as a string, returning `''` for
+     * anything that isn't a scalar. Guards against rendering a half-written or
+     * hand-edited record — casting an array to string would emit a notice and
+     * print "Array".
+     *
+     * @since 2.7.1
+     *
+     * @param  array<string, mixed>  $state  Persisted state.
+     * @param  string  $key  Field to read.
+     *
+     * @return string Field value, or an empty string.
+     */
+    protected function stringField( array $state, string $key ): string
+    {
+        $value = $state[ $key ] ?? null;
+
+        return is_scalar( $value ) ? trim( (string) $value ) : '';
+    }
+
+    /**
+     * Discard the recorded state when `--clear` was passed.
+     *
+     * @since 2.7.1
+     *
+     * @param  ApplicationUpdateManager  $manager  Update manager.
+     */
+    protected function maybeClear( ApplicationUpdateManager $manager ): void
+    {
+        if ( ! $this->option( 'clear' ) ) {
+            return;
+        }
+
+        $manager->clearUpdateState();
+
+        if ( ! $this->option( 'json' ) ) {
+            $this->newLine();
+            $this->info( __( 'Recorded update state cleared.' ) );
+        }
+    }
+}

--- a/src/Modules/Core/Updates/Enums/UpdateRunStatus.php
+++ b/src/Modules/Core/Updates/Enums/UpdateRunStatus.php
@@ -1,0 +1,55 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Modules\Core\Updates\Enums;
+
+/**
+ * Update Run Status
+ *
+ * Lifecycle status of the most recent `performUpdate()` run, persisted to the
+ * update state file. The distinction that matters operationally is
+ * `Failed` (the updater caught the error and rolled back) versus
+ * `Interrupted` (the process died before the catch block could run).
+ *
+ * @since 2.7.1
+ */
+enum UpdateRunStatus: string
+{
+    /**
+     * Human-readable description of the status.
+     *
+     * @since 2.7.1
+     *
+     * @return string Status label.
+     */
+    public function label(): string
+    {
+        return match ( $this ) {
+            self::InProgress  => __( 'In progress' ),
+            self::Completed   => __( 'Completed' ),
+            self::Failed      => __( 'Failed (rolled back)' ),
+            self::Interrupted => __( 'Interrupted (process died mid-update)' ),
+        };
+    }
+
+    /**
+     * Whether this status means the update left the installation in a state
+     * the operator needs to inspect.
+     *
+     * @since 2.7.1
+     *
+     * @return bool True when manual attention is warranted.
+     */
+    public function needsAttention(): bool
+    {
+        return self::Interrupted === $this || self::Failed === $this;
+    }
+    case InProgress = 'in_progress';
+
+    case Completed = 'completed';
+
+    case Failed = 'failed';
+
+    case Interrupted = 'interrupted';
+}

--- a/src/Modules/Core/Updates/Enums/UpdateStep.php
+++ b/src/Modules/Core/Updates/Enums/UpdateStep.php
@@ -1,0 +1,122 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Modules\Core\Updates\Enums;
+
+/**
+ * Update Step
+ *
+ * The ordered steps `ApplicationUpdateManager::performUpdate()` walks through.
+ * Persisted to the update state file so an update that dies mid-flight (PHP
+ * fatal, OOM, `kill -9`, FPM `request_terminate_timeout`) is diagnosable after
+ * the fact rather than requiring the operator to read framework source.
+ *
+ * @since 2.7.1
+ */
+enum UpdateStep: string
+{
+    /**
+     * The step's 1-based position in the update sequence.
+     *
+     * @since 2.7.1
+     *
+     * @return int Position in the update sequence.
+     */
+    public function number(): int
+    {
+        return match ( $this ) {
+            self::EnableMaintenanceMode  => 1,
+            self::Backup                 => 2,
+            self::Download               => 3,
+            self::VerifyChecksum         => 4,
+            self::Extract                => 5,
+            self::ComposerInstall        => 6,
+            self::Migrations             => 7,
+            self::ClearCaches            => 8,
+            self::Cleanup                => 9,
+            self::DisableMaintenanceMode => 10,
+        };
+    }
+
+    /**
+     * Human-readable description of the step.
+     *
+     * @since 2.7.1
+     *
+     * @return string Step label.
+     */
+    public function label(): string
+    {
+        return match ( $this ) {
+            self::EnableMaintenanceMode  => __( 'Enable maintenance mode' ),
+            self::Backup                 => __( 'Create pre-update backup' ),
+            self::Download               => __( 'Download release archive' ),
+            self::VerifyChecksum         => __( 'Verify release checksum' ),
+            self::Extract                => __( 'Extract release archive' ),
+            self::ComposerInstall        => __( 'Rebuild composer dependencies' ),
+            self::Migrations             => __( 'Run database migrations' ),
+            self::ClearCaches            => __( 'Clear application caches' ),
+            self::Cleanup                => __( 'Clean up temporary files' ),
+            self::DisableMaintenanceMode => __( 'Disable maintenance mode' ),
+        };
+    }
+
+    /**
+     * The command an operator can run by hand to complete this step after an
+     * interrupted update, or `null` when the step has no manual equivalent
+     * (downloading and extracting a half-applied release cannot be resumed —
+     * restore the pre-update snapshot instead).
+     *
+     * @since 2.7.1
+     *
+     * @return string|null Shell command, or null when the step is not resumable.
+     */
+    public function recoveryCommand(): ?string
+    {
+        return match ( $this ) {
+            self::ComposerInstall        => 'composer install --no-dev --no-interaction --optimize-autoloader',
+            self::Migrations             => 'php artisan migrate --force',
+            self::ClearCaches            => 'php artisan config:clear && php artisan cache:clear && php artisan route:clear && php artisan view:clear',
+            self::DisableMaintenanceMode => 'php artisan up',
+            default                      => null,
+        };
+    }
+
+    /**
+     * Steps that had not been reached when the update stopped at this step.
+     *
+     * The step itself is included: an interrupted update was *in* this step
+     * when it died, so there is no guarantee it finished.
+     *
+     * @since 2.7.1
+     *
+     * @return array<int, self> Steps still outstanding.
+     */
+    public function outstandingSteps(): array
+    {
+        return array_values( array_filter(
+            self::cases(),
+            fn ( self $step ): bool => $step->number() >= $this->number(),
+        ) );
+    }
+    case EnableMaintenanceMode = 'enable_maintenance_mode';
+
+    case Backup = 'backup';
+
+    case Download = 'download';
+
+    case VerifyChecksum = 'verify_checksum';
+
+    case Extract = 'extract';
+
+    case ComposerInstall = 'composer_install';
+
+    case Migrations = 'migrations';
+
+    case ClearCaches = 'clear_caches';
+
+    case Cleanup = 'cleanup';
+
+    case DisableMaintenanceMode = 'disable_maintenance_mode';
+}

--- a/src/Modules/Core/Updates/Managers/ApplicationUpdateManager.php
+++ b/src/Modules/Core/Updates/Managers/ApplicationUpdateManager.php
@@ -4,13 +4,17 @@ declare( strict_types=1 );
 
 namespace ArtisanPackUI\CMSFramework\Modules\Core\Updates\Managers;
 
+use ArtisanPackUI\CMSFramework\Modules\Core\Updates\Enums\UpdateRunStatus;
+use ArtisanPackUI\CMSFramework\Modules\Core\Updates\Enums\UpdateStep;
 use ArtisanPackUI\CMSFramework\Modules\Core\Updates\Enums\UpdateType;
 use ArtisanPackUI\CMSFramework\Modules\Core\Updates\Exceptions\UpdateException;
+use ArtisanPackUI\CMSFramework\Modules\Core\Updates\Support\UpdateStateStore;
 use ArtisanPackUI\CMSFramework\Modules\Core\Updates\UpdateChecker;
 use ArtisanPackUI\CMSFramework\Modules\Core\Updates\UpdateCheckerFactory;
 use ArtisanPackUI\CMSFramework\Modules\Core\Updates\ValueObjects\UpdateInfo;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Process;
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
@@ -58,6 +62,37 @@ class ApplicationUpdateManager
     protected ?string $backupPath = null;
 
     /**
+     * Persisted step marker for the current update run.
+     *
+     * @since 2.7.1
+     */
+    protected ?UpdateStateStore $state = null;
+
+    /**
+     * The step currently in flight, or `null` when no update is running.
+     *
+     * @since 2.7.1
+     */
+    protected ?UpdateStep $currentStep = null;
+
+    /**
+     * Whether this instance put the site into maintenance mode and has not
+     * taken it back out. Read by the shutdown guard to decide whether a dead
+     * process left the site serving 503s.
+     *
+     * @since 2.7.1
+     */
+    protected bool $maintenanceModeActive = false;
+
+    /**
+     * Whether the shutdown guard has already been registered, so repeated
+     * `enableMaintenanceMode()` calls don't stack handlers.
+     *
+     * @since 2.7.1
+     */
+    protected bool $shutdownGuardArmed = false;
+
+    /**
      * Check for available updates.
      *
      * @since 1.0.0
@@ -76,6 +111,18 @@ class ApplicationUpdateManager
     /**
      * Perform the update.
      *
+     * A full update — download, extract, `composer install` across a real
+     * dependency tree, migrate — routinely runs for several minutes. Two
+     * guards make that survivable when the caller is an HTTP request rather
+     * than the CLI:
+     *
+     * - `raiseExecutionLimits()` lifts PHP's `max_execution_time` (30s by
+     *   default under PHP-FPM) so the parent request isn't killed long before
+     *   the composer child's own timeout budget is reached.
+     * - `enableMaintenanceMode()` arms a shutdown guard so that if the process
+     *   dies anyway, maintenance mode is still lifted rather than leaving the
+     *   site serving 503s indefinitely.
+     *
      * @since 1.0.0
      *
      * @param  string|null  $version  Version to update to (null = latest)
@@ -86,6 +133,8 @@ class ApplicationUpdateManager
      */
     public function performUpdate( ?string $version = null ): bool
     {
+        $this->raiseExecutionLimits();
+
         $updateInfo = $this->checkForUpdate();
 
         if ( ! $updateInfo->hasUpdate() ) {
@@ -95,45 +144,159 @@ class ApplicationUpdateManager
         // Use specified version or latest
         $targetVersion = $version ?? $updateInfo->latestVersion;
 
+        $this->state()->begin( $targetVersion, $updateInfo->resolveCurrentVersion() );
+
         try {
             // Step 1: Enable maintenance mode
+            $this->beginStep( UpdateStep::EnableMaintenanceMode );
             $this->enableMaintenanceMode();
 
             // Step 2: Create backup
+            $this->beginStep( UpdateStep::Backup );
             if ( config( 'cms.updates.backup_enabled', true ) ) {
                 $this->createBackup();
             }
 
             // Step 3: Download update
+            $this->beginStep( UpdateStep::Download );
             $zipPath = $this->getUpdateChecker()->downloadUpdate( $targetVersion );
 
             // Step 4: Verify checksum (or surface the silent skip)
+            $this->beginStep( UpdateStep::VerifyChecksum );
             $this->maybeVerifyChecksum( $zipPath, $updateInfo, $targetVersion );
 
             // Step 5: Extract update
+            $this->beginStep( UpdateStep::Extract );
             $this->extractUpdate( $zipPath );
 
             // Step 6: Run composer install
+            $this->beginStep( UpdateStep::ComposerInstall );
             $this->runComposerInstall();
 
             // Step 7: Run migrations
+            $this->beginStep( UpdateStep::Migrations );
             $this->runMigrations();
 
             // Step 8: Clear caches
+            $this->beginStep( UpdateStep::ClearCaches );
             $this->clearCaches();
 
             // Step 9: Clean up
+            $this->beginStep( UpdateStep::Cleanup );
             $this->cleanup( $zipPath );
 
             // Step 10: Disable maintenance mode
+            $this->beginStep( UpdateStep::DisableMaintenanceMode );
             $this->disableMaintenanceMode();
+
+            $this->currentStep = null;
+            $this->state()->markStatus( UpdateRunStatus::Completed );
 
             return true;
         } catch ( Throwable $e ) {
+            $this->state()->markStatus( UpdateRunStatus::Failed, $e->getMessage() );
+
             // Rollback on failure
             $this->handleUpdateFailure( $e );
 
             throw $e;
+        }
+    }
+
+    /**
+     * Persisted record of the most recent update run, or `null` when no update
+     * has been recorded. Host applications can poll this to surface progress
+     * and to detect an update that died mid-flight.
+     *
+     * @since 2.7.1
+     *
+     * @return array<string, mixed>|null Persisted update state.
+     */
+    public function updateState(): ?array
+    {
+        return $this->state()->read();
+    }
+
+    /**
+     * Discard the persisted update state record.
+     *
+     * @since 2.7.1
+     */
+    public function clearUpdateState(): void
+    {
+        $this->state()->clear();
+    }
+
+    /**
+     * Shutdown guard: lift maintenance mode when the update process died
+     * before reaching step 10.
+     *
+     * An execution-time or out-of-memory fatal is not a catchable `Throwable`
+     * — it is raised at shutdown, so `performUpdate()`'s `catch` block never
+     * runs, `handleUpdateFailure()` never rolls back, and step 10 never
+     * executes. Without this guard the operator is left with a site returning
+     * 503 to every visitor, no error in the UI (the request died before
+     * rendering a response), and no automatic way back.
+     *
+     * Registered by `enableMaintenanceMode()` and public only so it can be
+     * exercised directly by tests; treat it as internal.
+     *
+     * @since 2.7.1
+     */
+    public function handleInterruptedUpdate(): void
+    {
+        if ( ! $this->maintenanceModeActive ) {
+            return;
+        }
+
+        // Clear first: a failure below must not re-enter this handler.
+        $this->maintenanceModeActive = false;
+
+        $fatal = $this->lastFatalError();
+
+        Log::critical(
+            'cms-framework: the update process terminated before it finished; the site was left in maintenance mode.',
+            [
+                'step'       => $this->currentStep?->value,
+                'step_label' => $this->currentStep?->label(),
+                'php_sapi'   => PHP_SAPI,
+                'error'      => $fatal,
+                'state_file' => $this->state()->path(),
+                'hint'       => 'Run `php artisan update:status` to see how far the update got and what remains.',
+            ],
+        );
+
+        // Re-record the step from memory before stamping the status: an
+        // earlier per-step write may have failed (read-only storage, a disk
+        // that filled up), and the whole value of the marker is that it agrees
+        // with where the update actually was when it died.
+        if ( null !== $this->currentStep ) {
+            $this->state()->markStep( $this->currentStep );
+        }
+
+        $this->state()->markStatus(
+            UpdateRunStatus::Interrupted,
+            $fatal['message'] ?? 'The update process terminated before completing.',
+        );
+
+        if ( ! config( 'cms.updates.lift_maintenance_on_interrupt', true ) ) {
+            Log::critical(
+                'cms-framework: cms.updates.lift_maintenance_on_interrupt is disabled, so the site is being left in maintenance mode. Run `php artisan up` once you have verified the install.',
+            );
+
+            return;
+        }
+
+        try {
+            $this->disableMaintenanceMode();
+
+            Log::critical( 'cms-framework: maintenance mode was lifted by the update shutdown guard. The installation may be half-applied — run `php artisan update:status` before trusting it.' );
+        } catch ( Throwable $e ) {
+            Log::critical( 'cms-framework: the update shutdown guard could not lift maintenance mode via `artisan up`.', [
+                'exception' => $e->getMessage(),
+            ] );
+
+            $this->forceLiftMaintenanceMode();
         }
     }
 
@@ -160,6 +323,10 @@ class ApplicationUpdateManager
      */
     public function rollback( string $backupPath ): void
     {
+        // Rollback re-runs `composer install`, so it is subject to the same
+        // execution-time ceiling as the update itself when invoked over HTTP.
+        $this->raiseExecutionLimits();
+
         if ( ! File::exists( $backupPath ) ) {
             throw UpdateException::rollbackFailed( "Backup not found: {$backupPath}" );
         }
@@ -293,7 +460,7 @@ class ApplicationUpdateManager
 
             if ( false === $filePath ) {
                 // getRealPath() failed - log and skip
-                \Illuminate\Support\Facades\Log::warning( 'Failed to get real path for file during backup', [
+                Log::warning( 'Failed to get real path for file during backup', [
                     'file' => $file->getPathname(),
                 ] );
 
@@ -303,7 +470,7 @@ class ApplicationUpdateManager
             // Verify the resolved path starts with base_path() to prevent traversal issues
             if ( ! str_starts_with( $filePath, $basePath ) ) {
                 // File is outside base path (symlink or external) - log and skip
-                \Illuminate\Support\Facades\Log::warning( 'Skipping file outside base path during backup', [
+                Log::warning( 'Skipping file outside base path during backup', [
                     'file'      => $filePath,
                     'base_path' => $basePath,
                 ] );
@@ -421,7 +588,7 @@ class ApplicationUpdateManager
             throw UpdateException::checksumRequired( $targetVersion );
         }
 
-        \Illuminate\Support\Facades\Log::warning( 'Skipping update integrity verification: update source did not advertise a SHA-256 checksum.', [
+        Log::warning( 'Skipping update integrity verification: update source did not advertise a SHA-256 checksum.', [
             'target_version' => $targetVersion,
             'source'         => $updateInfo->metadata['source'] ?? null,
         ] );
@@ -485,7 +652,7 @@ class ApplicationUpdateManager
                 || str_contains( $normalizedTarget, '/../' )
                 || str_ends_with( $normalizedTarget, '/..' )
             ) {
-                \Illuminate\Support\Facades\Log::warning( 'Skipping update ZIP entry with unsafe path', [
+                Log::warning( 'Skipping update ZIP entry with unsafe path', [
                     'entry' => $filename,
                 ] );
 
@@ -501,7 +668,7 @@ class ApplicationUpdateManager
                 }
 
                 if ( ! $this->isPathWithinExtractRoot( $fullTargetPath, $extractPath ) ) {
-                    \Illuminate\Support\Facades\Log::warning( 'Skipping update ZIP entry that resolved outside extract root', [
+                    Log::warning( 'Skipping update ZIP entry that resolved outside extract root', [
                         'entry' => $filename,
                     ] );
 
@@ -520,7 +687,7 @@ class ApplicationUpdateManager
             // Defense-in-depth: after the parent exists, resolve it and confirm
             // it still sits under the extract root before opening the write stream.
             if ( ! $this->isPathWithinExtractRoot( $targetDir, $extractPath ) ) {
-                \Illuminate\Support\Facades\Log::warning( 'Skipping update ZIP entry that resolved outside extract root', [
+                Log::warning( 'Skipping update ZIP entry that resolved outside extract root', [
                     'entry' => $filename,
                 ] );
 
@@ -533,7 +700,7 @@ class ApplicationUpdateManager
             // the middle of extraction.
             $entryStream = $zip->getStream( $filename );
             if ( false === $entryStream ) {
-                \Illuminate\Support\Facades\Log::error( 'Failed to open ZIP entry stream during update extraction', [
+                Log::error( 'Failed to open ZIP entry stream during update extraction', [
                     'entry' => $filename,
                 ] );
 
@@ -545,7 +712,7 @@ class ApplicationUpdateManager
                 fclose( $entryStream );
 
                 $error = error_get_last();
-                \Illuminate\Support\Facades\Log::error( 'Failed to open update target for writing', [
+                Log::error( 'Failed to open update target for writing', [
                     'entry'  => $filename,
                     'target' => $fullTargetPath,
                     'errno'  => $error['type'] ?? null,
@@ -562,7 +729,7 @@ class ApplicationUpdateManager
                 while ( ! feof( $entryStream ) ) {
                     $chunk = fread( $entryStream, 1024 * 1024 );
                     if ( false === $chunk ) {
-                        \Illuminate\Support\Facades\Log::error( 'Read failure while streaming update entry', [
+                        Log::error( 'Read failure while streaming update entry', [
                             'entry'  => $filename,
                             'target' => $fullTargetPath,
                         ] );
@@ -840,7 +1007,7 @@ class ApplicationUpdateManager
             }
         }
 
-        \Illuminate\Support\Facades\Log::warning(
+        Log::warning(
             'cms-framework: composer binary discovery failed; no candidate path was both a file and executable in the current PHP process context.',
             [
                 'candidates' => $results,
@@ -1026,7 +1193,8 @@ class ApplicationUpdateManager
     }
 
     /**
-     * Enable maintenance mode.
+     * Enable maintenance mode and arm the shutdown guard that lifts it again
+     * if this process dies before step 10.
      *
      * @since 1.0.0
      *
@@ -1039,10 +1207,17 @@ class ApplicationUpdateManager
         } catch ( Throwable $e ) {
             throw UpdateException::maintenanceModeFailure( 'enable' );
         }
+
+        $this->maintenanceModeActive = true;
+
+        $this->armShutdownGuard();
     }
 
     /**
      * Disable maintenance mode.
+     *
+     * The active flag is only cleared once `up` has actually succeeded, so a
+     * failure here leaves the shutdown guard armed for one more attempt.
      *
      * @since 1.0.0
      *
@@ -1054,6 +1229,154 @@ class ApplicationUpdateManager
             Artisan::call( 'up' );
         } catch ( Throwable $e ) {
             throw UpdateException::maintenanceModeFailure( 'disable' );
+        }
+
+        $this->maintenanceModeActive = false;
+    }
+
+    /**
+     * Lift PHP's own limits on how long the update may run.
+     *
+     * `runComposerInstall()` gives the composer child process a
+     * `cms.updates.composer_timeout` budget (default 600s), but that only
+     * bounds the child — the parent PHP request is still governed by
+     * `max_execution_time`, which defaults to 30 seconds under PHP-FPM. Left
+     * alone, the request is killed roughly twenty times sooner than composer's
+     * own budget allows for, and because an execution-time fatal is raised at
+     * shutdown rather than thrown, it bypasses `performUpdate()`'s catch block
+     * entirely.
+     *
+     * `ignore_user_abort( true )` matters for the same reason: without it,
+     * closing the browser tab mid-update aborts the request and produces the
+     * identical stuck-in-maintenance-mode outcome.
+     *
+     * Neither call is guaranteed to succeed — shared hosts routinely put
+     * `set_time_limit` in `disable_functions`, and FPM's
+     * `request_terminate_timeout` cannot be overridden from userland at all.
+     * That is what the shutdown guard in `handleInterruptedUpdate()` is for.
+     *
+     * @since 2.7.1
+     */
+    protected function raiseExecutionLimits(): void
+    {
+        if ( ! function_exists( 'set_time_limit' ) || ! @set_time_limit( 0 ) ) {
+            Log::warning(
+                'cms-framework: could not lift PHP\'s max_execution_time for the update; the request may be killed mid-flight.',
+                [
+                    'php_sapi'           => PHP_SAPI,
+                    'max_execution_time' => ini_get( 'max_execution_time' ),
+                    'hint'               => 'Run `php artisan update:perform` from the CLI instead, or remove set_time_limit from the host\'s disable_functions.',
+                ],
+            );
+        }
+
+        if ( function_exists( 'ignore_user_abort' ) ) {
+            ignore_user_abort( true );
+        }
+    }
+
+    /**
+     * Record that a step is now in flight, both in memory (for the shutdown
+     * guard's log context) and on disk (so the step survives the process).
+     *
+     * @since 2.7.1
+     *
+     * @param  UpdateStep  $step  Step being entered.
+     */
+    protected function beginStep( UpdateStep $step ): void
+    {
+        $this->currentStep = $step;
+
+        $this->state()->markStep( $step );
+    }
+
+    /**
+     * Persisted step marker for this manager instance.
+     *
+     * @since 2.7.1
+     *
+     * @return UpdateStateStore State store.
+     */
+    protected function state(): UpdateStateStore
+    {
+        return $this->state ??= new UpdateStateStore;
+    }
+
+    /**
+     * Register the shutdown guard exactly once per manager instance.
+     *
+     * @since 2.7.1
+     */
+    protected function armShutdownGuard(): void
+    {
+        if ( $this->shutdownGuardArmed ) {
+            return;
+        }
+
+        $this->shutdownGuardArmed = true;
+
+        register_shutdown_function( function (): void {
+            $this->handleInterruptedUpdate();
+        } );
+    }
+
+    /**
+     * The fatal error that ended the process, or `null` when the process is
+     * ending for some other reason (a client abort, an `exit()`).
+     *
+     * `error_get_last()` alone is not enough: it returns the last diagnostic
+     * of *any* severity, and the extractor deliberately uses `@fopen()` /
+     * `@chmod()`, so a suppressed warning from step 5 would otherwise be
+     * reported as the reason an update died at step 7.
+     *
+     * @since 2.7.1
+     *
+     * @return array{type: int, message: string, file: string, line: int}|null Fatal error details.
+     */
+    protected function lastFatalError(): ?array
+    {
+        $error = error_get_last();
+
+        if ( null === $error ) {
+            return null;
+        }
+
+        $fatalTypes = [E_ERROR, E_PARSE, E_CORE_ERROR, E_COMPILE_ERROR, E_USER_ERROR];
+
+        return in_array( $error['type'] ?? 0, $fatalTypes, true ) ? $error : null;
+    }
+
+    /**
+     * Last-ditch attempt to take the site out of maintenance mode by removing
+     * the file-driver marker directly.
+     *
+     * Reached only when `artisan up` itself failed — typically because the
+     * process is shutting down after an out-of-memory fatal and there isn't
+     * enough headroom left to boot a console command. Unlinking a single file
+     * needs almost none, so it is worth trying before giving up and leaving
+     * the site serving 503s. Hosts using the cache-backed maintenance driver
+     * have no such file; the log line says so rather than claiming success.
+     *
+     * @since 2.7.1
+     */
+    protected function forceLiftMaintenanceMode(): void
+    {
+        try {
+            $downFile = storage_path( 'framework/down' );
+
+            if ( ! File::exists( $downFile ) ) {
+                Log::critical( 'cms-framework: no storage/framework/down marker to remove; if this host uses the cache-backed maintenance driver, run `php artisan up` manually.' );
+
+                return;
+            }
+
+            File::delete( $downFile );
+
+            Log::critical( 'cms-framework: removed storage/framework/down directly to take the site out of maintenance mode.' );
+        } catch ( Throwable $e ) {
+            Log::critical( 'cms-framework: could not remove the maintenance-mode marker; the site is still serving 503s and needs `php artisan up`.', [
+                'exception' => $e->getMessage(),
+            ] );
         }
     }
 
@@ -1067,7 +1390,7 @@ class ApplicationUpdateManager
     protected function handleUpdateFailure( Throwable $exception ): void
     {
         // Log the original exception for debugging
-        \Illuminate\Support\Facades\Log::error( 'Update failed, beginning rollback', [
+        Log::error( 'Update failed, beginning rollback', [
             'exception' => $exception->getMessage(),
             'trace'     => $exception->getTraceAsString(),
             'file'      => $exception->getFile(),
@@ -1078,7 +1401,7 @@ class ApplicationUpdateManager
         try {
             $this->disableMaintenanceMode();
         } catch ( Throwable $e ) {
-            \Illuminate\Support\Facades\Log::error(
+            Log::error(
                 'Failed to disable maintenance mode during update rollback; host may remain in maintenance mode.',
                 ['exception' => $e->getMessage()],
             );

--- a/src/Modules/Core/Updates/Support/UpdateStateStore.php
+++ b/src/Modules/Core/Updates/Support/UpdateStateStore.php
@@ -1,0 +1,264 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Modules\Core\Updates\Support;
+
+use ArtisanPackUI\CMSFramework\Modules\Core\Updates\Enums\UpdateRunStatus;
+use ArtisanPackUI\CMSFramework\Modules\Core\Updates\Enums\UpdateStep;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Log;
+use RuntimeException;
+use Throwable;
+
+/**
+ * Update State Store
+ *
+ * Persists which step of `performUpdate()` is in flight so an update that is
+ * killed mid-process (PHP fatal, OOM, `kill -9`, FPM `request_terminate_timeout`)
+ * leaves a record behind. Without it there is no way to distinguish "update in
+ * progress", "update died at step 6", and "the site was manually put into
+ * maintenance mode".
+ *
+ * Deliberately a flat JSON file rather than the cache:
+ *
+ * - Step 8 of the update runs `cache:clear`, which would wipe a cache-backed
+ *   marker at exactly the point it becomes interesting.
+ * - The database-backed cache driver is unavailable while step 7's migrations
+ *   are mid-flight.
+ * - `storage/` is in `cms.updates.exclude_from_update`, so the file survives
+ *   extraction of the new release.
+ *
+ * Every write is best-effort: failing to record state must never abort an
+ * otherwise-healthy update.
+ *
+ * @since 2.7.1
+ */
+class UpdateStateStore
+{
+    /**
+     * Default state file location, relative to `storage_path()`.
+     *
+     * @since 2.7.1
+     */
+    public const DEFAULT_STATE_PATH = 'framework/cms-update-state.json';
+
+    /**
+     * Absolute path to the state file.
+     *
+     * Honours an absolute `cms.updates.state_path` verbatim so hosts (and
+     * tests) can place the marker outside `storage/`.
+     *
+     * @since 2.7.1
+     *
+     * @return string Absolute path to the state file.
+     */
+    public function path(): string
+    {
+        $configured = config( 'cms.updates.state_path', self::DEFAULT_STATE_PATH );
+
+        if ( ! is_string( $configured ) || '' === $configured ) {
+            $configured = self::DEFAULT_STATE_PATH;
+        }
+
+        if ( str_starts_with( $configured, DIRECTORY_SEPARATOR ) ) {
+            return $configured;
+        }
+
+        return storage_path( $configured );
+    }
+
+    /**
+     * Record the start of an update run, replacing any previous record.
+     *
+     * @since 2.7.1
+     *
+     * @param  string  $targetVersion  Version being installed.
+     * @param  string|null  $currentVersion  Version installed before the update.
+     */
+    public function begin( string $targetVersion, ?string $currentVersion = null ): void
+    {
+        $pid = getmypid();
+
+        $this->write( [
+            'status'          => UpdateRunStatus::InProgress->value,
+            'step'            => null,
+            'step_number'     => null,
+            'step_label'      => null,
+            'target_version'  => $targetVersion,
+            'current_version' => $currentVersion,
+            'php_sapi'        => PHP_SAPI,
+            'pid'             => false === $pid ? null : $pid,
+            'started_at'      => $this->timestamp(),
+            'error'           => null,
+        ] );
+    }
+
+    /**
+     * Record that a step is now in flight.
+     *
+     * @since 2.7.1
+     *
+     * @param  UpdateStep  $step  Step being entered.
+     */
+    public function markStep( UpdateStep $step ): void
+    {
+        $this->merge( [
+            'status'      => UpdateRunStatus::InProgress->value,
+            'step'        => $step->value,
+            'step_number' => $step->number(),
+            'step_label'  => $step->label(),
+        ] );
+    }
+
+    /**
+     * Record a terminal status for the current run.
+     *
+     * @since 2.7.1
+     *
+     * @param  UpdateRunStatus  $status  Status to record.
+     * @param  string|null  $error  Error message, when the run did not succeed.
+     */
+    public function markStatus( UpdateRunStatus $status, ?string $error = null ): void
+    {
+        $this->merge( [
+            'status' => $status->value,
+            'error'  => $error,
+        ] );
+    }
+
+    /**
+     * Read the persisted state, or `null` when no update has been recorded or
+     * the file is unreadable/corrupt.
+     *
+     * @since 2.7.1
+     *
+     * @return array<string, mixed>|null Persisted state.
+     */
+    public function read(): ?array
+    {
+        try {
+            $path = $this->path();
+
+            if ( ! File::exists( $path ) ) {
+                return null;
+            }
+
+            $decoded = json_decode( (string) File::get( $path ), true );
+        } catch ( Throwable $e ) {
+            Log::warning( 'cms-framework: could not read the update state file.', [
+                'exception' => $e->getMessage(),
+            ] );
+
+            return null;
+        }
+
+        return is_array( $decoded ) ? $decoded : null;
+    }
+
+    /**
+     * Delete the state file.
+     *
+     * @since 2.7.1
+     */
+    public function clear(): void
+    {
+        try {
+            $path = $this->path();
+
+            if ( File::exists( $path ) ) {
+                File::delete( $path );
+            }
+        } catch ( Throwable $e ) {
+            Log::warning( 'cms-framework: could not clear the update state file.', [
+                'exception' => $e->getMessage(),
+            ] );
+        }
+    }
+
+    /**
+     * Merge attributes into the persisted state.
+     *
+     * @since 2.7.1
+     *
+     * @param  array<string, mixed>  $attributes  Attributes to merge.
+     */
+    protected function merge( array $attributes ): void
+    {
+        $this->write( array_merge( $this->read() ?? [], $attributes ) );
+    }
+
+    /**
+     * Write the state file. Never throws — a host whose `storage/` is
+     * read-only still gets its update, it just loses the diagnostic.
+     *
+     * The write is staged through a temporary file and moved into place with
+     * `rename()`, which is atomic within a filesystem. Writing in place would
+     * truncate first, so a process dying mid-write — precisely the scenario
+     * this marker exists to record — could destroy the last good record and
+     * leave a truncated file behind instead.
+     *
+     * @since 2.7.1
+     *
+     * @param  array<string, mixed>  $state  State to persist.
+     */
+    protected function write( array $state ): void
+    {
+        $state['updated_at'] = $this->timestamp();
+
+        $temporaryPath = null;
+
+        try {
+            $path      = $this->path();
+            $directory = dirname( $path );
+
+            if ( ! File::isDirectory( $directory ) ) {
+                File::makeDirectory( $directory, 0755, true );
+            }
+
+            // Composer and migration output can carry arbitrary bytes, and a
+            // single invalid UTF-8 sequence in an error message would
+            // otherwise make the whole record unwritable.
+            $encoded = json_encode(
+                $state,
+                JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE,
+            );
+
+            if ( false === $encoded ) {
+                Log::warning( 'cms-framework: could not encode the update state; an interrupted update will not be diagnosable.' );
+
+                return;
+            }
+
+            $temporaryPath = $path . '.' . getmypid() . '.tmp';
+
+            File::put( $temporaryPath, $encoded, true );
+
+            if ( ! @rename( $temporaryPath, $path ) ) {
+                throw new RuntimeException( "Could not move the update state file into place at {$path}" );
+            }
+
+            $temporaryPath = null;
+        } catch ( Throwable $e ) {
+            if ( null !== $temporaryPath ) {
+                @unlink( $temporaryPath );
+            }
+
+            Log::warning( 'cms-framework: could not persist the update state file; an interrupted update will not be diagnosable.', [
+                'exception' => $e->getMessage(),
+            ] );
+        }
+    }
+
+    /**
+     * Current time as an ISO-8601 string.
+     *
+     * @since 2.7.1
+     *
+     * @return string ISO-8601 timestamp.
+     */
+    protected function timestamp(): string
+    {
+        return date( DATE_ATOM );
+    }
+}

--- a/src/Modules/Core/Updates/config/updates.php
+++ b/src/Modules/Core/Updates/config/updates.php
@@ -96,6 +96,50 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Update State File
+    |--------------------------------------------------------------------------
+    |
+    | Where the updater records which step of `performUpdate()` is in flight.
+    | Relative paths resolve against `storage_path()`; an absolute path is used
+    | verbatim.
+    |
+    | This is a plain file rather than a cache entry on purpose: step 8 of the
+    | update runs `cache:clear`, and the database cache driver is unavailable
+    | while step 7's migrations are mid-flight. `storage/` is in
+    | `exclude_from_update` below, so the marker survives extraction.
+    |
+    | Read it with `php artisan update:status`, or programmatically via
+    | `ApplicationUpdateManager::updateState()`.
+    |
+    */
+    'state_path' => 'framework/cms-update-state.json',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Lift Maintenance Mode On Interrupted Updates
+    |--------------------------------------------------------------------------
+    |
+    | An update that dies mid-flight (PHP fatal, out of memory, FPM's
+    | `request_terminate_timeout`, the operator closing the tab) never reaches
+    | step 10, so maintenance mode is never disabled and the site serves 503 to
+    | every visitor until somebody notices and runs `php artisan up`.
+    |
+    | When enabled (the default), a shutdown handler lifts maintenance mode in
+    | that case and logs a `critical` entry naming the step it died on. The
+    | install may be half-applied, which is a real trade-off — but an
+    | unattended outage the operator may not notice for hours is worse, and
+    | `php artisan update:status` reports exactly what is outstanding.
+    |
+    | Set to `false` to fail closed and keep the site down until an operator
+    | has verified the install by hand.
+    |
+    | Note this cannot help against `kill -9`, which runs no shutdown handlers.
+    |
+    */
+    'lift_maintenance_on_interrupt' => env( 'CMS_UPDATES_LIFT_MAINTENANCE_ON_INTERRUPT', true ),
+
+    /*
+    |--------------------------------------------------------------------------
     | Backup Settings
     |--------------------------------------------------------------------------
     |

--- a/tests/Support/RecordingApplicationUpdateManager.php
+++ b/tests/Support/RecordingApplicationUpdateManager.php
@@ -1,0 +1,251 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Tests\Support;
+
+use ArtisanPackUI\CMSFramework\Modules\Core\Updates\Enums\UpdateStep;
+use ArtisanPackUI\CMSFramework\Modules\Core\Updates\Managers\ApplicationUpdateManager;
+use ArtisanPackUI\CMSFramework\Modules\Core\Updates\ValueObjects\UpdateInfo;
+use RuntimeException;
+
+/**
+ * Recording Application Update Manager
+ *
+ * Test double for #256's execution-time and shutdown-guard coverage. Every
+ * side-effecting step of `performUpdate()` is stubbed out and recorded, so a
+ * test can drive the real orchestration — step tracking, maintenance-mode
+ * bookkeeping, the shutdown guard — without shelling out to composer or
+ * putting the test process into maintenance mode.
+ *
+ * @since 2.7.1
+ */
+class RecordingApplicationUpdateManager extends ApplicationUpdateManager
+{
+    /**
+     * Ordered record of the stubbed steps that ran.
+     *
+     * @since 2.7.1
+     *
+     * @var array<int, string>
+     */
+    public array $calls = [];
+
+    /**
+     * State snapshots taken as each step was entered, keyed by step value.
+     *
+     * @since 2.7.1
+     *
+     * @var array<string, array<string, mixed>>
+     */
+    public array $stateAtStep = [];
+
+    /**
+     * Step at which `performUpdate()` should throw, or null to run clean.
+     *
+     * @since 2.7.1
+     */
+    public ?UpdateStep $failAtStep = null;
+
+    /**
+     * Whether `disableMaintenanceMode()` should throw, exercising the
+     * force-lift fallback.
+     *
+     * @since 2.7.1
+     */
+    public bool $failDisableMaintenanceMode = false;
+
+    /**
+     * Whether the real shutdown handler should actually be registered with
+     * PHP. Off by default so tests don't leave handlers that fire at the end
+     * of the suite; tests invoke `handleInterruptedUpdate()` directly.
+     *
+     * @since 2.7.1
+     */
+    public bool $registerRealShutdownHandler = false;
+
+    /**
+     * Whether `armShutdownGuard()` was reached.
+     *
+     * @since 2.7.1
+     */
+    public bool $shutdownGuardWasArmed = false;
+
+    /**
+     * Put the double into the state a live update would be in when the process
+     * dies mid-flight.
+     *
+     * @since 2.7.1
+     *
+     * @param  UpdateStep  $step  Step to appear stuck on.
+     */
+    public function simulateInFlight( UpdateStep $step ): void
+    {
+        $this->currentStep           = $step;
+        $this->maintenanceModeActive = true;
+    }
+
+    /**
+     * Whether the manager currently believes the site is in maintenance mode.
+     *
+     * @since 2.7.1
+     *
+     * @return bool True when maintenance mode is believed active.
+     */
+    public function believesMaintenanceModeIsActive(): bool
+    {
+        return $this->maintenanceModeActive;
+    }
+
+    /**
+     * Invoke the protected execution-limit guard.
+     *
+     * @since 2.7.1
+     */
+    public function callRaiseExecutionLimits(): void
+    {
+        $this->raiseExecutionLimits();
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @since 2.7.1
+     */
+    protected function beginStep( UpdateStep $step ): void
+    {
+        parent::beginStep( $step );
+
+        $this->stateAtStep[ $step->value ] = $this->updateState() ?? [];
+
+        if ( $this->failAtStep === $step ) {
+            throw new RuntimeException( "Simulated failure at {$step->value}" );
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @since 2.7.1
+     */
+    protected function armShutdownGuard(): void
+    {
+        $this->shutdownGuardWasArmed = true;
+
+        if ( $this->registerRealShutdownHandler ) {
+            parent::armShutdownGuard();
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @since 2.7.1
+     */
+    protected function enableMaintenanceMode(): void
+    {
+        $this->calls[] = 'enable';
+
+        $this->maintenanceModeActive = true;
+
+        $this->armShutdownGuard();
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @since 2.7.1
+     */
+    protected function disableMaintenanceMode(): void
+    {
+        $this->calls[] = 'disable';
+
+        if ( $this->failDisableMaintenanceMode ) {
+            throw new RuntimeException( 'Simulated `artisan up` failure' );
+        }
+
+        $this->maintenanceModeActive = false;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @since 2.7.1
+     */
+    protected function createBackup(): void
+    {
+        $this->calls[] = 'backup';
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @since 2.7.1
+     */
+    protected function maybeVerifyChecksum( string $zipPath, UpdateInfo $updateInfo, string $targetVersion ): void
+    {
+        $this->calls[] = 'checksum';
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @since 2.7.1
+     */
+    protected function extractUpdate( string $zipPath ): void
+    {
+        $this->calls[] = 'extract';
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @since 2.7.1
+     */
+    protected function runComposerInstall(): void
+    {
+        $this->calls[] = 'composer';
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @since 2.7.1
+     */
+    protected function runMigrations(): void
+    {
+        $this->calls[] = 'migrate';
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @since 2.7.1
+     */
+    protected function clearCaches(): void
+    {
+        $this->calls[] = 'caches';
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @since 2.7.1
+     */
+    protected function cleanup( string $zipPath ): void
+    {
+        $this->calls[] = 'cleanup';
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @since 2.7.1
+     */
+    protected function forceLiftMaintenanceMode(): void
+    {
+        $this->calls[] = 'force-lift';
+
+        parent::forceLiftMaintenanceMode();
+    }
+}

--- a/tests/Unit/Updates/UpdateInterruptionGuardTest.php
+++ b/tests/Unit/Updates/UpdateInterruptionGuardTest.php
@@ -1,0 +1,409 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Tests\Unit\Updates;
+
+use ArtisanPackUI\CMSFramework\Modules\Core\Updates\Enums\UpdateRunStatus;
+use ArtisanPackUI\CMSFramework\Modules\Core\Updates\Enums\UpdateStep;
+use ArtisanPackUI\CMSFramework\Modules\Core\Updates\UpdateChecker;
+use ArtisanPackUI\CMSFramework\Modules\Core\Updates\ValueObjects\UpdateInfo;
+use ArtisanPackUI\CMSFramework\Tests\Support\RecordingApplicationUpdateManager;
+use Illuminate\Support\Facades\Log;
+use Orchestra\Testbench\TestCase;
+use RuntimeException;
+
+/**
+ * Update Interruption Guard Tests
+ *
+ * Regression coverage for #256: `performUpdate()` had no execution-time guard,
+ * so PHP's default 30s `max_execution_time` under FPM killed it mid-flight.
+ * The resulting fatal is raised at shutdown rather than thrown, so the catch
+ * block never ran, no rollback happened, and the site was left serving 503s
+ * indefinitely.
+ *
+ * @since 2.7.1
+ */
+class UpdateInterruptionGuardTest extends TestCase
+{
+    /**
+     * Absolute path to the state file used by the test.
+     *
+     * @since 2.7.1
+     */
+    protected string $statePath = '';
+
+    /**
+     * Point the state store at a temporary file for each test.
+     *
+     * @since 2.7.1
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->statePath = sys_get_temp_dir() . '/cmsfw-update-state-' . uniqid() . '.json';
+
+        config( [
+            'cms.updates.state_path'                    => $this->statePath,
+            'cms.updates.backup_enabled'                => true,
+            'cms.updates.lift_maintenance_on_interrupt' => true,
+        ] );
+    }
+
+    /**
+     * Remove the temporary state file.
+     *
+     * @since 2.7.1
+     */
+    protected function tearDown(): void
+    {
+        if ( '' !== $this->statePath && file_exists( $this->statePath ) ) {
+            @unlink( $this->statePath );
+        }
+
+        parent::tearDown();
+    }
+
+    /**
+     * Test that `performUpdate()` lifts PHP's execution-time limit. Without
+     * this the parent request dies after 30s under FPM while the composer
+     * child is still inside its own 600s budget.
+     *
+     * @since 2.7.1
+     */
+    public function test_raise_execution_limits_lifts_max_execution_time(): void
+    {
+        $original = ini_get( 'max_execution_time' );
+
+        try {
+            ini_set( 'max_execution_time', '30' );
+
+            $manager = new RecordingApplicationUpdateManager;
+            $manager->callRaiseExecutionLimits();
+
+            $this->assertSame( '0', ini_get( 'max_execution_time' ) );
+        } finally {
+            ini_set( 'max_execution_time', false === $original ? '0' : $original );
+        }
+    }
+
+    /**
+     * Test that `performUpdate()` opts out of connection-abort handling, so
+     * closing the browser tab mid-update doesn't strand the site in
+     * maintenance mode.
+     *
+     * @since 2.7.1
+     */
+    public function test_raise_execution_limits_ignores_user_abort(): void
+    {
+        $original = ignore_user_abort();
+
+        try {
+            ignore_user_abort( false );
+
+            $manager = new RecordingApplicationUpdateManager;
+            $manager->callRaiseExecutionLimits();
+
+            $this->assertSame( 1, ignore_user_abort() );
+        } finally {
+            ignore_user_abort( 1 === $original );
+        }
+    }
+
+    /**
+     * Test that a successful update records every step in order and finishes
+     * with a `completed` status.
+     *
+     * @since 2.7.1
+     */
+    public function test_successful_update_records_every_step_and_completes(): void
+    {
+        $manager = $this->managerWithUpdateAvailable();
+
+        $this->assertTrue( $manager->performUpdate() );
+
+        $this->assertSame(
+            array_map( fn ( UpdateStep $step ): string => $step->value, UpdateStep::cases() ),
+            array_keys( $manager->stateAtStep ),
+        );
+
+        // Each snapshot must name the step that was in flight when it was taken.
+        foreach ( UpdateStep::cases() as $step ) {
+            $this->assertSame( $step->value, $manager->stateAtStep[ $step->value ]['step'] );
+            $this->assertSame( $step->number(), $manager->stateAtStep[ $step->value ]['step_number'] );
+        }
+
+        $state = $manager->updateState();
+
+        $this->assertIsArray( $state );
+        $this->assertSame( UpdateRunStatus::Completed->value, $state['status'] );
+        $this->assertSame( '2.0.0', $state['target_version'] );
+        $this->assertNull( $state['error'] );
+    }
+
+    /**
+     * Test that a caught failure records a `failed` status and the error, and
+     * still leaves maintenance mode lifted.
+     *
+     * @since 2.7.1
+     */
+    public function test_caught_failure_records_failed_status(): void
+    {
+        $manager             = $this->managerWithUpdateAvailable();
+        $manager->failAtStep = UpdateStep::ComposerInstall;
+
+        try {
+            $manager->performUpdate();
+            $this->fail( 'Expected the simulated failure to propagate.' );
+        } catch ( RuntimeException $e ) {
+            $this->assertStringContainsString( 'Simulated failure', $e->getMessage() );
+        }
+
+        $state = $manager->updateState();
+
+        $this->assertIsArray( $state );
+        $this->assertSame( UpdateRunStatus::Failed->value, $state['status'] );
+        $this->assertSame( UpdateStep::ComposerInstall->value, $state['step'] );
+        $this->assertStringContainsString( 'Simulated failure', (string) $state['error'] );
+        $this->assertFalse( $manager->believesMaintenanceModeIsActive() );
+    }
+
+    /**
+     * Test that the shutdown guard lifts maintenance mode when the process
+     * died mid-update. This is the core #256 regression — before the fix a
+     * timed-out request left the site returning 503 to every visitor with no
+     * automatic way back.
+     *
+     * @since 2.7.1
+     */
+    public function test_shutdown_guard_lifts_maintenance_mode_after_a_mid_flight_death(): void
+    {
+        Log::spy();
+
+        $manager = new RecordingApplicationUpdateManager;
+        $manager->simulateInFlight( UpdateStep::Migrations );
+
+        $manager->handleInterruptedUpdate();
+
+        $this->assertContains( 'disable', $manager->calls );
+        $this->assertFalse( $manager->believesMaintenanceModeIsActive() );
+
+        Log::shouldHaveReceived( 'critical' );
+    }
+
+    /**
+     * Test that the shutdown guard records where the update died, so the
+     * operator can tell "died at step 7" from "manually put into maintenance
+     * mode".
+     *
+     * @since 2.7.1
+     */
+    public function test_shutdown_guard_records_the_interrupted_step(): void
+    {
+        Log::spy();
+
+        $manager = new RecordingApplicationUpdateManager;
+        $manager->simulateInFlight( UpdateStep::Migrations );
+        $manager->handleInterruptedUpdate();
+
+        $state = $manager->updateState();
+
+        $this->assertIsArray( $state );
+        $this->assertSame( UpdateRunStatus::Interrupted->value, $state['status'] );
+        $this->assertSame( UpdateStep::Migrations->value, $state['step'] );
+        $this->assertNotEmpty( $state['error'] );
+    }
+
+    /**
+     * Test that a stale suppressed warning is not reported as the reason the
+     * update died. The extractor deliberately uses `@fopen()`/`@chmod()`, so
+     * `error_get_last()` routinely holds a non-fatal diagnostic from an
+     * earlier step that has nothing to do with the interruption.
+     *
+     * @since 2.7.1
+     */
+    public function test_shutdown_guard_ignores_stale_non_fatal_warnings(): void
+    {
+        Log::spy();
+
+        // Leave a suppressed warning in error_get_last(), as step 5 would.
+        @file_get_contents( '/definitely/not/a/real/path' );
+
+        $manager = new RecordingApplicationUpdateManager;
+        $manager->simulateInFlight( UpdateStep::Migrations );
+        $manager->handleInterruptedUpdate();
+
+        $state = $manager->updateState();
+
+        $this->assertIsArray( $state );
+        $this->assertSame( 'The update process terminated before completing.', $state['error'] );
+        $this->assertStringNotContainsString( 'file_get_contents', (string) $state['error'] );
+    }
+
+    /**
+     * Test that the shutdown guard does nothing when the update finished
+     * normally — the handler stays registered for the rest of the request, so
+     * it must be inert once maintenance mode has been lifted.
+     *
+     * @since 2.7.1
+     */
+    public function test_shutdown_guard_is_inert_after_a_successful_update(): void
+    {
+        $manager = $this->managerWithUpdateAvailable();
+        $manager->performUpdate();
+
+        $callsAfterUpdate = $manager->calls;
+
+        $manager->handleInterruptedUpdate();
+
+        $this->assertSame( $callsAfterUpdate, $manager->calls );
+
+        $state = $manager->updateState();
+
+        $this->assertIsArray( $state );
+        $this->assertSame( UpdateRunStatus::Completed->value, $state['status'] );
+    }
+
+    /**
+     * Test that the shutdown guard is inert when no update ever started.
+     *
+     * @since 2.7.1
+     */
+    public function test_shutdown_guard_is_inert_when_no_update_ran(): void
+    {
+        $manager = new RecordingApplicationUpdateManager;
+
+        $manager->handleInterruptedUpdate();
+
+        $this->assertSame( [], $manager->calls );
+        $this->assertNull( $manager->updateState() );
+    }
+
+    /**
+     * Test that the guard only fires once, even if the handler is somehow
+     * invoked twice.
+     *
+     * @since 2.7.1
+     */
+    public function test_shutdown_guard_only_fires_once(): void
+    {
+        Log::spy();
+
+        $manager = new RecordingApplicationUpdateManager;
+        $manager->simulateInFlight( UpdateStep::Extract );
+
+        $manager->handleInterruptedUpdate();
+        $manager->handleInterruptedUpdate();
+
+        $this->assertSame( ['disable'], $manager->calls );
+    }
+
+    /**
+     * Test that a host can opt into failing closed — leaving the site down
+     * until an operator has verified a possibly half-applied install.
+     *
+     * @since 2.7.1
+     */
+    public function test_shutdown_guard_respects_the_fail_closed_opt_out(): void
+    {
+        Log::spy();
+
+        config( ['cms.updates.lift_maintenance_on_interrupt' => false] );
+
+        $manager = new RecordingApplicationUpdateManager;
+        $manager->simulateInFlight( UpdateStep::ComposerInstall );
+
+        $manager->handleInterruptedUpdate();
+
+        $this->assertNotContains( 'disable', $manager->calls );
+
+        // The run is still recorded so `update:status` can explain the outage.
+        $state = $manager->updateState();
+
+        $this->assertIsArray( $state );
+        $this->assertSame( UpdateRunStatus::Interrupted->value, $state['status'] );
+    }
+
+    /**
+     * Test that when `artisan up` itself fails — typical when the process is
+     * shutting down after an out-of-memory fatal and there is no headroom to
+     * boot a console command — the guard falls back to removing the
+     * file-driver maintenance marker directly.
+     *
+     * @since 2.7.1
+     */
+    public function test_shutdown_guard_falls_back_to_removing_the_down_marker(): void
+    {
+        Log::spy();
+
+        $downFile = storage_path( 'framework/down' );
+
+        if ( ! is_dir( dirname( $downFile ) ) ) {
+            mkdir( dirname( $downFile ), 0755, true );
+        }
+
+        file_put_contents( $downFile, '{}' );
+
+        try {
+            $manager                             = new RecordingApplicationUpdateManager;
+            $manager->failDisableMaintenanceMode = true;
+            $manager->simulateInFlight( UpdateStep::Extract );
+
+            $manager->handleInterruptedUpdate();
+
+            $this->assertSame( ['disable', 'force-lift'], $manager->calls );
+            $this->assertFileDoesNotExist( $downFile );
+        } finally {
+            @unlink( $downFile );
+        }
+    }
+
+    /**
+     * Test that entering maintenance mode arms the shutdown guard. Arming it
+     * anywhere later would leave a window in which a death produces the
+     * original stuck-in-maintenance-mode outcome.
+     *
+     * @since 2.7.1
+     */
+    public function test_entering_maintenance_mode_arms_the_shutdown_guard(): void
+    {
+        $manager             = $this->managerWithUpdateAvailable();
+        $manager->failAtStep = UpdateStep::Backup;
+
+        try {
+            $manager->performUpdate();
+        } catch ( RuntimeException $e ) {
+            // Expected.
+        }
+
+        $this->assertTrue( $manager->shutdownGuardWasArmed );
+    }
+
+    /**
+     * Build a recording manager wired to a checker that reports an available
+     * update.
+     *
+     * @since 2.7.1
+     *
+     * @return RecordingApplicationUpdateManager Configured test double.
+     */
+    protected function managerWithUpdateAvailable(): RecordingApplicationUpdateManager
+    {
+        $manager = new RecordingApplicationUpdateManager;
+
+        $updateInfo = new UpdateInfo(
+            currentVersion: '1.0.0',
+            latestVersion: '2.0.0',
+            downloadUrl: 'https://example.com/update.zip',
+        );
+
+        $checker = $this->createMock( UpdateChecker::class );
+        $checker->method( 'checkForUpdate' )->willReturn( $updateInfo );
+        $checker->method( 'downloadUpdate' )->willReturn( '/tmp/does-not-matter.zip' );
+
+        $manager->setUpdateChecker( $checker );
+
+        return $manager;
+    }
+}

--- a/tests/Unit/Updates/UpdateStateStoreTest.php
+++ b/tests/Unit/Updates/UpdateStateStoreTest.php
@@ -1,0 +1,275 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Tests\Unit\Updates;
+
+use ArtisanPackUI\CMSFramework\Modules\Core\Updates\Enums\UpdateRunStatus;
+use ArtisanPackUI\CMSFramework\Modules\Core\Updates\Enums\UpdateStep;
+use ArtisanPackUI\CMSFramework\Modules\Core\Updates\Support\UpdateStateStore;
+use Orchestra\Testbench\TestCase;
+
+/**
+ * Update State Store Tests
+ *
+ * Regression coverage for #256 — an update killed mid-flight must leave a
+ * durable record of how far it got.
+ *
+ * @since 2.7.1
+ */
+class UpdateStateStoreTest extends TestCase
+{
+    /**
+     * Absolute path to the state file used by the test.
+     *
+     * @since 2.7.1
+     */
+    protected string $statePath = '';
+
+    /**
+     * Set up a temporary, absolute state path for each test.
+     *
+     * @since 2.7.1
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->statePath = sys_get_temp_dir() . '/cmsfw-update-state-' . uniqid() . '.json';
+
+        config( ['cms.updates.state_path' => $this->statePath] );
+    }
+
+    /**
+     * Remove the temporary state file.
+     *
+     * @since 2.7.1
+     */
+    protected function tearDown(): void
+    {
+        if ( '' !== $this->statePath && file_exists( $this->statePath ) ) {
+            @unlink( $this->statePath );
+        }
+
+        parent::tearDown();
+    }
+
+    /**
+     * Test that an absolute `state_path` is honoured verbatim.
+     *
+     * @since 2.7.1
+     */
+    public function test_absolute_state_path_is_used_verbatim(): void
+    {
+        $store = new UpdateStateStore;
+
+        $this->assertSame( $this->statePath, $store->path() );
+    }
+
+    /**
+     * Test that a relative `state_path` resolves against storage_path().
+     *
+     * @since 2.7.1
+     */
+    public function test_relative_state_path_resolves_against_storage_path(): void
+    {
+        config( ['cms.updates.state_path' => 'framework/cms-update-state.json'] );
+
+        $store = new UpdateStateStore;
+
+        $this->assertSame( storage_path( 'framework/cms-update-state.json' ), $store->path() );
+    }
+
+    /**
+     * Test that a blank or non-string `state_path` falls back to the default.
+     *
+     * @since 2.7.1
+     */
+    public function test_blank_state_path_falls_back_to_default(): void
+    {
+        config( ['cms.updates.state_path' => ''] );
+
+        $store = new UpdateStateStore;
+
+        $this->assertSame( storage_path( UpdateStateStore::DEFAULT_STATE_PATH ), $store->path() );
+    }
+
+    /**
+     * Test that reading returns null when nothing has been recorded.
+     *
+     * @since 2.7.1
+     */
+    public function test_read_returns_null_when_no_state_recorded(): void
+    {
+        $store = new UpdateStateStore;
+
+        $this->assertNull( $store->read() );
+    }
+
+    /**
+     * Test that beginning a run records the versions and an in-progress status.
+     *
+     * @since 2.7.1
+     */
+    public function test_begin_records_versions_and_in_progress_status(): void
+    {
+        $store = new UpdateStateStore;
+        $store->begin( '0.3.0', '0.2.4' );
+
+        $state = $store->read();
+
+        $this->assertIsArray( $state );
+        $this->assertSame( UpdateRunStatus::InProgress->value, $state['status'] );
+        $this->assertSame( '0.3.0', $state['target_version'] );
+        $this->assertSame( '0.2.4', $state['current_version'] );
+        $this->assertSame( PHP_SAPI, $state['php_sapi'] );
+        $this->assertNull( $state['step'] );
+        $this->assertNotEmpty( $state['started_at'] );
+        $this->assertNotEmpty( $state['updated_at'] );
+    }
+
+    /**
+     * Test that marking a step records its identifier, number, and label.
+     *
+     * @since 2.7.1
+     */
+    public function test_mark_step_records_step_details(): void
+    {
+        $store = new UpdateStateStore;
+        $store->begin( '0.3.0', '0.2.4' );
+        $store->markStep( UpdateStep::ComposerInstall );
+
+        $state = $store->read();
+
+        $this->assertIsArray( $state );
+        $this->assertSame( UpdateStep::ComposerInstall->value, $state['step'] );
+        $this->assertSame( 6, $state['step_number'] );
+        $this->assertSame( UpdateStep::ComposerInstall->label(), $state['step_label'] );
+        // Merging must not drop attributes recorded by begin().
+        $this->assertSame( '0.3.0', $state['target_version'] );
+    }
+
+    /**
+     * Test that marking a status preserves the last recorded step, which is
+     * the whole point of the marker — an interrupted run must still say where
+     * it stopped.
+     *
+     * @since 2.7.1
+     */
+    public function test_mark_status_preserves_last_step(): void
+    {
+        $store = new UpdateStateStore;
+        $store->begin( '0.3.0', '0.2.4' );
+        $store->markStep( UpdateStep::Migrations );
+        $store->markStatus( UpdateRunStatus::Interrupted, 'Maximum execution time of 30 seconds exceeded' );
+
+        $state = $store->read();
+
+        $this->assertIsArray( $state );
+        $this->assertSame( UpdateRunStatus::Interrupted->value, $state['status'] );
+        $this->assertSame( UpdateStep::Migrations->value, $state['step'] );
+        $this->assertSame( 'Maximum execution time of 30 seconds exceeded', $state['error'] );
+    }
+
+    /**
+     * Test that clearing removes the state file.
+     *
+     * @since 2.7.1
+     */
+    public function test_clear_removes_the_state_file(): void
+    {
+        $store = new UpdateStateStore;
+        $store->begin( '0.3.0', '0.2.4' );
+
+        $this->assertFileExists( $this->statePath );
+
+        $store->clear();
+
+        $this->assertFileDoesNotExist( $this->statePath );
+        $this->assertNull( $store->read() );
+    }
+
+    /**
+     * Test that clearing when nothing was recorded is a no-op rather than an
+     * error — the shutdown path must never throw.
+     *
+     * @since 2.7.1
+     */
+    public function test_clear_is_a_no_op_when_no_state_exists(): void
+    {
+        $store = new UpdateStateStore;
+        $store->clear();
+
+        $this->assertNull( $store->read() );
+    }
+
+    /**
+     * Test that an error message carrying invalid UTF-8 — composer and
+     * migration output can contain arbitrary bytes — still produces a
+     * readable record rather than silently failing to encode.
+     *
+     * @since 2.7.1
+     */
+    public function test_invalid_utf8_in_an_error_message_still_persists(): void
+    {
+        $store = new UpdateStateStore;
+        $store->begin( '0.3.0', '0.2.4' );
+        $store->markStatus( UpdateRunStatus::Interrupted, "composer failed: \xB1\x31 bad bytes" );
+
+        $state = $store->read();
+
+        $this->assertIsArray( $state );
+        $this->assertSame( UpdateRunStatus::Interrupted->value, $state['status'] );
+        $this->assertStringContainsString( 'composer failed', (string) $state['error'] );
+    }
+
+    /**
+     * Test that writes are staged atomically and leave no temporary file
+     * behind. Writing in place would truncate first, so a process dying
+     * mid-write — exactly what this marker exists to record — could destroy
+     * the last good record.
+     *
+     * @since 2.7.1
+     */
+    public function test_writes_are_staged_and_leave_no_temporary_file(): void
+    {
+        $store = new UpdateStateStore;
+        $store->begin( '0.3.0', '0.2.4' );
+        $store->markStep( UpdateStep::Extract );
+
+        $strays = glob( $this->statePath . '.*.tmp' );
+
+        $this->assertSame( [], false === $strays ? [] : $strays );
+        $this->assertIsArray( $store->read() );
+    }
+
+    /**
+     * Test that a corrupt state file reads as null rather than throwing. A
+     * truncated write (the process died mid-`fwrite`) must not take down the
+     * status command that exists to diagnose it.
+     *
+     * @since 2.7.1
+     */
+    public function test_corrupt_state_file_reads_as_null(): void
+    {
+        file_put_contents( $this->statePath, '{ this is not json' );
+
+        $store = new UpdateStateStore;
+
+        $this->assertNull( $store->read() );
+    }
+
+    /**
+     * Test that a JSON scalar (valid JSON, wrong shape) reads as null.
+     *
+     * @since 2.7.1
+     */
+    public function test_non_array_state_file_reads_as_null(): void
+    {
+        file_put_contents( $this->statePath, '"in_progress"' );
+
+        $store = new UpdateStateStore;
+
+        $this->assertNull( $store->read() );
+    }
+}

--- a/tests/Unit/Updates/UpdateStatusCommandTest.php
+++ b/tests/Unit/Updates/UpdateStatusCommandTest.php
@@ -1,0 +1,190 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Tests\Unit\Updates;
+
+use ArtisanPackUI\CMSFramework\Modules\Core\Providers\CoreServiceProvider;
+use ArtisanPackUI\CMSFramework\Modules\Core\Updates\Enums\UpdateRunStatus;
+use ArtisanPackUI\CMSFramework\Modules\Core\Updates\Enums\UpdateStep;
+use ArtisanPackUI\CMSFramework\Modules\Core\Updates\Support\UpdateStateStore;
+use Illuminate\Foundation\Application;
+use Orchestra\Testbench\TestCase;
+
+/**
+ * Update Status Command Tests
+ *
+ * @since 2.7.1
+ */
+class UpdateStatusCommandTest extends TestCase
+{
+    /**
+     * Absolute path to the state file used by the test.
+     *
+     * @since 2.7.1
+     */
+    protected string $statePath = '';
+
+    /**
+     * Point the state store at a temporary file for each test.
+     *
+     * @since 2.7.1
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->statePath = sys_get_temp_dir() . '/cmsfw-update-state-' . uniqid() . '.json';
+
+        config( ['cms.updates.state_path' => $this->statePath] );
+    }
+
+    /**
+     * Remove the temporary state file.
+     *
+     * @since 2.7.1
+     */
+    protected function tearDown(): void
+    {
+        if ( '' !== $this->statePath && file_exists( $this->statePath ) ) {
+            @unlink( $this->statePath );
+        }
+
+        parent::tearDown();
+    }
+
+    /**
+     * Test the command reports cleanly when no update has ever been recorded.
+     *
+     * @since 2.7.1
+     */
+    public function test_reports_when_no_update_has_been_recorded(): void
+    {
+        $this->artisan( 'update:status' )
+            ->expectsOutputToContain( 'No application update has been recorded.' )
+            ->assertSuccessful();
+    }
+
+    /**
+     * Test the command exits successfully for a completed update.
+     *
+     * @since 2.7.1
+     */
+    public function test_reports_a_completed_update(): void
+    {
+        $store = new UpdateStateStore;
+        $store->begin( '2.0.0', '1.0.0' );
+        $store->markStep( UpdateStep::DisableMaintenanceMode );
+        $store->markStatus( UpdateRunStatus::Completed );
+
+        $this->artisan( 'update:status' )
+            ->expectsOutputToContain( 'Completed' )
+            ->assertSuccessful();
+    }
+
+    /**
+     * Test the command fails and prints the outstanding recovery steps when
+     * an update was interrupted mid-flight. This is the diagnostic that used
+     * to require reading framework source.
+     *
+     * @since 2.7.1
+     */
+    public function test_reports_recovery_steps_for_an_interrupted_update(): void
+    {
+        $store = new UpdateStateStore;
+        $store->begin( '0.3.0', '0.2.4' );
+        $store->markStep( UpdateStep::Migrations );
+        $store->markStatus( UpdateRunStatus::Interrupted, 'Maximum execution time of 30 seconds exceeded' );
+
+        $this->artisan( 'update:status' )
+            ->expectsOutputToContain( 'Maximum execution time of 30 seconds exceeded' )
+            ->expectsOutputToContain( 'php artisan migrate --force' )
+            ->expectsOutputToContain( 'php artisan up' )
+            ->assertFailed();
+    }
+
+    /**
+     * Test that an update interrupted during extraction points the operator at
+     * the snapshot rather than at a resume-by-hand checklist — a partially
+     * overwritten application tree cannot be finished manually.
+     *
+     * @since 2.7.1
+     */
+    public function test_recommends_snapshot_restore_when_interrupted_during_extraction(): void
+    {
+        $store = new UpdateStateStore;
+        $store->begin( '0.3.0', '0.2.4' );
+        $store->markStep( UpdateStep::Extract );
+        $store->markStatus( UpdateRunStatus::Interrupted, 'Allowed memory size exhausted' );
+
+        $this->artisan( 'update:status' )
+            ->expectsOutputToContain( 'storage/backups/application/' )
+            ->doesntExpectOutputToContain( 'php artisan migrate --force' )
+            ->assertFailed();
+    }
+
+    /**
+     * Test that a hand-edited or half-written record renders without notices
+     * instead of printing "Array". The command exists to be run after a crash,
+     * so it must tolerate a malformed record.
+     *
+     * @since 2.7.1
+     */
+    public function test_renders_a_malformed_record_without_erroring(): void
+    {
+        file_put_contents( $this->statePath, (string) json_encode( [
+            'status'         => ['unexpected' => 'shape'],
+            'step'           => 99,
+            'target_version' => ['also' => 'wrong'],
+            'error'          => null,
+        ] ) );
+
+        $this->artisan( 'update:status' )->assertSuccessful();
+    }
+
+    /**
+     * Test the `--json` option emits the raw persisted state.
+     *
+     * @since 2.7.1
+     */
+    public function test_json_option_emits_the_raw_state(): void
+    {
+        $store = new UpdateStateStore;
+        $store->begin( '2.0.0', '1.0.0' );
+        $store->markStep( UpdateStep::ComposerInstall );
+
+        $this->artisan( 'update:status', ['--json' => true] )
+            ->expectsOutputToContain( '"step": "composer_install"' )
+            ->assertSuccessful();
+    }
+
+    /**
+     * Test the `--clear` option discards the recorded state.
+     *
+     * @since 2.7.1
+     */
+    public function test_clear_option_discards_the_recorded_state(): void
+    {
+        $store = new UpdateStateStore;
+        $store->begin( '2.0.0', '1.0.0' );
+        $store->markStatus( UpdateRunStatus::Completed );
+
+        $this->artisan( 'update:status', ['--clear' => true] )->assertSuccessful();
+
+        $this->assertNull( ( new UpdateStateStore )->read() );
+    }
+
+    /**
+     * Register the core provider so the update commands are available.
+     *
+     * @since 2.7.1
+     *
+     * @param  Application  $app
+     *
+     * @return array<int, class-string>
+     */
+    protected function getPackageProviders( $app ): array
+    {
+        return [CoreServiceProvider::class];
+    }
+}

--- a/tests/Unit/Updates/UpdateStepTest.php
+++ b/tests/Unit/Updates/UpdateStepTest.php
@@ -1,0 +1,106 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Tests\Unit\Updates;
+
+use ArtisanPackUI\CMSFramework\Modules\Core\Updates\Enums\UpdateRunStatus;
+use ArtisanPackUI\CMSFramework\Modules\Core\Updates\Enums\UpdateStep;
+use Orchestra\Testbench\TestCase;
+
+/**
+ * Update Step / Update Run Status Enum Tests
+ *
+ * @since 2.7.1
+ */
+class UpdateStepTest extends TestCase
+{
+    /**
+     * Test that step numbers are unique, contiguous, and ordered to match the
+     * sequence in `performUpdate()`.
+     *
+     * @since 2.7.1
+     */
+    public function test_step_numbers_are_contiguous_and_ordered(): void
+    {
+        $numbers = array_map( fn ( UpdateStep $step ): int => $step->number(), UpdateStep::cases() );
+
+        $this->assertSame( range( 1, count( UpdateStep::cases() ) ), $numbers );
+    }
+
+    /**
+     * Test that every step has a non-empty label.
+     *
+     * @since 2.7.1
+     */
+    public function test_every_step_has_a_label(): void
+    {
+        foreach ( UpdateStep::cases() as $step ) {
+            $this->assertNotSame( '', $step->label() );
+        }
+    }
+
+    /**
+     * Test that outstanding steps include the step itself — an interrupted
+     * update was *in* that step when it died, so it cannot be assumed done.
+     *
+     * @since 2.7.1
+     */
+    public function test_outstanding_steps_include_the_current_step(): void
+    {
+        $outstanding = UpdateStep::Migrations->outstandingSteps();
+
+        $this->assertSame(
+            [
+                UpdateStep::Migrations,
+                UpdateStep::ClearCaches,
+                UpdateStep::Cleanup,
+                UpdateStep::DisableMaintenanceMode,
+            ],
+            $outstanding,
+        );
+    }
+
+    /**
+     * Test that the last step has exactly one outstanding step: itself.
+     *
+     * @since 2.7.1
+     */
+    public function test_last_step_is_its_own_only_outstanding_step(): void
+    {
+        $this->assertSame(
+            [UpdateStep::DisableMaintenanceMode],
+            UpdateStep::DisableMaintenanceMode->outstandingSteps(),
+        );
+    }
+
+    /**
+     * Test that the recoverable steps expose the command an operator would run
+     * by hand, and the unrecoverable ones do not pretend to.
+     *
+     * @since 2.7.1
+     */
+    public function test_recovery_commands_are_exposed_for_resumable_steps_only(): void
+    {
+        $this->assertSame( 'php artisan migrate --force', UpdateStep::Migrations->recoveryCommand() );
+        $this->assertSame( 'php artisan up', UpdateStep::DisableMaintenanceMode->recoveryCommand() );
+        $this->assertStringContainsString( 'composer install', (string) UpdateStep::ComposerInstall->recoveryCommand() );
+
+        $this->assertNull( UpdateStep::Download->recoveryCommand() );
+        $this->assertNull( UpdateStep::Extract->recoveryCommand() );
+        $this->assertNull( UpdateStep::Backup->recoveryCommand() );
+    }
+
+    /**
+     * Test which run statuses warrant operator attention.
+     *
+     * @since 2.7.1
+     */
+    public function test_statuses_needing_attention(): void
+    {
+        $this->assertTrue( UpdateRunStatus::Interrupted->needsAttention() );
+        $this->assertTrue( UpdateRunStatus::Failed->needsAttention() );
+        $this->assertFalse( UpdateRunStatus::Completed->needsAttention() );
+        $this->assertFalse( UpdateRunStatus::InProgress->needsAttention() );
+    }
+}


### PR DESCRIPTION
## Description

`performUpdate()` had no execution-time guard. `runComposerInstall()` gave the composer child a `cms.updates.composer_timeout` budget (default 600s), but the parent PHP request was still governed by `max_execution_time` — **30 seconds** by default under PHP-FPM, which is the path the admin UI uses. Composer was given ten minutes and the request was killed after thirty seconds.

The failure mode was the serious part. An execution-time fatal is raised at shutdown rather than thrown, so `performUpdate()`'s `catch` block never ran: `handleUpdateFailure()` never rolled back, and step 10's `disableMaintenanceMode()` never executed. The operator was left with a site returning 503 to every visitor, no error in the UI (the request died before rendering a response), and no automatic way back. Every other failure in this module to date failed *safely*; this one failed open.

**Closes:** #256

## Type of Change

- [x] Bug fix (fixes an issue)
- [ ] New feature (adds new functionality)
- [ ] Enhancement (improves existing functionality)
- [ ] Refactoring (code improvement, no behavior change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Security fix
- [ ] Breaking change (breaks backward compatibility)

## Related Issue

**Issue:** #256

## Motivation and Context

As #256 notes, #254 and #255 both failed *fast* — well inside 30 seconds — so they surfaced as clean rollbacks and masked this. Only once composer got far enough to do real work did the request survive long enough to hit the time limit. Any host that fixes those two meets this one immediately, hence the v2.7.1 milestone.

## Changes Made

**Fix A — lift PHP's own limits.** `performUpdate()` and `rollback()` call `set_time_limit( 0 )` and `ignore_user_abort( true )` up front. `ignore_user_abort()` matters independently: closing the browser tab mid-update produced the identical stuck-in-maintenance-mode outcome. Hosts with `set_time_limit` in `disable_functions` get a warning log naming `php artisan update:perform` as the supported path instead of failing silently.

**Fix B — shutdown-safe maintenance mode.** Fix A cannot help against OOM or FPM's `request_terminate_timeout`. `enableMaintenanceMode()` now arms a shutdown guard that lifts maintenance mode if the process dies before step 10, logging a `critical` entry naming the step. If `artisan up` itself fails — likely when shutting down after an OOM fatal, where there is no headroom to boot a console command — it removes `storage/framework/down` directly. `cms.updates.lift_maintenance_on_interrupt=false` opts into failing closed instead.

Only fatal error types are treated as the interruption cause: the extractor deliberately uses `@fopen()`/`@chmod()`, so a bare `error_get_last()` would report a suppressed warning from step 5 as the reason an update died at step 7.

**Fix C — persist the current step.** Each of the ten steps is recorded to a state file as it is entered, so a killed update is *detectable*. Previously there was no way to distinguish "update in progress", "update died at step 6", and "the site was manually put into maintenance mode". Surfaced by a new `php artisan update:status` (with `--json` and `--clear`) and by `ApplicationUpdateManager::updateState()` / `clearUpdateState()` for admin UIs.

A flat file rather than a cache entry on purpose: step 8 runs `cache:clear`, and the database cache driver is unavailable while step 7's migrations are mid-flight. `storage/` is in `exclude_from_update`, so the marker survives extraction. Writes are staged through a temp file and `rename()`d into place — an in-place write truncates first, so a process dying mid-write could destroy the last good record, which is exactly the scenario the marker exists for.

```console
$ php artisan update:status
✗ Interrupted (process died mid-update)

  From version    0.2.4
  To version      0.3.0
  Last step       7/10 — Run database migrations

Error: Maximum execution time of 30 seconds exceeded

These steps had not completed. Run them in order to finish the update:

  7. Run database migrations
     php artisan migrate --force
  8. Clear application caches
     php artisan config:clear && php artisan cache:clear && ...
  10. Disable maintenance mode
     php artisan up
```

A run interrupted during download or extraction is not resumable, so the command points at the pre-update snapshot in `storage/backups/application/` rather than a resume checklist.

**Fix D (queued job) is deliberately out of scope** for this patch — it would add new public API on a `2.7.1` milestone. As #256 says, A/B/C are worth doing regardless since integrators will keep calling `performUpdate()` directly. Filed as #258.

### New config keys

| Key | Default | Purpose |
|-----|---------|---------|
| `cms.updates.state_path` | `framework/cms-update-state.json` | Where the step marker is written. Relative paths resolve against `storage_path()`. |
| `cms.updates.lift_maintenance_on_interrupt` | `true` | Whether the shutdown guard lifts maintenance mode. Env: `CMS_UPDATES_LIFT_MAINTENANCE_ON_INTERRUPT`. |

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS 27.0 (Darwin 27.0.0) with Laravel Herd
- Browser (if applicable): n/a — console + package test suite
- PHP Version: 8.4.23
- Project Version: cms-framework 2.7.0 → 2.7.1

**Tests Performed:**
1. Full package suite: **1518 passed, 7 skipped** (3,871 assertions). 39 new tests across four files.
2. `php artisan update:status` exercised end-to-end against the `artisanpack-ui-dev` host app (which symlinks this branch) in every mode: no record, completed, interrupted, `--json`, `--clear`. Verified exit codes (0 / 1) and that no `.tmp` files are left behind.
3. Verified the pre-existing 128M OOM in the full suite is **not** from this branch — it reproduces identically with all four new test files excluded, at the same point in `tests/Feature/Notifications`. The suite passes at `-d memory_limit=1G`.

**Not yet exercised against a real release** — the original repro needs a live FPM host and a real update. @jacobmartella is validating that path while shipping Keystone CMS to production.

## Accessibility Tests Run

- [ ] Keyboard navigation tested
- [ ] Screen reader tested
- [ ] Color contrast verified
- [ ] ARIA labels checked

**Details:** Not applicable — this change is entirely backend (update manager, a console command, config). No markup or UI surface is touched. The console command's status is conveyed by text labels (`✓`/`✗`/`…` plus a written status word), not by colour alone.

## Tests Added

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] All tests passing

**Test details:**

- `UpdateInterruptionGuardTest` (13) — the execution-limit lift, `ignore_user_abort`, full step recording across a successful run, the caught-failure path, and the shutdown guard: lifting maintenance mode after a mid-flight death, recording the interrupted step, staying inert after success and when no update ran, firing only once, honouring the fail-closed opt-out, falling back to removing the down marker, and ignoring stale non-fatal warnings.
- `UpdateStateStoreTest` (13) — path resolution (absolute / relative / blank), begin/markStep/markStatus round-trips, that `markStatus` preserves the last step, clear semantics, atomic staging with no stray temp files, invalid UTF-8 in an error message, and corrupt/non-array files reading as `null`.
- `UpdateStatusCommandTest` (7) — every output mode plus a deliberately malformed record.
- `UpdateStepTest` (6) — step numbering contiguity, outstanding-step derivation, recovery commands.
- `tests/Support/RecordingApplicationUpdateManager.php` — test double that stubs every side-effecting step so the real orchestration can be driven without shelling out to composer or putting the test process into maintenance mode.

## Documentation

- [x] Inline code documentation added
- [ ] README updated
- [ ] Wiki updated
- [ ] API documentation updated

**Documentation details:** `docs/self-updater.md` gains a "Long-running updates and interrupted processes" section covering all three guards, the `update:status` output, and why the marker is a file rather than a cache entry. Both new config keys are added to the reference tables. `CHANGELOG.md` updated under `[Unreleased]`.

Two operational consequences are called out explicitly in the docs, since lifting the time limit changes the risk profile:

- **Keep `performUpdate()` behind admin authorization.** An HTTP-triggered update now occupies an FPM worker for the whole update and keeps occupying it if the caller disconnects. The phases stay individually bounded (`download_timeout`, `composer_timeout`), but an unauthorized update endpoint became a cheaper way to exhaust the worker pool than it was at 30 seconds.
- **Nothing serializes concurrent updates.** Two overlapping calls fight over the same tree and marker. True before this change too, but the longer window makes an overlap easier to hit. Worth a follow-up if the admin UI can double-dispatch.

## Screenshots

n/a — console output is inlined above.

## Pre-Submission Checklist

- [x] Followed contributing guidelines
- [x] Checked for other open PRs for same update
- [x] Code passes all tests
- [x] Code has been linted
- [ ] Accessibility tests completed — n/a, see above
- [x] Code follows project style guide
- [x] Self-review completed
- [x] Comments added for complex code
- [x] No new warnings generated

**Note on linting:** `php-cs-fixer` is clean. `phpcs` reports findings on the new files, but all are pre-existing repo-wide categories that untouched siblings share identically — `declare( strict_types=1 )` spacing (nearly every file in the repo), `LineLength` (e.g. `MetadataClient.php`), and missing type declarations on Laravel's `$signature`/`$description` (e.g. `CheckForUpdateCommand.php`). No new category is introduced.

PHPCS reports 3,292 violations repo-wide and the CI Lint job sets `continue-on-error: true` on that step, so it cannot fail a build today. Tracked in #259.
