### PR TITLE
security: drop custom-field payload keys that shadow a real column

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- **A custom-field value whose key named a real column overwrote that column** ([#253](https://github.com/ArtisanPack-UI/cms-framework/issues/253)) — `HasCustomFields::findCustomFieldByKey()` has always refused to resolve a key that shadows a real DB column, so the metadata write was blocked; what it never blocked was the *fall-through*. `__set()` handed the value to `parent::__set()`, which wrote it straight into the column. `BlogManager::applyCustomFields()` and `PageManager::applyCustomFields()` ([#250](https://github.com/ArtisanPack-UI/cms-framework/issues/250)) assigned each payload key that way, and the custom-field half of a request payload gets no fillable filtering — so `custom_fields[author_id]` on a post update reassigned the author, whatever the attribute allowlist said. A registration wasn't even required: any key naming a column worked.
+
+  New `HasCustomFields::applyCustomFieldValues()` is the supported way to apply an untrusted custom-field payload. It routes each value through the same magic setter as before, but silently drops keys that name a real column, cast, mutator, accessor, or relation first. Both managers now delegate to it, so `create()`/`update()` are covered on `Post` and `Page`, and any host content type using the trait gets the same guard for free — downstream apps no longer need to reimplement the check ahead of the manager call.
+
+  DB-registered fields are exempt, because they legitimately own the column they name: `createField()` adds it, and a persisted row is always column-storage (`custom_fields` has no `storage` column, so `CustomField::storageMode()` resolves an existing row to `column`). The exemption keys off `exists`, which `CustomFieldManager::filterFieldsForContentType()` forces to `false` on every filter-registered field — so a plugin cannot buy itself a real-column write by declaring `storage => 'column'`, and only a row in the `custom_fields` table, which takes the custom-field admin capability to create, qualifies.
+
+  The magic setter itself is deliberately unchanged. Guarding `__set()` would have meant that a plugin registering a field keyed to `title` could stop host code from writing `$post->title` at all — a required-column write turned into a save failure by anyone able to register a field. Trusted assignment and untrusted payload application are separate operations, and only the latter is guarded. Nothing legitimate is lost: a shadowing field can never round-trip, because the getter resolves a real column through Eloquent and never consults metadata.
+
 ## [2.7.0] - 2026-07-30
 
 ### Added

--- a/docs/developer/custom-fields.md
+++ b/docs/developer/custom-fields.md
@@ -12,6 +12,7 @@ Custom fields allow you to add additional data to content types in Digital Shopf
 - [Column Types](#column-types)
 - [Migration Generation](#migration-generation)
 - [Retrieving and Displaying Values](#retrieving-and-displaying-values)
+- [Applying Values From Untrusted Input](#applying-values-from-untrusted-input)
 - [Data Migration](#data-migration)
 - [Best Practices](#best-practices)
 
@@ -470,6 +471,42 @@ $products = $category->products()
     ->orderBy('price', 'asc')
     ->get();
 ```
+
+## Applying Values From Untrusted Input
+
+A custom-field payload that came from request input must be applied with
+`applyCustomFieldValues()`, not by assigning each key directly:
+
+```php
+// Correct — drops keys that shadow a real column.
+$post->applyCustomFieldValues($request->input('custom_fields', []));
+
+// Unsafe — `custom_fields[author_id]` would overwrite the real column.
+foreach ($request->input('custom_fields', []) as $key => $value) {
+    $post->{$key} = $value;
+}
+```
+
+The magic setter routes a metadata-storage field into the model's `metadata`
+JSON column, but a key naming a real column falls through to Eloquent and
+writes that column — and the custom-field half of a payload gets no fillable
+filtering. `applyCustomFieldValues()` silently drops any key that names a real
+column, cast, mutator, accessor, or relation before assigning the rest, whether
+or not a field was ever registered under that key.
+
+DB-registered fields are the exception: they own the column they name, so their
+values still write through. Filter-registered fields never qualify for that
+exemption, even if the registration declares `'storage' => 'column'` — only a
+row in the `custom_fields` table can authorize a real-column write.
+
+`BlogManager::create()`/`update()` and `PageManager::create()`/`update()` apply
+their `$customFields` argument through this method already, so callers passing
+custom fields to a manager are covered without doing anything.
+
+Direct assignment from your own code is unaffected — `$post->title = 'New'`
+still writes the column even when a plugin has registered `title` as a custom
+field. Only the payload path is guarded, so a registration can never block a
+host model from writing its own columns.
 
 ## Data Migration
 

--- a/src/Modules/Blog/Managers/BlogManager.php
+++ b/src/Modules/Blog/Managers/BlogManager.php
@@ -458,6 +458,10 @@ class BlogManager
      * magic setter before save so a single INSERT/UPDATE captures both
      * the hardcoded columns and the metadata JSON.
      *
+     * Delegates to `applyCustomFieldValues()` rather than assigning each
+     * key directly: the payload is untrusted, and that method drops keys
+     * that shadow a real column before they can reach the column ( #253 ).
+     *
      * @param  array<string,mixed>|null  $customFields
      */
     protected function applyCustomFields( Post $post, ?array $customFields ): void
@@ -466,9 +470,7 @@ class BlogManager
             return;
         }
 
-        foreach ( $customFields as $key => $value ) {
-            $post->{$key} = $value;
-        }
+        $post->applyCustomFieldValues( $customFields );
     }
 
     /**

--- a/src/Modules/ContentTypes/Models/Concerns/HasCustomFields.php
+++ b/src/Modules/ContentTypes/Models/Concerns/HasCustomFields.php
@@ -82,6 +82,12 @@ trait HasCustomFields
     /**
      * Magic setter for custom field values.
      *
+     * Assignment here is trusted: a key naming a real column falls through
+     * to `parent::__set()` so host code keeps writing its own columns even
+     * while a plugin has that key filter-registered as a custom field.
+     * Untrusted custom-field payloads must go through
+     * {@see applyCustomFieldValues()}, which drops shadowing keys first.
+     *
      * @since 1.0.0
      *
      * @param  string  $key
@@ -102,6 +108,52 @@ trait HasCustomFields
         }
 
         parent::__set( $key, $value );
+    }
+
+    /**
+     * Apply an untrusted map of custom-field values onto this model.
+     *
+     * Every value routes through the magic setter above, so a
+     * metadata-storage field lands in the `metadata` JSON column exactly as
+     * a direct `$model->key = $value` write would. The difference is the
+     * guard: a key that names a real DB column, cast, mutator, accessor, or
+     * relation is **silently dropped** rather than written, unless it is a
+     * DB-persisted column-storage custom field ( see
+     * {@see isPersistedColumnCustomField()} ), whose whole purpose is to
+     * write its own column.
+     *
+     * That guard is the whole point of routing custom-field payloads through
+     * here instead of assigning them directly. The payload originates in
+     * request input, and the keys it may carry are whatever a plugin has
+     * filter-registered — neither is trusted. Without the check, a payload
+     * key naming a real column (`author_id`, `status`, `password` on a host
+     * model) falls through the trait's setter to `parent::__set()` and
+     * overwrites the column, sidestepping the fillable allowlist the caller
+     * applied to the attribute half of the same request. Dropping the key is
+     * safe because a shadowing field can never round-trip anyway: the getter
+     * resolves a real column through Eloquent, never through metadata.
+     *
+     * The magic setter itself deliberately does *not* apply this guard —
+     * `$post->title = 'New title'` from host code must keep working even
+     * while a rogue plugin has `title` filter-registered as a custom field.
+     * Trusted assignment and untrusted payload application are different
+     * operations; this method is the untrusted one.
+     *
+     * @since 2.7.1
+     *
+     * @param  array<string,mixed>  $values  Custom-field values keyed by field key.
+     */
+    public function applyCustomFieldValues( array $values ): void
+    {
+        foreach ( $values as $key => $value ) {
+            $key = ( string ) $key;
+
+            if ( $this->isReservedModelAttribute( $key ) && ! $this->isPersistedColumnCustomField( $key ) ) {
+                continue;
+            }
+
+            $this->{$key} = $value;
+        }
     }
 
     /**
@@ -160,34 +212,7 @@ trait HasCustomFields
      */
     protected function findCustomFieldByKey( string $key ): ?CustomField
     {
-        if ( array_key_exists( $key, $this->attributes ) ) {
-            return null;
-        }
-        if ( array_key_exists( $key, $this->getCasts() ) ) {
-            return null;
-        }
-        if ( $this->isRealDatabaseColumn( $key ) ) {
-            return null;
-        }
-        if ( method_exists( $this, $key ) ) {
-            return null;
-        }
-        if ( method_exists( $this, 'hasGetMutator' ) && $this->hasGetMutator( $key ) ) {
-            return null;
-        }
-        if ( method_exists( $this, 'hasSetMutator' ) && $this->hasSetMutator( $key ) ) {
-            return null;
-        }
-        if ( method_exists( $this, 'hasAttributeMutator' ) && $this->hasAttributeMutator( $key ) ) {
-            return null;
-        }
-        if ( method_exists( $this, 'hasAttributeGetMutator' ) && $this->hasAttributeGetMutator( $key ) ) {
-            return null;
-        }
-        if ( method_exists( $this, 'hasAttributeSetMutator' ) && $this->hasAttributeSetMutator( $key ) ) {
-            return null;
-        }
-        if ( method_exists( $this, 'isRelation' ) && $this->isRelation( $key ) ) {
+        if ( $this->isReservedModelAttribute( $key ) ) {
             return null;
         }
 
@@ -198,6 +223,90 @@ trait HasCustomFields
         }
 
         return null;
+    }
+
+    /**
+     * Whether the given key already belongs to the host model — a real DB
+     * column, a hydrated attribute, a cast, a mutator/accessor, or a
+     * relation. Such a key can never resolve to a custom field, so both
+     * {@see findCustomFieldByKey()} and {@see applyCustomFieldValues()}
+     * short-circuit on it.
+     *
+     * @since 2.7.1
+     */
+    protected function isReservedModelAttribute( string $key ): bool
+    {
+        if ( array_key_exists( $key, $this->attributes ) ) {
+            return true;
+        }
+        if ( array_key_exists( $key, $this->getCasts() ) ) {
+            return true;
+        }
+        if ( $this->isRealDatabaseColumn( $key ) ) {
+            return true;
+        }
+        if ( method_exists( $this, $key ) ) {
+            return true;
+        }
+        if ( method_exists( $this, 'hasGetMutator' ) && $this->hasGetMutator( $key ) ) {
+            return true;
+        }
+        if ( method_exists( $this, 'hasSetMutator' ) && $this->hasSetMutator( $key ) ) {
+            return true;
+        }
+        if ( method_exists( $this, 'hasAttributeMutator' ) && $this->hasAttributeMutator( $key ) ) {
+            return true;
+        }
+        if ( method_exists( $this, 'hasAttributeGetMutator' ) && $this->hasAttributeGetMutator( $key ) ) {
+            return true;
+        }
+        if ( method_exists( $this, 'hasAttributeSetMutator' ) && $this->hasAttributeSetMutator( $key ) ) {
+            return true;
+        }
+        if ( method_exists( $this, 'isRelation' ) && $this->isRelation( $key ) ) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Whether the key names a DB-persisted, column-storage custom field on
+     * this content type — an admin-created field whose physical column
+     * {@see CustomFieldManager::createField()} added to the table.
+     *
+     * Such a field is the one legitimate reason a custom-field payload may
+     * carry a key that names a real column, so
+     * {@see applyCustomFieldValues()} exempts it from the shadow-column
+     * drop. Without the exemption, every DB-registered field's value would
+     * be discarded — they are always column-storage, because the
+     * `custom_fields` table has no `storage` column and
+     * {@see CustomField::storageMode()} resolves a persisted row to
+     * `column`.
+     *
+     * The `exists` check is the trust boundary. Filter-registered fields are
+     * hydrated by `CustomFieldManager::filterFieldsForContentType()`, which
+     * forces `exists = false` on every one, so a plugin cannot mint a field
+     * that authorizes a real-column write — not even by declaring
+     * `storage => 'column'` in its registration args. Only a row in the
+     * `custom_fields` table qualifies, and writing one requires the
+     * custom-field admin capability.
+     *
+     * @since 2.7.1
+     */
+    protected function isPersistedColumnCustomField( string $key ): bool
+    {
+        if ( ! $this->isRealDatabaseColumn( $key ) ) {
+            return false;
+        }
+
+        foreach ( $this->getCustomFieldsForType() as $field ) {
+            if ( $field->key === $key && $field->exists && 'column' === $field->storageMode() ) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/src/Modules/Pages/Managers/PageManager.php
+++ b/src/Modules/Pages/Managers/PageManager.php
@@ -506,6 +506,10 @@ class PageManager
      * magic setter before save so a single write captures both the
      * hardcoded columns and the metadata JSON.
      *
+     * Delegates to `applyCustomFieldValues()` rather than assigning each
+     * key directly: the payload is untrusted, and that method drops keys
+     * that shadow a real column before they can reach the column ( #253 ).
+     *
      * @param  array<string,mixed>|null  $customFields
      */
     protected function applyCustomFields( Page $page, ?array $customFields ): void
@@ -514,9 +518,7 @@ class PageManager
             return;
         }
 
-        foreach ( $customFields as $key => $value ) {
-            $page->{$key} = $value;
-        }
+        $page->applyCustomFieldValues( $customFields );
     }
 
     /**

--- a/tests/Feature/Blog/BlogManagerWriteTest.php
+++ b/tests/Feature/Blog/BlogManagerWriteTest.php
@@ -117,6 +117,75 @@ test( 'create applies custom-field values into the metadata column before insert
     expect( $post->fresh()->metadata )->toBe( ['reading_time' => '4 minutes'] );
 } );
 
+test( 'create drops a custom-field value whose key shadows a real posts column', function (): void {
+    // #253 — a plugin filter-registers a metadata field keyed to `author_id`,
+    // so a request payload carrying `custom_fields[author_id]` would reach
+    // `parent::__set()` and hijack the author. The key must be dropped.
+    addFilter( 'ap.contentTypes.registeredCustomFields', function ( array $fields ): array {
+        $fields['author_id'] = [
+            'key'           => 'author_id',
+            'name'          => 'Author Id',
+            'type'          => 'text',
+            'content_types' => ['posts'],
+            'required'      => false,
+            'default_value' => null,
+            'storage'       => 'metadata',
+        ];
+
+        return $fields;
+    } );
+
+    $post = $this->manager->create( [
+        'title'    => 'Hijack attempt',
+        'status'   => ContentStatus::Draft,
+        'metadata' => [],
+    ], [
+        'author_id' => 999_999,
+    ], $this->user->id );
+
+    expect( $post->fresh()->author_id )->toBe( $this->user->id );
+    expect( $post->fresh()->metadata )->toBe( [] );
+} );
+
+test( 'update drops a custom-field value whose key shadows a real posts column', function (): void {
+    addFilter( 'ap.contentTypes.registeredCustomFields', function ( array $fields ): array {
+        $fields['author_id'] = [
+            'key'           => 'author_id',
+            'name'          => 'Author Id',
+            'type'          => 'text',
+            'content_types' => ['posts'],
+            'required'      => false,
+            'default_value' => null,
+            'storage'       => 'metadata',
+        ];
+
+        return $fields;
+    } );
+
+    $post = $this->manager->create( [
+        'title'  => 'Owned',
+        'status' => ContentStatus::Draft,
+    ], null, $this->user->id );
+
+    $this->manager->update( $post, ['title' => 'Still owned'], ['author_id' => 999_999] );
+
+    expect( $post->fresh()->author_id )->toBe( $this->user->id );
+    expect( $post->fresh()->title )->toBe( 'Still owned' );
+} );
+
+test( 'create drops an unregistered custom-field key that names a real posts column', function (): void {
+    // No registration at all: the payload keys are request input, so a bare
+    // column name must be dropped on the same terms as a registered one.
+    $post = $this->manager->create( [
+        'title'  => 'No registration needed',
+        'status' => ContentStatus::Draft,
+    ], [
+        'author_id' => 999_999,
+    ], $this->user->id );
+
+    expect( $post->fresh()->author_id )->toBe( $this->user->id );
+} );
+
 test( 'create rejects attributes outside the fillable + write allowlist', function (): void {
     $post = $this->manager->create( [
         'title'      => 'Guarded',

--- a/tests/Feature/Pages/PageManagerWriteTest.php
+++ b/tests/Feature/Pages/PageManagerWriteTest.php
@@ -126,6 +126,47 @@ test( 'create applies custom-field values into the metadata column before insert
     expect( $page->fresh()->metadata )->toBe( ['landing_cta' => 'Sign up now'] );
 } );
 
+test( 'create drops a custom-field value whose key shadows a real pages column', function (): void {
+    // #253 — same shadow-column guard as BlogManager: a filter-registered
+    // metadata field keyed to `author_id` must not reach the real column.
+    addFilter( 'ap.contentTypes.registeredCustomFields', function ( array $fields ): array {
+        $fields['author_id'] = [
+            'key'           => 'author_id',
+            'name'          => 'Author Id',
+            'type'          => 'text',
+            'content_types' => ['pages'],
+            'required'      => false,
+            'default_value' => null,
+            'storage'       => 'metadata',
+        ];
+
+        return $fields;
+    } );
+
+    $page = $this->manager->create( [
+        'title'    => 'Hijack attempt',
+        'status'   => ContentStatus::Draft,
+        'metadata' => [],
+    ], [
+        'author_id' => 999_999,
+    ], $this->user->id );
+
+    expect( $page->fresh()->author_id )->toBe( $this->user->id );
+    expect( $page->fresh()->metadata )->toBe( [] );
+} );
+
+test( 'update drops a custom-field value whose key shadows a real pages column', function (): void {
+    $page = $this->manager->create( [
+        'title'  => 'Owned',
+        'status' => ContentStatus::Draft,
+    ], null, $this->user->id );
+
+    $this->manager->update( $page, ['title' => 'Still owned'], ['author_id' => 999_999] );
+
+    expect( $page->fresh()->author_id )->toBe( $this->user->id );
+    expect( $page->fresh()->title )->toBe( 'Still owned' );
+} );
+
 test( 'update stamps published_at exactly once on the first draft -> published transition', function (): void {
     $page = $this->manager->create( [
         'title'  => 'Was Draft',

--- a/tests/Unit/ContentTypes/HasCustomFieldsTest.php
+++ b/tests/Unit/ContentTypes/HasCustomFieldsTest.php
@@ -174,6 +174,170 @@ test( 'plugin custom field write on a model without metadata column fails loud',
     Schema::dropIfExists( 'test_no_meta_hcf' );
 } );
 
+test( 'applyCustomFieldValues routes a registered metadata field into the metadata column', function (): void {
+    app( CustomFieldManager::class )->registerField( [
+        'name'          => 'Plugin Field',
+        'key'           => 'plugin_subtitle',
+        'type'          => 'text',
+        'column_type'   => 'string',
+        'content_types' => ['test_hcf_posts'],
+    ] );
+
+    $post        = new TestHasCustomFieldsPost;
+    $post->title = 'Payload Post';
+    $post->applyCustomFieldValues( ['plugin_subtitle' => 'From the payload'] );
+    $post->save();
+
+    $reloaded = TestHasCustomFieldsPost::find( $post->id );
+
+    expect( $reloaded->metadata )->toBe( ['plugin_subtitle' => 'From the payload'] );
+    expect( $reloaded->plugin_subtitle )->toBe( 'From the payload' );
+} );
+
+test( 'applyCustomFieldValues silently drops a metadata field whose key names a real column', function (): void {
+    // The #253 attack: a plugin filter-registers a metadata field keyed to a
+    // real column, so an untrusted custom-field payload carrying that key
+    // reaches `parent::__set()` and overwrites the column. The payload key
+    // must be dropped — neither the column nor the metadata JSON may change.
+    // `title` is a real column on `test_hcf_posts`.
+    app( CustomFieldManager::class )->registerField( [
+        'name'          => 'Hijack Attempt',
+        'key'           => 'title',
+        'type'          => 'text',
+        'column_type'   => 'string',
+        'content_types' => ['test_hcf_posts'],
+    ] );
+
+    $post        = new TestHasCustomFieldsPost;
+    $post->title = 'Legit Title';
+    $post->applyCustomFieldValues( ['title' => 'Hijacked Title'] );
+    $post->save();
+
+    $reloaded = TestHasCustomFieldsPost::find( $post->id );
+
+    expect( $reloaded->title )->toBe( 'Legit Title' );
+    expect( $reloaded->metadata )->toBeNull();
+} );
+
+test( 'applyCustomFieldValues drops a real-column key even when nothing registered it', function (): void {
+    // The payload is untrusted whether or not a plugin registered the key,
+    // so an unregistered column name must be dropped on the same terms.
+    $post        = new TestHasCustomFieldsPost;
+    $post->title = 'Legit Title';
+    $post->applyCustomFieldValues( ['title' => 'Hijacked Title'] );
+    $post->save();
+
+    expect( TestHasCustomFieldsPost::find( $post->id )->title )->toBe( 'Legit Title' );
+} );
+
+test( 'applyCustomFieldValues drops a key naming the metadata column itself', function (): void {
+    // `metadata` is both a real column and a cast attribute; a payload key
+    // matching it would otherwise replace the entire custom-field store.
+    $post           = new TestHasCustomFieldsPost;
+    $post->title    = 'Meta Post';
+    $post->metadata = ['kept' => 'yes'];
+    $post->applyCustomFieldValues( ['metadata' => ['wiped' => 'everything']] );
+    $post->save();
+
+    expect( TestHasCustomFieldsPost::find( $post->id )->metadata )->toBe( ['kept' => 'yes'] );
+} );
+
+test( 'applyCustomFieldValues applies the safe keys alongside a dropped one', function (): void {
+    app( CustomFieldManager::class )->registerField( [
+        'name'          => 'Plugin Field',
+        'key'           => 'plugin_blurb',
+        'type'          => 'text',
+        'column_type'   => 'string',
+        'content_types' => ['test_hcf_posts'],
+    ] );
+
+    $post        = new TestHasCustomFieldsPost;
+    $post->title = 'Mixed Payload';
+    $post->applyCustomFieldValues( [
+        'title'        => 'Hijacked Title',
+        'plugin_blurb' => 'A blurb.',
+    ] );
+    $post->save();
+
+    $reloaded = TestHasCustomFieldsPost::find( $post->id );
+
+    expect( $reloaded->title )->toBe( 'Mixed Payload' );
+    expect( $reloaded->metadata )->toBe( ['plugin_blurb' => 'A blurb.'] );
+} );
+
+test( 'applyCustomFieldValues writes a DB-registered field into its own column', function (): void {
+    // DB-registered fields are always column-storage and own a physical
+    // column, so the shadow-column drop must not swallow their values —
+    // otherwise every admin-created custom field stops persisting.
+    Schema::table( 'test_hcf_posts', function ( $table ): void {
+        $table->string( 'sku' )->nullable();
+    } );
+
+    CustomField::create( [
+        'name'          => 'SKU',
+        'key'           => 'sku',
+        'type'          => 'text',
+        'column_type'   => 'string',
+        'content_types' => ['test_hcf_posts'],
+        'order'         => 1,
+        'required'      => false,
+    ] );
+
+    $post        = new TestHasCustomFieldsPost;
+    $post->title = 'DB Field Payload';
+    $post->applyCustomFieldValues( ['sku' => 'ABC-123'] );
+    $post->save();
+
+    $reloaded = TestHasCustomFieldsPost::find( $post->id );
+
+    expect( $reloaded->sku )->toBe( 'ABC-123' );
+    expect( $reloaded->metadata )->toBeNull();
+} );
+
+test( 'applyCustomFieldValues ignores a filter registration claiming column storage', function (): void {
+    // The DB-registered exemption keys off `exists`, not the declared
+    // storage mode. A plugin declaring `storage => column` on a key that
+    // names a real column must still be dropped, or #253 reopens verbatim.
+    addFilter( 'ap.contentTypes.registeredCustomFields', function ( array $fields ): array {
+        $fields['title'] = [
+            'key'           => 'title',
+            'name'          => 'Hijack Attempt',
+            'type'          => 'text',
+            'column_type'   => 'string',
+            'content_types' => ['test_hcf_posts'],
+            'storage'       => 'column',
+        ];
+
+        return $fields;
+    } );
+
+    $post        = new TestHasCustomFieldsPost;
+    $post->title = 'Legit Title';
+    $post->applyCustomFieldValues( ['title' => 'Hijacked Title'] );
+    $post->save();
+
+    expect( TestHasCustomFieldsPost::find( $post->id )->title )->toBe( 'Legit Title' );
+} );
+
+test( 'direct assignment to a real column still wins over a shadowing registration', function (): void {
+    // The guard belongs to the untrusted payload path only. Host code
+    // writing its own column must keep working, otherwise any plugin could
+    // brick saves by registering a field keyed to a required column.
+    app( CustomFieldManager::class )->registerField( [
+        'name'          => 'Hijack Attempt',
+        'key'           => 'title',
+        'type'          => 'text',
+        'column_type'   => 'string',
+        'content_types' => ['test_hcf_posts'],
+    ] );
+
+    $post        = new TestHasCustomFieldsPost;
+    $post->title = 'Written By The Host';
+    $post->save();
+
+    expect( TestHasCustomFieldsPost::find( $post->id )->title )->toBe( 'Written By The Host' );
+} );
+
 test( 'getCustomFieldsForType is memoized per instance', function (): void {
     app( CustomFieldManager::class )->registerField( [
         'name'          => 'Plugin Field',


### PR DESCRIPTION
## Description

A custom-field payload key that names a real DB column fell through `HasCustomFields::__set()` to `parent::__set()` and wrote the column. The custom-field half of a request payload gets no fillable filtering, so `custom_fields[author_id]` on a post update reassigned the author regardless of the attribute allowlist that `fillableSubset()` applied to the other half of the same request.

The trait's existing defense stopped only half of it: `findCustomFieldByKey()` refuses to resolve a key that shadows a real column, so the *metadata* write was blocked — but the fall-through wasn't, and that's the half that reached the column. `BlogManager::applyCustomFields()` and `PageManager::applyCustomFields()` (#250) assigned each payload key that way.

Worth noting: a plugin registration was never actually required. The issue frames the attack as a plugin filter-registering a metadata field keyed to `author_id`, but a bare `custom_fields[author_id]` with no registration anywhere took the identical path. Both are closed here.

**Closes:** #253

## Type of Change

- [x] Security fix

## Related Issue

**Issue:** #253

## Motivation and Context

Keystone's `App\Support\ContentEdit\CustomFieldSupport::apply()` already guards this, which is why its controllers call `apply()` in front of the manager instead of passing `custom_fields` straight through. The guard belongs in the framework so downstream apps stop reinventing it — and so it covers every content type using the trait, not just the two the managers know about.

### Deviation from the issue's preferred option

The issue preferred **Option A** — guard inside `HasCustomFields::__set()`. I didn't do that literally, for two reasons:

1. It contradicts an existing passing test. `HasCustomFieldsTest.php:103` registers `title` as a metadata field and then asserts `$post->title = 'Legit Title'` still writes the column. Option A drops that write.
2. It hands every plugin a kill switch. Register a metadata field keyed to a required column (`title`, `slug`) and every host `$post->title = …` silently becomes a no-op, turning ordinary saves into `NOT NULL` failures. The guard would fire on *trusted* host assignment, which `__set()` can't distinguish from an untrusted payload.

So the guard sits at the payload boundary instead — but still in the trait, which keeps Option A's "every content type, not just the managers" property. That's the part of Option A worth having.

## Changes Made

- **New `HasCustomFields::applyCustomFieldValues( array $values )`** — the supported way to apply an untrusted custom-field payload. Values route through the same magic setter as before, so metadata-storage fields land in the `metadata` JSON exactly as they did; keys naming a real column, cast, mutator, accessor, or relation are silently dropped first.
- **`BlogManager` / `PageManager` `applyCustomFields()` delegate to it** — `create()` and `update()` are covered on `Post` and `Page`.
- **Extracted `isReservedModelAttribute()`** from `findCustomFieldByKey()` so both paths share one definition of "this key already belongs to the model". No behavior change to `findCustomFieldByKey()`.
- **`isPersistedColumnCustomField()` exemption** — DB-registered fields legitimately own the column they name (`createField()` adds it, and a persisted row is always column-storage since `custom_fields` has no `storage` column). Without this, every admin-created custom field would silently stop persisting through the managers. I caught this during self-review, not from the issue.
- **`__set()` is unchanged**, deliberately — see the reasoning above. Documented in the method's docblock so the omission doesn't read as an oversight.

### Why the exemption isn't a way back in

It keys off `$field->exists`, not the declared storage mode. `CustomFieldManager::filterFieldsForContentType()` forces `exists = false` on every filter-registered field after `forceFill()`, so a plugin declaring `'storage' => 'column'` on a key naming a real column still gets dropped (test added for exactly this). Only a row in the `custom_fields` table qualifies, and creating one goes through `authorize( 'create', CustomField::class )`.

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS (Darwin 27.0.0)
- Browser (if applicable): n/a — no UI surface
- PHP Version: 8.4.23
- Project Version: 2.7.1 (branched from `release/2.7.1`)

**Tests Performed:**
1. Full Pest suite: **1550 passed, 7 skipped, 3933 assertions**.
2. Each new test verified to fail against the unpatched source (stashed `src/`, re-ran: 10 failures), so none of them pass vacuously.
3. The DB-registered exemption verified the same way — removing the exemption clause fails `applyCustomFieldValues writes a DB-registered field into its own column`.
4. `php-cs-fixer --dry-run`: clean. PHPCS error count on the six touched files is identical before and after (49), i.e. no new violations; the remainder are pre-existing sniff noise (`declare( strict_types=1 )` spacing, untyped `__set()` magic-method params).

No manual browser testing — the change is model-layer with no UI surface of its own.

## Accessibility Tests Run

- [ ] Keyboard navigation tested
- [ ] Screen reader tested
- [ ] Color contrast verified
- [ ] ARIA labels checked

**Details:** Not applicable. The change is confined to a model trait and two manager methods; it renders nothing and alters no markup.

## Tests Added

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] All tests passing

**Test details:**

`tests/Unit/ContentTypes/HasCustomFieldsTest.php` (8 new):
- routes a registered metadata field into `metadata`
- silently drops a metadata field whose key names a real column
- drops a real-column key even when nothing registered it
- drops a key naming the `metadata` column itself (would otherwise wipe the store)
- applies the safe keys alongside a dropped one
- writes a DB-registered field into its own column (exemption)
- ignores a filter registration claiming `storage => column` (exemption can't be forged)
- direct assignment to a real column still wins over a shadowing registration (the anti-kill-switch case)

`tests/Feature/Blog/BlogManagerWriteTest.php` (3 new) and `tests/Feature/Pages/PageManagerWriteTest.php` (2 new): `create()`/`update()` drop a shadowing `author_id`, registered and unregistered.

## Documentation

- [x] Inline code documentation added
- [ ] README updated
- [x] Wiki updated
- [ ] API documentation updated

**Documentation details:** New "Applying Values From Untrusted Input" section in `docs/developer/custom-fields.md` (with TOC entry) contrasting `applyCustomFieldValues()` against the unsafe direct-assignment loop. CHANGELOG entry under `[Unreleased] → Security`.

## Screenshots

n/a

## Follow-ups (not in this PR)

- `CustomFieldManager::addColumnToTable()` silently returns when the column already exists, so an admin with `create` on `CustomField` can adopt an existing column (e.g. `author_id`) as a custom field, which the exemption then honors. Admin-gated, and strictly narrower than the pre-fix behavior where no row was needed at all — but `createField()` arguably ought to reject a key that collides with an existing column.
- `isRealDatabaseColumn()` returns `false` when `Schema::getColumnListing()` throws. That predates this PR, but the guard is now load-bearing for a security control, so the fail-open deserves a second look.
- An unregistered payload key that *doesn't* name a real column still reaches `parent::__set()` and dies with a QueryException on save. Left alone on purpose: dropping unregistered keys wholesale would silently swallow legitimate values whenever a plugin's registration hasn't loaded, trading a loud error for silent data loss.

## Pre-Submission Checklist

- [x] Followed contributing guidelines
- [x] Checked for other open PRs for same update
- [x] Code passes all tests
- [x] Code has been linted
- [ ] Accessibility tests completed — n/a, see above
- [x] Code follows project style guide
- [x] Self-review completed
- [x] Comments added for complex code
- [x] No new warnings generated


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security**
  - Protected real content attributes from being overwritten by untrusted custom-field data.
  - Reserved fields, relationships, casts, and accessors are now excluded from custom-field persistence.
  - Registered custom fields that use dedicated storage columns continue to work as expected.

- **Documentation**
  - Added guidance on safely handling custom-field values and the behavior of create and update operations.

- **Tests**
  - Added coverage for blog and page creation, updates, metadata handling, and protected attributes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->