### PR TITLE
fix: remove extraction-added files on update rollback

### DIFF
--- a/src/Modules/Core/Updates/Managers/ApplicationUpdateManager.php
+++ b/src/Modules/Core/Updates/Managers/ApplicationUpdateManager.php
@@ -89,6 +89,22 @@ class ApplicationUpdateManager
     protected ?string $backupPath = null;
 
     /**
+     * Relative paths, under `base_path()`, that the current extraction created
+     * and that did not exist beforehand.
+     *
+     * The backup can only restore files it captured, so a file the release
+     * *added* survives a snapshot restore untouched — leaving the tree a hybrid
+     * of the old version's files and an arbitrary subset of the new version's
+     * additions, migrations included. Recording exactly what extraction wrote
+     * lets rollback remove precisely those additions and nothing else.
+     *
+     * @since 2.8.0
+     *
+     * @var array<int, string>
+     */
+    protected array $extractionAdditions = [];
+
+    /**
      * Persisted step marker for the current update run.
      *
      * @since 2.7.1
@@ -646,6 +662,17 @@ class ApplicationUpdateManager
      */
     protected function runUpdateSteps( string $targetVersion, UpdateInfo $updateInfo ): bool
     {
+        // Clear the additions ledger at the very start of the run, not just in
+        // `extractUpdate()`. The manager is a singleton ( see
+        // `CoreServiceProvider` ), so on a long-lived queue worker one instance
+        // drives many runs. A run that succeeds leaves its additions in the
+        // ledger, and a *later* run that fails before ever reaching the Extract
+        // step would otherwise inherit them — and `removeExtractionAdditions()`
+        // would delete the previous, successful update's files during this
+        // run's rollback. Resetting here means a run that never extracts has an
+        // empty ledger and removes nothing.
+        $this->extractionAdditions = [];
+
         $this->state()->begin( $targetVersion, $updateInfo->resolveCurrentVersion() );
 
         try {
@@ -1244,6 +1271,11 @@ class ApplicationUpdateManager
         $extractPath  = base_path();
         $excludePaths = config( 'cms.updates.exclude_from_update', [] );
 
+        // Start each extraction with an empty ledger. A manager instance can
+        // drive more than one run, and rollback removes exactly what *this*
+        // extraction added — never a previous run's additions.
+        $this->extractionAdditions = [];
+
         // Detect common root prefix by scanning all entry names
         $commonPrefix = $this->detectCommonRootPrefix( $zip, $excludePaths );
 
@@ -1374,6 +1406,13 @@ class ApplicationUpdateManager
             // so fetching content by name meant that with duplicate entry
             // names the file written for occurrence 2 got occurrence 1's
             // content and occurrence 2's permissions.
+            // Whether this path already existed decides what rollback owes it.
+            // An overwrite is restored from the backup; a brand-new file is
+            // not in the backup at all, so rollback has to delete it or it
+            // survives orphaned. Captured before the write because `fopen(
+            // …, 'wb' )` below creates the file either way.
+            $existedBeforeWrite = File::exists( $fullTargetPath );
+
             $entryStream = $zip->getStreamIndex( $i );
             if ( false === $entryStream ) {
                 Log::error( 'Failed to open ZIP entry stream during update extraction', [
@@ -1399,6 +1438,18 @@ class ApplicationUpdateManager
                     $filename,
                     "could not open target for writing: {$fullTargetPath}",
                 );
+            }
+
+            // Record the addition the moment `fopen` creates the file, before
+            // streaming — not after. If `streamEntryToDisk()` throws partway,
+            // it best-effort `@unlink`s the target, but should that unlink fail
+            // ( read-only parent, races ) a brand-new, half-written file would
+            // survive un-ledgered and neither rollback nor the backup could
+            // remove it. Ledgering here lets rollback delete it. A later
+            // successful overwrite of a path that existed before is still not
+            // recorded, because `$existedBeforeWrite` was captured pre-`fopen`.
+            if ( ! $existedBeforeWrite ) {
+                $this->extractionAdditions[] = $targetPath;
             }
 
             $this->streamEntryToDisk( $entryStream, $out, $filename, $fullTargetPath );
@@ -2679,6 +2730,80 @@ class ApplicationUpdateManager
     }
 
     /**
+     * Remove the files the current extraction added, after the snapshot has
+     * been restored.
+     *
+     * `rollback()` puts back every file the pre-update snapshot captured, but a
+     * snapshot cannot restore a file that did not exist when it was taken.
+     * Without this, every path the extraction *added* survives the restore,
+     * leaving the tree a hybrid of the old version's files and an arbitrary
+     * subset of the new version's additions — migrations included, whose next
+     * `migrate` run would apply schema for a version that was rolled back.
+     *
+     * Only paths this extraction recorded as newly created are touched, and the
+     * exclusion list is honoured a second time so a rollback can never delete
+     * `storage/`, `.env`, or `vendor/` contents even if one slipped into the
+     * ledger.
+     *
+     * @since 2.8.0
+     */
+    protected function removeExtractionAdditions(): void
+    {
+        if ( empty( $this->extractionAdditions ) ) {
+            return;
+        }
+
+        $excludePaths = config( 'cms.updates.exclude_from_update', [] );
+        $basePath     = base_path();
+        $removed      = 0;
+
+        foreach ( $this->extractionAdditions as $relativePath ) {
+            if ( $this->isPathExcluded( $relativePath, $excludePaths ) ) {
+                continue;
+            }
+
+            $fullPath = $basePath . DIRECTORY_SEPARATOR . $relativePath;
+
+            // The extraction only ever wrote regular files, so a symlink or a
+            // directory at this path is something else on disk — never follow
+            // or remove it. Also covers the case where restoring the backup
+            // already replaced the addition with something the snapshot owned.
+            if ( is_link( $fullPath ) || ! is_file( $fullPath ) ) {
+                continue;
+            }
+
+            // Defence in depth: resolve the path and confirm it still sits
+            // under base_path() before unlinking, mirroring the extraction
+            // guards. A file always resolves, so realpath() cannot fail here.
+            if ( ! $this->isPathWithinExtractRoot( $fullPath, $basePath ) ) {
+                continue;
+            }
+
+            try {
+                File::delete( $fullPath );
+                $removed++;
+            } catch ( Throwable $e ) {
+                // A file that cannot be removed is logged, not fatal: the
+                // rollback of the backed-up files has already succeeded, and
+                // aborting here would turn a partial cleanup into a reported
+                // rollback failure.
+                Log::warning( 'cms-framework: could not remove a file the rolled-back update had added; it remains on disk.', [
+                    'path'      => $relativePath,
+                    'exception' => $e->getMessage(),
+                ] );
+            }
+        }
+
+        if ( $removed > 0 ) {
+            Log::info( 'cms-framework: removed files the rolled-back update had added.', [
+                'count' => $removed,
+            ] );
+        }
+
+        $this->extractionAdditions = [];
+    }
+
+    /**
      * Handle update failure and attempt rollback.
      *
      * @since 1.0.0
@@ -2727,6 +2852,14 @@ class ApplicationUpdateManager
         if ( $this->backupPath && File::exists( $this->backupPath ) ) {
             try {
                 $this->rollback( $this->backupPath );
+
+                // The snapshot restore reinstated every backed-up file, but a
+                // snapshot cannot restore a file that did not exist when it
+                // was taken. Remove the files this extraction added so the
+                // tree matches the pre-update version rather than a hybrid of
+                // both — otherwise orphaned code and, worse, orphaned
+                // migrations are left behind.
+                $this->removeExtractionAdditions();
 
                 $this->state()->markRollback( true );
             } catch ( Throwable $e ) {

--- a/tests/Unit/Updates/ApplicationUpdateManagerTest.php
+++ b/tests/Unit/Updates/ApplicationUpdateManagerTest.php
@@ -553,6 +553,315 @@ class ApplicationUpdateManagerTest extends TestCase
     }
 
     /**
+     * Regression for #272: `extractUpdate` must record the paths it *adds* —
+     * files that did not exist beforehand — and leave overwrites of existing
+     * files out of that ledger, since the backup restores overwrites but is the
+     * only thing that can delete additions.
+     *
+     * @since 2.8.0
+     */
+    public function test_extract_update_records_added_paths_but_not_overwrites(): void
+    {
+        $tempRoot = sys_get_temp_dir() . '/cmsfw-additions-' . bin2hex( random_bytes( 6 ) );
+        $target   = $tempRoot . '/target';
+        mkdir( $target . '/app', 0755, true );
+
+        // A file that already exists at version N — extraction overwrites it.
+        file_put_contents( $target . '/app/Old.php', "<?php\n// old\n" );
+
+        $zipPath = $tempRoot . '/update.zip';
+
+        $zip = new ZipArchive;
+        $this->assertTrue( true === $zip->open( $zipPath, ZipArchive::CREATE | ZipArchive::OVERWRITE ) );
+        $zip->addFromString( 'release-root/app/Old.php', "<?php\n// new-old\n" );
+        $zip->addFromString( 'release-root/app/New.php', "<?php\n// added\n" );
+        $zip->addFromString( 'release-root/database/migrations/2026_01_01_000000_add.php', "<?php\n// migration\n" );
+        $zip->close();
+
+        $manager = new class extends ApplicationUpdateManager {
+            public function extractInto( string $zipPath ): void
+            {
+                $this->extractUpdate( $zipPath );
+            }
+        };
+
+        $originalBase = base_path();
+        app()->setBasePath( $target );
+
+        try {
+            $manager->extractInto( $zipPath );
+
+            $reflection = new ReflectionClass( ApplicationUpdateManager::class );
+            $property   = $reflection->getProperty( 'extractionAdditions' );
+            $property->setAccessible( true );
+            $additions = $property->getValue( $manager );
+
+            sort( $additions );
+
+            $this->assertSame(
+                ['app/New.php', 'database/migrations/2026_01_01_000000_add.php'],
+                $additions,
+                'Only newly-created paths belong in the additions ledger; the overwritten app/Old.php must be excluded.',
+            );
+        } finally {
+            app()->setBasePath( $originalBase );
+            @unlink( $zipPath );
+            $this->removeDirectory( $target );
+            @rmdir( $tempRoot );
+        }
+    }
+
+    /**
+     * Regression for #272: a failed update that rolls back must not leave the
+     * files the extraction added behind. Restoring the snapshot reinstates
+     * overwritten files but cannot remove additions — including migrations —
+     * so the manager has to delete them itself.
+     *
+     * @since 2.8.0
+     */
+    public function test_rollback_removes_files_the_extraction_added(): void
+    {
+        $tempRoot = sys_get_temp_dir() . '/cmsfw-rollback-additions-' . bin2hex( random_bytes( 6 ) );
+        $target   = $tempRoot . '/target';
+        mkdir( $target . '/app', 0755, true );
+
+        // Version N on disk.
+        file_put_contents( $target . '/app/Old.php', "<?php\n// old\n" );
+
+        // The pre-update snapshot: it captured only the files that existed at
+        // version N. Clean relative names so rollback's extractTo restores them.
+        $backupPath = $tempRoot . '/backup.zip';
+        $backup     = new ZipArchive;
+        $this->assertTrue( true === $backup->open( $backupPath, ZipArchive::CREATE | ZipArchive::OVERWRITE ) );
+        $backup->addFromString( 'app/Old.php', "<?php\n// old\n" );
+        $backup->close();
+
+        // The release: overwrites Old.php and adds two files N never had.
+        $zipPath = $tempRoot . '/update.zip';
+        $zip     = new ZipArchive;
+        $this->assertTrue( true === $zip->open( $zipPath, ZipArchive::CREATE | ZipArchive::OVERWRITE ) );
+        $zip->addFromString( 'release-root/app/Old.php', "<?php\n// new-old\n" );
+        $zip->addFromString( 'release-root/app/New.php', "<?php\n// added\n" );
+        $zip->addFromString( 'release-root/database/migrations/2026_01_01_000000_add.php', "<?php\n// migration\n" );
+        $zip->close();
+
+        $manager = new class( $backupPath ) extends ApplicationUpdateManager {
+            public function __construct( string $preparedBackupPath )
+            {
+                $this->backupPath = $preparedBackupPath;
+            }
+
+            public function extractInto( string $zipPath ): void
+            {
+                $this->extractUpdate( $zipPath );
+            }
+
+            public function callHandleFailure( Throwable $e ): void
+            {
+                $this->handleUpdateFailure( $e );
+            }
+
+            protected function disableMaintenanceMode(): void
+            {
+            }
+
+            protected function verifyComposerBinaryAvailable(): void
+            {
+            }
+
+            protected function runComposerInstall(): void
+            {
+            }
+
+            protected function clearCaches(): void
+            {
+            }
+        };
+
+        $originalBase = base_path();
+        app()->setBasePath( $target );
+
+        try {
+            $manager->extractInto( $zipPath );
+
+            // Sanity: the release landed before the (simulated) failure.
+            $this->assertFileExists( $target . '/app/New.php' );
+            $this->assertFileExists( $target . '/database/migrations/2026_01_01_000000_add.php' );
+
+            $manager->callHandleFailure( new RuntimeException( 'composer install failed' ) );
+
+            // The overwrite is restored from the snapshot.
+            $this->assertFileExists( $target . '/app/Old.php' );
+            $this->assertStringContainsString( '// old', (string) file_get_contents( $target . '/app/Old.php' ) );
+
+            // The additions — orphaned code and, critically, the migration —
+            // are gone.
+            $this->assertFileDoesNotExist( $target . '/app/New.php' );
+            $this->assertFileDoesNotExist( $target . '/database/migrations/2026_01_01_000000_add.php' );
+        } finally {
+            app()->setBasePath( $originalBase );
+            @unlink( $zipPath );
+            @unlink( $backupPath );
+            $this->removeDirectory( $target );
+            @rmdir( $tempRoot );
+        }
+    }
+
+    /**
+     * Regression for #272: removing extraction additions on rollback must honour
+     * the exclusion list, so a rollback can never delete `storage/`, `.env`, or
+     * `vendor/` contents even if such a path reached the additions ledger.
+     *
+     * @since 2.8.0
+     */
+    public function test_remove_extraction_additions_honours_the_exclusion_list(): void
+    {
+        $tempRoot = sys_get_temp_dir() . '/cmsfw-additions-excluded-' . bin2hex( random_bytes( 6 ) );
+        $target   = $tempRoot . '/target';
+        mkdir( $target . '/app', 0755, true );
+        mkdir( $target . '/storage/logs', 0755, true );
+
+        file_put_contents( $target . '/app/New.php', "<?php\n// added\n" );
+        file_put_contents( $target . '/storage/logs/laravel.log', "log\n" );
+
+        $manager = new class extends ApplicationUpdateManager {
+            /**
+             * @param  array<int, string>  $paths
+             */
+            public function seedAdditions( array $paths ): void
+            {
+                $this->extractionAdditions = $paths;
+            }
+
+            public function callRemove(): void
+            {
+                $this->removeExtractionAdditions();
+            }
+        };
+
+        $manager->seedAdditions( ['app/New.php', 'storage/logs/laravel.log'] );
+
+        $originalBase = base_path();
+        app()->setBasePath( $target );
+        config( ['cms.updates.exclude_from_update' => ['storage', '.env', 'vendor']] );
+
+        try {
+            $manager->callRemove();
+
+            $this->assertFileDoesNotExist( $target . '/app/New.php' );
+            $this->assertFileExists(
+                $target . '/storage/logs/laravel.log',
+                'An excluded path must survive rollback cleanup even when it is in the additions ledger.',
+            );
+        } finally {
+            app()->setBasePath( $originalBase );
+            $this->removeDirectory( $target );
+            @rmdir( $tempRoot );
+        }
+    }
+
+    /**
+     * Regression for #272: the manager is a singleton, so one instance drives
+     * many runs on a long-lived queue worker. A run that fails *before* the
+     * Extract step must not delete files a previous successful run added — the
+     * additions ledger has to be reset at the start of every run, not only in
+     * `extractUpdate()`. Without the run-start reset a stale ledger from a
+     * prior successful run would have its files unlinked during this run's
+     * rollback.
+     *
+     * @since 2.8.0
+     */
+    public function test_run_start_reset_prevents_a_later_failure_deleting_a_prior_runs_files(): void
+    {
+        $tempRoot = sys_get_temp_dir() . '/cmsfw-crossrun-' . bin2hex( random_bytes( 6 ) );
+        $target   = $tempRoot . '/target';
+        mkdir( $target . '/app', 0755, true );
+
+        // A file a previous, successful update added — now part of the current
+        // version and captured by this run's backup.
+        file_put_contents( $target . '/app/FromRun1.php', "<?php\n// installed by the prior run\n" );
+
+        $backupPath = $tempRoot . '/backup.zip';
+        $backup     = new ZipArchive;
+        $this->assertTrue( true === $backup->open( $backupPath, ZipArchive::CREATE | ZipArchive::OVERWRITE ) );
+        $backup->addFromString( 'app/FromRun1.php', "<?php\n// installed by the prior run\n" );
+        $backup->close();
+
+        $manager = new class( $backupPath ) extends ApplicationUpdateManager {
+            public function __construct( string $preparedBackupPath )
+            {
+                $this->backupPath = $preparedBackupPath;
+            }
+
+            /**
+             * @param  array<int, string>  $paths
+             */
+            public function seedAdditions( array $paths ): void
+            {
+                $this->extractionAdditions = $paths;
+            }
+
+            public function runSteps( string $version, UpdateInfo $info ): void
+            {
+                $this->runUpdateSteps( $version, $info );
+            }
+
+            // Fail the run at step 1 — before extraction ever runs.
+            protected function enableMaintenanceMode(): void
+            {
+                throw new RuntimeException( 'simulated early failure before extraction' );
+            }
+
+            protected function disableMaintenanceMode(): void
+            {
+            }
+
+            protected function verifyComposerBinaryAvailable(): void
+            {
+            }
+
+            protected function runComposerInstall(): void
+            {
+            }
+
+            protected function clearCaches(): void
+            {
+            }
+        };
+
+        // The stale ledger the prior successful run left on the singleton.
+        $manager->seedAdditions( ['app/FromRun1.php'] );
+
+        $originalBase = base_path();
+        app()->setBasePath( $target );
+
+        try {
+            $info = new UpdateInfo(
+                currentVersion: '1.0.0',
+                latestVersion: '2.0.0',
+                downloadUrl: 'https://example.test/update.zip',
+            );
+
+            try {
+                $manager->runSteps( '2.0.0', $info );
+                $this->fail( 'Expected the simulated early failure to propagate.' );
+            } catch ( RuntimeException $e ) {
+                $this->assertStringContainsString( 'simulated early failure', $e->getMessage() );
+            }
+
+            $this->assertFileExists(
+                $target . '/app/FromRun1.php',
+                'A run that fails before extraction must not delete files a prior run added; the ledger has to reset at run start.',
+            );
+        } finally {
+            app()->setBasePath( $originalBase );
+            @unlink( $backupPath );
+            $this->removeDirectory( $target );
+            @rmdir( $tempRoot );
+        }
+    }
+
+    /**
      * Regression for #225: `COMPOSER_BINARY` env var wins over both config and
      * discovery and is invoked via `PHP_BINARY` so the PHP-FPM pool's `PATH`
      * never has to resolve composer's shebang.


### PR DESCRIPTION
## Description

A failed application update's rollback restored every backed-up file but never removed the files the extraction **added**. A pre-update snapshot cannot capture a file that did not exist when it was taken, so every path the release introduced survived a rollback that reported success — leaving the tree a hybrid of the old version's files and an arbitrary subset of the new version's additions. Two of those, on the real install that surfaced this, were **migrations**: the next `migrate` run would apply schema for a version that had been rolled back.

This records what extraction writes and deletes exactly those additions when a snapshot is restored.

**Closes:** #272

## Type of Change

- [x] Bug fix (fixes an issue)

## Related Issue

**Issue:** #272

## Motivation and Context

Observed on a real install (Keystone 0.2.5 → 0.3.1, failing at the composer step from #255): 48 files across 32 paths — including two migrations — were left behind after the rollback reported success. The failure is silent on a non-version-controlled production install.

## Changes Made

- `extractUpdate()` records each relative path it **creates that did not exist beforehand** into an additions ledger. Overwrites are excluded — the backup restores those. The path is recorded the moment `fopen()` creates the file, so a partial-extraction orphan whose best-effort `@unlink` fails is still recoverable.
- New `removeExtractionAdditions()` deletes exactly those recorded paths after a successful snapshot restore. It re-checks the exclusion list, refuses to follow symlinks or touch non-regular files, and re-validates `realpath()` containment under `base_path()` before each `unlink`. Delete failures are logged, not fatal (the file-restore already succeeded).
- `handleUpdateFailure()` calls it only after a successful `rollback()`, only when a backup exists — correctly skipped on the forward-fix early return (`currentStep > Migrations`) and the backups-disabled path.
- The ledger is reset at the **start of every run**, not just in `extractUpdate()`. The manager is a singleton, so on a long-lived queue worker one instance drives many runs; a run that fails before the Extract step would otherwise inherit a prior successful run's ledger and delete its files during rollback.

**Scope notes:** the public `update:rollback` (arbitrary ZIP) does not remove additions — it has no extraction ledger — matching the narrow, safer option in the issue. Empty leftover directories are not pruned (cosmetic vs. orphaned migrations).

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS 27.0 (Darwin), Laravel Herd
- Browser (if applicable): n/a
- PHP Version: 8.4
- Project Version: cms-framework 2.7.2 → 2.8

**Tests Performed:**
1. Full package suite: **1846 passed, 7 skipped, 0 failures**.
2. Manual repro per the issue: forced the composer step to fail after extraction; confirmed the added files (incl. migration) are gone after the reported rollback.
3. php-cs-fixer clean (0 changes); PHPCS clean.

## Accessibility Tests Run

- [ ] Keyboard navigation tested
- [ ] Screen reader tested
- [ ] Color contrast verified
- [ ] ARIA labels checked

**Details:** N/A — backend self-updater change, no UI surface.

## Tests Added

- [x] Unit tests added/updated
- [x] All tests passing

**Test details:**
- `test_extract_update_records_added_paths_but_not_overwrites` — only newly-created paths enter the ledger.
- `test_rollback_removes_files_the_extraction_added` — end-to-end: overwrite restored from backup, added file + migration deleted.
- `test_remove_extraction_additions_honours_the_exclusion_list` — an excluded path in the ledger survives cleanup.
- `test_run_start_reset_prevents_a_later_failure_deleting_a_prior_runs_files` — regression for the singleton cross-run state leak.

## Documentation

- [x] Inline code documentation added

**Documentation details:** New method and property carry full PHPDoc explaining the snapshot-vs-additions rationale and the singleton reset.

## Pre-Submission Checklist

- [x] Followed contributing guidelines
- [x] Checked for other open PRs for same update
- [x] Code passes all tests
- [x] Code has been linted
- [ ] Accessibility tests completed (N/A — backend change)
- [x] Code follows project style guide
- [x] Self-review completed
- [x] Comments added for complex code
- [x] No new warnings generated
