### PR TITLE
feat: add a GitHub Releases update source for plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Plugins can update from GitHub Releases** ([#277](https://github.com/ArtisanPack-UI/cms-framework/issues/277)) — a new optional `update` key in `plugin.json` declares where self-updates come from, and `Modules\Plugins\Managers\UpdateManager` resolves it through the same `UpdateCheckerFactory` / `UpdateSourceInterface` the application updater uses. `{"update": {"github": "owner/repo"}}` is shorthand for the GitHub Releases source; `{"update": {"url": "https://..."}}` is handed to the source detector as-is, so GitLab repositories and custom JSON endpoints fall out of the same key. Both forms are https-only. Publishing a plugin update is now `git tag` plus a GitHub Release, with no separately-hosted JSON feed. `UpdateCheckerFactory` already accepted `UpdateType::Plugin` and already resolved a plugin's installed version out of the `plugins` table — nothing had ever called it with that type.
+- **`cms.plugins.updateTokens`** — access tokens for plugins whose `update` source is a private repository, keyed by plugin slug. Deliberately per-slug rather than one global token: a plugin names its own update host in its own manifest, so a shared token would be handed to whatever host any installed plugin asks for. Public repositories need no entry.
+- **`PluginUpdateException::updateFailed()`** — carries a reason string, so an integrity failure surfaces as what it is instead of being collapsed into `downloadFailed()`'s "Failed to download update for plugin".
+
 ### Changed
+
+- **Source-backed plugin updates stream to disk and are checksum-verified** ([#277](https://github.com/ArtisanPack-UI/cms-framework/issues/277)) — a plugin using the new `update` key downloads through its update source, which streams the archive via `StreamsDownloadsToDisk` rather than buffering the whole ZIP in memory (the OOM shape fixed for the core updater in #214 / #216 / #219) and enforces https across the initial request and every redirect. The archive is then verified against the SHA-256 the release advertises — a `{asset}.zip.sha256` sidecar, or a `SHA-256:` line in the release body — honoring `cms.updates.verify_checksum` and `cms.updates.allow_unverified_updates` exactly as `ApplicationUpdateManager` does. With the shipped defaults a release publishing neither is refused; see #271 for the publishing-side workflow change that attaches the sidecar.
+- **Plugin update checks normalize on `UpdateInfo` internally**, which is what makes `sha256` reachable at all. The payload at `GET /api/v1/plugins/updates` is unchanged: source-backed results are flattened onto the same `version` / `download_url` keys the endpoint has always returned, with `sha256`, `changelog`, `release_date`, `file_size` and `metadata` added alongside. Plugins declaring only the legacy `update_url` keep the existing custom-JSON behavior verbatim — raw feed payload as the response body, no checksum enforcement.
+- **`UpdateChecker` no longer evicts plugin and theme cache entries using `app.version`** — the staleness heuristic added in 2.5.3 compares a cached `currentVersion` against the host application's version, which for a plugin is a different number by construction. Every plugin cache entry was therefore stale on its first read, so the cache was written and never served. The heuristic now applies only to `UpdateType::Application`.
 
 ### Deprecated
 
 ### Removed
 
+### Security
+
+- **Plugin update sources are re-checked for https at the point of use**, not only during install-time manifest validation. `UpdateManager::updatePlugin()` refreshes a plugin's `meta` straight from the manifest inside the downloaded ZIP and never re-runs `PluginManager::validateManifest()`, so an update can seat an `update` value that never passed validation. A plaintext source is not cosmetic there: `CustomJsonUpdateSource` would fetch the update metadata over http, and a network attacker rewriting that response chooses both the download URL *and* the `sha256` it is checked against — digest and archive come from the same document, so verification would confirm the attacker's own archive, which is then extracted into `plugins/` and executed as PHP. A non-https source is now ignored with a warning instead of being fetched.
+
 ### Fixed
+
+- **A plugin update that fails while taking its backup no longer trips an undefined-variable error** — `updatePlugin()` referenced `$backupPath` from its `catch` blocks, but the variable is assigned by the first statement of the `try`. When `backupPlugin()` itself threw, the recovery path died on the undefined variable instead of reporting the backup failure. `restoreFromBackup()` now takes a nullable path and returns early when there is no backup to restore from, rather than deleting a working install it has nothing to replace.
 
 ## [2.7.2] - 2026-08-02
 

--- a/docs/plugin-authoring.md
+++ b/docs/plugin-authoring.md
@@ -93,6 +93,8 @@ A plugin's root directory MUST contain a `plugin.json` file:
 | `migrations`        | string ( path ) | Relative path to your migrations directory. Auto-run on activate. |
 | `federated_modules` | array           | See [Federated React modules](#federated-react-modules). |
 | `nav`               | array           | Static nav entries; equivalent to calling `registerNavEntry()` from your provider. |
+| `update`            | object          | Where self-updates come from. See [Shipping updates](#shipping-updates). |
+| `update_url`        | string ( URL )  | Legacy custom JSON update feed. Superseded by `update`; still honored. |
 
 ## Base `PluginServiceProvider`
 
@@ -319,6 +321,74 @@ Semver your plugin. Declare host-compatibility in `plugin.json`:
 
 `PluginManager::install()` refuses installation when the running framework
 version does not satisfy the `cms-framework` constraint.
+
+## Shipping updates
+
+Declare an update source in `plugin.json` and publishing a new version is
+`git tag` plus a GitHub Release — no hosted JSON feed, no manual ZIP upload:
+
+```json
+"update": {
+    "github": "ArtisanPack-UI/artisanpack-ui-plugin"
+}
+```
+
+`update` accepts either form:
+
+| Key      | Value | Notes |
+| -------- | ----- | ----- |
+| `github` | `owner/repo`, or a full `https://github.com/owner/repo` URL | Shorthand for the GitHub Releases source. |
+| `url`    | Absolute `https://` URL | Handed to the source detector as-is, so GitLab repository URLs and custom JSON endpoints work through the same key. |
+
+Both forms are https-only: the resolved archive is extracted into your
+`plugins/` directory and its PHP is executed by the host.
+
+`UpdateManager` walks your releases, skips prereleases, and picks the first
+release asset ending in `.zip` — falling back to GitHub's generated
+`zipball_url` when the release has no attached asset. **Attach a real ZIP.**
+The generated zipball's root directory is named for the repository and commit,
+not for your plugin slug, so extraction lands the plugin in the wrong
+directory.
+
+### Checksums
+
+The updater verifies the downloaded archive against a SHA-256 digest, resolved
+from either:
+
+- a release asset named `{your-asset}.zip.sha256`, or
+- a `SHA-256: <64 hex chars>` line in the release description.
+
+With the shipped defaults ( `cms.updates.verify_checksum = true`,
+`cms.updates.allow_unverified_updates = false` ) a release that publishes
+**neither** is refused. Add a sidecar step to your release workflow:
+
+```bash
+sha256sum my-plugin.zip | cut -d' ' -f1 > my-plugin.zip.sha256
+```
+
+This is an integrity check, not an authenticity check — the digest comes from
+the same release as the archive. It catches truncation and CDN corruption; it
+does not defend against a compromised release-editor account.
+
+Legacy `update_url` feeds are unaffected by this: they have never advertised a
+digest, and checksum enforcement does not apply to them.
+
+### Private repositories
+
+Public repositories need no credentials. For a private one, the host adds a
+token keyed by your plugin slug:
+
+```php
+// config/cms.php
+'plugins' => [
+    'updateTokens' => [
+        'my-private-plugin' => env( 'MY_PRIVATE_PLUGIN_UPDATE_TOKEN' ),
+    ],
+],
+```
+
+Tokens live in host config, never in `plugin.json` — the manifest ships inside
+the distributed ZIP.
 
 ## Testing your plugin
 

--- a/docs/plugin-authoring.md
+++ b/docs/plugin-authoring.md
@@ -324,7 +324,7 @@ version does not satisfy the `cms-framework` constraint.
 
 ## Shipping updates
 
-Declare an update source in `plugin.json` and publishing a new version is
+Declare an update source in `plugin.json`. Publishing a new version is then
 `git tag` plus a GitHub Release — no hosted JSON feed, no manual ZIP upload:
 
 ```json

--- a/src/Modules/Core/Updates/UpdateChecker.php
+++ b/src/Modules/Core/Updates/UpdateChecker.php
@@ -245,6 +245,16 @@ class UpdateChecker
      */
     protected function cacheIsStale( UpdateInfo $cached ): bool
     {
+        // `app.version` describes the host application, not a plugin or theme.
+        // Comparing a plugin's cached `currentVersion` ( its own semver ) against
+        // it marks every plugin entry stale on the first read, so the cache is
+        // written and never read back. Plugin and theme callers re-read the
+        // installed version from their own store on every check and own their
+        // own freshness window.
+        if ( UpdateType::Application !== $this->type ) {
+            return false;
+        }
+
         $configured = config( 'app.version' );
 
         if ( ! is_string( $configured ) || '' === $configured ) {

--- a/src/Modules/Plugins/Exceptions/PluginUpdateException.php
+++ b/src/Modules/Plugins/Exceptions/PluginUpdateException.php
@@ -17,4 +17,14 @@ class PluginUpdateException extends CMSFrameworkException
     {
         return new self( "Failed to create backup for plugin '{$slug}'." );
     }
+
+    /**
+     * An update failed for a reason worth surfacing verbatim — a checksum
+     * mismatch, or an archive whose source published no digest to verify
+     * against.
+     */
+    public static function updateFailed( string $slug, string $reason ): self
+    {
+        return new self( "Failed to update plugin '{$slug}': {$reason}" );
+    }
 }

--- a/src/Modules/Plugins/Exceptions/PluginUpdateException.php
+++ b/src/Modules/Plugins/Exceptions/PluginUpdateException.php
@@ -8,11 +8,19 @@ use ArtisanPackUI\CMSFramework\Exceptions\CMSFrameworkException;
 
 class PluginUpdateException extends CMSFrameworkException
 {
+    /**
+     * The update archive could not be retrieved, or the update failed for a
+     * reason with no more specific factory.
+     */
     public static function downloadFailed( string $slug ): self
     {
         return new self( "Failed to download update for plugin '{$slug}'." );
     }
 
+    /**
+     * The pre-update backup could not be written, so the update was not
+     * attempted.
+     */
     public static function backupFailed( string $slug ): self
     {
         return new self( "Failed to create backup for plugin '{$slug}'." );

--- a/src/Modules/Plugins/Managers/PluginManager.php
+++ b/src/Modules/Plugins/Managers/PluginManager.php
@@ -27,6 +27,10 @@ class PluginManager
 
     private ClassLoader $classLoader;
 
+    /**
+     * Resolve Composer's runtime ClassLoader so discovered plugins can register
+     * their own PSR-4 prefixes.
+     */
     public function __construct()
     {
         // Get Composer's ClassLoader instance from registered autoloaders
@@ -616,9 +620,7 @@ class PluginManager
         }
 
         if ( null !== $github ) {
-            $isShorthand = is_string( $github ) && 1 === preg_match( '#^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$#', $github );
-
-            if ( ! $isShorthand && ! $this->isAbsoluteHttpsUrl( $github ) ) {
+            if ( ! $this->isRepositoryShorthand( $github ) && ! $this->isAbsoluteHttpsUrl( $github ) ) {
                 throw PluginValidationException::invalidManifest( 'Invalid update.github. Must be "owner/repo" or an absolute https repository URL.' );
             }
         }
@@ -626,6 +628,32 @@ class PluginManager
         if ( null !== $url && ! $this->isAbsoluteHttpsUrl( $url ) ) {
             throw PluginValidationException::invalidManifest( 'Invalid update.url. Must be an absolute https URL.' );
         }
+    }
+
+    /**
+     * Whether a manifest value is an `owner/repo` repository shorthand.
+     *
+     * Both segments must carry at least one non-dot character. The character
+     * class alone accepts `../..`, `./x` and `x/.`, and
+     * `UpdateManager::resolveUpdateSourceUrl()` interpolates the shorthand into
+     * a URL that `GitHubUpdateSource::parseUrl()` then splits back into the
+     * owner and repository of an api.github.com path — so a dot-only segment
+     * becomes a relative path segment in the API request. The host stays
+     * github.com either way, so this is not a redirection primitive; it is an
+     * input that reaches a URL builder as something other than a repository
+     * name, which is worth refusing outright rather than reasoning about.
+     *
+     * @param  mixed  $value  Value to test.
+     *
+     * @return bool True when the value is a usable owner/repo pair.
+     */
+    protected function isRepositoryShorthand( mixed $value ): bool
+    {
+        if ( ! is_string( $value ) || 1 !== preg_match( '#^([A-Za-z0-9_.-]+)/([A-Za-z0-9_.-]+)$#', $value, $matches ) ) {
+            return false;
+        }
+
+        return '' !== trim( $matches[1], '.' ) && '' !== trim( $matches[2], '.' );
     }
 
     /**

--- a/src/Modules/Plugins/Managers/PluginManager.php
+++ b/src/Modules/Plugins/Managers/PluginManager.php
@@ -584,6 +584,62 @@ class PluginManager
                 throw PluginValidationException::invalidManifest( 'Invalid migrations_path. Must be a relative path inside the plugin directory (no "..", no absolute paths).' );
             }
         }
+
+        if ( isset( $manifest['update'] ) ) {
+            $this->validateUpdateSourceManifestField( $manifest['update'] );
+        }
+    }
+
+    /**
+     * Validate the optional `update` manifest key, which declares the source
+     * `UpdateManager` resolves plugin updates from.
+     *
+     * Both forms are transport-restricted to https: the resolved URL is handed
+     * to an update source that downloads an archive whose PHP the host then
+     * executes.
+     *
+     * @param  mixed  $update  Raw `update` value from the manifest.
+     *
+     * @throws PluginValidationException If the key is malformed.
+     */
+    protected function validateUpdateSourceManifestField( mixed $update ): void
+    {
+        if ( ! is_array( $update ) || array_is_list( $update ) ) {
+            throw PluginValidationException::invalidManifest( 'Invalid update. Must be an object with a "github" or "url" key.' );
+        }
+
+        $github = $update['github'] ?? null;
+        $url    = $update['url'] ?? null;
+
+        if ( null === $github && null === $url ) {
+            throw PluginValidationException::invalidManifest( 'Invalid update. Must declare "github" ("owner/repo") or "url" (absolute https URL).' );
+        }
+
+        if ( null !== $github ) {
+            $isShorthand = is_string( $github ) && 1 === preg_match( '#^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$#', $github );
+
+            if ( ! $isShorthand && ! $this->isAbsoluteHttpsUrl( $github ) ) {
+                throw PluginValidationException::invalidManifest( 'Invalid update.github. Must be "owner/repo" or an absolute https repository URL.' );
+            }
+        }
+
+        if ( null !== $url && ! $this->isAbsoluteHttpsUrl( $url ) ) {
+            throw PluginValidationException::invalidManifest( 'Invalid update.url. Must be an absolute https URL.' );
+        }
+    }
+
+    /**
+     * Whether a manifest value is a well-formed absolute https URL.
+     *
+     * @param  mixed  $value  Value to test.
+     *
+     * @return bool True when the value is an https URL.
+     */
+    protected function isAbsoluteHttpsUrl( mixed $value ): bool
+    {
+        return is_string( $value )
+            && str_starts_with( $value, 'https://' )
+            && false !== filter_var( $value, FILTER_VALIDATE_URL );
     }
 
     /**

--- a/src/Modules/Plugins/Managers/UpdateManager.php
+++ b/src/Modules/Plugins/Managers/UpdateManager.php
@@ -21,6 +21,9 @@ use ZipArchive;
 
 class UpdateManager
 {
+    /**
+     * @param  PluginManager  $pluginManager  Used to deactivate and reactivate a plugin around an update.
+     */
     public function __construct(
         private PluginManager $pluginManager,
     ) {

--- a/src/Modules/Plugins/Managers/UpdateManager.php
+++ b/src/Modules/Plugins/Managers/UpdateManager.php
@@ -4,6 +4,11 @@ declare( strict_types=1 );
 
 namespace ArtisanPackUI\CMSFramework\Modules\Plugins\Managers;
 
+use ArtisanPackUI\CMSFramework\Modules\Core\Updates\Enums\UpdateType;
+use ArtisanPackUI\CMSFramework\Modules\Core\Updates\Exceptions\UpdateException;
+use ArtisanPackUI\CMSFramework\Modules\Core\Updates\UpdateChecker;
+use ArtisanPackUI\CMSFramework\Modules\Core\Updates\UpdateCheckerFactory;
+use ArtisanPackUI\CMSFramework\Modules\Core\Updates\ValueObjects\UpdateInfo;
 use ArtisanPackUI\CMSFramework\Modules\Plugins\Exceptions\IncompatiblePluginException;
 use ArtisanPackUI\CMSFramework\Modules\Plugins\Exceptions\PluginUpdateException;
 use ArtisanPackUI\CMSFramework\Modules\Plugins\Models\Plugin;
@@ -11,6 +16,7 @@ use Exception;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Http;
+use Throwable;
 use ZipArchive;
 
 class UpdateManager
@@ -44,6 +50,19 @@ class UpdateManager
     /**
      * Check update for specific plugin.
      *
+     * Two resolution paths, in priority order:
+     *
+     * 1. The manifest declares an `update` object — the check runs through
+     *    `UpdateCheckerFactory`, so a plugin published on GitHub or GitLab
+     *    Releases needs no hosted JSON feed and gets checksum metadata for
+     *    free.
+     * 2. The manifest declares only the legacy `update_url` — the original
+     *    custom-JSON behavior, unchanged.
+     *
+     * The return shape stays an array keyed `version` / `download_url` in both
+     * cases so `GET /api/v1/plugins/updates` is unaffected; source-backed
+     * checks add `sha256` and friends alongside those keys.
+     *
      * @param  string  $slug  Plugin slug
      *
      * @return array|null Update info or null if no update available
@@ -52,26 +71,23 @@ class UpdateManager
     {
         $plugin = Plugin::where( 'slug', sanitizeText( $slug ) )->first();
 
-        if ( ! $plugin || ! isset( $plugin->meta['update_url'] ) ) {
+        if ( ! $plugin ) {
+            return null;
+        }
+
+        $sourceUrl = $this->resolveUpdateSourceUrl( $plugin );
+
+        if ( null === $sourceUrl && ! isset( $plugin->meta['update_url'] ) ) {
             return null;
         }
 
         $cacheKey = "plugin.update.{$slug}";
 
-        return Cache::remember( $cacheKey, config( 'cms.plugins.updateCacheTtl' ), function () use ( $plugin ) {
+        return Cache::remember( $cacheKey, config( 'cms.plugins.updateCacheTtl' ), function () use ( $plugin, $sourceUrl ) {
             try {
-                $response = Http::timeout( config( 'cms.plugins.updateCheckTimeout' ) )
-                    ->get( $plugin->meta['update_url'] );
-
-                if ( ! $response->successful() ) {
-                    return null;
-                }
-
-                $updateData = $response->json();
-
-                if ( $this->isUpdateAvailable( $plugin->version, $updateData['version'] ?? '' ) ) {
-                    return $updateData;
-                }
+                return null !== $sourceUrl
+                    ? $this->checkViaUpdateSource( $plugin )
+                    : $this->checkViaCustomFeed( $plugin );
             } catch ( Exception $e ) {
                 logger()->error( "Failed to check update for plugin: {$plugin->slug}", [
                     'exception' => $e->getMessage(),
@@ -80,6 +96,56 @@ class UpdateManager
 
             return null;
         } );
+    }
+
+    /**
+     * Resolve the update-source URL declared by a plugin manifest's `update` key.
+     *
+     * Accepts either `{"update": {"github": "owner/repo"}}` — normalized to a
+     * github.com URL — or `{"update": {"url": "https://..."}}`, which is handed
+     * to `UpdateCheckerFactory` verbatim so the GitLab and custom-JSON sources
+     * fall out of the same key.
+     *
+     * The https requirement is re-checked here rather than trusted from
+     * install-time validation. `updatePlugin()` refreshes `meta` straight from
+     * the manifest inside the downloaded ZIP without re-running
+     * `PluginManager::validateManifest()`, so an update can seat a value that
+     * never passed validation. A plaintext source is not a cosmetic problem:
+     * `CustomJsonUpdateSource` would fetch the update metadata over http, and
+     * a network attacker rewriting that response chooses both the download URL
+     * and the `sha256` it is checked against — the digest and the archive come
+     * from the same document, so verification would confirm the attacker's own
+     * archive. Refusing the source is the only safe reading.
+     *
+     * @param  Plugin  $plugin  Plugin whose manifest to read.
+     *
+     * @return string|null Absolute https URL, or null when the manifest declares no usable source.
+     */
+    public function resolveUpdateSourceUrl( Plugin $plugin ): ?string
+    {
+        $update = $plugin->meta['update'] ?? null;
+
+        if ( ! is_array( $update ) ) {
+            return null;
+        }
+
+        $url = $this->nonEmptyString( $update['url'] ?? null );
+
+        if ( null !== $url ) {
+            return $this->rejectInsecureSource( $url, $plugin->slug );
+        }
+
+        $github = $this->nonEmptyString( $update['github'] ?? null );
+
+        if ( null === $github ) {
+            return null;
+        }
+
+        if ( str_contains( $github, '://' ) ) {
+            return $this->rejectInsecureSource( $github, $plugin->slug );
+        }
+
+        return 'https://github.com/' . ltrim( $github, '/' );
     }
 
     /**
@@ -109,6 +175,7 @@ class UpdateManager
         $oldVersion             = $plugin->version;
         $oldMeta                = $plugin->meta;
         $oldServiceProvider     = $plugin->service_provider;
+        $backupPath             = null;
 
         doAction( 'ap.cmsFramework.plugin.updating', $slug, $oldVersion, $updateInfo['version'] );
 
@@ -122,7 +189,7 @@ class UpdateManager
             }
 
             // 3. Download new version
-            $zipPath = $this->downloadUpdate( $updateInfo['download_url'] );
+            $zipPath = $this->downloadUpdateArchive( $plugin, $updateInfo );
 
             // 4. Delete old files
             $pluginPath = base_path( config( 'cms.plugins.directory' ) . '/' . $slug );
@@ -163,6 +230,15 @@ class UpdateManager
             $this->revertPluginRow( $plugin, $oldVersion, $oldMeta, $oldServiceProvider );
 
             throw $e;
+        } catch ( UpdateException $e ) {
+            // A checksum mismatch or an unverifiable archive is not a download
+            // failure, and collapsing it into `downloadFailed()` hides the one
+            // detail an operator needs to tell a corrupted mirror apart from a
+            // release that shipped without a `.sha256` sidecar.
+            $this->restoreFromBackup( $slug, $backupPath );
+            $this->revertPluginRow( $plugin, $oldVersion, $oldMeta, $oldServiceProvider );
+
+            throw PluginUpdateException::updateFailed( $slug, $e->getMessage() );
         } catch ( Exception $e ) {
             // Restore from backup on failure
             $this->restoreFromBackup( $slug, $backupPath );
@@ -170,6 +246,176 @@ class UpdateManager
 
             throw PluginUpdateException::downloadFailed( $slug );
         }
+    }
+
+    /**
+     * Pass an update-source URL through only when it is https.
+     *
+     * @param  string  $url  Declared source URL.
+     * @param  string  $slug  Plugin slug, for the log line.
+     *
+     * @return string|null The URL, or null when it is not https.
+     */
+    protected function rejectInsecureSource( string $url, string $slug ): ?string
+    {
+        if ( str_starts_with( strtolower( $url ), 'https://' ) ) {
+            return $url;
+        }
+
+        logger()->warning( 'Ignoring plugin update source: update sources must use https.', [
+            'plugin' => $slug,
+            'url'    => $url,
+        ] );
+
+        return null;
+    }
+
+    /**
+     * Check for an update through the shared update-source abstraction.
+     *
+     * @param  Plugin  $plugin  Plugin to check.
+     *
+     * @return array|null Normalized update info, or null when already current.
+     */
+    protected function checkViaUpdateSource( Plugin $plugin ): ?array
+    {
+        $checker = $this->makeUpdateChecker( $plugin );
+
+        if ( null === $checker ) {
+            return null;
+        }
+
+        $updateInfo = $checker->checkForUpdate();
+
+        // Deliberately not `UpdateInfo::hasUpdate()`: that method resolves the
+        // installed version from `config('app.version')`, which describes the
+        // host application and not this plugin.
+        if ( ! $this->isUpdateAvailable( $plugin->version, $updateInfo->latestVersion ) ) {
+            return null;
+        }
+
+        return $this->serializeUpdateInfo( $updateInfo, $plugin->version );
+    }
+
+    /**
+     * Check for an update through the legacy custom JSON feed.
+     *
+     * @param  Plugin  $plugin  Plugin to check.
+     *
+     * @return array|null Raw feed payload, or null when already current.
+     */
+    protected function checkViaCustomFeed( Plugin $plugin ): ?array
+    {
+        $response = Http::timeout( config( 'cms.plugins.updateCheckTimeout' ) )
+            ->get( $plugin->meta['update_url'] );
+
+        if ( ! $response->successful() ) {
+            return null;
+        }
+
+        $updateData = $response->json();
+
+        if ( $this->isUpdateAvailable( $plugin->version, $updateData['version'] ?? '' ) ) {
+            return $updateData;
+        }
+
+        return null;
+    }
+
+    /**
+     * Build an update checker for a plugin's declared source.
+     *
+     * @param  Plugin  $plugin  Plugin to build a checker for.
+     *
+     * @return UpdateChecker|null Configured checker, or null when no source is declared.
+     */
+    protected function makeUpdateChecker( Plugin $plugin ): ?UpdateChecker
+    {
+        $sourceUrl = $this->resolveUpdateSourceUrl( $plugin );
+
+        if ( null === $sourceUrl ) {
+            return null;
+        }
+
+        $checker = UpdateCheckerFactory::buildUpdateChecker(
+            $sourceUrl,
+            UpdateType::Plugin,
+            $plugin->slug,
+            $plugin->version,
+        );
+
+        $token = $this->resolveUpdateToken( $plugin->slug );
+
+        if ( null !== $token ) {
+            $checker->setAuthentication( $token );
+        }
+
+        return $checker;
+    }
+
+    /**
+     * Resolve the access token for a plugin's private update source.
+     *
+     * Tokens are keyed by plugin slug in config rather than read from the
+     * manifest ( which ships inside the distributed ZIP ) and are deliberately
+     * not global: a single shared token would be sent to whatever host any
+     * installed plugin names in its manifest.
+     *
+     * @param  string  $slug  Plugin slug.
+     *
+     * @return string|null Token, or null when the source is public.
+     */
+    protected function resolveUpdateToken( string $slug ): ?string
+    {
+        $tokens = config( 'cms.plugins.updateTokens', [] );
+
+        if ( ! is_array( $tokens ) ) {
+            return null;
+        }
+
+        return $this->nonEmptyString( $tokens[ $slug ] ?? null );
+    }
+
+    /**
+     * Flatten an `UpdateInfo` onto the array shape the plugin update API has
+     * always returned, so normalizing internally does not change the payload at
+     * `GET /api/v1/plugins/updates`.
+     *
+     * @param  UpdateInfo  $updateInfo  Value object from the update source.
+     * @param  string  $currentVersion  Installed plugin version.
+     *
+     * @return array<string, mixed> Serialized update info.
+     */
+    protected function serializeUpdateInfo( UpdateInfo $updateInfo, string $currentVersion ): array
+    {
+        return [
+            'version'      => $updateInfo->latestVersion,
+            'download_url' => $updateInfo->downloadUrl,
+            'current'      => $currentVersion,
+            'changelog'    => $updateInfo->changelog,
+            'release_date' => $updateInfo->releaseDate,
+            'sha256'       => $updateInfo->sha256,
+            'file_size'    => $updateInfo->fileSize,
+            'metadata'     => $updateInfo->metadata,
+        ];
+    }
+
+    /**
+     * Narrow a mixed manifest/config value to a trimmed non-empty string.
+     *
+     * @param  mixed  $value  Value to narrow.
+     *
+     * @return string|null Trimmed string, or null when unusable.
+     */
+    protected function nonEmptyString( mixed $value ): ?string
+    {
+        if ( ! is_string( $value ) ) {
+            return null;
+        }
+
+        $trimmed = trim( $value );
+
+        return '' === $trimmed ? null : $trimmed;
     }
 
     /**
@@ -230,10 +476,17 @@ class UpdateManager
      * Restore plugin from backup on failure.
      *
      * @param  string  $slug  Plugin slug
-     * @param  string  $backupPath  Path to backup
+     * @param  string|null  $backupPath  Path to backup, or null when the backup step itself failed
      */
-    protected function restoreFromBackup( string $slug, string $backupPath ): void
+    protected function restoreFromBackup( string $slug, ?string $backupPath ): void
     {
+        // `backupPlugin()` runs inside the same try block that calls this, so a
+        // failure there leaves nothing to restore from. Deleting the plugin
+        // directory in that state would destroy a working install.
+        if ( null === $backupPath || ! File::exists( $backupPath ) ) {
+            return;
+        }
+
         $pluginPath = base_path( config( 'cms.plugins.directory' ) . '/' . $slug );
 
         // Delete failed update
@@ -246,6 +499,90 @@ class UpdateManager
         $zip->open( $backupPath );
         $zip->extractTo( $pluginPath );
         $zip->close();
+    }
+
+    /**
+     * Download the update archive for a plugin.
+     *
+     * Source-backed plugins download through the update source itself, which
+     * streams the archive to disk via `StreamsDownloadsToDisk` instead of
+     * buffering it in memory, enforces https on the download and every
+     * redirect, and gives us a digest to verify against. Legacy `update_url`
+     * plugins keep the original buffered `Http::get()` path.
+     *
+     * @param  Plugin  $plugin  Plugin being updated.
+     * @param  array  $updateInfo  Update info from `checkPluginUpdate()`.
+     *
+     * @throws UpdateException When integrity verification fails or is impossible.
+     *
+     * @return string Path to downloaded file
+     */
+    protected function downloadUpdateArchive( Plugin $plugin, array $updateInfo ): string
+    {
+        $checker = $this->makeUpdateChecker( $plugin );
+
+        if ( null === $checker ) {
+            return $this->downloadUpdate( $updateInfo['download_url'] );
+        }
+
+        $version = (string) $updateInfo['version'];
+        $zipPath = $checker->downloadUpdate( $version );
+
+        try {
+            $this->verifyArchiveChecksum( $zipPath, $updateInfo['sha256'] ?? null, $version );
+        } catch ( Throwable $e ) {
+            // The rejected archive is ours to clean up; nothing downstream will
+            // ever see this path again.
+            File::delete( $zipPath );
+
+            throw $e;
+        }
+
+        return $zipPath;
+    }
+
+    /**
+     * Verify a downloaded archive against the digest its source advertised.
+     *
+     * Mirrors `ApplicationUpdateManager::maybeVerifyChecksum()`: honors
+     * `cms.updates.verify_checksum` and fails closed when no digest is
+     * published unless `cms.updates.allow_unverified_updates` is set.
+     *
+     * Only source-backed updates reach this. Legacy `update_url` feeds have
+     * never advertised a digest, so enforcing it there would break every
+     * existing custom-feed plugin.
+     *
+     * @param  string  $zipPath  Path to the downloaded archive.
+     * @param  mixed  $expectedHash  Digest advertised by the source, if any.
+     * @param  string  $version  Version being installed.
+     *
+     * @throws UpdateException On mismatch, or when no digest is available and unverified updates are disallowed.
+     */
+    protected function verifyArchiveChecksum( string $zipPath, mixed $expectedHash, string $version ): void
+    {
+        if ( ! config( 'cms.updates.verify_checksum', true ) ) {
+            return;
+        }
+
+        $expected = $this->nonEmptyString( $expectedHash );
+
+        if ( null !== $expected ) {
+            $actual = (string) hash_file( 'sha256', $zipPath );
+
+            if ( ! hash_equals( strtolower( $expected ), $actual ) ) {
+                throw UpdateException::checksumMismatch( $expected, $actual );
+            }
+
+            return;
+        }
+
+        if ( ! config( 'cms.updates.allow_unverified_updates', false ) ) {
+            throw UpdateException::checksumRequired( $version );
+        }
+
+        logger()->warning( 'Skipping plugin update integrity verification: update source did not advertise a SHA-256 checksum.', [
+            'version' => $version,
+        ] );
     }
 
     /**

--- a/src/Modules/Plugins/config/plugins.php
+++ b/src/Modules/Plugins/config/plugins.php
@@ -55,6 +55,24 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Plugin Update Source Tokens
+    |--------------------------------------------------------------------------
+    | Access tokens for plugins whose `update` manifest key points at a private
+    | repository, keyed by plugin slug:
+    |
+    |     'updateTokens' => [
+    |         'my-private-plugin' => env( 'MY_PRIVATE_PLUGIN_UPDATE_TOKEN' ),
+    |     ],
+    |
+    | Deliberately per-slug rather than one global token. A plugin names its own
+    | update host in its own manifest, so a shared token would be handed to
+    | whatever host any installed plugin asks for. Public repositories — the
+    | normal case — need no entry here.
+    */
+    'updateTokens' => [],
+
+    /*
+    |--------------------------------------------------------------------------
     | Auto-clear Framework Caches on Lifecycle Events
     |--------------------------------------------------------------------------
     | If true, activate/deactivate/delete will run route:clear, config:clear

--- a/tests/Unit/Plugins/ManifestSchemaExtensionTest.php
+++ b/tests/Unit/Plugins/ManifestSchemaExtensionTest.php
@@ -143,6 +143,70 @@ describe( 'migrations_path', function (): void {
     } );
 } );
 
+describe( 'update', function (): void {
+    it( 'accepts an owner/repo shorthand', function (): void {
+        $manifest = array_merge( $this->base, [
+            'update' => ['github' => 'ArtisanPack-UI/artisanpack-ui-plugin'],
+        ] );
+
+        expect( fn () => invokeMethod( $this->manager, 'validateManifest', [$manifest] ) )
+            ->not->toThrow( PluginValidationException::class );
+    } );
+
+    it( 'accepts a full github repository URL', function (): void {
+        $manifest = array_merge( $this->base, [
+            'update' => ['github' => 'https://github.com/ArtisanPack-UI/artisanpack-ui-plugin'],
+        ] );
+
+        expect( fn () => invokeMethod( $this->manager, 'validateManifest', [$manifest] ) )
+            ->not->toThrow( PluginValidationException::class );
+    } );
+
+    it( 'accepts a non-github url so other sources fall out of the same key', function (): void {
+        $manifest = array_merge( $this->base, [
+            'update' => ['url' => 'https://gitlab.com/owner/repo'],
+        ] );
+
+        expect( fn () => invokeMethod( $this->manager, 'validateManifest', [$manifest] ) )
+            ->not->toThrow( PluginValidationException::class );
+    } );
+
+    it( 'rejects a non-object value', function (): void {
+        $manifest = array_merge( $this->base, ['update' => 'ArtisanPack-UI/artisanpack-ui-plugin'] );
+
+        expect( fn () => invokeMethod( $this->manager, 'validateManifest', [$manifest] ) )
+            ->toThrow( PluginValidationException::class, 'Invalid update.' );
+    } );
+
+    it( 'rejects an object declaring neither github nor url', function (): void {
+        $manifest = array_merge( $this->base, ['update' => ['gitea' => 'owner/repo']] );
+
+        expect( fn () => invokeMethod( $this->manager, 'validateManifest', [$manifest] ) )
+            ->toThrow( PluginValidationException::class, 'Must declare' );
+    } );
+
+    it( 'rejects a malformed github shorthand', function (): void {
+        $manifest = array_merge( $this->base, ['update' => ['github' => 'not-a-repo']] );
+
+        expect( fn () => invokeMethod( $this->manager, 'validateManifest', [$manifest] ) )
+            ->toThrow( PluginValidationException::class, 'Invalid update.github' );
+    } );
+
+    it( 'rejects a plaintext http url', function (): void {
+        $manifest = array_merge( $this->base, ['update' => ['url' => 'http://example.com/updates.json']] );
+
+        expect( fn () => invokeMethod( $this->manager, 'validateManifest', [$manifest] ) )
+            ->toThrow( PluginValidationException::class, 'Invalid update.url' );
+    } );
+
+    it( 'rejects a plaintext http github url', function (): void {
+        $manifest = array_merge( $this->base, ['update' => ['github' => 'http://github.com/owner/repo']] );
+
+        expect( fn () => invokeMethod( $this->manager, 'validateManifest', [$manifest] ) )
+            ->toThrow( PluginValidationException::class, 'Invalid update.github' );
+    } );
+} );
+
 describe( 'Plugin model accessors', function (): void {
     it( 'exposes the new manifest fields ergonomically', function (): void {
         $plugin = new Plugin( [

--- a/tests/Unit/Plugins/ManifestSchemaExtensionTest.php
+++ b/tests/Unit/Plugins/ManifestSchemaExtensionTest.php
@@ -192,6 +192,25 @@ describe( 'update', function (): void {
             ->toThrow( PluginValidationException::class, 'Invalid update.github' );
     } );
 
+    it( 'rejects dot-only shorthand segments', function ( string $shorthand ): void {
+        $manifest = array_merge( $this->base, ['update' => ['github' => $shorthand]] );
+
+        expect( fn () => invokeMethod( $this->manager, 'validateManifest', [$manifest] ) )
+            ->toThrow( PluginValidationException::class, 'Invalid update.github' );
+    } )->with( [
+        'traversal pair'  => '../..',
+        'dot owner'       => './repo',
+        'dot repo'        => 'owner/.',
+        'single dot pair' => './.',
+    ] );
+
+    it( 'still accepts dots inside otherwise-valid segments', function (): void {
+        $manifest = array_merge( $this->base, ['update' => ['github' => 'ArtisanPack-UI/cms.framework']] );
+
+        expect( fn () => invokeMethod( $this->manager, 'validateManifest', [$manifest] ) )
+            ->not->toThrow( PluginValidationException::class );
+    } );
+
     it( 'rejects a plaintext http url', function (): void {
         $manifest = array_merge( $this->base, ['update' => ['url' => 'http://example.com/updates.json']] );
 

--- a/tests/Unit/Plugins/UpdateManagerTest.php
+++ b/tests/Unit/Plugins/UpdateManagerTest.php
@@ -2,6 +2,8 @@
 
 declare( strict_types=1 );
 
+use ArtisanPackUI\CMSFramework\Modules\Core\Updates\Exceptions\UpdateException;
+use ArtisanPackUI\CMSFramework\Modules\Core\Updates\Support\MetadataClient;
 use ArtisanPackUI\CMSFramework\Modules\Plugins\Managers\PluginManager;
 use ArtisanPackUI\CMSFramework\Modules\Plugins\Managers\UpdateManager;
 use ArtisanPackUI\CMSFramework\Modules\Plugins\Models\Plugin;
@@ -11,7 +13,34 @@ use Illuminate\Support\Facades\Http;
 beforeEach( function (): void {
     $this->pluginManager = app( PluginManager::class );
     $this->updateManager = new UpdateManager( $this->pluginManager );
+
+    // Release metadata is fetched through raw Guzzle in production; bridge it
+    // back onto the `Http::` facade so `Http::fake()` intercepts it here.
+    MetadataClient::useHttpFacadeBridge();
 } );
+
+afterEach( function (): void {
+    MetadataClient::reset();
+} );
+
+/**
+ * Build a minimal GitHub `/releases` payload.
+ */
+function githubReleasesResponse( string $tag, array $assets = [], ?string $body = null ): array
+{
+    return [
+        [
+            'id'           => 1,
+            'tag_name'     => $tag,
+            'prerelease'   => false,
+            'body'         => $body,
+            'published_at' => '2026-08-01T00:00:00Z',
+            'html_url'     => 'https://github.com/owner/repo/releases/tag/' . $tag,
+            'zipball_url'  => 'https://api.github.com/repos/owner/repo/zipball/' . $tag,
+            'assets'       => $assets,
+        ],
+    ];
+}
 
 describe( 'Update Checking', function (): void {
     it( 'checks for updates for all plugins', function (): void {
@@ -268,5 +297,347 @@ describe( 'Version Comparison', function (): void {
         $method->setAccessible( true );
 
         expect( $method->invoke( $updateManager, '1.0.0', '1.0.0' ) )->toBeFalse();
+    } );
+} );
+
+describe( 'Update Source Resolution', function (): void {
+    it( 'normalizes an owner/repo shorthand to a github URL', function (): void {
+        $plugin = new Plugin( [
+            'slug'    => 'test-plugin',
+            'name'    => 'Test Plugin',
+            'version' => '1.0.0',
+            'meta'    => ['update' => ['github' => 'ArtisanPack-UI/artisanpack-ui-plugin']],
+        ] );
+
+        expect( $this->updateManager->resolveUpdateSourceUrl( $plugin ) )
+            ->toBe( 'https://github.com/ArtisanPack-UI/artisanpack-ui-plugin' );
+    } );
+
+    it( 'passes a full URL through untouched so other sources can claim it', function (): void {
+        $plugin = new Plugin( [
+            'slug'    => 'test-plugin',
+            'name'    => 'Test Plugin',
+            'version' => '1.0.0',
+            'meta'    => ['update' => ['url' => 'https://gitlab.com/owner/repo']],
+        ] );
+
+        expect( $this->updateManager->resolveUpdateSourceUrl( $plugin ) )
+            ->toBe( 'https://gitlab.com/owner/repo' );
+    } );
+
+    it( 'prefers an explicit url over the github shorthand', function (): void {
+        $plugin = new Plugin( [
+            'slug'    => 'test-plugin',
+            'name'    => 'Test Plugin',
+            'version' => '1.0.0',
+            'meta'    => ['update' => [
+                'github' => 'owner/repo',
+                'url'    => 'https://gitlab.com/owner/repo',
+            ]],
+        ] );
+
+        expect( $this->updateManager->resolveUpdateSourceUrl( $plugin ) )
+            ->toBe( 'https://gitlab.com/owner/repo' );
+    } );
+
+    it( 'refuses a plaintext http source', function (): void {
+        $plugin = new Plugin( [
+            'slug'    => 'test-plugin',
+            'name'    => 'Test Plugin',
+            'version' => '1.0.0',
+            'meta'    => ['update' => ['url' => 'http://example.com/updates.json']],
+        ] );
+
+        expect( $this->updateManager->resolveUpdateSourceUrl( $plugin ) )->toBeNull();
+    } );
+
+    it( 'refuses a plaintext http github source', function (): void {
+        $plugin = new Plugin( [
+            'slug'    => 'test-plugin',
+            'name'    => 'Test Plugin',
+            'version' => '1.0.0',
+            'meta'    => ['update' => ['github' => 'http://github.com/owner/repo']],
+        ] );
+
+        expect( $this->updateManager->resolveUpdateSourceUrl( $plugin ) )->toBeNull();
+    } );
+
+    it( 'does not check for updates at all when the declared source is insecure', function (): void {
+        Plugin::create( [
+            'slug'    => 'test-plugin',
+            'name'    => 'Test Plugin',
+            'version' => '1.0.0',
+            'meta'    => ['update' => ['url' => 'http://example.com/updates.json']],
+        ] );
+
+        Http::fake();
+
+        expect( $this->updateManager->checkPluginUpdate( 'test-plugin' ) )->toBeNull();
+
+        Http::assertNothingSent();
+    } );
+
+    it( 'returns null for a manifest with no update key', function (): void {
+        $plugin = new Plugin( [
+            'slug'    => 'test-plugin',
+            'name'    => 'Test Plugin',
+            'version' => '1.0.0',
+            'meta'    => ['update_url' => 'https://example.com/updates/test-plugin'],
+        ] );
+
+        expect( $this->updateManager->resolveUpdateSourceUrl( $plugin ) )->toBeNull();
+    } );
+} );
+
+describe( 'GitHub Releases Update Source', function (): void {
+    it( 'reports an available update from a GitHub release', function (): void {
+        Plugin::create( [
+            'slug'    => 'test-plugin',
+            'name'    => 'Test Plugin',
+            'version' => '1.0.0',
+            'meta'    => ['update' => ['github' => 'owner/repo']],
+        ] );
+
+        Http::fake( [
+            'https://api.github.com/repos/owner/repo/releases' => Http::response(
+                githubReleasesResponse( 'v2.0.0', [
+                    [
+                        'name'                 => 'test-plugin.zip',
+                        'browser_download_url' => 'https://github.com/owner/repo/releases/download/v2.0.0/test-plugin.zip',
+                    ],
+                ] ),
+            ),
+        ] );
+
+        $updateInfo = $this->updateManager->checkPluginUpdate( 'test-plugin' );
+
+        expect( $updateInfo )->not->toBeNull()
+            ->and( $updateInfo['version'] )->toBe( '2.0.0' )
+            ->and( $updateInfo['download_url'] )
+            ->toBe( 'https://github.com/owner/repo/releases/download/v2.0.0/test-plugin.zip' )
+            ->and( $updateInfo['current'] )->toBe( '1.0.0' )
+            ->and( $updateInfo['metadata']['source'] )->toBe( 'github' );
+    } );
+
+    it( 'surfaces the sha256 published in the release body', function (): void {
+        $digest = str_repeat( 'a', 64 );
+
+        Plugin::create( [
+            'slug'    => 'test-plugin',
+            'name'    => 'Test Plugin',
+            'version' => '1.0.0',
+            'meta'    => ['update' => ['github' => 'owner/repo']],
+        ] );
+
+        Http::fake( [
+            'https://api.github.com/repos/owner/repo/releases' => Http::response(
+                githubReleasesResponse(
+                    'v2.0.0',
+                    [
+                        [
+                            'name'                 => 'test-plugin.zip',
+                            'browser_download_url' => 'https://github.com/owner/repo/releases/download/v2.0.0/test-plugin.zip',
+                        ],
+                    ],
+                    "Release notes\n\nSHA-256: {$digest}",
+                ),
+            ),
+        ] );
+
+        $updateInfo = $this->updateManager->checkPluginUpdate( 'test-plugin' );
+
+        expect( $updateInfo['sha256'] )->toBe( $digest );
+    } );
+
+    it( 'returns null when the latest release is not newer', function (): void {
+        Plugin::create( [
+            'slug'    => 'test-plugin',
+            'name'    => 'Test Plugin',
+            'version' => '2.0.0',
+            'meta'    => ['update' => ['github' => 'owner/repo']],
+        ] );
+
+        Http::fake( [
+            'https://api.github.com/repos/owner/repo/releases' => Http::response(
+                githubReleasesResponse( 'v2.0.0' ),
+            ),
+        ] );
+
+        expect( $this->updateManager->checkPluginUpdate( 'test-plugin' ) )->toBeNull();
+    } );
+
+    it( 'prefers the update key over a legacy update_url', function (): void {
+        Plugin::create( [
+            'slug'    => 'test-plugin',
+            'name'    => 'Test Plugin',
+            'version' => '1.0.0',
+            'meta'    => [
+                'update'     => ['github' => 'owner/repo'],
+                'update_url' => 'https://example.com/updates/test-plugin',
+            ],
+        ] );
+
+        Http::fake( [
+            'https://api.github.com/repos/owner/repo/releases' => Http::response(
+                githubReleasesResponse( 'v2.0.0' ),
+            ),
+            'https://example.com/updates/test-plugin' => Http::response( ['version' => '9.9.9'] ),
+        ] );
+
+        $updateInfo = $this->updateManager->checkPluginUpdate( 'test-plugin' );
+
+        expect( $updateInfo['version'] )->toBe( '2.0.0' );
+
+        Http::assertNotSent( fn ( $request ) => 'https://example.com/updates/test-plugin' === $request->url() );
+    } );
+
+    it( 'logs and returns null when the GitHub API fails', function (): void {
+        Plugin::create( [
+            'slug'    => 'test-plugin',
+            'name'    => 'Test Plugin',
+            'version' => '1.0.0',
+            'meta'    => ['update' => ['github' => 'owner/repo']],
+        ] );
+
+        Http::fake( [
+            'https://api.github.com/repos/owner/repo/releases' => Http::response( null, 404 ),
+        ] );
+
+        expect( $this->updateManager->checkPluginUpdate( 'test-plugin' ) )->toBeNull();
+    } );
+} );
+
+describe( 'Archive Integrity Verification', function (): void {
+    beforeEach( function (): void {
+        $this->archive = tempnam( sys_get_temp_dir(), 'plugin-update-' );
+        file_put_contents( $this->archive, 'archive-contents' );
+        $this->digest = hash_file( 'sha256', $this->archive );
+    } );
+
+    afterEach( function (): void {
+        if ( is_string( $this->archive ) && file_exists( $this->archive ) ) {
+            unlink( $this->archive );
+        }
+    } );
+
+    it( 'accepts an archive whose digest matches', function (): void {
+        expect( fn () => invokeMethod(
+            $this->updateManager,
+            'verifyArchiveChecksum',
+            [$this->archive, $this->digest, '2.0.0'],
+        ) )->not->toThrow( Exception::class );
+    } );
+
+    it( 'accepts an uppercase digest', function (): void {
+        expect( fn () => invokeMethod(
+            $this->updateManager,
+            'verifyArchiveChecksum',
+            [$this->archive, strtoupper( $this->digest ), '2.0.0'],
+        ) )->not->toThrow( Exception::class );
+    } );
+
+    it( 'rejects an archive whose digest does not match', function (): void {
+        expect( fn () => invokeMethod(
+            $this->updateManager,
+            'verifyArchiveChecksum',
+            [$this->archive, str_repeat( 'b', 64 ), '2.0.0'],
+        ) )->toThrow( UpdateException::class, 'Checksum mismatch' );
+    } );
+
+    it( 'fails closed when the source advertises no digest', function (): void {
+        config()->set( 'cms.updates.allow_unverified_updates', false );
+
+        expect( fn () => invokeMethod(
+            $this->updateManager,
+            'verifyArchiveChecksum',
+            [$this->archive, null, '2.0.0'],
+        ) )->toThrow( UpdateException::class, 'did not advertise a SHA-256 checksum' );
+    } );
+
+    it( 'proceeds without a digest once unverified updates are opted into', function (): void {
+        config()->set( 'cms.updates.allow_unverified_updates', true );
+
+        expect( fn () => invokeMethod(
+            $this->updateManager,
+            'verifyArchiveChecksum',
+            [$this->archive, null, '2.0.0'],
+        ) )->not->toThrow( Exception::class );
+    } );
+
+    it( 'skips verification entirely when it is disabled', function (): void {
+        config()->set( 'cms.updates.verify_checksum', false );
+
+        expect( fn () => invokeMethod(
+            $this->updateManager,
+            'verifyArchiveChecksum',
+            [$this->archive, str_repeat( 'b', 64 ), '2.0.0'],
+        ) )->not->toThrow( Exception::class );
+    } );
+} );
+
+describe( 'Update Archive Download', function (): void {
+    it( 'uses the legacy buffered download for update_url plugins', function (): void {
+        $plugin = new Plugin( [
+            'slug'    => 'test-plugin',
+            'name'    => 'Test Plugin',
+            'version' => '1.0.0',
+            'meta'    => ['update_url' => 'https://example.com/updates/test-plugin'],
+        ] );
+
+        Http::fake( [
+            'https://example.com/downloads/test-plugin.zip' => Http::response( 'fake-zip-content' ),
+        ] );
+
+        $path = invokeMethod( $this->updateManager, 'downloadUpdateArchive', [
+            $plugin,
+            [
+                'version'      => '2.0.0',
+                'download_url' => 'https://example.com/downloads/test-plugin.zip',
+            ],
+        ] );
+
+        expect( file_get_contents( $path ) )->toBe( 'fake-zip-content' );
+
+        unlink( $path );
+    } );
+
+    it( 'deletes the streamed archive when verification rejects it', function (): void {
+        config()->set( 'cms.updates.allow_unverified_updates', false );
+
+        $plugin = new Plugin( [
+            'slug'    => 'test-plugin',
+            'name'    => 'Test Plugin',
+            'version' => '1.0.0',
+            'meta'    => ['update' => ['github' => 'owner/repo']],
+        ] );
+
+        Http::fake( [
+            'https://api.github.com/repos/owner/repo/releases/tags/v2.0.0' => Http::response( [
+                'tag_name' => 'v2.0.0',
+                'body'     => null,
+                'assets'   => [
+                    [
+                        'name'                 => 'test-plugin.zip',
+                        'browser_download_url' => 'https://github.com/owner/repo/releases/download/v2.0.0/test-plugin.zip',
+                    ],
+                ],
+            ] ),
+            'https://github.com/owner/repo/releases/download/v2.0.0/test-plugin.zip' => Http::response( 'fake-zip-content' ),
+        ] );
+
+        $temporaryArchives = fn (): array => glob( storage_path( 'app/temp/update-*.zip' ) ) ?: [];
+
+        $before = $temporaryArchives();
+
+        expect( fn () => invokeMethod( $this->updateManager, 'downloadUpdateArchive', [
+            $plugin,
+            [
+                'version'      => '2.0.0',
+                'download_url' => 'https://github.com/owner/repo/releases/download/v2.0.0/test-plugin.zip',
+                'sha256'       => null,
+            ],
+        ] ) )->toThrow( UpdateException::class );
+
+        expect( $temporaryArchives() )->toBe( $before );
     } );
 } );

--- a/tests/Unit/Updates/UpdateCheckerTest.php
+++ b/tests/Unit/Updates/UpdateCheckerTest.php
@@ -197,6 +197,61 @@ class UpdateCheckerTest extends TestCase
     }
 
     /**
+     * A plugin's `currentVersion` is its own semver, not the host's, so the
+     * `app.version` staleness heuristic never matches and would evict every
+     * plugin cache entry on its first read — writing a cache that is never
+     * served. Non-application types keep their cache.
+     *
+     * @since 2.8.0
+     */
+    public function test_check_for_update_serves_cache_for_plugin_type_regardless_of_app_version(): void
+    {
+        config( ['app.version' => '2.8.0'] );
+
+        $cacheKey = 'cms.' . UpdateType::Plugin->value . '.test-plugin.update_check';
+
+        Cache::put( $cacheKey, $this->cachedPayload( '1.0.0', '1.1.0' ), 3600 );
+
+        $source = new class implements UpdateSourceInterface {
+            public int $checkCount = 0;
+
+            public function supports( string $url ): bool
+            {
+                return true;
+            }
+
+            public function checkForUpdate(): UpdateInfo
+            {
+                $this->checkCount++;
+
+                return new UpdateInfo( '0.0.0', '0.0.0', '' );
+            }
+
+            public function downloadUpdate( string $version ): string
+            {
+                return '/tmp/noop.zip';
+            }
+
+            public function setAuthentication( string|array $credentials ): void
+            {
+            }
+
+            public function getName(): string
+            {
+                return 'Fake';
+            }
+        };
+
+        $checker = new UpdateChecker( $source, UpdateType::Plugin, 'test-plugin' );
+
+        $result = $checker->checkForUpdate();
+
+        $this->assertSame( 0, $source->checkCount, 'A plugin cache entry must not be evicted by app.version.' );
+        $this->assertSame( '1.0.0', $result->currentVersion );
+        $this->assertSame( '1.1.0', $result->latestVersion );
+    }
+
+    /**
      * Define environment setup.
      *
      * @since 2.5.3


### PR DESCRIPTION
## Description

Plugins could only self-update from a hand-rolled JSON feed pointed at by `meta['update_url']`, so a plugin author publishing on GitHub — the normal case for this ecosystem — had to stand up and host a separate endpoint mirroring their releases, with no checksum story at all.

The machinery to do this properly already existed and was simply never wired up. `UpdateCheckerFactory::buildUpdateChecker()` already accepted `UpdateType::Plugin` and `detectCurrentVersion()` already resolved a plugin's installed version out of the `plugins` table — but `ApplicationUpdateManager` was its only caller. The contract, the source and the enum case were all there; Plugins just never got connected to them.

A new optional `update` key in `plugin.json` declares the source, and `UpdateManager::checkPluginUpdate()` resolves it through `UpdateCheckerFactory` / `UpdateSourceInterface`:

```json
{ "update": { "github": "ArtisanPack-UI/artisanpack-ui-plugin" } }
```

Publishing a plugin update is now `git tag` plus a GitHub Release, and nothing else.

**Closes:** #277

## Type of Change

- [ ] Bug fix (fixes an issue)
- [x] New feature (adds new functionality)
- [ ] Enhancement (improves existing functionality)
- [ ] Refactoring (code improvement, no behavior change)
- [ ] Documentation update
- [ ] Performance improvement
- [x] Security fix
- [ ] Breaking change (breaks backward compatibility)

## Related Issue

**Issue:** #277

## Motivation and Context

Phase 5 of the artisanpackui.dev repo-less transition. The success criterion for that work is that `ArtisanPack-UI/artisanpack-ui-plugin` self-updates on the production droplet from a GitHub Release with no repo checked out on the server. Secondarily, any third-party plugin author gets update delivery for free without hosting a JSON feed.

## Changes Made

- **`update` manifest key.** Accepts `{"github": "owner/repo"}` (normalized to a github.com URL) or `{"url": "https://..."}` (handed to `detectSource()` as-is, so `GitLabUpdateSource` and `CustomJsonUpdateSource` fall out of the same key for free). Validated in `PluginManager::validateOptionalManifestFields()` alongside the other v2.4 optional fields.
- **Resolution order** in `checkPluginUpdate()`: `meta['update']` → build a checker via `UpdateCheckerFactory::buildUpdateChecker( $url, UpdateType::Plugin, $slug )`; `meta['update_url']` with no `meta['update']` → existing custom-JSON behavior, unchanged; neither → no update source, as today.
- **Normalized on `UpdateInfo` internally**, which is what makes `sha256` reachable at all — then flattened back onto the existing `version` / `download_url` keys. See Backwards Compatibility below.
- **Checksum verification.** `verifyArchiveChecksum()` mirrors `ApplicationUpdateManager::maybeVerifyChecksum()`, honoring `cms.updates.verify_checksum` / `allow_unverified_updates`. A rejected archive is deleted rather than left in `storage/app/temp`.
- **Streamed download.** Source-backed updates reuse `GitHubUpdateSource::downloadUpdate()` (`StreamsDownloadsToDisk`) instead of `File::put( $tempPath, $response->body() )`, which fixes the OOM shape addressed for the core updater in #214 / #216 / #219 as a side effect, and enforces https on the download and every redirect.
- **Authentication.** `cms.plugins.updateTokens`, keyed by plugin slug. The issue left this open (config vs. manifest); manifest is wrong because it ships in the ZIP, so it is config. Deliberately per-slug rather than one global token — a plugin names its own update host in its own manifest, so a shared token would be handed to whatever host any installed plugin asks for.
- **`PluginUpdateException::updateFailed( $slug, $reason )`** so an integrity failure surfaces as what it is instead of being collapsed into `downloadFailed()`'s "Failed to download update for plugin".

### Found during the security pass

`updatePlugin()` sets `$plugin->meta = $manifest` straight from the manifest inside the downloaded ZIP and **never** re-runs `PluginManager::validateManifest()` — only `install()` validates. So install-time validation is not a durable guarantee for anything in `meta`.

The https requirement is therefore re-checked in `resolveUpdateSourceUrl()`, at the point of use. A plaintext source is not cosmetic there: `CustomJsonUpdateSource` would fetch the update metadata over http, and a network attacker rewriting that response chooses both the download URL *and* the `sha256` it is checked against — digest and archive come from the same document, so verification would confirm the attacker's own archive, which is then extracted into `plugins/` and executed as PHP. A non-https source is now ignored with a warning instead of being fetched.

> **Follow-up worth filing:** the same missing re-validation also means an update can seat a `migrations_path` that never passed the traversal check, or a `permissions` list that never passed the slug-prefix check. Both of those validations exist specifically to stop a manifest from reaching outside its own plugin. Out of scope here, but it is the same root cause.

### Two adjacent defects the wiring exposed

- **`UpdateChecker::cacheIsStale()`** compared a cached `currentVersion` against `config( 'app.version' )`. For a plugin that is a different number by construction, so every plugin cache entry was stale on its first read — the cache was written and never served. Not cosmetic: without it, every up-to-date plugin re-hits the GitHub API on each check, and unauthenticated GitHub is 60 requests/hour. The heuristic now applies only to `UpdateType::Application`.
- **`updatePlugin()`** referenced `$backupPath` from its `catch` blocks, but the variable is assigned by the first statement of the `try`. A failure inside `backupPlugin()` died on an undefined variable instead of reporting the backup failure. `restoreFromBackup()` now takes a nullable path and returns early rather than deleting an install it has nothing to replace.

## Backwards Compatibility

The issue flagged the response-shape question and preferred the compatible option. That is what this does.

- `update` is optional and `update_url` keeps working untouched — including its lack of checksum enforcement. Enforcing digests on legacy feeds would break every existing custom-feed plugin, since those feeds have never advertised one.
- `PluginsController::checkUpdates()` returns `UpdateManager::checkForUpdates()` verbatim, so `checkPluginUpdate()` still returns an array keyed `version` / `download_url`. Source-backed results add `current`, `changelog`, `release_date`, `sha256`, `file_size` and `metadata` alongside those keys. **`GET /api/v1/plugins/updates` is additive-only — not a breaking API change.**
- `UpdateInfo::hasUpdate()` and `toArray()` are deliberately not used for plugins: both resolve the installed version from `config( 'app.version' )`, which describes the host and not the plugin. Version comparison goes through the existing `isUpdateAvailable( $plugin->version, ... )`.

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS (Darwin 27.0.0)
- Browser (if applicable): n/a — API and manager-level change
- PHP Version: 8.4.23
- Project Version: 2.8 (branched from `release/2.8`)

**Tests Performed:**
1. Full suite: `composer test` — 1638 passed, 7 skipped (all pre-existing skips), 4120 assertions.
2. `./vendor/bin/php-cs-fixer fix --dry-run --diff` — 0 of 515 files need fixing.
3. Manual verification against a real GitHub repository with a published release: update appears at `GET /api/v1/plugins/updates` with the release version, asset URL and sidecar digest; `POST /api/v1/plugins/{slug}/update` installs it; a release with no digest is refused; a plugin still on `update_url` behaves as before.

## Accessibility Tests Run

- [ ] Keyboard navigation tested
- [ ] Screen reader tested
- [ ] Color contrast verified
- [ ] ARIA labels checked

**Details:** Not applicable — this PR touches no UI. The changes are confined to the Plugins update manager, manifest validation, config and the Core updater's cache-staleness check. There is no rendered output, no markup and no user-facing control in the diff.

## Tests Added

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] All tests passing

**Test details:**

`tests/Unit/Plugins/UpdateManagerTest.php` (+371) — source resolution (shorthand normalization, full-URL passthrough, `url` preferred over `github`, plaintext http refused for both forms, and that an insecure source sends no HTTP at all); GitHub Releases checks (available update, `sha256` from the release body, no update when not newer, `update` preferred over `update_url` with `Http::assertNotSent` on the legacy endpoint, API failure returns null); integrity verification (digest match, uppercase digest, mismatch, fail-closed with no digest, opt-in via `allow_unverified_updates`, skip when `verify_checksum` is off); download routing (legacy buffered path for `update_url` plugins, and that a rejected streamed archive is deleted rather than left behind).

Release metadata is fetched through raw Guzzle in production, so these bridge it back onto the `Http::` facade with `MetadataClient::useHttpFacadeBridge()` and reset in `afterEach`, matching `GitHubUpdateSourceTest`.

`tests/Unit/Plugins/ManifestSchemaExtensionTest.php` (+64) — a new `update` describe block covering both accepted forms plus every rejection: non-object, neither key present, malformed shorthand, and plaintext http for `url` and `github`.

`tests/Unit/Updates/UpdateCheckerTest.php` (+55) — regression proving a `UpdateType::Plugin` cache entry survives a mismatched `app.version`.

## Documentation

- [x] Inline code documentation added
- [ ] README updated
- [x] Wiki updated
- [ ] API documentation updated

**Documentation details:** `docs/plugin-authoring.md` gains a "Shipping updates" section covering both `update` forms, the checksum requirement with a copy-pasteable `sha256sum` release step, and the private-repository token config. `update` and `update_url` are added to the optional-fields table. The section explicitly warns authors to attach a real `.zip` asset — GitHub's generated `zipball_url` fallback has a root directory named for the repo and commit rather than the plugin slug, so extraction would land the plugin in the wrong directory.

`CHANGELOG.md` records the work under Added / Changed / Security / Fixed.

## Screenshots

Not applicable — no UI changes.

## Pre-Submission Checklist

- [x] Followed contributing guidelines
- [x] Checked for other open PRs for same update
- [x] Code passes all tests
- [x] Code has been linted
- [x] Accessibility tests completed
- [x] Code follows project style guide
- [x] Self-review completed
- [x] Comments added for complex code
- [x] No new warnings generated

### One note on linting

`composer cs` (PHPCS) fails on this branch — but it fails identically on `release/2.8`. PHPCS is red codebase-wide: the plugins and updates files alone carry 152 pre-existing errors before this diff. The additions here sit in the same cosmetic sniff categories as the surrounding code (array-item alignment, a line-length sniff that misreports line numbers and lengths, and a `TraitUseNotAtTop` false positive on a closure's `use`). `php-cs-fixer`, which per `CLAUDE.md` is the enforced formatter with PHPCS reserved for what the fixer cannot express, reports **0 of 515 files** needing fixes.

## Dependencies on other issues

- **#271** — release workflows must publish a `{asset}.zip.sha256` sidecar for checksum verification to have anything to verify. Theme and plugin repos need the same workflow step. Until that lands, a source-backed plugin release without a digest is refused under the shipped defaults, which is the intended fail-closed behavior.
- **#42** — plugin update tests with mock ZIP infrastructure. The two `->skip()`ed tests in `tests/Feature/Plugins/PluginUpdateTest.php` are still skipped for want of that harness; a full extract-and-activate round trip is not covered here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for plugin updates from GitHub releases and secure HTTPS sources.
  * Added optional per-plugin access tokens for private update repositories.
  * Added SHA-256 verification for downloaded plugin archives.
  * Preserved compatibility with legacy plugin update feeds.
* **Bug Fixes**
  * Improved recovery when creating an update backup fails.
  * Corrected plugin and theme update cache handling.
  * Update failures now provide clearer reasons.
* **Documentation**
  * Added plugin authoring guidance for update sources, releases, checksums, and security requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->