### PR TITLE
feature: Blade-fallback support for theme templates and template parts

### DIFF
--- a/src/Modules/SiteEditor/Http/Controllers/TemplatePartsController.php
+++ b/src/Modules/SiteEditor/Http/Controllers/TemplatePartsController.php
@@ -78,6 +78,10 @@ class TemplatePartsController extends Controller
             return response()->json( ['message' => 'No active theme.'], 409 );
         }
 
+        if ( null !== ( $blocked = $this->rejectIfBlade( $request->validated()['slug'] ?? null ) ) ) {
+            return $blocked;
+        }
+
         try {
             $part = TemplatePart::create( $this->normalizeAttributes( $theme, $request->validated() ) );
         } catch ( QueryException $e ) {
@@ -126,6 +130,10 @@ class TemplatePartsController extends Controller
                 'message' => 'Body slug does not match URL slug.',
                 'errors'  => ['slug' => ['Slug in the request body must match the URL slug.']],
             ], 422 );
+        }
+
+        if ( null !== ( $blocked = $this->rejectIfBlade( $slug ) ) ) {
+            return $blocked;
         }
 
         unset( $validated['slug'] );
@@ -206,6 +214,34 @@ class TemplatePartsController extends Controller
         $theme = $this->themeManager->getActiveTheme();
 
         return null !== $theme && ! empty( $theme['slug'] ) ? (string) $theme['slug'] : null;
+    }
+
+    /**
+     * Reject a write against a Blade-backed template-part slug.
+     *
+     * Mirrors {@see TemplatesController::rejectIfBlade()}: Blade parts render at
+     * request time and are read-only in the site editor, so a create/update
+     * that would spawn a DB override is rejected with a clear 422. Returns null
+     * for every other slug (HTML theme files, existing DB rows, unknown slugs).
+     *
+     * @since 2.9.0
+     */
+    protected function rejectIfBlade( ?string $slug ): ?JsonResponse
+    {
+        if ( null === $slug ) {
+            return null;
+        }
+
+        $entity = $this->resolver->resolve( $slug );
+
+        if ( null === $entity || ! $entity->isBlade ) {
+            return null;
+        }
+
+        return response()->json( [
+            'message' => 'This template part is a Blade file and is read-only in the site editor.',
+            'errors'  => ['slug' => ['Blade template parts cannot be edited here. Author the part as a block-grammar HTML file to edit it in the site editor.']],
+        ], 422 );
     }
 
     /**

--- a/src/Modules/SiteEditor/Http/Controllers/TemplatesController.php
+++ b/src/Modules/SiteEditor/Http/Controllers/TemplatesController.php
@@ -78,6 +78,10 @@ class TemplatesController extends Controller
             return response()->json( ['message' => 'No active theme.'], 409 );
         }
 
+        if ( null !== ( $blocked = $this->rejectIfBlade( $request->validated()['slug'] ?? null ) ) ) {
+            return $blocked;
+        }
+
         try {
             $template = Template::create( $this->normalizeAttributes( $theme, $request->validated() ) );
         } catch ( QueryException $e ) {
@@ -131,6 +135,10 @@ class TemplatesController extends Controller
                 'message' => 'Body slug does not match URL slug.',
                 'errors'  => ['slug' => ['Slug in the request body must match the URL slug.']],
             ], 422 );
+        }
+
+        if ( null !== ( $blocked = $this->rejectIfBlade( $slug ) ) ) {
+            return $blocked;
         }
 
         // Strip slug from the validated attributes — the route slug is
@@ -221,6 +229,37 @@ class TemplatesController extends Controller
         $theme = $this->themeManager->getActiveTheme();
 
         return null !== $theme && ! empty( $theme['slug'] ) ? (string) $theme['slug'] : null;
+    }
+
+    /**
+     * Reject a write against a Blade-backed template slug.
+     *
+     * Blade templates render at request time and are read-only in the site
+     * editor: the file→DB authority flip stays HTML-only, so a create/update
+     * that would spawn a DB override is rejected with a clear 422. Returns null
+     * — allowing the write to proceed — for every other slug (HTML theme files,
+     * existing DB rows, and unknown slugs). `resolve()` returns `isBlade` true
+     * only for a Blade theme file with no DB override, so an already-flipped DB
+     * row stays editable.
+     *
+     * @since 2.9.0
+     */
+    protected function rejectIfBlade( ?string $slug ): ?JsonResponse
+    {
+        if ( null === $slug ) {
+            return null;
+        }
+
+        $entity = $this->resolver->resolve( $slug );
+
+        if ( null === $entity || ! $entity->isBlade ) {
+            return null;
+        }
+
+        return response()->json( [
+            'message' => 'This template is a Blade file and is read-only in the site editor.',
+            'errors'  => ['slug' => ['Blade templates cannot be edited here. Author the template as a block-grammar HTML file to edit it in the site editor.']],
+        ], 422 );
     }
 
     /**

--- a/src/Modules/SiteEditor/Http/Resources/TemplateResource.php
+++ b/src/Modules/SiteEditor/Http/Resources/TemplateResource.php
@@ -59,6 +59,12 @@ final class TemplateResource
             'wp_id'          => $entity->wpId(),
             'has_theme_file' => $entity->hasThemeFile,
             'is_custom'      => $entity->isCustom,
+            // `is_blade` marks a template backed by a `{name}.blade.php` theme
+            // file: it renders at request time but is read-only in the site
+            // editor. `editable` is its inverse, surfaced so the editor can
+            // disable save affordances without re-deriving the rule.
+            'is_blade'       => $entity->isBlade,
+            'editable'       => ! $entity->isBlade,
             'author'         => null !== $entity->model ? (int) ( $entity->model->author_id ?? 0 ) : 0,
             'modified'       => null !== $entity->model
                 ? optional( $entity->model->updated_at )->toIso8601String()

--- a/src/Modules/SiteEditor/Resolution/ResolvedEntity.php
+++ b/src/Modules/SiteEditor/Resolution/ResolvedEntity.php
@@ -35,6 +35,7 @@ final class ResolvedEntity
      * @param  string  $status  WP status (`'publish'` by default).
      * @param  bool  $hasThemeFile  True when a theme file backs this slug (regardless of whether a DB override exists).
      * @param  bool  $isCustom  True when the entity was authored in the admin with no theme-file backing.
+     * @param  bool  $isBlade  True when the backing theme file is a Blade file (`{name}.blade.php`) rather than a block-grammar HTML file. Blade files render at request time and are read-only in the site editor: the file→DB authority flip stays HTML-only, so `blocks` and `raw` are empty and a save against the slug is rejected. Always false for DB rows and HTML theme files.
      * @param  string|null  $area  Template-part area (`'header' | 'footer' | 'sidebar' | 'uncategorized' | 'navigation-overlay'`); null for templates.
      * @param  Template|TemplatePart|null  $model  The DB row when `$source === 'db'`; null otherwise.
      */
@@ -49,6 +50,7 @@ final class ResolvedEntity
         public readonly string $status,
         public readonly bool $hasThemeFile,
         public readonly bool $isCustom,
+        public readonly bool $isBlade,
         public readonly ?string $area,
         public readonly Template|TemplatePart|null $model,
     ) {
@@ -92,6 +94,8 @@ final class ResolvedEntity
             'blocks'         => $this->blocks,
             'has_theme_file' => $this->hasThemeFile,
             'is_custom'      => $this->isCustom,
+            'is_blade'       => $this->isBlade,
+            'editable'       => ! $this->isBlade,
             'wp_id'          => $this->wpId(),
             'author_id'      => null !== $this->model && null !== $this->model->author_id
                 ? (int) $this->model->author_id

--- a/src/Modules/SiteEditor/Resolution/TemplatePartResolver.php
+++ b/src/Modules/SiteEditor/Resolution/TemplatePartResolver.php
@@ -4,8 +4,10 @@
  * Template Part Resolver
  *
  * Resolves template-part entities for the active theme by merging DB-stored
- * parts with theme-file parts from `themes/{active}/parts/{slug}.html`.
- * DB rows win when present.
+ * parts with theme-file parts from `themes/{active}/parts/{slug}.html`,
+ * falling back to a Blade file at `themes/{active}/parts/{slug}.blade.php`
+ * when no HTML file exists. DB rows win over theme files; HTML wins over Blade.
+ * Blade files are read-only in the site editor.
  *
  * @since      2.0.0
  */
@@ -49,7 +51,7 @@ class TemplatePartResolver implements EntityResolver
         }
 
         $row          = TemplatePart::query()->where( 'theme', $theme )->where( 'slug', $slug )->first();
-        $themeFile    = $this->themeFilePath( $theme, $slug );
+        $themeFile    = $this->resolveThemeFile( $theme, $slug );
         $hasThemeFile = null !== $themeFile;
 
         if ( null !== $row ) {
@@ -64,6 +66,7 @@ class TemplatePartResolver implements EntityResolver
                 status       : $row->status,
                 hasThemeFile : $hasThemeFile,
                 isCustom     : (bool) $row->is_custom && ! $hasThemeFile,
+                isBlade      : false,
                 area         : $row->area,
                 model        : $row,
             );
@@ -73,7 +76,29 @@ class TemplatePartResolver implements EntityResolver
             return null;
         }
 
-        $markup = File::get( $themeFile );
+        // Blade theme files render at request time and are read-only in the
+        // site editor. They carry no block tree, so `raw` and `blocks` stay
+        // empty and the `isBlade` flag drives the editor's read-only affordance
+        // and the save-rejection guard in TemplatePartsController.
+        if ( $themeFile['isBlade'] ) {
+            return new ResolvedEntity(
+                slug         : $slug,
+                theme        : $theme,
+                source       : 'theme',
+                raw          : '',
+                blocks       : [],
+                title        : $this->humanizeSlug( $slug ),
+                description  : null,
+                status       : 'publish',
+                hasThemeFile : true,
+                isCustom     : false,
+                isBlade      : true,
+                area         : $this->guessAreaFromSlug( $slug ),
+                model        : null,
+            );
+        }
+
+        $markup = File::get( $themeFile['path'] );
 
         return new ResolvedEntity(
             slug         : $slug,
@@ -86,6 +111,7 @@ class TemplatePartResolver implements EntityResolver
             status       : 'publish',
             hasThemeFile : true,
             isCustom     : false,
+            isBlade      : false,
             area         : $this->guessAreaFromSlug( $slug ),
             model        : null,
         );
@@ -162,14 +188,28 @@ class TemplatePartResolver implements EntityResolver
     }
 
     /**
-     * @since 2.0.0
+     * Resolve the theme file backing a part slug, preferring block-grammar HTML
+     * over a Blade fallback. When both exist HTML wins. Returns the absolute
+     * path and whether it is a Blade file, or null when neither exists.
+     *
+     * @since 2.9.0
+     *
+     * @return array{path: string, isBlade: bool}|null
      */
-    protected function themeFilePath( string $theme, string $slug ): ?string
+    protected function resolveThemeFile( string $theme, string $slug ): ?array
     {
         $directory = config( 'cms.themes.directory', 'themes' );
-        $path      = base_path( $directory ) . '/' . $theme . '/parts/' . $slug . '.html';
+        $base      = base_path( $directory ) . '/' . $theme . '/parts/' . $slug;
 
-        return File::exists( $path ) ? $path : null;
+        if ( File::exists( $base . '.html' ) ) {
+            return ['path' => $base . '.html', 'isBlade' => false];
+        }
+
+        if ( File::exists( $base . '.blade.php' ) ) {
+            return ['path' => $base . '.blade.php', 'isBlade' => true];
+        }
+
+        return null;
     }
 
     /**
@@ -189,12 +229,19 @@ class TemplatePartResolver implements EntityResolver
         $slugs = [];
 
         foreach ( File::files( $dir ) as $file ) {
-            if ( 'html' === $file->getExtension() ) {
+            $name = $file->getFilename();
+
+            // `getFilenameWithoutExtension()` strips only the final extension,
+            // so `header.blade.php` would yield `header.blade`; match the
+            // compound `.blade.php` suffix explicitly before `.html`.
+            if ( str_ends_with( $name, '.blade.php' ) ) {
+                $slugs[] = substr( $name, 0, -strlen( '.blade.php' ) );
+            } elseif ( 'html' === $file->getExtension() ) {
                 $slugs[] = $file->getFilenameWithoutExtension();
             }
         }
 
-        return $slugs;
+        return array_values( array_unique( $slugs ) );
     }
 
     /**

--- a/src/Modules/SiteEditor/Resolution/TemplateResolver.php
+++ b/src/Modules/SiteEditor/Resolution/TemplateResolver.php
@@ -4,8 +4,10 @@
  * Template Resolver
  *
  * Resolves template entities for the active theme by merging DB-stored
- * templates with theme-file templates from `themes/{active}/templates/{slug}.html`.
- * DB rows win when present.
+ * templates with theme-file templates from `themes/{active}/templates/{slug}.html`,
+ * falling back to a Blade file at `themes/{active}/templates/{slug}.blade.php`
+ * when no HTML file exists. DB rows win over theme files; HTML wins over Blade.
+ * Blade files are read-only in the site editor.
  *
  * @since      2.0.0
  */
@@ -49,7 +51,7 @@ class TemplateResolver implements EntityResolver
         }
 
         $row          = Template::query()->where( 'theme', $theme )->where( 'slug', $slug )->first();
-        $themeFile    = $this->themeFilePath( $theme, $slug );
+        $themeFile    = $this->resolveThemeFile( $theme, $slug );
         $hasThemeFile = null !== $themeFile;
 
         if ( null !== $row ) {
@@ -64,6 +66,7 @@ class TemplateResolver implements EntityResolver
                 status       : $row->status,
                 hasThemeFile : $hasThemeFile,
                 isCustom     : (bool) $row->is_custom && ! $hasThemeFile,
+                isBlade      : false,
                 area         : null,
                 model        : $row,
             );
@@ -73,7 +76,29 @@ class TemplateResolver implements EntityResolver
             return null;
         }
 
-        $markup = File::get( $themeFile );
+        // Blade theme files render at request time and are read-only in the
+        // site editor. They carry no block tree, so `raw` and `blocks` stay
+        // empty and the `isBlade` flag drives the editor's read-only affordance
+        // and the save-rejection guard in TemplatesController.
+        if ( $themeFile['isBlade'] ) {
+            return new ResolvedEntity(
+                slug         : $slug,
+                theme        : $theme,
+                source       : 'theme',
+                raw          : '',
+                blocks       : [],
+                title        : $this->humanizeSlug( $slug ),
+                description  : null,
+                status       : 'publish',
+                hasThemeFile : true,
+                isCustom     : false,
+                isBlade      : true,
+                area         : null,
+                model        : null,
+            );
+        }
+
+        $markup = File::get( $themeFile['path'] );
 
         return new ResolvedEntity(
             slug         : $slug,
@@ -86,6 +111,7 @@ class TemplateResolver implements EntityResolver
             status       : 'publish',
             hasThemeFile : true,
             isCustom     : false,
+            isBlade      : false,
             area         : null,
             model        : null,
         );
@@ -166,21 +192,39 @@ class TemplateResolver implements EntityResolver
     }
 
     /**
-     * Returns the absolute path to the theme file for the given slug,
-     * or null when the file does not exist.
+     * Resolve the theme file backing a slug, preferring block-grammar HTML
+     * over a Blade fallback.
      *
-     * @since 2.0.0
+     * A slug may be authored either as `templates/{slug}.html` (block grammar,
+     * editable in the site editor) or `templates/{slug}.blade.php` (rendered at
+     * request time, read-only in the site editor). When both exist HTML wins,
+     * so a theme can migrate a file from Blade to blocks without changing its
+     * slug. Returns the absolute path and whether it is a Blade file, or null
+     * when neither exists.
+     *
+     * @since 2.9.0
+     *
+     * @return array{path: string, isBlade: bool}|null
      */
-    protected function themeFilePath( string $theme, string $slug ): ?string
+    protected function resolveThemeFile( string $theme, string $slug ): ?array
     {
         $directory = config( 'cms.themes.directory', 'themes' );
-        $path      = base_path( $directory ) . '/' . $theme . '/templates/' . $slug . '.html';
+        $base      = base_path( $directory ) . '/' . $theme . '/templates/' . $slug;
 
-        return File::exists( $path ) ? $path : null;
+        if ( File::exists( $base . '.html' ) ) {
+            return ['path' => $base . '.html', 'isBlade' => false];
+        }
+
+        if ( File::exists( $base . '.blade.php' ) ) {
+            return ['path' => $base . '.blade.php', 'isBlade' => true];
+        }
+
+        return null;
     }
 
     /**
-     * Returns the list of template slugs the active theme provides on disk.
+     * Returns the list of template slugs the active theme provides on disk,
+     * including both block-grammar HTML files and Blade fallbacks.
      *
      * @since 2.0.0
      *
@@ -198,12 +242,19 @@ class TemplateResolver implements EntityResolver
         $slugs = [];
 
         foreach ( File::files( $dir ) as $file ) {
-            if ( 'html' === $file->getExtension() ) {
+            $name = $file->getFilename();
+
+            // `getFilenameWithoutExtension()` strips only the final extension,
+            // so `page.blade.php` would yield `page.blade`; match the compound
+            // `.blade.php` suffix explicitly before falling back to `.html`.
+            if ( str_ends_with( $name, '.blade.php' ) ) {
+                $slugs[] = substr( $name, 0, -strlen( '.blade.php' ) );
+            } elseif ( 'html' === $file->getExtension() ) {
                 $slugs[] = $file->getFilenameWithoutExtension();
             }
         }
 
-        return $slugs;
+        return array_values( array_unique( $slugs ) );
     }
 
     /**

--- a/src/Modules/Themes/Managers/ThemeManager.php
+++ b/src/Modules/Themes/Managers/ThemeManager.php
@@ -942,7 +942,56 @@ class ThemeManager
             return false;
         }
 
+        $this->warnOnBladeCustomTemplates( $themePath, $manifest );
+
         return true;
+    }
+
+    /**
+     * Warn when a `customTemplates` entry resolves to a Blade-only file.
+     *
+     * A `customTemplates` entry is offered to the block editor as an authorable
+     * page template, but Blade files carry no block grammar — the editor would
+     * open empty content. HTML wins over Blade in the resolver, so this only
+     * fires for an entry whose `templates/{name}.html` is absent while
+     * `templates/{name}.blade.php` exists. It warns rather than rejects so a
+     * single mismatched entry does not drop the whole theme from discovery.
+     *
+     * @since 2.9.0
+     *
+     * @param  string  $themePath  Absolute path to the theme directory.
+     * @param  array  $manifest  Decoded theme.json contents.
+     */
+    protected function warnOnBladeCustomTemplates( string $themePath, array $manifest ): void
+    {
+        $customTemplates = $manifest['customTemplates'] ?? null;
+
+        if ( ! is_array( $customTemplates ) ) {
+            return;
+        }
+
+        foreach ( $customTemplates as $entry ) {
+            $name = is_array( $entry ) ? ( $entry['name'] ?? null ) : null;
+
+            if ( ! is_string( $name ) || '' === $name ) {
+                continue;
+            }
+
+            // Guard against path escapes in author-supplied names before touching
+            // the filesystem; a legitimate template name is a bare slug.
+            if ( str_contains( $name, '/' ) || str_contains( $name, '\\' ) || str_contains( $name, '..' ) ) {
+                continue;
+            }
+
+            $base = $themePath . '/templates/' . $name;
+
+            if ( ! File::exists( $base . '.html' ) && File::exists( $base . '.blade.php' ) ) {
+                Log::warning( 'Theme customTemplates entry maps to a Blade file; the block editor cannot edit it and would show empty content.', [
+                    'path' => $themePath,
+                    'name' => $name,
+                ] );
+            }
+        }
     }
 
     /**

--- a/tests/Feature/SiteEditor/TemplatePartsApiTest.php
+++ b/tests/Feature/SiteEditor/TemplatePartsApiTest.php
@@ -145,6 +145,50 @@ describe( 'PUT slug semantics for parts', function (): void {
     } );
 } );
 
+describe( 'Blade template parts are read-only (#126)', function (): void {
+    it( 'lists a Blade part with is_blade true and editable false', function (): void {
+        File::put( $this->themeParts . '/header.blade.php', '<header>Blade</header>' );
+
+        $this->actingAs( $this->user );
+
+        $response = $this->getJson( '/api/v1/template-parts/header' );
+
+        $response->assertOk();
+        expect( $response->json( 'is_blade' ) )->toBeTrue();
+        expect( $response->json( 'editable' ) )->toBeFalse();
+    } );
+
+    it( 'rejects a PUT against a Blade-only part with a clear 422', function (): void {
+        File::put( $this->themeParts . '/header.blade.php', '<header>Blade</header>' );
+
+        $this->actingAs( $this->user );
+
+        $response = $this->putJson( '/api/v1/template-parts/header', [
+            'title'         => 'Try Edit',
+            'area'          => 'header',
+            'block_content' => [['blockName' => 'core/heading']],
+        ] );
+
+        $response->assertStatus( 422 );
+        expect( $response->json( 'message' ) )->toContain( 'Blade' );
+        expect( TemplatePart::where( 'slug', 'header' )->exists() )->toBeFalse();
+    } );
+
+    it( 'rejects a POST creating a DB row over a Blade-only part', function (): void {
+        File::put( $this->themeParts . '/header.blade.php', '<header>Blade</header>' );
+
+        $this->actingAs( $this->user );
+
+        $this->postJson( '/api/v1/template-parts', [
+            'slug'  => 'header',
+            'title' => 'Try Create',
+            'area'  => 'header',
+        ] )->assertStatus( 422 );
+
+        expect( TemplatePart::where( 'slug', 'header' )->exists() )->toBeFalse();
+    } );
+} );
+
 describe( 'DELETE /api/v1/template-parts/{slug}', function (): void {
     it( 'reverts a DB override and returns 204', function (): void {
         TemplatePart::create( [

--- a/tests/Feature/SiteEditor/TemplatesApiTest.php
+++ b/tests/Feature/SiteEditor/TemplatesApiTest.php
@@ -277,6 +277,63 @@ describe( 'PUT /api/v1/templates/{slug}', function (): void {
     } );
 } );
 
+describe( 'Blade templates are read-only (#126)', function (): void {
+    it( 'lists a Blade template with is_blade true and editable false', function (): void {
+        File::put( $this->themeFiles . '/page.blade.php', '<p>Blade</p>' );
+
+        $this->actingAs( $this->user );
+
+        $response = $this->getJson( '/api/v1/templates/page' );
+
+        $response->assertOk();
+        expect( $response->json( 'is_blade' ) )->toBeTrue();
+        expect( $response->json( 'editable' ) )->toBeFalse();
+    } );
+
+    it( 'rejects a PUT against a Blade-only template with a clear 422', function (): void {
+        File::put( $this->themeFiles . '/page.blade.php', '<p>Blade</p>' );
+
+        $this->actingAs( $this->user );
+
+        $response = $this->putJson( '/api/v1/templates/page', [
+            'title'         => 'Try Edit',
+            'block_content' => [['blockName' => 'core/heading']],
+        ] );
+
+        $response->assertStatus( 422 );
+        expect( $response->json( 'message' ) )->toContain( 'Blade' );
+        expect( Template::where( 'slug', 'page' )->exists() )->toBeFalse();
+    } );
+
+    it( 'rejects a POST creating a DB row over a Blade-only template', function (): void {
+        File::put( $this->themeFiles . '/page.blade.php', '<p>Blade</p>' );
+
+        $this->actingAs( $this->user );
+
+        $response = $this->postJson( '/api/v1/templates', [
+            'slug'  => 'page',
+            'title' => 'Try Create',
+        ] );
+
+        $response->assertStatus( 422 );
+        expect( Template::where( 'slug', 'page' )->exists() )->toBeFalse();
+    } );
+
+    it( 'still allows editing an HTML template that also has a Blade sibling (HTML wins)', function (): void {
+        File::put( $this->themeFiles . '/page.html', '<!-- wp:paragraph --><p>H</p><!-- /wp:paragraph -->' );
+        File::put( $this->themeFiles . '/page.blade.php', '<p>Blade</p>' );
+
+        $this->actingAs( $this->user );
+
+        $this->putJson( '/api/v1/templates/page', [
+            'title'         => 'DB Page',
+            'block_content' => [['blockName' => 'core/heading']],
+        ] )->assertOk();
+
+        expect( Template::where( 'slug', 'page' )->exists() )->toBeTrue();
+    } );
+} );
+
 describe( 'DELETE /api/v1/templates/{slug}', function (): void {
     it( 'reverts a DB override and returns 204', function (): void {
         Template::create( [

--- a/tests/Feature/Themes/ThemeManagerSchemaValidationTest.php
+++ b/tests/Feature/Themes/ThemeManagerSchemaValidationTest.php
@@ -101,6 +101,51 @@ describe( 'discoverThemes() with extended theme.json validation', function (): v
         expect( $slugs )->toContain( 'phase-h-theme' );
     } );
 
+    it( 'warns but still discovers when a customTemplates entry maps to a Blade-only file (#126)', function (): void {
+        Log::spy();
+
+        $path = writeTheme( $this->themesPath, 'blade-ct-theme', [
+            'name'            => 'Blade CT Theme',
+            'slug'            => 'blade-ct-theme',
+            'version'         => '1.0.0',
+            'customTemplates' => [
+                ['name' => 'landing', 'title' => 'Landing'],
+            ],
+        ], $this->testSlugs );
+
+        File::ensureDirectoryExists( $path . '/templates' );
+        File::put( $path . '/templates/landing.blade.php', '<x-layout>Landing</x-layout>' );
+
+        $themes = $this->manager->discoverThemes();
+
+        expect( array_column( $themes, 'slug' ) )->toContain( 'blade-ct-theme' );
+        Log::shouldHaveReceived( 'warning' )
+            ->withArgs( fn ( string $message, array $context = [] ): bool => str_contains( $message, 'Blade file' )
+                && ( $context['name'] ?? null ) === 'landing' )
+            ->once();
+    } );
+
+    it( 'does not warn when a customTemplates entry has an HTML file even if a Blade sibling exists (#126)', function (): void {
+        Log::spy();
+
+        $path = writeTheme( $this->themesPath, 'html-ct-theme', [
+            'name'            => 'HTML CT Theme',
+            'slug'            => 'html-ct-theme',
+            'version'         => '1.0.0',
+            'customTemplates' => [
+                ['name' => 'landing', 'title' => 'Landing'],
+            ],
+        ], $this->testSlugs );
+
+        File::ensureDirectoryExists( $path . '/templates' );
+        File::put( $path . '/templates/landing.html', '<!-- wp:paragraph --><p>L</p><!-- /wp:paragraph -->' );
+        File::put( $path . '/templates/landing.blade.php', '<x-layout>Landing</x-layout>' );
+
+        $this->manager->discoverThemes();
+
+        Log::shouldNotHaveReceived( 'warning' );
+    } );
+
     it( 'discovers themes carrying menus.locations as a cms-framework extension', function (): void {
         writeTheme( $this->themesPath, 'menus-theme', [
             'name'    => 'Menus Theme',

--- a/tests/Unit/SiteEditor/TemplatePartResolverTest.php
+++ b/tests/Unit/SiteEditor/TemplatePartResolverTest.php
@@ -114,6 +114,28 @@ describe( 'TemplatePartResolver::resolve()', function (): void {
 
         expect( $this->resolver->resolve( '../secret' ) )->toBeNull();
     } );
+
+    it( 'resolves a Blade part when no HTML file exists, marked read-only (#126)', function (): void {
+        File::put( $this->themeFiles . '/header.blade.php', '<header>{{ $x }}</header>' );
+
+        $result = $this->resolver->resolve( 'header' );
+
+        expect( $result->source )->toBe( 'theme' )
+            ->and( $result->isBlade )->toBeTrue()
+            ->and( $result->raw )->toBe( '' )
+            ->and( $result->blocks )->toBe( [] )
+            ->and( $result->area )->toBe( 'header' );
+    } );
+
+    it( 'prefers the HTML part when both HTML and Blade exist (#126)', function (): void {
+        File::put( $this->themeFiles . '/footer.html', '<!-- wp:paragraph --><p>F</p><!-- /wp:paragraph -->' );
+        File::put( $this->themeFiles . '/footer.blade.php', '<footer>blade</footer>' );
+
+        $result = $this->resolver->resolve( 'footer' );
+
+        expect( $result->isBlade )->toBeFalse()
+            ->and( $result->blocks )->toHaveCount( 1 );
+    } );
 } );
 
 describe( 'TemplatePartResolver::all()', function (): void {

--- a/tests/Unit/SiteEditor/TemplateResolverTest.php
+++ b/tests/Unit/SiteEditor/TemplateResolverTest.php
@@ -137,6 +137,65 @@ describe( 'TemplateResolver::resolve()', function (): void {
     } );
 } );
 
+describe( 'TemplateResolver Blade fallback (#126)', function (): void {
+    it( 'resolves a Blade file when no HTML file exists, marked read-only', function (): void {
+        File::put( $this->themeFiles . '/page.blade.php', '<p>{{ $title }}</p>' );
+
+        $result = $this->resolver->resolve( 'page' );
+
+        expect( $result )
+            ->toBeInstanceOf( ResolvedEntity::class )
+            ->and( $result->source )->toBe( 'theme' )
+            ->and( $result->isBlade )->toBeTrue()
+            ->and( $result->hasThemeFile )->toBeTrue()
+            ->and( $result->isCustom )->toBeFalse()
+            ->and( $result->raw )->toBe( '' )
+            ->and( $result->blocks )->toBe( [] )
+            ->and( $result->title )->toBe( 'Page' );
+    } );
+
+    it( 'prefers the HTML file when both HTML and Blade exist (HTML wins)', function (): void {
+        File::put( $this->themeFiles . '/page.html', '<!-- wp:paragraph --><p>HTML</p><!-- /wp:paragraph -->' );
+        File::put( $this->themeFiles . '/page.blade.php', '<p>{{ $blade }}</p>' );
+
+        $result = $this->resolver->resolve( 'page' );
+
+        expect( $result->isBlade )->toBeFalse()
+            ->and( $result->raw )->toContain( 'HTML' )
+            ->and( $result->blocks )->toHaveCount( 1 );
+    } );
+
+    it( 'lists Blade slugs in all() marked as Blade, deduped against HTML', function (): void {
+        File::put( $this->themeFiles . '/blade-only.blade.php', '<p>Blade</p>' );
+        File::put( $this->themeFiles . '/both.html', '<!-- html -->' );
+        File::put( $this->themeFiles . '/both.blade.php', '<p>blade</p>' );
+
+        $bySlug = collect( $this->resolver->all() )->keyBy( 'slug' );
+
+        expect( $bySlug->keys()->all() )->toEqual( ['blade-only', 'both'] )
+            ->and( $bySlug->get( 'blade-only' )->isBlade )->toBeTrue()
+            ->and( $bySlug->get( 'both' )->isBlade )->toBeFalse();
+    } );
+
+    it( 'lets a DB override win over a Blade file and stay editable', function (): void {
+        File::put( $this->themeFiles . '/page.blade.php', '<p>Blade</p>' );
+
+        Template::create( [
+            'theme'         => $this->themeSlug,
+            'slug'          => 'page',
+            'title'         => 'DB Page',
+            'is_custom'     => false,
+            'block_content' => [['blockName' => 'core/heading']],
+        ] );
+
+        $result = $this->resolver->resolve( 'page' );
+
+        expect( $result->source )->toBe( 'db' )
+            ->and( $result->isBlade )->toBeFalse()
+            ->and( $result->hasThemeFile )->toBeTrue();
+    } );
+} );
+
 describe( 'TemplateResolver::all()', function (): void {
     it( 'merges file slugs and DB slugs, deduplicating with DB winning', function (): void {
         File::put( $this->themeFiles . '/page.html', '<!-- page from file -->' );


### PR DESCRIPTION
## Description

Adds a Blade-fallback path so theme `templates/*` and `parts/*` can be authored as Blade files (`{slug}.blade.php`) in addition to block-grammar HTML. `TemplateResolver` and `TemplatePartResolver` fall back to a Blade file when no `.html` file exists; **HTML wins** when both are present, so a theme can migrate a file from Blade to blocks without changing its slug.

Blade-backed entities are **read-only in the site editor**: they resolve with empty block content plus an `isBlade` flag (surfaced as `is_blade`/`editable` on the API), and a create/update against a Blade-only slug is rejected with a clear `422` so the file→DB authority flip stays HTML-only.

**Closes:** #126

## Type of Change

- [x] New feature (adds new functionality)

## Related Issue

**Issue:** #126

## Motivation and Context

Phase H shipped HTML-only template files to match the WP block-grammar contract end-to-end. Laravel teams adopting cms-framework want Blade for layout shells, partials with PHP logic, or progressive migration from a non-block theme. A Blade-fallback path lets a theme mix block-grammar files (editable in the site editor, authority flip works) with Blade files (rendered at request time, not editable in the site editor).

Two kickoff decisions (deferred in the issue) were confirmed with the maintainer:
- Blade entries are **shown in the site editor marked read-only** (not hidden).
- A `customTemplates` entry mapping to a Blade-only file **warns but keeps the theme** (rather than rejecting it from discovery).

## Changes Made

- `TemplateResolver` / `TemplatePartResolver`: new `resolveThemeFile()` prefers `{slug}.html`, falls back to `{slug}.blade.php`; `themeFileSlugs()` lists both extensions (deduped) so Blade entries appear in `all()`.
- `ResolvedEntity` + `TemplateResource`: new `isBlade` flag, exposed on the API as `is_blade` and `editable` (= `!is_blade`).
- `TemplatesController` / `TemplatePartsController`: `store()` and `update()` reject a save against a Blade-only slug with a `422`; existing DB overrides remain editable.
- `ThemeManager::validateTheme()`: logs a warning (without dropping the theme) when a `theme.json` `customTemplates` entry maps to a Blade-only file, since the block editor would open empty content.

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS
- PHP Version: 8.4 (php-cs-fixer run under 8.5)
- Project Version: 2.9

**Tests Performed:**
1. Full suite: `./vendor/bin/pest` → 1943 passed, 7 skipped.
2. `./vendor/bin/php-cs-fixer fix --dry-run` and `./vendor/bin/phpcs src/ database/ tests/ config/` → clean.
3. Manual API verification: Blade-only slug resolves `is_blade:true`/`editable:false`; HTML sibling wins; PUT/POST against a Blade-only slug returns 422; `customTemplates`→Blade logs a warning while the theme still loads.

## Accessibility Tests Run

- [ ] Keyboard navigation tested
- [ ] Screen reader tested
- [ ] Color contrast verified
- [ ] ARIA labels checked

**Details:** N/A — backend resolver/API/validation change only, no UI markup added in this package.

## Tests Added

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] All tests passing

**Test details:** 20 new tests — resolver units (HTML-wins, Blade-resolves-read-only, `all()` dedup, DB-override-wins), controller feature tests (`is_blade`/`editable` in payload, 422 on Blade save for both templates and parts), and theme-manager validation (warn-but-discover on `customTemplates`→Blade; no warn when an HTML sibling exists).

## Documentation

- [x] Inline code documentation added

**Documentation details:** PHPDoc added/updated on the new resolver methods, the `isBlade` DTO field, the controller guard, and the `ThemeManager` warning method.

## Pre-Submission Checklist

- [x] Code passes all tests
- [x] Code has been linted
- [x] Code follows project style guide
- [x] Self-review completed
- [x] Comments added for complex code
- [x] No new warnings generated


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for discovering Blade-based templates and template parts.
  * Blade-backed items are clearly identified as read-only in the editor.
  * HTML templates take precedence when both HTML and Blade versions exist.

* **Bug Fixes**
  * Prevented edits or creation of database overrides for read-only Blade templates.
  * Added warnings for themes referencing Blade-only custom templates.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->