### PR TITLE
chore: reconcile phpcs.xml with PHP-CS-Fixer so composer lint passes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,6 @@ jobs:
         run: ./vendor/bin/php-cs-fixer fix --dry-run --diff
 
       - name: Run PHPCS
-        continue-on-error: true
         run: ./vendor/bin/phpcs src/ database/ tests/ config/
 
   test:

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -2,8 +2,14 @@
 <ruleset name="ArtisanPack UI CMS Framework">
     <description>PHP_CodeSniffer configuration for ArtisanPack UI CMS Framework</description>
 
-    <!-- Use the ArtisanPackUIStandard coding standard -->
-    <rule ref="ArtisanPackUIStandard"/>
+    <!--
+    NOTE: PHP-CS-Fixer is the authoritative formatter for this repo and handles
+    most formatting rules. PHPCS is used here only for the rules PHP-CS-Fixer
+    cannot express and that do not conflict with what the fixer emits. Enabling
+    the full ArtisanPackUIStandard here conflicts with the fixer (for example the
+    fixer emits `declare( strict_types=1 )` while the spacing sniffs demand
+    `declare( strict_types = 1 )`), which makes `composer lint` permanently red.
+    -->
 
     <!-- Files to check -->
     <file>src/</file>
@@ -13,24 +19,38 @@
 
     <!-- Exclude vendor directory -->
     <exclude-pattern>*/vendor/*</exclude-pattern>
-    
+
     <!-- Exclude compiled files and caches -->
     <exclude-pattern>*/storage/*</exclude-pattern>
     <exclude-pattern>*/bootstrap/cache/*</exclude-pattern>
-    
+
     <!-- Exclude node modules if present -->
     <exclude-pattern>*/node_modules/*</exclude-pattern>
-    
+
     <!-- Exclude specific Laravel files that may not follow standards -->
     <exclude-pattern>*/database/migrations/*</exclude-pattern>
-    
+
+    <!-- Exclude Blade templates - PHP-CS-Fixer is the authority for these -->
+    <exclude-pattern>*.blade.php</exclude-pattern>
+
+    <!-- Functions sniffs - catch disallowed functions (die, exit, var_dump, print_r) -->
+    <rule ref="ArtisanPackUIStandard.Functions.DisallowedFunctions"/>
+
+    <!-- PHP sniffs -->
+    <rule ref="ArtisanPackUIStandard.PHP.PhpTags"/>
+
+    <!-- Disable line length checks -->
+    <rule ref="Generic.Files.LineLength">
+        <severity>0</severity>
+    </rule>
+
     <!-- Show progress -->
     <arg name="colors"/>
     <arg value="p"/>
-    
+
     <!-- Run checks in parallel for faster execution -->
     <arg name="parallel" value="4"/>
-    
+
     <!-- Show sniff codes in all reports -->
     <arg value="s"/>
 </ruleset>


### PR DESCRIPTION
## Description

The full `ArtisanPackUIStandard` PHPCS ruleset conflicted with PHP-CS-Fixer — the authoritative formatter for this repo — most visibly on `declare( strict_types=1 )` (fixer) vs `declare( strict_types = 1 )` (PHPCS spacing sniffs). This left ~3,690 PHPCS violations across ~500 files and a permanently-red `composer lint`, where running either tool re-broke the other. Hand-fixing was not an option (it re-breaks the fixer).

This narrows `phpcs.xml` to the ecosystem-reference non-conflicting sniffs, matching the `forms`/`package-blueprint` reference config, so `composer lint` exits 0 and the lint signal becomes real again.

**Closes:** #263

## Type of Change

- [x] Enhancement (improves existing functionality)

## Related Issue

**Issue:** #263

## Motivation and Context

A permanently-red `composer lint` means a genuinely new violation is invisible — developer-experience and signal-quality problem. PHPCS was already non-blocking in CI (`continue-on-error: true`), so this was not a release gate, but the noise hid real regressions.

## Changes Made

- Narrow `phpcs.xml` from the full `ArtisanPackUIStandard` to only `ArtisanPackUIStandard.Functions.DisallowedFunctions` + `ArtisanPackUIStandard.PHP.PhpTags` (both non-conflicting, currently 0 violations), and disable `Generic.Files.LineLength` — mirroring the ecosystem reference config.
- Exclude `*.blade.php` from PHPCS to mirror PHP-CS-Fixer's `->notName('*.blade.php')` (removes spurious `Internal.NoCodeFound` warnings).
- Remove `continue-on-error: true` from the PHPCS CI step so the now-passing gate surfaces real regressions.

**Tradeoff (approved):** the formatting/alignment/array sniffs (redundant with the fixer) and the security/naming sniffs are no longer part of the automated gate. A full-standard audit remains available manually via `phpcs --standard=ArtisanPackUIStandard src/`.

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS
- PHP Version: 8.4.3
- Project Version: 2.8 (release/2.8)

**Tests Performed:**
1. `composer lint` → exits **0** (PHP-CS-Fixer: 0 of 533 files; PHPCS: no errors/warnings).
2. `phpcs -e --standard=phpcs.xml` → resolves exactly 3 sniffs, confirming no unknown-ref that would break the CI parse.

## Accessibility Tests Run

- [ ] Keyboard navigation tested
- [ ] Screen reader tested
- [ ] Color contrast verified
- [ ] ARIA labels checked

**Details:** N/A — CI/tooling configuration change only, no UI surface.

## Tests Added

- [x] All tests passing

**Test details:** No unit test applies to a lint-config change; the programmatic verification is `composer lint` exiting 0.

## Documentation

**Documentation details:** N/A — behavior of shipped code unchanged. Rationale captured in an inline comment at the top of `phpcs.xml`.

## Pre-Submission Checklist

- [x] Code passes all tests
- [x] Code has been linted
- [x] Code follows project style guide
- [x] Self-review completed
- [x] Comments added for complex code
- [x] No new warnings generated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Lint checks now fail when PHP coding-standard violations are detected, preventing invalid changes from passing CI.

* **Chores**
  * Updated coding-standard configuration to clarify formatting ownership and enforce additional PHP syntax and function rules.
  * Excluded Blade templates and disabled line-length checks where appropriate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->