### PR TITLE
fix: discover Laravel Herd's bundled composer in the self-updater

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **The updater never looked for composer where Laravel Herd puts it, so a Herd-only macOS host could not self-update at all** ([#254](https://github.com/ArtisanPack-UI/cms-framework/issues/254)) — `phpCandidatePaths()` has listed Herd's `php` **first** since [#225](https://github.com/ArtisanPack-UI/cms-framework/issues/225), annotated "so hosts that use Herd for both FPM and CLI stay on a single toolchain". Herd bundles composer in that same `bin/` directory, but `composerCandidatePaths()` never learned about it — the one place the Herd awareness didn't get carried over. On a clean Herd install with no Homebrew composer and no global composer (Herd ships one, so there's no reason to `brew install` another), all five candidate paths missed, discovery returned `null`, and the updater fell through to bare `composer install` — which PHP-FPM's stripped `PATH` (`/usr/bin:/bin:/usr/sbin:/sbin`) cannot resolve:
+
+  ```
+  Update failed: Rollback failed: Composer install failed. Output: sh: composer: command not found .
+  Original update error: Composer install failed. Output: sh: composer: command not found .
+  Manual intervention required. The pre-update snapshot was restored.
+  ```
+
+  Three changes:
+
+  - **`~/Library/Application Support/Herd/bin/composer` now leads the composer candidate list**, mirroring the PHP list's ordering and rationale. Herd's composer is a `#!/usr/bin/env php` script rather than a standalone binary, which needed no other changes: `buildComposerCommand()` already invokes the discovered path as `{CLI PHP} {binary} install ...`.
+  - **Both candidate lists now derive Herd's `bin/` directory from a single `herdBinPath()` helper**, so they cannot drift apart again the way they did here.
+  - **A failed rollback `--version` probe against a path PHP also cannot `stat()` now throws the new `UpdateException::configuredComposerBinaryMissing`**, naming the offending path. Such a path can only have come from `COMPOSER_BINARY` / `cms.updates.composer_binary`, since discovery only ever returns a path it has already stat'd. This closes a second, more confusing failure: because `/opt/homebrew/bin/composer` is advertised in the `composerBinaryNotFound` message and is the canonical macOS location, the natural next move on a Herd-only machine was to set `COMPOSER_BINARY` to it — producing "Composer binary was located but could not be executed … Could not open input file" closing with a `CMS_PHP_BINARY` hint. It was never located, only configured; and `resolvePhpBinary()` had done its job correctly, so the trailing hint blamed the one component that was already right.
+
+    The stat runs **after** the probe rather than gating it, which matters for [#233](https://github.com/ArtisanPack-UI/cms-framework/issues/233): a path PHP cannot `stat()` may still be perfectly reachable by the shelled-out child under PHP-FPM sandboxing, and pointing `COMPOSER_BINARY` at such a path is the documented workaround for that case. A pre-flight `is_file()` gate would have closed that escape hatch. Probes that succeed are still honoured regardless of what `is_file()` thinks.
+
+  Hosts on an older framework version can work around this by setting the full path in `.env`, quoted because it contains spaces: `COMPOSER_BINARY="/Users/{you}/Library/Application Support/Herd/bin/composer"`.
+
 - **The updater excluded `composer.lock` from extraction but ran `composer install`, breaking every release that changed a dependency constraint** ([#255](https://github.com/ArtisanPack-UI/cms-framework/issues/255)) — `composer.lock` sat in the `exclude_from_update` default annotated `// Rebuilt via composer install`. It isn't: `composer install` only ever *reads* a lock file and aborts when it disagrees with `composer.json`; only `composer update` / `composer require` write one. The identical comment on the neighbouring `vendor` entry *is* correct, which made the pair easy to read past. The consequence was that `extractUpdate()` skipped the release's lock — leaving the **old** one in place — while `composer.json` was not excluded and was overwritten with the **new** one, then handed that mismatched pair to composer:
 
   ```

--- a/docs/self-updater.md
+++ b/docs/self-updater.md
@@ -34,11 +34,14 @@ The download path still uses `Http::sink()` — it's shielded by a `withResponse
 2. **`cms.updates.composer_install_command` config value**, when it differs from the shipped default. Full shell string — set this when you need extra flags, a prepended `PATH`, or a bespoke composer wrapper. Backwards-compatible escape hatch for hosts that already carry a custom command.
 
 3. **Auto-discovery** across common install paths, first hit wins:
+   - `~/Library/Application Support/Herd/bin/composer`
    - `/usr/local/bin/composer`
    - `/opt/homebrew/bin/composer`
    - `~/.composer/vendor/bin/composer`
    - `~/.config/composer/vendor/bin/composer`
    - `/usr/bin/composer`
+
+   Laravel Herd's bundled composer leads the list for the same reason the CLI PHP list leads with Herd's `php`: a host that uses Herd for both FPM and CLI stays on a single toolchain. Herd's composer is a `#!/usr/bin/env php` script rather than a standalone binary, which is fine — the command is built as `{CLI PHP} {binary} install ...` regardless. Both lists derive the Herd `bin/` directory from one `herdBinPath()` helper so they can't drift apart.
 
    When discovery fails, the framework logs a structured `Log::warning` with the `is_file()`/`is_executable()` result for each candidate path, the current `php_sapi`, and a pointer at the fix. `UpdateException::composerBinaryNotFound()` renders the same per-candidate stat outcome in the exception message, so operators can distinguish a wrong-path failure from a PHP-FPM sandboxed-stat failure (macOS Herd Pro sandboxes `/opt/homebrew/*`; chrooted FPM pools and restrictive `open_basedir` behave the same way) without digging through the log.
 
@@ -58,7 +61,7 @@ The resolved CLI PHP is used to build both the install command and the rollback 
 
 ### When you need the escape hatch
 
-Laravel Herd's PHP-FPM pool ships a minimal `PATH` (`/usr/bin:/bin:/usr/sbin:/sbin`) that doesn't include Homebrew or Herd's own composer. Auto-discovery handles `/opt/homebrew/bin/composer` cleanly; if your composer lives elsewhere, either point `COMPOSER_BINARY` at it or set a full command:
+Laravel Herd's PHP-FPM pool ships a minimal `PATH` (`/usr/bin:/bin:/usr/sbin:/sbin`) that doesn't include Homebrew or Herd's own composer. Auto-discovery covers both `~/Library/Application Support/Herd/bin/composer` and `/opt/homebrew/bin/composer`, so a stock Herd or Homebrew install needs no configuration; if your composer lives elsewhere, either point `COMPOSER_BINARY` at it or set a full command:
 
 ```php
 // AppServiceProvider::boot()
@@ -74,6 +77,10 @@ config()->set(
 When an update fails, the framework rolls back to the pre-update backup. Two behaviors matter for diagnostics:
 
 - **Before invoking rollback's `composer install`, the framework runs `{binary} --version` with a 10-second timeout.** If that fails, you get `UpdateException::composerBinaryNotFound` naming the paths inspected and the `COMPOSER_BINARY` override — not the vague "Manual intervention required".
+
+- **When that probe fails, the diagnosis depends on whether PHP can see the binary on disk.** If `is_file()` also reports false, you get `UpdateException::configuredComposerBinaryMissing` naming the configured path — such a path can only have come from `COMPOSER_BINARY` / `cms.updates.composer_binary`, since auto-discovery only ever returns a path it has already stat'd. Otherwise you get `composerVerificationFailed` as before, with its exit code, captured output, and `CMS_PHP_BINARY` hint. Previously every failure took the second form, blaming the PHP interpreter on hosts where the interpreter had resolved correctly and the composer path was the sole fault.
+
+  The stat runs **after** the probe, never as a pre-flight gate — deliberately. A path PHP cannot `stat()` may still be perfectly reachable by the shelled-out child under PHP-FPM sandboxing, and pointing `COMPOSER_BINARY` at such a path is the documented workaround for exactly that case (see the discovery section above). Gating the probe on `is_file()` would close that escape hatch. Once the probe has failed too, the path is overwhelmingly just wrong.
 
 - **When rollback itself fails, the resulting exception preserves the original update-failure message.** You'll see both `Rollback failed: {rollback error}. Original update error: {original error}. Manual intervention required.` — no more losing the actual first-error text.
 

--- a/src/Modules/Core/Updates/Exceptions/UpdateException.php
+++ b/src/Modules/Core/Updates/Exceptions/UpdateException.php
@@ -227,6 +227,44 @@ class UpdateException extends CMSFrameworkException
     }
 
     /**
+     * An explicitly configured composer binary failed its `--version` probe
+     * and is not visible to PHP on disk either.
+     *
+     * Distinct from `composerBinaryNotFound()` (auto-discovery exhausted its
+     * candidate list) and from `composerVerificationFailed()` (the probe
+     * failed against a binary PHP *can* see, so the interpreter is a live
+     * suspect). Raised only after the probe has already failed, never as a
+     * pre-flight gate: a path PHP cannot `stat()` may still be perfectly
+     * reachable by the shelled-out child under PHP-FPM sandboxing, which is
+     * the case `COMPOSER_BINARY` exists to work around.
+     *
+     * Once the probe has failed too, though, the path is overwhelmingly just
+     * wrong — and saying so beats `composerVerificationFailed()`'s "located
+     * but could not be executed" plus its trailing `CMS_PHP_BINARY` hint,
+     * which points the operator at the PHP interpreter when the composer path
+     * is the sole fault.
+     *
+     * @since 2.7.1
+     *
+     * @param  string  $binary  The configured path that could not be reached.
+     */
+    public static function configuredComposerBinaryMissing( string $binary ): self
+    {
+        return new self(
+            "The configured composer binary could not be found at: {$binary}. "
+            . 'It failed a `--version` probe and PHP cannot see a file there either. '
+            . 'This path came from `COMPOSER_BINARY` in your `.env` file, an OS-level '
+            . '`COMPOSER_BINARY` export, or `cms.updates.composer_binary` — not from '
+            . 'auto-discovery, which only ever returns a path it has already verified. '
+            . 'Correct the path or unset it to fall back to auto-discovery. '
+            . 'On macOS, run `which composer` in a shell to find the real one; Laravel '
+            . 'Herd bundles it at `~/Library/Application Support/Herd/bin/composer`, '
+            . 'which auto-discovery already checks. Quote the value in `.env` if the '
+            . 'path contains spaces.',
+        );
+    }
+
+    /**
      * Composer binary was located but `--version` execution failed. Surfaces
      * the resolved binary, the PHP interpreter used to invoke it, the exit
      * code, and any captured output so operators can distinguish an

--- a/src/Modules/Core/Updates/Managers/ApplicationUpdateManager.php
+++ b/src/Modules/Core/Updates/Managers/ApplicationUpdateManager.php
@@ -1039,8 +1039,11 @@ class ApplicationUpdateManager
      *
      * @since 2.5.3
      *
-     * @throws UpdateException When the binary is resolvable but `--version`
-     *                         cannot be executed.
+     * @throws UpdateException When `--version` cannot be executed — as
+     *                         `configuredComposerBinaryMissing` if the binary
+     *                         is also absent from PHP's view of the
+     *                         filesystem, otherwise as
+     *                         `composerVerificationFailed`.
      */
     protected function verifyComposerBinaryAvailable(): void
     {
@@ -1057,6 +1060,22 @@ class ApplicationUpdateManager
             ->run( $command );
 
         if ( ! $result->successful() ) {
+            // Select the diagnosis *after* the probe, never before it. A path
+            // PHP cannot stat is not automatically a wrong path: PHP-FPM
+            // sandboxes (macOS Herd Pro, chrooted pools, restrictive
+            // `open_basedir`) hide real files from `is_file()` while the
+            // shelled-out child reaches them fine, which is precisely why
+            // `COMPOSER_BINARY` is the documented escape hatch for that case
+            // (#233). Gating the probe on `is_file()` would close it. Once the
+            // probe has already failed, though, a path PHP also cannot see is
+            // overwhelmingly a typo'd or stale override rather than a
+            // sandboxed one — and saying so beats "located but could not be
+            // executed" plus a `CMS_PHP_BINARY` hint, which blames the PHP
+            // interpreter on hosts where it resolved perfectly well (#254).
+            if ( ! is_file( $binary ) ) {
+                throw UpdateException::configuredComposerBinaryMissing( $binary );
+            }
+
             $stderr = trim( (string) $result->errorOutput() );
             $stdout = trim( (string) $result->output() );
             $detail = '' !== $stderr ? $stderr : $stdout;
@@ -1173,12 +1192,24 @@ class ApplicationUpdateManager
      */
     protected function composerCandidatePaths(): array
     {
-        $home = getenv( 'HOME' );
+        $home    = getenv( 'HOME' );
+        $herdBin = $this->herdBinPath();
 
-        $candidates = [
-            '/usr/local/bin/composer',
-            '/opt/homebrew/bin/composer',
-        ];
+        $candidates = [];
+
+        if ( null !== $herdBin ) {
+            // Laravel Herd on macOS bundles composer alongside its PHP
+            // binaries. Prefer it for the same reason phpCandidatePaths()
+            // prefers Herd's php: hosts that use Herd for both FPM and CLI
+            // stay on a single toolchain. Without this a Herd-only machine —
+            // no Homebrew composer, no global install — matches none of the
+            // paths below and discovery falls through to bare `composer`,
+            // which PHP-FPM's stripped `PATH` cannot resolve.
+            $candidates[] = $herdBin . '/composer';
+        }
+
+        $candidates[] = '/usr/local/bin/composer';
+        $candidates[] = '/opt/homebrew/bin/composer';
 
         if ( is_string( $home ) && '' !== $home ) {
             $candidates[] = $home . '/.composer/vendor/bin/composer';
@@ -1188,6 +1219,32 @@ class ApplicationUpdateManager
         $candidates[] = '/usr/bin/composer';
 
         return $candidates;
+    }
+
+    /**
+     * Absolute path to Laravel Herd's macOS `bin/` directory, or `null` when
+     * `HOME` is unset or empty.
+     *
+     * Herd keeps both its `php` symlink and its bundled `composer` script in
+     * this one directory, and both `phpCandidatePaths()` and
+     * `composerCandidatePaths()` need it. Deriving it in one place keeps the
+     * two lists from drifting apart — the drift that produced #254, where the
+     * PHP list learned about Herd in #225 and the composer list never did.
+     *
+     * The directory is not checked for existence: callers append a filename
+     * and stat that, and a non-Herd host simply misses on every candidate.
+     *
+     * @since 2.7.1
+     */
+    protected function herdBinPath(): ?string
+    {
+        $home = getenv( 'HOME' );
+
+        if ( ! is_string( $home ) || '' === $home ) {
+            return null;
+        }
+
+        return $home . '/Library/Application Support/Herd/bin';
     }
 
     /**
@@ -1255,15 +1312,15 @@ class ApplicationUpdateManager
      */
     protected function phpCandidatePaths(): array
     {
-        $home = getenv( 'HOME' );
+        $herdBin = $this->herdBinPath();
 
         $candidates = [];
 
-        if ( is_string( $home ) && '' !== $home ) {
+        if ( null !== $herdBin ) {
             // Laravel Herd on macOS ships a `php` symlink pointing at the
             // currently-active CLI binary (e.g. `php84`). Prefer it so hosts
             // that use Herd for both FPM and CLI stay on a single toolchain.
-            $candidates[] = $home . '/Library/Application Support/Herd/bin/php';
+            $candidates[] = $herdBin . '/php';
         }
 
         $candidates[] = '/opt/homebrew/bin/php';

--- a/src/Modules/Core/Updates/config/updates.php
+++ b/src/Modules/Core/Updates/config/updates.php
@@ -59,9 +59,13 @@ return [
     |    OS-level env var visible to `getenv()` in the PHP-FPM pool.
     | 2. A non-default value for this config key — set this to a bespoke shell
     |    string if you need full control (custom flags, prepended PATH, etc.).
-    | 3. Auto-discovery across common install paths (`/usr/local/bin/composer`,
-    |    `/opt/homebrew/bin/composer`, `~/.composer/vendor/bin/composer`,
+    | 3. Auto-discovery across common install paths
+    |    (`~/Library/Application Support/Herd/bin/composer`,
+    |    `/usr/local/bin/composer`, `/opt/homebrew/bin/composer`,
+    |    `~/.composer/vendor/bin/composer`,
     |    `~/.config/composer/vendor/bin/composer`, `/usr/bin/composer`).
+    |    Laravel Herd's bundled composer leads the list so a macOS Herd host
+    |    stays on one toolchain for both FPM and CLI.
     | 4. This default command (bare `composer`).
     |
     | The PHP interpreter used to invoke composer is resolved from a CLI SAPI

--- a/tests/Unit/Updates/ApplicationUpdateManagerTest.php
+++ b/tests/Unit/Updates/ApplicationUpdateManagerTest.php
@@ -784,6 +784,12 @@ class ApplicationUpdateManagerTest extends TestCase
      * documented common install paths in preference order so the diagnostic
      * message stays honest and hosts see the same list the framework tried.
      *
+     * Regression for #254: Herd's bundled composer leads the list, mirroring
+     * `phpCandidatePaths()`. A Herd-only macOS host — no Homebrew composer, no
+     * global install — matched none of the other five paths, so discovery
+     * returned null and the updater fell through to bare `composer`, which
+     * PHP-FPM's stripped `PATH` cannot resolve.
+     *
      * @since 2.5.3
      */
     public function test_composer_candidate_paths_covers_documented_locations(): void
@@ -802,6 +808,7 @@ class ApplicationUpdateManagerTest extends TestCase
 
             $this->assertSame(
                 [
+                    '/home/tester/Library/Application Support/Herd/bin/composer',
                     '/usr/local/bin/composer',
                     '/opt/homebrew/bin/composer',
                     '/home/tester/.composer/vendor/bin/composer',
@@ -812,6 +819,145 @@ class ApplicationUpdateManagerTest extends TestCase
             );
         } finally {
             putenv( false === $original ? 'HOME' : 'HOME=' . $original );
+        }
+    }
+
+    /**
+     * Regression for #254: with no `HOME` there is no Herd directory to derive,
+     * so the Herd entry is omitted rather than rendered against an empty
+     * string — which would stat `/Library/Application Support/Herd/bin/composer`
+     * on every candidate walk.
+     *
+     * @since 2.7.1
+     */
+    public function test_composer_candidate_paths_omits_herd_entry_without_home(): void
+    {
+        $original = getenv( 'HOME' );
+        putenv( 'HOME' );
+
+        try {
+            $manager = new ApplicationUpdateManager;
+
+            $reflection = new ReflectionClass( $manager );
+            $method     = $reflection->getMethod( 'composerCandidatePaths' );
+            $method->setAccessible( true );
+
+            $this->assertSame(
+                [
+                    '/usr/local/bin/composer',
+                    '/opt/homebrew/bin/composer',
+                    '/usr/bin/composer',
+                ],
+                $method->invoke( $manager ),
+            );
+        } finally {
+            putenv( false === $original ? 'HOME' : 'HOME=' . $original );
+        }
+    }
+
+    /**
+     * Regression for #254: both candidate lists derive Herd's `bin/` directory
+     * from the same helper, so they cannot drift apart again — the drift that
+     * left the composer list without Herd awareness after #225 taught the PHP
+     * list about it.
+     *
+     * @since 2.7.1
+     */
+    public function test_herd_bin_path_is_shared_by_both_candidate_lists(): void
+    {
+        $original = getenv( 'HOME' );
+        putenv( 'HOME=/home/tester' );
+
+        try {
+            $manager = new ApplicationUpdateManager;
+
+            $reflection = new ReflectionClass( $manager );
+
+            $herdBin = $reflection->getMethod( 'herdBinPath' );
+            $herdBin->setAccessible( true );
+
+            $composerPaths = $reflection->getMethod( 'composerCandidatePaths' );
+            $composerPaths->setAccessible( true );
+
+            $phpPaths = $reflection->getMethod( 'phpCandidatePaths' );
+            $phpPaths->setAccessible( true );
+
+            $resolved = $herdBin->invoke( $manager );
+
+            $this->assertSame( '/home/tester/Library/Application Support/Herd/bin', $resolved );
+            $this->assertSame( $resolved . '/composer', $composerPaths->invoke( $manager )[0] );
+            $this->assertSame( $resolved . '/php', $phpPaths->invoke( $manager )[0] );
+        } finally {
+            putenv( false === $original ? 'HOME' : 'HOME=' . $original );
+        }
+    }
+
+    /**
+     * Regression for #254: `herdBinPath()` returns null when `HOME` is unset or
+     * empty, so callers omit the Herd candidate entirely.
+     *
+     * @since 2.7.1
+     */
+    public function test_herd_bin_path_returns_null_without_usable_home(): void
+    {
+        $original = getenv( 'HOME' );
+
+        try {
+            $manager = new ApplicationUpdateManager;
+
+            $reflection = new ReflectionClass( $manager );
+            $method     = $reflection->getMethod( 'herdBinPath' );
+            $method->setAccessible( true );
+
+            putenv( 'HOME' );
+            $this->assertNull( $method->invoke( $manager ) );
+
+            putenv( 'HOME=' );
+            $this->assertNull( $method->invoke( $manager ) );
+        } finally {
+            putenv( false === $original ? 'HOME' : 'HOME=' . $original );
+        }
+    }
+
+    /**
+     * Regression for #254: Herd's bundled composer wins discovery on a host
+     * that also carries a Homebrew composer, keeping a Herd machine on a single
+     * toolchain — the same rationale `phpCandidatePaths()` applies.
+     *
+     * @since 2.7.1
+     */
+    public function test_discover_composer_binary_prefers_herd_over_homebrew(): void
+    {
+        $tempHome = sys_get_temp_dir() . '/cmsfw-herd-' . bin2hex( random_bytes( 6 ) );
+        $herdBin  = $tempHome . '/Library/Application Support/Herd/bin';
+        mkdir( $herdBin, 0755, true );
+
+        $herdComposer = $herdBin . '/composer';
+        file_put_contents( $herdComposer, "#!/usr/bin/env php\n" );
+        chmod( $herdComposer, 0755 );
+
+        $original = getenv( 'HOME' );
+        putenv( 'HOME=' . $tempHome );
+
+        try {
+            $manager = new class extends ApplicationUpdateManager {
+                public function callDiscover(): ?string
+                {
+                    return $this->discoverComposerBinary();
+                }
+            };
+
+            Log::shouldReceive( 'warning' )->never();
+
+            $this->assertSame( $herdComposer, $manager->callDiscover() );
+        } finally {
+            putenv( false === $original ? 'HOME' : 'HOME=' . $original );
+            @unlink( $herdComposer );
+            @rmdir( $herdBin );
+            @rmdir( $tempHome . '/Library/Application Support/Herd' );
+            @rmdir( $tempHome . '/Library/Application Support' );
+            @rmdir( $tempHome . '/Library' );
+            @rmdir( $tempHome );
         }
     }
 
@@ -951,6 +1097,11 @@ class ApplicationUpdateManagerTest extends TestCase
      * the binary *was* located, so the misleading "not found" wording was
      * masking real interpreter mismatches on PHP-FPM hosts.
      *
+     * As of 2.7.1 this branch requires the binary to be visible to PHP on
+     * disk; a failed probe against a path PHP cannot see takes the
+     * `configuredComposerBinaryMissing` branch instead (see #254), hence the
+     * real temp file below.
+     *
      * @since 2.5.3
      */
     public function test_rollback_throws_composer_verification_failed_when_version_check_fails(): void
@@ -959,10 +1110,17 @@ class ApplicationUpdateManagerTest extends TestCase
             '*--version*' => Process::result( '', 'command not found', 127 ),
         ] );
 
-        $manager = new class extends ApplicationUpdateManager {
+        $composerBinary = tempnam( sys_get_temp_dir(), 'cmsfw-composer-' );
+        file_put_contents( $composerBinary, "#!/usr/bin/env php\n" );
+
+        $manager = new class( $composerBinary ) extends ApplicationUpdateManager {
+            public function __construct( protected string $binary )
+            {
+            }
+
             protected function resolveComposerBinaryForVerification(): ?string
             {
-                return '/opt/homebrew/bin/composer';
+                return $this->binary;
             }
         };
 
@@ -979,6 +1137,105 @@ class ApplicationUpdateManagerTest extends TestCase
             $manager->rollback( $backupPath );
         } finally {
             @unlink( $backupPath );
+            @unlink( $composerBinary );
+        }
+    }
+
+    /**
+     * Regression for #254: when the probe fails against a path PHP cannot see
+     * either, the error names that path as the fault instead of reporting
+     * "Composer binary was located but could not be executed" with a trailing
+     * `CMS_PHP_BINARY` hint — which blames the PHP interpreter that had
+     * resolved correctly and buries the real cause mid-sentence.
+     *
+     * @since 2.7.1
+     */
+    public function test_rollback_throws_configured_binary_missing_when_path_does_not_exist(): void
+    {
+        Process::fake( [
+            '*--version*' => Process::result( '', 'Could not open input file', 1 ),
+        ] );
+
+        $missing = sys_get_temp_dir() . '/cmsfw-nonexistent-composer-' . bin2hex( random_bytes( 6 ) );
+
+        $manager = new class( $missing ) extends ApplicationUpdateManager {
+            public function __construct( protected string $binary )
+            {
+            }
+
+            protected function resolveComposerBinaryForVerification(): ?string
+            {
+                return $this->binary;
+            }
+        };
+
+        $backupPath = tempnam( sys_get_temp_dir(), 'cmsfw-backup-' ) . '.zip';
+        $zip        = new ZipArchive;
+        $this->assertTrue( true === $zip->open( $backupPath, ZipArchive::CREATE | ZipArchive::OVERWRITE ) );
+        $zip->addFromString( 'placeholder.txt', 'ok' );
+        $zip->close();
+
+        try {
+            $manager->rollback( $backupPath );
+            $this->fail( 'Expected UpdateException for the missing configured composer binary.' );
+        } catch ( UpdateException $e ) {
+            $this->assertStringContainsString( 'could not be found at', $e->getMessage() );
+            $this->assertStringContainsString( $missing, $e->getMessage() );
+            $this->assertStringContainsString( 'COMPOSER_BINARY', $e->getMessage() );
+            $this->assertStringNotContainsString( 'CMS_PHP_BINARY', $e->getMessage() );
+        } finally {
+            @unlink( $backupPath );
+        }
+    }
+
+    /**
+     * Regression for #254 guarding #233: a `COMPOSER_BINARY` whose `--version`
+     * probe *succeeds* must be accepted even when `is_file()` reports false for
+     * it. PHP-FPM sandboxing (macOS Herd Pro, chrooted pools, restrictive
+     * `open_basedir`) hides real files from `stat()` while the shelled-out
+     * child reaches them fine — the exact case `COMPOSER_BINARY` exists to work
+     * around. Gating the probe on `is_file()` would have closed that escape
+     * hatch, so the stat may only select the message after a failed probe.
+     *
+     * @since 2.7.1
+     */
+    public function test_rollback_accepts_unstattable_binary_whose_version_probe_succeeds(): void
+    {
+        Process::fake( [
+            '*--version*' => Process::result( 'Composer version 2.10.1', '', 0 ),
+            '*'           => Process::result( '', '', 0 ),
+        ] );
+
+        $sandboxed = '/opt/homebrew/bin/composer-visible-only-to-the-shell';
+        $this->assertFalse( is_file( $sandboxed ), 'Fixture path must be unstattable for this test to mean anything.' );
+
+        $manager = new class( $sandboxed ) extends ApplicationUpdateManager {
+            public function __construct( protected string $binary )
+            {
+            }
+
+            protected function resolveComposerBinaryForVerification(): ?string
+            {
+                return $this->binary;
+            }
+
+            protected function clearCaches(): void
+            {
+                // No-op; nothing to clear in this unit context.
+            }
+        };
+
+        $backupPath = tempnam( sys_get_temp_dir(), 'cmsfw-backup-' ) . '.zip';
+        $zip        = new ZipArchive;
+        $this->assertTrue( true === $zip->open( $backupPath, ZipArchive::CREATE | ZipArchive::OVERWRITE ) );
+        $zip->addFromString( 'placeholder.txt', 'ok' );
+        $zip->close();
+
+        try {
+            $manager->rollback( $backupPath );
+        } finally {
+            @unlink( $backupPath );
+            @unlink( base_path( 'placeholder.txt' ) );
         }
     }
 

--- a/tests/Unit/Updates/UpdateExceptionTest.php
+++ b/tests/Unit/Updates/UpdateExceptionTest.php
@@ -92,4 +92,26 @@ class UpdateExceptionTest extends TestCase
         $this->assertStringContainsString( '/opt/homebrew/bin/composer', $message );
         $this->assertStringContainsString( '/usr/local/bin/composer', $message );
     }
+
+    /**
+     * Regression for #254: `configuredComposerBinaryMissing()` names the
+     * offending path as the fault and points at the override that supplied it,
+     * without the `CMS_PHP_BINARY` hint that `composerVerificationFailed()`
+     * carries — that hint blamed the PHP interpreter on a host where the
+     * interpreter had resolved correctly and only the composer path was wrong.
+     *
+     * @since 2.7.1
+     */
+    public function test_configured_composer_binary_missing_names_the_path_and_the_override(): void
+    {
+        $exception = UpdateException::configuredComposerBinaryMissing( '/opt/homebrew/bin/composer' );
+
+        $message = $exception->getMessage();
+
+        $this->assertStringContainsString( 'could not be found at: /opt/homebrew/bin/composer', $message );
+        $this->assertStringContainsString( 'COMPOSER_BINARY', $message );
+        $this->assertStringContainsString( 'cms.updates.composer_binary', $message );
+        $this->assertStringContainsString( 'auto-discovery', $message );
+        $this->assertStringNotContainsString( 'CMS_PHP_BINARY', $message );
+    }
 }


### PR DESCRIPTION
## Description

`phpCandidatePaths()` has listed Herd's `php` **first** since #225, annotated "so hosts that use Herd for both FPM and CLI stay on a single toolchain". Herd bundles composer in that same `bin/` directory, but `composerCandidatePaths()` never learned about it — the one place the Herd awareness didn't get carried over.

On a clean Herd install with no Homebrew composer and no global composer (Herd ships one, so there's no reason to `brew install` another), all five candidate paths missed, discovery returned `null`, and the updater fell through to bare `composer install` — which PHP-FPM's stripped `PATH` (`/usr/bin:/bin:/usr/sbin:/sbin`) cannot resolve:

```
Update failed: Rollback failed: Composer install failed. Output: sh: composer: command not found .
Original update error: Composer install failed. Output: sh: composer: command not found .
Manual intervention required. The pre-update snapshot was restored.
```

Implements Fix A + Fix C from the issue, plus a variant of Fix B (see below).

**Closes:** #254

## Type of Change

- [x] Bug fix (fixes an issue)
- [ ] New feature (adds new functionality)
- [ ] Enhancement (improves existing functionality)
- [ ] Refactoring (code improvement, no behavior change)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Security fix
- [ ] Breaking change (breaks backward compatibility)

## Related Issue

**Issue:** #254

## Motivation and Context

#225 taught the updater to find Herd's *PHP*. This is the same lesson applied to Herd's *composer*. Herd's composer sits in the directory the framework already knows how to find for PHP, fully functional, and discovery never looked there — so a Herd-only macOS host could not self-update at all, with no configuration that would make it work short of the `COMPOSER_BINARY` workaround.

Distinct from #233's root cause: there `/opt/homebrew/bin/composer` genuinely existed and PHP-FPM's sandbox couldn't `stat()` it. Here there's no sandboxing involved — the file simply wasn't on the candidate list.

## Changes Made

- **`~/Library/Application Support/Herd/bin/composer` now leads `composerCandidatePaths()`**, mirroring the PHP list's ordering and its single-toolchain rationale. Herd's composer is a `#!/usr/bin/env php` script rather than a standalone binary, which needed no other changes — `buildComposerCommand()` already invokes the discovered path as `{CLI PHP} {binary} install ...`.
- **New `herdBinPath(): ?string` helper**, used by both `composerCandidatePaths()` and `phpCandidatePaths()`, so the two lists can't drift apart again the way they did here (Fix C).
- **New `UpdateException::configuredComposerBinaryMissing()`.** A failed rollback `--version` probe against a path PHP also cannot `stat()` now throws this, naming the offending path — such a path can only have come from `COMPOSER_BINARY` / `cms.updates.composer_binary`, since discovery only ever returns a path it has already verified. This closes the issue's second, more confusing failure: because `/opt/homebrew/bin/composer` is advertised in the `composerBinaryNotFound` message and is the canonical macOS location, the natural next move on a Herd-only machine was to point `COMPOSER_BINARY` at it, producing "Composer binary was located but could not be executed … Could not open input file" closing with a `CMS_PHP_BINARY` hint. It was never located, only configured — and `resolvePhpBinary()` had done its job correctly, so the trailing hint blamed the one component that was already right.
- Config block, `docs/self-updater.md`, and `CHANGELOG.md` updated to match.

### Two notes for the maintainer call

**1. Fix B runs *after* the probe, not as a pre-flight gate.** The issue proposed `is_file()`-ing the resolved binary *before* the `--version` probe. Implemented that way it would regress #233: a path PHP cannot `stat()` may still be perfectly reachable by the shelled-out child under PHP-FPM sandboxing, and `docs/self-updater.md` documents pointing `COMPOSER_BINARY` at exactly such a path as the workaround for that case. A pre-flight gate would close that escape hatch. So the stat only selects the *message* once the probe has already failed — a probe that succeeds is still honoured regardless of what `is_file()` reports. A regression test covers this (`test_rollback_accepts_unstattable_binary_whose_version_probe_succeeds`).

**2. Herd is ordered first, per the issue's recommendation** — the alternative was ordering it last to avoid a behavior change on hosts carrying both. Two consequences worth naming:

- On a macOS host with both Herd and Homebrew composer, discovery now switches to Herd's. Given `resolvePhpBinary()` already prefers Herd's PHP on such a host, this makes the pair consistent rather than mixed.
- Security-wise, a `HOME`-derived (user-writable) path now outranks two root-owned system paths in discovery order. This is not a new trust boundary — `composerCandidatePaths()` already trusted `HOME` for `~/.composer/vendor/bin/composer`, and `phpCandidatePaths()` already lets a `HOME`-derived path outrank every system path for the *interpreter*, a strictly higher-value target. But it is a priority shift, and reordering Herd last would avoid it if you'd rather.

Otherwise no new attack surface: no new shell input (`$binary` was and remains `escapeshellarg()`'d in both call sites), no new file writes, and the new exception discloses only a path the operator configured, in the same admin-gated surface as the three existing composer exceptions.

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS 27.0 with Laravel Herd
- Browser (if applicable): n/a
- PHP Version: 8.4.23 (Herd, `php84`)
- Project Version: cms-framework 2.7.1 (branch `release/2.7.1`)

**Tests Performed:**
1. Full test suite: **1537 passed, 7 skipped** (3912 assertions). Note the suite OOMs at PHP's default 128M limit — pre-existing, unrelated to this change; run with `php -d memory_limit=1G ./vendor/bin/pest`.
2. `php-cs-fixer` dry run: **0 of 508 files need fixing**. No added line exceeds the 120-char limit. (`composer lint`'s `phpcs` half is not gate-clean on this branch — ~3,768 pre-existing errors; the deltas from this PR are snake_case test method names and an anonymous-class `__construct`, both matching patterns already used throughout the touched files.)
3. Verified on the reporting machine that the path the fix now checks resolves, is executable, and runs under the exact invocation `buildComposerCommand()` builds:
   ```console
   $ "$HOME/Library/Application Support/Herd/bin/php" \
     "$HOME/Library/Application Support/Herd/bin/composer" --version
   Composer version 2.10.1 2026-06-04 10:25:59
   PHP version 8.4.23 (/Users/…/Library/Application Support/Herd/bin/php84)
   ```

## Accessibility Tests Run

- [ ] Keyboard navigation tested
- [ ] Screen reader tested
- [ ] Color contrast verified
- [ ] ARIA labels checked

**Details:** Not applicable — this PR touches only backend binary-discovery logic and exception message text in the updater. No UI, markup, or user-facing view is changed.

## Tests Added

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] All tests passing

**Test details:** Six new tests, two existing ones updated.

New:
- `test_composer_candidate_paths_omits_herd_entry_without_home` — no `HOME` means no Herd entry, rather than one rendered against an empty string.
- `test_herd_bin_path_is_shared_by_both_candidate_lists` — both lists derive from the one helper, locking in Fix C.
- `test_herd_bin_path_returns_null_without_usable_home` — unset and empty `HOME`.
- `test_discover_composer_binary_prefers_herd_over_homebrew` — Herd wins discovery on a host carrying both.
- `test_rollback_throws_configured_binary_missing_when_path_does_not_exist` — asserts the message names the path and `COMPOSER_BINARY`, and does **not** carry the `CMS_PHP_BINARY` hint.
- `test_rollback_accepts_unstattable_binary_whose_version_probe_succeeds` — the #233 guard described above.

Updated:
- `test_composer_candidate_paths_covers_documented_locations` — asserts the new six-entry list and ordering.
- `test_rollback_throws_composer_verification_failed_when_version_check_fails` — now uses a real temp file, since a probe failure against an unstattable path takes the new branch.

## Documentation

- [x] Inline code documentation added
- [ ] README updated
- [ ] Wiki updated
- [ ] API documentation updated

**Documentation details:** `docs/self-updater.md` — Herd added to the documented discovery list with the single-toolchain rationale, the escape-hatch section corrected (auto-discovery now covers a stock Herd install with no configuration), and a new bullet in "Rollback error surfacing" explaining the two-way diagnosis and why the stat follows the probe. `src/Modules/Core/Updates/config/updates.php` — discovery path list updated. `CHANGELOG.md` — entry under `[Unreleased] → Fixed`. PHPDoc on all new and changed methods, plus inline comments on the non-obvious ordering decisions.

## Screenshots

n/a — no UI changes.

## Pre-Submission Checklist

- [x] Followed contributing guidelines
- [x] Checked for other open PRs for same update
- [x] Code passes all tests
- [x] Code has been linted
- [x] Accessibility tests completed
- [x] Code follows project style guide
- [x] Self-review completed
- [x] Comments added for complex code
- [x] No new warnings generated

🤖 Generated with [Claude Code](https://claude.com/claude-code)
