### PR TITLE
fix: resolve the configured user model in Post and Page factories

### DIFF
--- a/src/Modules/Blog/Database/Factories/CommentFactory.php
+++ b/src/Modules/Blog/Database/Factories/CommentFactory.php
@@ -15,15 +15,16 @@ declare( strict_types=1 );
 namespace ArtisanPackUI\CMSFramework\Modules\Blog\Database\Factories;
 
 use ArtisanPackUI\CMSFramework\Modules\Blog\Models\Comment;
+use ArtisanPackUI\CMSFramework\Modules\Users\Database\Factories\Concerns\ResolvesUserFactory;
 use Illuminate\Database\Eloquent\Factories\Factory;
-use Illuminate\Database\Eloquent\Factories\HasFactory;
-use Illuminate\Database\Eloquent\Model;
 
 /**
  * @extends Factory<Comment>
  */
 class CommentFactory extends Factory
 {
+    use ResolvesUserFactory;
+
     /**
      * @var class-string<Comment>
      */
@@ -123,38 +124,5 @@ class CommentFactory extends Factory
             'status'      => Comment::STATUS_TRASH,
             'approved_at' => null,
         ] );
-    }
-
-    /**
-     * Resolve the configured user model's factory so host apps whose
-     * `auth.providers.users.model` is not `App\Models\User` still
-     * create the right user when `byUser()` is called without an id.
-     * Mirrors `Post::author()`'s use of the same config key.
-     *
-     * @since 2.1.0
-     */
-    protected function resolveUserFactory(): Factory|int|null
-    {
-        $userModel = config( 'auth.providers.users.model' );
-
-        if ( ! is_string( $userModel ) || ! class_exists( $userModel ) ) {
-            return null;
-        }
-
-        if ( ! is_subclass_of( $userModel, Model::class ) ) {
-            return null;
-        }
-
-        // `HasFactory` is the conventional gate; if the host's User
-        // model doesn't expose a factory, fall back to leaving
-        // `user_id` null so the caller must supply it explicitly.
-        if ( ! in_array( HasFactory::class, class_uses_recursive( $userModel ), true ) ) {
-            return null;
-        }
-
-        /** @var Factory $factory */
-        $factory = $userModel::factory();
-
-        return $factory;
     }
 }

--- a/src/Modules/Blog/Database/Factories/PostFactory.php
+++ b/src/Modules/Blog/Database/Factories/PostFactory.php
@@ -13,9 +13,9 @@ declare( strict_types=1 );
 
 namespace ArtisanPackUI\CMSFramework\Modules\Blog\Database\Factories;
 
-use App\Models\User;
 use ArtisanPackUI\CMSFramework\Modules\Blog\Models\Post;
 use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Enums\ContentStatus;
+use ArtisanPackUI\CMSFramework\Modules\Users\Database\Factories\Concerns\ResolvesUserFactory;
 use DateTimeInterface;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Support\Str;
@@ -31,6 +31,8 @@ use Illuminate\Support\Str;
  */
 class PostFactory extends Factory
 {
+    use ResolvesUserFactory;
+
     /**
      * The name of the factory's corresponding model.
      *
@@ -58,7 +60,7 @@ class PostFactory extends Factory
             'slug'         => Str::slug( $title ),
             'content'      => fake()->paragraphs( 5, true ),
             'excerpt'      => fake()->paragraph(),
-            'author_id'    => User::factory(),
+            'author_id'    => $this->resolveUserFactory(),
             'status'       => ContentStatus::Published->value,
             'published_at' => now(),
             'metadata'     => [

--- a/src/Modules/Pages/Database/Factories/PageFactory.php
+++ b/src/Modules/Pages/Database/Factories/PageFactory.php
@@ -13,9 +13,9 @@ declare( strict_types=1 );
 
 namespace ArtisanPackUI\CMSFramework\Modules\Pages\Database\Factories;
 
-use App\Models\User;
 use ArtisanPackUI\CMSFramework\Modules\ContentTypes\Enums\ContentStatus;
 use ArtisanPackUI\CMSFramework\Modules\Pages\Models\Page;
+use ArtisanPackUI\CMSFramework\Modules\Users\Database\Factories\Concerns\ResolvesUserFactory;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Support\Str;
 
@@ -30,6 +30,8 @@ use Illuminate\Support\Str;
  */
 class PageFactory extends Factory
 {
+    use ResolvesUserFactory;
+
     /**
      * The name of the factory's corresponding model.
      *
@@ -57,7 +59,7 @@ class PageFactory extends Factory
             'slug'         => Str::slug( $title ),
             'content'      => fake()->paragraphs( 3, true ),
             'excerpt'      => fake()->paragraph(),
-            'author_id'    => User::factory(),
+            'author_id'    => $this->resolveUserFactory(),
             'parent_id'    => null,
             'order'        => fake()->numberBetween( 0, 100 ),
             'template'     => 'default',

--- a/src/Modules/Users/Database/Factories/Concerns/ResolvesUserFactory.php
+++ b/src/Modules/Users/Database/Factories/Concerns/ResolvesUserFactory.php
@@ -1,0 +1,68 @@
+<?php
+
+declare( strict_types=1 );
+
+/**
+ * Resolves the host application's configured user model factory.
+ *
+ * Shared by the package's factories so that host apps whose user
+ * model is not `App\Models\User` still create the right user when a
+ * factory needs to populate a user foreign key.
+ *
+ * @since 2.9.0
+ */
+
+namespace ArtisanPackUI\CMSFramework\Modules\Users\Database\Factories\Concerns;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * Provides `resolveUserFactory()` to factories that need to seed a
+ * user foreign key without hard-coding `App\Models\User`.
+ *
+ * @since 2.9.0
+ */
+trait ResolvesUserFactory
+{
+    /**
+     * Resolve the configured user model's factory so host apps whose
+     * `auth.providers.users.model` is not `App\Models\User` still
+     * create the right user. Mirrors `Post::author()`'s use of the
+     * same config key.
+     *
+     * Returns `null` when the host's user model is missing, isn't an
+     * Eloquent model, or doesn't expose a factory — in which case the
+     * caller must supply the user foreign key explicitly rather than
+     * fatally erroring.
+     *
+     * @since 2.1.0
+     *
+     * @return Factory|null The resolved user factory, or null when unavailable.
+     */
+    protected function resolveUserFactory(): ?Factory
+    {
+        $userModel = config( 'auth.providers.users.model' );
+
+        if ( ! is_string( $userModel ) || ! class_exists( $userModel ) ) {
+            return null;
+        }
+
+        if ( ! is_subclass_of( $userModel, Model::class ) ) {
+            return null;
+        }
+
+        // `HasFactory` is the conventional gate; if the host's User
+        // model doesn't expose a factory, fall back to leaving the
+        // foreign key null so the caller must supply it explicitly.
+        if ( ! in_array( HasFactory::class, class_uses_recursive( $userModel ), true ) ) {
+            return null;
+        }
+
+        /** @var Factory $factory */
+        $factory = $userModel::factory();
+
+        return $factory;
+    }
+}

--- a/src/Modules/Users/Http/Controllers/UserController.php
+++ b/src/Modules/Users/Http/Controllers/UserController.php
@@ -13,7 +13,6 @@ declare( strict_types=1 );
 
 namespace ArtisanPackUI\CMSFramework\Modules\Users\Http\Controllers;
 
-use App\Models\User;
 use ArtisanPackUI\CMSFramework\Http\Controllers\Concerns\HasIncludableRelationships;
 use ArtisanPackUI\CMSFramework\Modules\Users\Http\Requests\BulkUserRequest;
 use ArtisanPackUI\CMSFramework\Modules\Users\Http\Resources\UserResource;

--- a/tests/Feature/Blog/PostFactoryTest.php
+++ b/tests/Feature/Blog/PostFactoryTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\CMSFramework\Modules\Blog\Database\Factories\PostFactory;
+use ArtisanPackUI\CMSFramework\Modules\Blog\Models\Post;
+use ArtisanPackUI\CMSFramework\Tests\Support\TestUser;
+
+test( 'the post factory populates author_id from the configured user model', function (): void {
+    $post = PostFactory::new()->create();
+
+    expect( $post )->toBeInstanceOf( Post::class )
+        ->and( $post->author_id )->not->toBeNull()
+        ->and( TestUser::whereKey( $post->author_id )->exists() )->toBeTrue();
+} );
+
+test( 'the post factory resolves the configured model rather than App\\Models\\User', function (): void {
+    $post = PostFactory::new()->create();
+
+    expect( $post->author )->toBeInstanceOf( TestUser::class );
+} );
+
+test( 'the post factory leaves author_id null when the user model cannot be resolved', function (): void {
+    config( ['auth.providers.users.model' => 'Definitely\\Missing\\User'] );
+
+    $attributes = PostFactory::new()->definition();
+
+    expect( $attributes['author_id'] )->toBeNull();
+} );

--- a/tests/Feature/Pages/PageFactoryTest.php
+++ b/tests/Feature/Pages/PageFactoryTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\CMSFramework\Modules\Pages\Database\Factories\PageFactory;
+use ArtisanPackUI\CMSFramework\Modules\Pages\Models\Page;
+use ArtisanPackUI\CMSFramework\Tests\Support\TestUser;
+
+test( 'the page factory populates author_id from the configured user model', function (): void {
+    $page = PageFactory::new()->create();
+
+    expect( $page )->toBeInstanceOf( Page::class )
+        ->and( $page->author_id )->not->toBeNull()
+        ->and( TestUser::whereKey( $page->author_id )->exists() )->toBeTrue();
+} );
+
+test( 'the page factory resolves the configured model rather than App\\Models\\User', function (): void {
+    $page = PageFactory::new()->create();
+
+    expect( $page->author )->toBeInstanceOf( TestUser::class );
+} );
+
+test( 'the page factory leaves author_id null when the user model cannot be resolved', function (): void {
+    config( ['auth.providers.users.model' => 'Definitely\\Missing\\User'] );
+
+    $attributes = PageFactory::new()->definition();
+
+    expect( $attributes['author_id'] )->toBeNull();
+} );

--- a/tests/Unit/Users/ResolvesUserFactoryTest.php
+++ b/tests/Unit/Users/ResolvesUserFactoryTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\CMSFramework\Modules\Users\Database\Factories\Concerns\ResolvesUserFactory;
+use ArtisanPackUI\CMSFramework\Tests\Support\TestPlainContentTypeModel;
+use ArtisanPackUI\CMSFramework\Tests\Support\TestUser;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * Exposes the trait's protected resolver so each guard branch can be
+ * exercised directly.
+ */
+function makeResolvingFactory(): object
+{
+    return new class extends Factory {
+        use ResolvesUserFactory;
+
+        public function definition(): array
+        {
+            return [];
+        }
+
+        public function resolve(): ?Factory
+        {
+            return $this->resolveUserFactory();
+        }
+    };
+}
+
+test( 'it resolves the configured user model factory when available', function (): void {
+    config( ['auth.providers.users.model' => TestUser::class] );
+
+    expect( makeResolvingFactory()->resolve() )->toBeInstanceOf( Factory::class );
+} );
+
+test( 'it returns null when the configured user model class does not exist', function (): void {
+    config( ['auth.providers.users.model' => 'Definitely\\Missing\\User'] );
+
+    expect( makeResolvingFactory()->resolve() )->toBeNull();
+} );
+
+test( 'it returns null when the configured user model is not an eloquent model', function (): void {
+    config( ['auth.providers.users.model' => stdClass::class] );
+
+    expect( makeResolvingFactory()->resolve() )->toBeNull();
+} );
+
+test( 'it returns null when the configured user model has no factory', function (): void {
+    config( ['auth.providers.users.model' => TestPlainContentTypeModel::class] );
+
+    expect( makeResolvingFactory()->resolve() )->toBeNull();
+} );


### PR DESCRIPTION
## Description

`PostFactory` and `PageFactory` hard-coded `App\Models\User::factory()`, so `Post::factory()` / `Page::factory()` fatal on any host app whose user model is namespaced elsewhere — even though the models' `author()` relations, `CommentFactory`, and the rest of the package already resolve `config('auth.providers.users.model')`.

This lifts `CommentFactory::resolveUserFactory()` into a shared `ResolvesUserFactory` trait and points all three factories at it, so the config-resolution and guard logic lives in one place.

**Closes:** #279

## Type of Change

- [x] Bug fix (fixes an issue)
- [ ] New feature (adds new functionality)
- [ ] Enhancement (improves existing functionality)
- [ ] Refactoring (code improvement, no behavior change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Security fix
- [ ] Breaking change (breaks backward compatibility)

## Related Issue

**Issue:** #279

## Motivation and Context

On a host app whose user model is not literally `App\Models\User`, every `Post::factory()` / `Page::factory()` call died with `Class "App\Models\User" not found`. The config key is honoured everywhere else in the package, so the app was correctly configured — only these two factory call sites ignored it. The severity is limited to test/seed paths, but it is a hard blocker there with no configuration workaround (host apps otherwise have to keep an `App\Models\User` class alias shim for a name they retired).

## Changes Made

- Added `src/Modules/Users/Database/Factories/Concerns/ResolvesUserFactory.php` — a shared trait holding `resolveUserFactory()` (reads `auth.providers.users.model`; guards `class_exists` → `is_subclass_of(Model)` → `HasFactory`; returns `null` when unresolvable so the caller supplies the FK explicitly rather than fatally erroring).
- `PostFactory` / `PageFactory` now `use ResolvesUserFactory` and set `'author_id' => $this->resolveUserFactory()`; dropped `use App\Models\User`.
- `CommentFactory` now uses the shared trait; its private copy of the method was removed (single source of truth, behavior unchanged).
- Removed the unused `use App\Models\User` import from `UserController` (same latent assumption, never referenced).

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS (Darwin 27.0.0)
- PHP Version: 8.5
- Project Version: artisanpack-ui/cms-framework 2.9 (branch `release/2.9`)

**Tests Performed:**
1. New `PostFactoryTest` / `PageFactoryTest` (Feature) — author_id populated from the configured model, `->author` resolves to the configured `TestUser` (not `App\Models\User`), and null degradation when the model can't be resolved.
2. New `ResolvesUserFactoryTest` (Unit) — all four guard branches of the trait (resolvable model, missing class, non-Eloquent class, model without `HasFactory`).
3. Manual reproduction in the dev app: pointed `auth.providers.users.model` / `artisanpack.cms-framework.user_model` at a non-`App\Models\User` model and confirmed both factories now create that model as the author.
4. Full package suite: **1953 passed, 7 skipped**. `composer lint` (php-cs-fixer + phpcs) clean.

## Accessibility Tests Run

- [ ] Keyboard navigation tested
- [ ] Screen reader tested
- [ ] Color contrast verified
- [ ] ARIA labels checked

**Details:** N/A — backend-only change to test/seed factory code; no UI surface.

## Tests Added

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] All tests passing

**Test details:** `tests/Feature/Blog/PostFactoryTest.php`, `tests/Feature/Pages/PageFactoryTest.php`, `tests/Unit/Users/ResolvesUserFactoryTest.php`.

## Documentation

- [x] Inline code documentation added

**Documentation details:** PHPDoc on the new trait and method (method retains `@since 2.1.0` provenance; trait tagged `@since 2.9.0`).

## Pre-Submission Checklist

- [x] Code passes all tests
- [x] Code has been linted
- [x] Code follows project style guide
- [x] Self-review completed
- [x] No new warnings generated
