### PR TITLE
fix: resolve theme-file templates and parts to a populated block tree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`ThemeFileBlockParser`** (`Modules\SiteEditor\Support`) — the seam that turns a block theme's raw `.html` markup into the block tree `ResolvedEntity::$blocks` carries. Prefers visual-editor's `BlockMarkupHydrator` (resolved out of the container by name, so visual-editor stays a non-dependency) and falls back to `BlockMarkupParser`'s WP `parse_blocks()` output when it is absent. A hydrator that throws is logged and degrades to the fallback rather than taking the template down.
+
 ### Changed
 
 ### Deprecated
@@ -16,6 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 ### Fixed
+
+- **Theme-file templates and parts now resolve to a populated block tree** ([#274](https://github.com/ArtisanPack-UI/cms-framework/issues/274)) — `TemplateResolver` and `TemplatePartResolver` put a theme file's markup in `ResolvedEntity::$raw` and left `$blocks` empty, but every consumer in the stack reads `$blocks` and ignores `$raw`. On a fresh activation the `templates` table is empty, so every template and part in a block theme resolved to `[]` and the front end rendered no theme markup at all — visual-editor's `TemplatePartInliner` inlined empty `<header>` wrappers, and the public render pipeline produced nothing. Both resolvers now parse the file on resolve via the new `ThemeFileBlockParser`, making `$blocks` authoritative regardless of source. With visual-editor ≥ 1.5.5 installed the tree comes back in the same editor shape DB rows store, with block text recovered from the saved HTML ([visual-editor#688](https://github.com/ArtisanPack-UI/visual-editor/issues/688)); standalone, it comes back in the WP `parse_blocks()` shape. Theme files are parsed on every resolve — there is no parse cache, matching `PatternResolver`'s existing behavior. `GET /api/v1/templates/{slug}` for a theme-file slug consequently returns a populated `content.blocks` where it previously returned `[]`.
 
 ## [2.7.1] - 2026-08-01
 

--- a/docs/site-editor/Templates.md
+++ b/docs/site-editor/Templates.md
@@ -41,7 +41,9 @@ Mirrors WordPress's `/wp/v2/templates`:
     "origin": null,
     "content": {
         "raw": "<!-- wp:paragraph --><p>Hello</p><!-- /wp:paragraph -->",
-        "blocks": [],
+        "blocks": [
+            { "name": "core/paragraph", "attributes": { "content": "Hello" }, "innerBlocks": [] }
+        ],
         "block_version": 1
     },
     "title": { "raw": "Page", "rendered": "Page" },
@@ -58,9 +60,22 @@ Mirrors WordPress's `/wp/v2/templates`:
 - `id` is always the `theme//slug` form, matching WP exactly.
 - `wp_id` carries the DB row's integer ID separately (0 when only a theme file backs the slug).
 - `content.raw` carries the file contents for theme-file-sourced entities and is the empty string `''` for DB-stored entities.
-- `content.blocks` carries the parsed block array for DB-stored entities and is empty `[]` for theme-file-sourced entities.
+- `content.blocks` carries the parsed block array for **both** sources. DB-stored entities return their `block_content` column verbatim; theme-file entities are parsed on resolve (since 2.7.2 — before that they returned `[]`, so a block theme resolved to nothing anywhere in the stack).
 
 cms-framework's `HasBlockContent` trait stores only the parsed block array — never a raw HTML mirror — so consumers requiring HTML render through the matching renderer package, and consumers needing the parsed tree read from `content.blocks`.
+
+#### Block shape for theme-file entities
+
+`content.blocks` is authoritative for both sources: a consumer reads it and never needs to fall back to `content.raw`. Which *shape* it carries for a theme file depends on whether visual-editor is installed:
+
+| Install | Shape | Text recovery |
+|---------|-------|---------------|
+| With `artisanpack-ui/visual-editor` ≥ 1.5.5 | Editor shape (`{name, attributes, innerBlocks}`) — matches what DB rows store | Yes — `attributes.content` and other `source`-declared attributes are recovered from the saved HTML |
+| Standalone cms-framework | WP `parse_blocks()` shape (`{blockName, attrs, innerBlocks, innerHTML, innerContent}`) | No — block text stays in `innerHTML` |
+
+The split exists because Gutenberg persists most block text in the saved HTML rather than in the delimiter's JSON, so recovering it needs each block type's `block.json` `source` definitions — which live with the block partials in visual-editor, not here. `ThemeFileBlockParser` looks up visual-editor's `BlockMarkupHydrator` through the container and falls back to `BlockMarkupParser`'s WP-shape output when it is absent.
+
+Theme files are read and parsed on every resolve; there is no parse cache. `all()` therefore parses every template the active theme ships.
 
 ### Conflict and validation behavior
 

--- a/src/Modules/SiteEditor/Resolution/ResolvedEntity.php
+++ b/src/Modules/SiteEditor/Resolution/ResolvedEntity.php
@@ -29,7 +29,7 @@ final class ResolvedEntity
      * @param  string  $theme  The active theme slug at resolution time.
      * @param  'db'|'theme'  $source  Whether the resolved content came from a DB row or a theme file.
      * @param  string  $raw  The raw block markup string. Populated for theme files (the file contents) and empty for DB rows — cms-framework stores only the parsed block array, never a raw HTML mirror, to match the visual-editor adapter convention (`Adapters\CmsFramework\WpEntityResource`).
-     * @param  array<int, array<string, mixed>>  $blocks  The parsed block tree. Populated for DB rows; empty for theme files (we don't parse `.html` on the fly in V1).
+     * @param  array<int, array<string, mixed>>  $blocks  The parsed block tree, authoritative for both sources — consumers read this and never have to fall back to `$raw`. DB rows carry the editor shape (`{name, attributes, innerBlocks}`) their `block_content` column stores; theme files are parsed on resolve by {@see \ArtisanPackUI\CMSFramework\Modules\SiteEditor\Support\ThemeFileBlockParser}, which matches that shape when visual-editor's `BlockMarkupHydrator` is installed and degrades to the WP `parse_blocks()` shape when it isn't. Empty only when the entity genuinely has no blocks.
      * @param  string|null  $title  Display title; null when only a theme file exists and the file has no title metadata.
      * @param  string|null  $description  Display description.
      * @param  string  $status  WP status (`'publish'` by default).

--- a/src/Modules/SiteEditor/Resolution/TemplatePartResolver.php
+++ b/src/Modules/SiteEditor/Resolution/TemplatePartResolver.php
@@ -16,6 +16,7 @@ namespace ArtisanPackUI\CMSFramework\Modules\SiteEditor\Resolution;
 
 use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Models\TemplatePart;
 use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Support\SlugValidator;
+use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Support\ThemeFileBlockParser;
 use ArtisanPackUI\CMSFramework\Modules\Themes\Managers\ThemeManager;
 use Illuminate\Support\Facades\File;
 
@@ -72,12 +73,14 @@ class TemplatePartResolver implements EntityResolver
             return null;
         }
 
+        $markup = File::get( $themeFile );
+
         return new ResolvedEntity(
             slug         : $slug,
             theme        : $theme,
             source       : 'theme',
-            raw          : File::get( $themeFile ),
-            blocks       : [],
+            raw          : $markup,
+            blocks       : ThemeFileBlockParser::parse( $markup ),
             title        : $this->humanizeSlug( $slug ),
             description  : null,
             status       : 'publish',

--- a/src/Modules/SiteEditor/Resolution/TemplateResolver.php
+++ b/src/Modules/SiteEditor/Resolution/TemplateResolver.php
@@ -16,6 +16,7 @@ namespace ArtisanPackUI\CMSFramework\Modules\SiteEditor\Resolution;
 
 use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Models\Template;
 use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Support\SlugValidator;
+use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Support\ThemeFileBlockParser;
 use ArtisanPackUI\CMSFramework\Modules\Themes\Managers\ThemeManager;
 use Illuminate\Support\Facades\File;
 
@@ -72,12 +73,14 @@ class TemplateResolver implements EntityResolver
             return null;
         }
 
+        $markup = File::get( $themeFile );
+
         return new ResolvedEntity(
             slug         : $slug,
             theme        : $theme,
             source       : 'theme',
-            raw          : File::get( $themeFile ),
-            blocks       : [],
+            raw          : $markup,
+            blocks       : ThemeFileBlockParser::parse( $markup ),
             title        : $this->humanizeSlug( $slug ),
             description  : null,
             status       : 'publish',

--- a/src/Modules/SiteEditor/Support/BlockMarkupParser.php
+++ b/src/Modules/SiteEditor/Support/BlockMarkupParser.php
@@ -19,8 +19,9 @@
  * {@see PatternFileParser}. Without a parsed block tree the pattern browser
  * shows the "Empty pattern" placeholder for every shipped pattern. The parser
  * is deliberately generic — the sibling `TemplateResolver` and
- * `TemplatePartResolver` theme-file branches ship the same `blocks: []` gap
- * and can drop this in as-is.
+ * `TemplatePartResolver` theme-file branches closed the same `blocks: []` gap
+ * in 2.7.2 (#274) via {@see ThemeFileBlockParser}, which wraps this parser to
+ * prefer visual-editor's editor-shape hydrator when it is installed.
  *
  * ## Correctness scope
  *

--- a/src/Modules/SiteEditor/Support/ThemeFileBlockParser.php
+++ b/src/Modules/SiteEditor/Support/ThemeFileBlockParser.php
@@ -1,0 +1,135 @@
+<?php
+
+/**
+ * Theme File Block Parser
+ *
+ * Turns a block theme's raw `.html` markup (`templates/{slug}.html`,
+ * `parts/{slug}.html`) into the block tree `ResolvedEntity::$blocks` carries,
+ * so consumers get an authoritative tree regardless of whether the entity
+ * came from the DB or from disk (#274). See
+ * {@see \ArtisanPackUI\CMSFramework\Modules\SiteEditor\Resolution\ResolvedEntity}
+ * for the contract that tree satisfies.
+ *
+ * ## Why this isn't just `BlockMarkupParser::parse()`
+ *
+ * {@see BlockMarkupParser} emits the WP `parse_blocks()` shape
+ * (`{blockName, attrs, innerHTML}`), but a DB row's `block_content` column
+ * holds the editor shape (`{name, attributes, innerBlocks}`) the visual
+ * editor serializes. Handing consumers the WP shape for theme files and the
+ * editor shape for DB rows would push a shape sniff onto every one of them.
+ *
+ * Worse, a key rename alone would not close the gap: Gutenberg persists most
+ * block text in the saved HTML rather than in the delimiter's JSON, so a
+ * renamed tree renders structurally correct but textless. Recovering those
+ * attributes needs each block type's `block.json` `source` definitions, which
+ * live with the block partials in visual-editor — hence
+ * `BlockMarkupHydrator` (visual-editor#688) rather than a local converter.
+ *
+ * ## Degradation
+ *
+ * visual-editor is not a cms-framework dependency, so the hydrator is looked
+ * up by name. Without it — cms-framework running standalone, or with a
+ * visual-editor older than 1.5.5 — this falls back to the WP-shape parse.
+ * That is still strictly better than the empty array shipped before #274
+ * (consumers that sniff both key sets render something), but text recovery
+ * only happens with the hydrator present.
+ *
+ * @since      2.7.2
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Modules\SiteEditor\Support;
+
+use Illuminate\Support\Facades\Log;
+use Throwable;
+
+/**
+ * @since 2.7.2
+ */
+final class ThemeFileBlockParser
+{
+    /**
+     * visual-editor's markup hydrator. Referenced as a string, and without
+     * a leading backslash so the name matches the key Laravel's container
+     * stores `BlockMarkupHydrator::class` under — a leading slash makes
+     * `app()` treat it as a distinct binding and build a fresh instance,
+     * ignoring visual-editor's singleton and any test override.
+     *
+     * @since 2.7.2
+     */
+    public const HYDRATOR_CLASS = 'ArtisanPackUI\\VisualEditor\\Support\\BlockMarkupHydrator';
+
+    /**
+     * Parse raw theme-file block markup into a block tree.
+     *
+     * Returns the editor shape when visual-editor's hydrator is available,
+     * and the WP `parse_blocks()` shape otherwise. Blank markup yields an
+     * empty array from either path.
+     *
+     * @since 2.7.2
+     *
+     * @param  string  $markup  The raw contents of a theme `.html` file.
+     *
+     * @return array<int, array<string, mixed>> The parsed block tree.
+     */
+    public static function parse( string $markup ): array
+    {
+        if ( '' === trim( $markup ) ) {
+            return [];
+        }
+
+        $hydrator = self::hydrator();
+
+        if ( null !== $hydrator ) {
+            try {
+                return $hydrator->hydrate( $markup );
+            } catch ( Throwable $exception ) {
+                // A hydrator failure must not take the whole template down —
+                // the WP-shape parse below still gives consumers a tree.
+                Log::warning(
+                    'ThemeFileBlockParser: block hydration failed; falling back to the parse_blocks() shape.',
+                    [
+                        'exception' => $exception->getMessage(),
+                    ],
+                );
+            }
+        }
+
+        return BlockMarkupParser::parse( $markup );
+    }
+
+    /**
+     * Resolve visual-editor's hydrator, or null when it is unavailable.
+     *
+     * Checks the container binding first so a host (or a test) can supply
+     * its own hydrator without the concrete class being on the classpath;
+     * falls back to `class_exists` for the ordinary installed case, where
+     * the container auto-resolves the concrete class.
+     *
+     * @since 2.7.2
+     */
+    private static function hydrator(): ?object
+    {
+        $container = app();
+
+        if ( ! $container->bound( self::HYDRATOR_CLASS ) && ! class_exists( self::HYDRATOR_CLASS ) ) {
+            return null;
+        }
+
+        try {
+            $hydrator = $container->make( self::HYDRATOR_CLASS );
+        } catch ( Throwable $exception ) {
+            Log::warning(
+                'ThemeFileBlockParser: could not resolve the block hydrator; falling back to the parse_blocks() shape.',
+                [
+                    'exception' => $exception->getMessage(),
+                ],
+            );
+
+            return null;
+        }
+
+        return is_object( $hydrator ) && method_exists( $hydrator, 'hydrate' ) ? $hydrator : null;
+    }
+}

--- a/tests/Feature/SiteEditor/TemplatesApiTest.php
+++ b/tests/Feature/SiteEditor/TemplatesApiTest.php
@@ -124,7 +124,9 @@ describe( 'GET /api/v1/templates/{slug}', function (): void {
         expect( $response->json( 'has_theme_file' ) )->toBeTrue();
         expect( $response->json( 'wp_id' ) )->toBe( 0 );
         expect( $response->json( 'content.raw' ) )->toContain( 'wp:heading' );
-        expect( $response->json( 'content.blocks' ) )->toBe( [] );
+        // #274 — theme files are parsed on resolve, so `blocks` is populated
+        // for both sources rather than only for DB rows.
+        expect( $response->json( 'content.blocks.0.blockName' ) )->toBe( 'core/heading' );
     } );
 
     it( 'returns DB-stored templates with empty content.raw and populated content.blocks', function (): void {

--- a/tests/Support/BlockMarkupHydratorStub.php
+++ b/tests/Support/BlockMarkupHydratorStub.php
@@ -1,0 +1,73 @@
+<?php
+
+/**
+ * Test-only stand-in for visual-editor's block-markup hydrator.
+ *
+ * {@see \ArtisanPackUI\CMSFramework\Modules\SiteEditor\Support\ThemeFileBlockParser}
+ * resolves `BlockMarkupHydrator` out of the container by name so cms-framework
+ * stays installable without visual-editor. Tests bind an instance of this class
+ * under that name to exercise the hydrated branch — no dev dependency on
+ * visual-editor, and no autoloaded class shadowing the real one (which would
+ * make `class_exists()` true for every later test in the process).
+ *
+ * @since      2.7.2
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Tests\Support;
+
+use RuntimeException;
+
+/**
+ * @since 2.7.2
+ */
+class BlockMarkupHydratorStub
+{
+    /**
+     * Markup strings passed to {@see hydrate()}, in call order. Lets a test
+     * assert the resolver handed over the file contents verbatim.
+     *
+     * @since 2.7.2
+     *
+     * @var array<int, string>
+     */
+    public array $received = [];
+
+    /**
+     * @since 2.7.2
+     *
+     * @param  bool  $shouldThrow  When true, {@see hydrate()} throws so tests can cover the fallback path.
+     */
+    public function __construct(
+        public bool $shouldThrow = false,
+    ) {
+    }
+
+    /**
+     * Return a marker tree in the editor shape so assertions can tell a
+     * hydrated result apart from the WP `parse_blocks()` fallback.
+     *
+     * @since 2.7.2
+     *
+     * @param  string  $markup  The raw block markup.
+     *
+     * @return array<int, array<string, mixed>> The stub's editor-shape tree.
+     */
+    public function hydrate( string $markup ): array
+    {
+        $this->received[] = $markup;
+
+        if ( $this->shouldThrow ) {
+            throw new RuntimeException( 'Stub hydration failure.' );
+        }
+
+        return [
+            [
+                'name'        => 'core/paragraph',
+                'attributes'  => ['content' => 'hydrated'],
+                'innerBlocks' => [],
+            ],
+        ];
+    }
+}

--- a/tests/Unit/SiteEditor/TemplatePartResolverTest.php
+++ b/tests/Unit/SiteEditor/TemplatePartResolverTest.php
@@ -1,0 +1,129 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Models\TemplatePart;
+use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Resolution\ResolvedEntity;
+use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Resolution\TemplatePartResolver;
+use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Support\ThemeFileBlockParser;
+use ArtisanPackUI\CMSFramework\Modules\Themes\Managers\ThemeManager;
+use ArtisanPackUI\CMSFramework\Tests\Support\BlockMarkupHydratorStub;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\File;
+
+uses( RefreshDatabase::class );
+
+beforeEach( function (): void {
+    $this->themesPath = base_path( 'themes' );
+    $this->themeSlug  = 'test-theme';
+    $this->themeFiles = $this->themesPath . '/' . $this->themeSlug . '/parts';
+
+    File::ensureDirectoryExists( $this->themeFiles );
+    File::put(
+        $this->themesPath . '/' . $this->themeSlug . '/theme.json',
+        json_encode( ['name' => 'Test', 'slug' => $this->themeSlug, 'version' => '1.0.0'] ),
+    );
+
+    config()->set( 'cms.themes.cacheEnabled', false );
+
+    $themeManager = $this->mock( ThemeManager::class, function ( $mock ): void {
+        $mock->shouldReceive( 'getActiveTheme' )->andReturn( [
+            'name' => 'Test',
+            'slug' => $this->themeSlug,
+        ] );
+    } );
+
+    $this->resolver = new TemplatePartResolver( $themeManager );
+} );
+
+afterEach( function (): void {
+    File::deleteDirectory( $this->themesPath . '/' . $this->themeSlug );
+} );
+
+describe( 'TemplatePartResolver::resolve()', function (): void {
+    it( 'returns the theme file with both raw content and a parsed block tree (#274)', function (): void {
+        File::put(
+            $this->themeFiles . '/header.html',
+            '<!-- wp:group --><!-- wp:site-title /--><!-- /wp:group -->',
+        );
+
+        $result = $this->resolver->resolve( 'header' );
+
+        expect( $result )
+            ->toBeInstanceOf( ResolvedEntity::class )
+            ->and( $result->source )->toBe( 'theme' )
+            ->and( $result->area )->toBe( 'header' )
+            ->and( $result->raw )->toContain( 'wp:group' )
+            ->and( $result->blocks )->toHaveCount( 1 )
+            ->and( $result->blocks[0]['blockName'] )->toBe( 'core/group' )
+            ->and( $result->blocks[0]['innerBlocks'][0]['blockName'] )->toBe( 'core/site-title' )
+            ->and( $result->wpId() )->toBe( 0 );
+    } );
+
+    it( 'hands theme-file markup to the block hydrator when visual-editor supplies one (#274)', function (): void {
+        File::put( $this->themeFiles . '/footer.html', '<!-- wp:paragraph --><p>Footer</p><!-- /wp:paragraph -->' );
+
+        $stub = new BlockMarkupHydratorStub();
+        app()->instance( ThemeFileBlockParser::HYDRATOR_CLASS, $stub );
+
+        $result = $this->resolver->resolve( 'footer' );
+
+        expect( $result->blocks )->toBe( [
+            [
+                'name'        => 'core/paragraph',
+                'attributes'  => ['content' => 'hydrated'],
+                'innerBlocks' => [],
+            ],
+        ] )
+            ->and( $stub->received )->toBe( ['<!-- wp:paragraph --><p>Footer</p><!-- /wp:paragraph -->'] );
+    } );
+
+    it( 'leaves blocks empty for an empty theme file', function (): void {
+        File::put( $this->themeFiles . '/blank.html', '' );
+
+        expect( $this->resolver->resolve( 'blank' )->blocks )->toBe( [] );
+    } );
+
+    it( 'returns the DB row over the theme file when both exist (DB wins)', function (): void {
+        File::put( $this->themeFiles . '/header.html', '<!-- wp:paragraph --><p>From file</p><!-- /wp:paragraph -->' );
+
+        $row = TemplatePart::create( [
+            'theme'         => $this->themeSlug,
+            'slug'          => 'header',
+            'title'         => 'DB Header',
+            'area'          => 'header',
+            'is_custom'     => false,
+            'block_content' => [['name' => 'core/heading', 'attributes' => [], 'innerBlocks' => []]],
+        ] );
+
+        $result = $this->resolver->resolve( 'header' );
+
+        expect( $result->source )->toBe( 'db' )
+            ->and( $result->raw )->toBe( '' )
+            ->and( $result->blocks )->toBe( [['name' => 'core/heading', 'attributes' => [], 'innerBlocks' => []]] )
+            ->and( $result->hasThemeFile )->toBeTrue()
+            ->and( $result->wpId() )->toBe( $row->id );
+    } );
+
+    it( 'returns null when neither DB nor file has the slug', function (): void {
+        expect( $this->resolver->resolve( 'missing' ) )->toBeNull();
+    } );
+
+    it( 'rejects path-traversal slugs', function (): void {
+        File::put( $this->themesPath . '/' . $this->themeSlug . '/secret.html', '<!-- secret -->' );
+
+        expect( $this->resolver->resolve( '../secret' ) )->toBeNull();
+    } );
+} );
+
+describe( 'TemplatePartResolver::all()', function (): void {
+    it( 'populates blocks for every theme-file part (#274)', function (): void {
+        File::put( $this->themeFiles . '/header.html', '<!-- wp:paragraph --><p>Head</p><!-- /wp:paragraph -->' );
+        File::put( $this->themeFiles . '/footer.html', '<!-- wp:heading --><h2>Foot</h2><!-- /wp:heading -->' );
+
+        $bySlug = collect( $this->resolver->all() )->keyBy( 'slug' );
+
+        expect( $bySlug->get( 'header' )->blocks[0]['blockName'] )->toBe( 'core/paragraph' )
+            ->and( $bySlug->get( 'footer' )->blocks[0]['blockName'] )->toBe( 'core/heading' );
+    } );
+} );

--- a/tests/Unit/SiteEditor/TemplateResolverTest.php
+++ b/tests/Unit/SiteEditor/TemplateResolverTest.php
@@ -5,7 +5,9 @@ declare( strict_types=1 );
 use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Models\Template;
 use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Resolution\ResolvedEntity;
 use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Resolution\TemplateResolver;
+use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Support\ThemeFileBlockParser;
 use ArtisanPackUI\CMSFramework\Modules\Themes\Managers\ThemeManager;
+use ArtisanPackUI\CMSFramework\Tests\Support\BlockMarkupHydratorStub;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\File;
 
@@ -40,7 +42,7 @@ afterEach( function (): void {
 } );
 
 describe( 'TemplateResolver::resolve()', function (): void {
-    it( 'returns the theme file with raw content populated and blocks empty', function (): void {
+    it( 'returns the theme file with both raw content and a parsed block tree', function (): void {
         File::put( $this->themeFiles . '/page.html', '<!-- wp:paragraph --><p>Page</p><!-- /wp:paragraph -->' );
 
         $result = $this->resolver->resolve( 'page' );
@@ -51,10 +53,45 @@ describe( 'TemplateResolver::resolve()', function (): void {
             ->and( $result->slug )->toBe( 'page' )
             ->and( $result->theme )->toBe( $this->themeSlug )
             ->and( $result->raw )->toContain( 'wp:paragraph' )
-            ->and( $result->blocks )->toBe( [] )
+            ->and( $result->blocks )->toHaveCount( 1 )
+            ->and( $result->blocks[0]['blockName'] )->toBe( 'core/paragraph' )
             ->and( $result->hasThemeFile )->toBeTrue()
             ->and( $result->isCustom )->toBeFalse()
             ->and( $result->wpId() )->toBe( 0 );
+    } );
+
+    it( 'hands theme-file markup to the block hydrator when visual-editor supplies one (#274)', function (): void {
+        File::put( $this->themeFiles . '/home.html', '<!-- wp:heading --><h2>Home</h2><!-- /wp:heading -->' );
+
+        $stub = new BlockMarkupHydratorStub();
+        app()->instance( ThemeFileBlockParser::HYDRATOR_CLASS, $stub );
+
+        $result = $this->resolver->resolve( 'home' );
+
+        expect( $result->blocks )->toBe( [
+            [
+                'name'        => 'core/paragraph',
+                'attributes'  => ['content' => 'hydrated'],
+                'innerBlocks' => [],
+            ],
+        ] )
+            ->and( $stub->received )->toBe( ['<!-- wp:heading --><h2>Home</h2><!-- /wp:heading -->'] );
+    } );
+
+    it( 'leaves blocks empty for an empty theme file', function (): void {
+        File::put( $this->themeFiles . '/blank.html', '' );
+
+        expect( $this->resolver->resolve( 'blank' )->blocks )->toBe( [] );
+    } );
+
+    it( 'populates blocks for every theme-file entity returned by all() (#274)', function (): void {
+        File::put( $this->themeFiles . '/one.html', '<!-- wp:paragraph --><p>One</p><!-- /wp:paragraph -->' );
+        File::put( $this->themeFiles . '/two.html', '<!-- wp:heading --><h2>Two</h2><!-- /wp:heading -->' );
+
+        $all = collect( $this->resolver->all() )->keyBy( 'slug' );
+
+        expect( $all->get( 'one' )->blocks[0]['blockName'] )->toBe( 'core/paragraph' )
+            ->and( $all->get( 'two' )->blocks[0]['blockName'] )->toBe( 'core/heading' );
     } );
 
     it( 'returns the DB row with blocks populated and raw empty (custom template)', function (): void {

--- a/tests/Unit/SiteEditor/ThemeFileBlockParserTest.php
+++ b/tests/Unit/SiteEditor/ThemeFileBlockParserTest.php
@@ -1,0 +1,81 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Support\ThemeFileBlockParser;
+use ArtisanPackUI\CMSFramework\Tests\Support\BlockMarkupHydratorStub;
+use Illuminate\Support\Facades\Log;
+
+beforeEach( function (): void {
+    $this->markup = '<!-- wp:paragraph --><p>Hello</p><!-- /wp:paragraph -->';
+} );
+
+describe( 'ThemeFileBlockParser::parse() without a hydrator', function (): void {
+    it( 'returns an empty tree for blank markup', function (): void {
+        expect( ThemeFileBlockParser::parse( '' ) )->toBe( [] )
+            ->and( ThemeFileBlockParser::parse( "  \n\t " ) )->toBe( [] );
+    } );
+
+    it( 'falls back to the parse_blocks() shape when visual-editor is absent', function (): void {
+        // Guards the premise: if visual-editor ever lands in cms-framework's
+        // dev deps, this test would silently start exercising the hydrated
+        // branch instead of the fallback it is here to cover.
+        expect( class_exists( ThemeFileBlockParser::HYDRATOR_CLASS ) )->toBeFalse();
+
+        $blocks = ThemeFileBlockParser::parse( $this->markup );
+
+        expect( $blocks )->toHaveCount( 1 )
+            ->and( $blocks[0]['blockName'] )->toBe( 'core/paragraph' )
+            ->and( $blocks[0]['innerHTML'] )->toContain( '<p>Hello</p>' );
+    } );
+} );
+
+describe( 'ThemeFileBlockParser::parse() with a hydrator bound', function (): void {
+    it( 'hydrates to the editor shape and passes the markup through verbatim', function (): void {
+        $stub = new BlockMarkupHydratorStub();
+        app()->instance( ThemeFileBlockParser::HYDRATOR_CLASS, $stub );
+
+        $blocks = ThemeFileBlockParser::parse( $this->markup );
+
+        expect( $blocks )->toBe( [
+            [
+                'name'        => 'core/paragraph',
+                'attributes'  => ['content' => 'hydrated'],
+                'innerBlocks' => [],
+            ],
+        ] )
+            ->and( $stub->received )->toBe( [$this->markup] );
+    } );
+
+    it( 'does not call the hydrator for blank markup', function (): void {
+        $stub = new BlockMarkupHydratorStub();
+        app()->instance( ThemeFileBlockParser::HYDRATOR_CLASS, $stub );
+
+        expect( ThemeFileBlockParser::parse( '   ' ) )->toBe( [] )
+            ->and( $stub->received )->toBe( [] );
+    } );
+
+    it( 'falls back to the parse_blocks() shape and logs when hydration throws', function (): void {
+        Log::shouldReceive( 'warning' )
+            ->once()
+            ->withArgs( fn ( string $message ): bool => str_contains( $message, 'block hydration failed' ) );
+
+        app()->instance(
+            ThemeFileBlockParser::HYDRATOR_CLASS,
+            new BlockMarkupHydratorStub( shouldThrow: true ),
+        );
+
+        $blocks = ThemeFileBlockParser::parse( $this->markup );
+
+        expect( $blocks )->toHaveCount( 1 )
+            ->and( $blocks[0]['blockName'] )->toBe( 'core/paragraph' );
+    } );
+
+    it( 'ignores a bound value that cannot hydrate', function (): void {
+        app()->instance( ThemeFileBlockParser::HYDRATOR_CLASS, new stdClass() );
+
+        $blocks = ThemeFileBlockParser::parse( $this->markup );
+
+        expect( $blocks[0]['blockName'] )->toBe( 'core/paragraph' );
+    } );
+} );


### PR DESCRIPTION
## Description

`TemplateResolver` and `TemplatePartResolver` put a theme file's markup in `ResolvedEntity::$raw` and left `$blocks` empty, but every consumer in the stack reads `$blocks` and ignores `$raw`. On a fresh activation the `templates` table is empty, so every template and part in a block theme resolved to `[]` and the front end rendered no theme markup at all — visual-editor's `TemplatePartInliner` inlined empty `<header>` wrappers, and the public render pipeline produced nothing.

Both resolvers now parse the file on resolve via a new `ThemeFileBlockParser`, making `$blocks` authoritative regardless of source.

**Closes:** #274

## Type of Change

- [x] Bug fix (fixes an issue)
- [ ] New feature (adds new functionality)
- [ ] Enhancement (improves existing functionality)
- [ ] Refactoring (code improvement, no behavior change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Security fix
- [ ] Breaking change (breaks backward compatibility)

## Related Issue

**Issue:** #274

## Motivation and Context

The issue asked for a sequencing decision between two options. It leaned toward option 1 — wait for the visual-editor converter, then call its hydrator behind a guard — and that is what this implements, since [visual-editor#688](https://github.com/ArtisanPack-UI/visual-editor/issues/688) now provides `BlockMarkupHydrator`.

One deviation from the issue's sketch: rather than a hard-coded `class_exists` on a FQCN, the hydrator is resolved **out of the container** by name. That keeps visual-editor a non-dependency, avoids a brittle class-name contract between the two packages, and lets a host or test substitute its own hydrator.

Parsing alone was never enough — Gutenberg persists most block text in the saved HTML rather than the delimiter's JSON, so a key rename would produce a structurally-correct but textless tree. Recovering it needs each block type's `block.json` `source` definitions, which live with the block partials in visual-editor. Hence the split:

| Install | `$blocks` shape | Text recovery |
|---------|-----------------|---------------|
| With `artisanpack-ui/visual-editor` >= 1.5.5 | Editor shape (`{name, attributes, innerBlocks}`) — matches what DB rows store | Yes |
| Standalone cms-framework | WP `parse_blocks()` shape | No — text stays in `innerHTML` |

The standalone fallback is inconsistent with DB rows, but strictly better than the empty array it replaces: consumers that sniff both key sets render something.

## Changes Made

- **New `Modules\SiteEditor\Support\ThemeFileBlockParser`** — prefers visual-editor's `BlockMarkupHydrator` (container-resolved by name), falls back to `BlockMarkupParser`'s WP-shape output when absent. A hydrator that throws is logged and degrades to the fallback rather than taking the template down; a bound value that can't hydrate is ignored.
- **`TemplateResolver` / `TemplatePartResolver`** — theme-file branch parses the markup instead of passing `blocks: []`. `File::get()` is hoisted to a local so the file is read once, not twice.
- **`ResolvedEntity`** — `$blocks` docblock now states the real contract (authoritative for both sources) instead of documenting the gap.
- **`BlockMarkupParser`** — class docblock no longer advertises the resolver gap as open.
- **Docs / CHANGELOG** — corrected the `content.blocks` response shape in `docs/site-editor/Templates.md`, documented the two block shapes, and noted the absence of a parse cache.

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS (Darwin 27.0.0)
- Browser (if applicable): n/a — server-side resolution
- PHP Version: 8.5.7
- Project Version: 2.7.2 (branched from `release/2.7.2`)

**Tests Performed:**
1. Full suite: **1609 passed, 7 pre-existing skips** (`./vendor/bin/pest`).
2. `./vendor/bin/php-cs-fixer fix --dry-run --diff` — clean, 0 of 515 files.
3. Verified end-to-end in the ArtisanPack UI dev app against the `dev-sample` theme with visual-editor's #688 branch symlinked in — `templates/page.html` resolves `source=theme` with 2 top-level blocks in editor shape, `parts/header.html` with 1, and `attributes.content` correctly recovered from the saved HTML (`"Dev Sample — Page"`). Both returned 0 blocks before this change.

## Accessibility Tests Run

- [ ] Keyboard navigation tested
- [ ] Screen reader tested
- [ ] Color contrast verified
- [ ] ARIA labels checked

**Details:** Not applicable — this change is entirely server-side block-tree resolution with no UI surface. It is, however, a prerequisite for a block theme rendering at all, so the rendered output it unblocks is subject to the block partials' own accessibility characteristics.

## Tests Added

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] All tests passing

**Test details:**

- **New `ThemeFileBlockParserTest`** — blank input, WP-shape fallback with no hydrator (guarded by an explicit `class_exists` assertion so the premise can't silently rot), hydrated editor shape with markup passed through verbatim, hydrator not called for blank markup, fallback + log on a throwing hydrator, and a bound value that can't hydrate.
- **New `TemplatePartResolverTest`** — the part resolver had no test file at all. Covers the theme-file branch (nested `innerBlocks`, area inference), the hydrated branch, empty files, DB-wins precedence, and path-traversal rejection.
- **Updated `TemplateResolverTest`** — the theme-file case asserted `blocks === []`, i.e. the bug. Now asserts a parsed tree, plus new cases for the hydrated branch, empty files, and `all()`.
- **Updated `TemplatesApiTest`** — `GET /api/v1/templates/{slug}` asserted `content.blocks === []` for a theme-file slug; now asserts the populated tree.
- **New `tests/Support/BlockMarkupHydratorStub.php`** — bound under the hydrator's container key so the hydrated branch is testable without adding visual-editor to cms-framework's dev deps.

## Documentation

- [x] Inline code documentation added
- [ ] README updated
- [ ] Wiki updated
- [x] API documentation updated

**Documentation details:** `docs/site-editor/Templates.md` had the old contract stated twice — the JSON example showed `"blocks": []` and the prose said blocks are "empty `[]` for theme-file-sourced entities". Both corrected, with a new subsection covering the two shapes and the no-parse-cache behavior. `ThemeFileBlockParser` carries a full class docblock explaining why a key rename is insufficient and how it degrades without visual-editor.

## Screenshots

n/a — server-side change.

## Notes for the reviewer

Two deliberate calls, both documented in the changelog and docs:

1. **No parse cache.** Theme files are re-read and re-parsed on every `resolve()`, and `all()` parses every template the theme ships — which now includes DOM-based attribute recovery per block on the templates index endpoint. This matches `PatternResolver`'s existing per-request behavior and keeps the diff scoped to the bug, but it is the obvious follow-up if it shows up in profiling.
2. **Standalone fallback emits the WP shape rather than `[]`**, accepting shape inconsistency with DB rows in exchange for non-empty output.

A security pass over the diff found no HIGH or MEDIUM issues. Worth stating explicitly, though: the hydrator recovers `rich-text`/`html` attributes that block partials emit unescaped, so this fix inherits visual-editor's documented trust boundary — it is only safe because the input is theme files on disk. `$slug` remains gated by `SlugValidator` before any path construction, and `content.raw` on the same authenticated endpoint already returned identical bytes, so nothing new is disclosed.

## Pre-Submission Checklist

- [x] Followed contributing guidelines
- [x] Checked for other open PRs for same update
- [x] Code passes all tests
- [x] Code has been linted
- [ ] Accessibility tests completed
- [x] Code follows project style guide
- [x] Self-review completed
- [x] Comments added for complex code
- [x] No new warnings generated


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Theme-based templates and template parts now include parsed block trees in `content.blocks`.
  - Block data supports visual-editor formatting when available, with standard parsing as a fallback.
  - Raw theme markup remains available alongside parsed block content.

- **Bug Fixes**
  - Empty block data is no longer returned for theme-file templates and parts.
  - Parsing failures degrade gracefully while preserving template resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->