### PR TITLE
fix: match plugin manifest slug against the plugin being installed/updated

### DIFF
--- a/src/Modules/Plugins/Managers/PluginManager.php
+++ b/src/Modules/Plugins/Managers/PluginManager.php
@@ -146,6 +146,21 @@ class PluginManager
 
         $this->validateManifest( $manifest );
 
+        // `validateManifest()` already enforced that a non-empty, well-formed
+        // `slug` is present. Now make sure it matches the extracted directory
+        // name. The row's `slug` is derived from the directory while `meta` is
+        // seated verbatim from the manifest, so a divergence lets a plugin
+        // declare — and later, on uninstall, remove — permission rows namespaced
+        // under a different plugin's slug. Mirror the Themes module, which
+        // asserts the same match after extraction.
+        if ( $manifest['slug'] !== $slug ) {
+            File::deleteDirectory( $this->getPluginsPath() . '/' . $slug );
+
+            throw PluginValidationException::invalidManifest(
+                "Manifest slug '{$manifest['slug']}' must match extracted directory slug '{$slug}'.",
+            );
+        }
+
         // Check if already installed
         if ( Plugin::where( 'slug', sanitizeText( $slug ) )->exists() ) {
             throw PluginInstallationException::alreadyInstalled( $slug );

--- a/src/Modules/Plugins/Managers/UpdateManager.php
+++ b/src/Modules/Plugins/Managers/UpdateManager.php
@@ -267,6 +267,20 @@ class UpdateManager
 
             $this->pluginManager->assertManifestValid( $manifest );
 
+            // The update archive must be an update *of this plugin*. Step 6
+            // seats `meta` straight from the manifest, and `meta['slug']` (with
+            // its permission namespace) is trusted downstream — so a manifest
+            // that declared a different `slug` than the plugin being updated
+            // would let it claim, and later remove, another plugin's permission
+            // rows. `assertManifestValid()` only checks the slug's *format*;
+            // this asserts its *identity*, the way the Themes module does after
+            // extraction. A mismatch unwinds through the backup-restore path.
+            if ( $manifest['slug'] !== $slug ) {
+                throw PluginValidationException::invalidManifest(
+                    "Update archive manifest declares slug '{$manifest['slug']}', but plugin '{$slug}' is being updated.",
+                );
+            }
+
             // 6. Update database
             $plugin->version          = $updateInfo['version'];
             $plugin->meta             = $manifest;

--- a/tests/Feature/Plugins/PluginSecurityTest.php
+++ b/tests/Feature/Plugins/PluginSecurityTest.php
@@ -346,4 +346,32 @@ describe( 'File System Security', function (): void {
 
         File::delete( $zipPath );
     } );
+
+    it( 'rejects a plugin ZIP whose manifest slug differs from the directory it installs as', function (): void {
+        $zipPath = storage_path( 'app/slug-mismatch-plugin-' . uniqid() . '.zip' );
+        File::ensureDirectoryExists( dirname( $zipPath ) );
+
+        // The archive installs as `installed-as`, but the manifest declares a
+        // different `slug` (with a permission namespace to match) — the divergence
+        // this fix rejects.
+        $zip = new ZipArchive;
+        $zip->open( $zipPath, ZipArchive::CREATE | ZipArchive::OVERWRITE );
+        $zip->addFromString( 'installed-as/plugin.json', json_encode( [
+            'slug'        => 'other-plugin',
+            'name'        => 'Slug Mismatch Plugin',
+            'version'     => '1.0.0',
+            'permissions' => ['other-plugin.manage'],
+        ] ) );
+        $zip->close();
+
+        expect( fn () => $this->manager->installFromZip( $zipPath ) )
+            ->toThrow( PluginValidationException::class, 'must match extracted directory slug' );
+
+        // Rollback: the extracted directory is gone and no row was seated.
+        expect( File::exists( $this->pluginsPath . '/installed-as' ) )->toBeFalse();
+        expect( Plugin::where( 'slug', 'installed-as' )->exists() )->toBeFalse();
+        expect( Plugin::where( 'slug', 'other-plugin' )->exists() )->toBeFalse();
+
+        File::delete( $zipPath );
+    } );
 } );

--- a/tests/Feature/Plugins/PluginUpdateTest.php
+++ b/tests/Feature/Plugins/PluginUpdateTest.php
@@ -433,6 +433,41 @@ describe( 'Manifest re-validation on update (#283)', function (): void {
 
         File::delete( $zipPath );
     } );
+
+    it( 'rejects an update whose manifest slug differs from the plugin being updated (#315)', function () use ( $buildUpdateZip, $installPlugin ): void {
+        $installPlugin->call( $this );
+        // The archive's directory is still `valid-plugin` (so extraction lines
+        // up), but its manifest declares a different `slug` — with a permission
+        // namespace to match — the divergence this fix rejects.
+        [$zipPath, $sha256] = $buildUpdateZip( [
+            'slug'        => 'other-plugin',
+            'permissions' => ['other-plugin.manage'],
+        ] );
+
+        Http::fake( [
+            'https://example.com/updates/valid-plugin' => Http::response( [
+                'version'      => '2.0.0',
+                'download_url' => 'https://example.com/downloads/valid-plugin-2.0.0.zip',
+                'sha256'       => $sha256,
+            ] ),
+            'https://example.com/downloads/valid-plugin-2.0.0.zip' => Http::response( File::get( $zipPath ) ),
+        ] );
+
+        expect( fn () => $this->updateManager->updatePlugin( 'valid-plugin' ) )
+            ->toThrow( PluginUpdateException::class );
+
+        // Row rolled back: version and the foreign slug/permissions never seated.
+        $plugin = Plugin::where( 'slug', 'valid-plugin' )->first();
+        expect( $plugin->version )->toBe( '1.0.0' );
+        expect( $plugin->meta['slug'] )->toBe( 'valid-plugin' );
+        expect( $plugin->meta )->not->toHaveKey( 'permissions' );
+
+        // Files restored from backup: the on-disk manifest is the 1.0.0 original.
+        $onDisk = json_decode( File::get( $this->pluginsPath . '/valid-plugin/plugin.json' ), true );
+        expect( $onDisk['version'] )->toBe( '1.0.0' );
+
+        File::delete( $zipPath );
+    } );
 } );
 
 // Helper function


### PR DESCRIPTION
## Description

`PluginManager::validateManifest()` validated a manifest's `slug` for **format** only — it never checked that `$manifest['slug']` matched the plugin the manifest actually belongs to. The install and update paths derive the real plugin identity from the ZIP's top-level directory but seat `meta['slug']` verbatim from the manifest, so the two could diverge.

Because the permission-prefix guard in `validateOptionalManifestFields()` derives its allowed namespace from `$manifest['slug']`, and `Plugin::declared_permissions` reads `meta['permissions']` verbatim, a plugin could ship a ZIP whose directory is `plugin-a` but whose `plugin.json` declares `"slug": "plugin-b"` (with matching `plugin-b.*` permissions), pass validation, and on uninstall have `removeSeededPermissions()` delete permission rows owned by a *different* plugin.

This mirrors `ThemeManager::stageThemeFromZip()`, which already asserts `$manifest['slug'] === $slug` after extraction.

**Closes:** #315

## Type of Change

- [x] Security fix

## Related Issue

**Issue:** #315

## Motivation and Context

A plugin should not be able to seed or remove another plugin's permission rows, and `plugins.slug` should not diverge from `meta['slug']` in the row. The re-validation added in #283 (PR #314) closed the "install-time checks skipped on update" bypass but re-ran the same rules, which trust the manifest's self-declared slug — so this divergence survived. It was confirmed pre-existing by the security and code reviews on PR #314 and deferred to this issue.

## Changes Made

- `PluginManager::installFromZip()` — after `validateManifest()`, assert `$manifest['slug']` equals the slug derived from `extractZip()`. On mismatch, roll back the extracted directory and throw `PluginValidationException` before any DB row is created.
- `UpdateManager::updatePlugin()` — after `assertManifestValid()`, assert `$manifest['slug']` equals the slug of the plugin being updated. On mismatch, throw `PluginValidationException`, which unwinds through the existing backup-restore + row-revert path (#283).

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS
- PHP Version: 8.5 (project min 8.3)
- Project Version: 2.9

**Tests Performed:**
1. Full Plugins suite (`tests/Feature/Plugins` + `tests/Unit/Plugins`): 245 passed, 4 skipped (pre-existing).
2. `php-cs-fixer --dry-run`: clean (0 fixable). `phpcs`: clean.
3. Focused security review of the diff: no new vulnerabilities; the change reduces attack surface.

## Accessibility Tests Run

- [ ] Keyboard navigation tested
- [ ] Screen reader tested
- [ ] Color contrast verified
- [ ] ARIA labels checked

**Details:** N/A — backend manifest-validation change, no UI surface.

## Tests Added

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] All tests passing

**Test details:**
- `PluginSecurityTest` — install ZIP whose directory is `installed-as` but whose manifest declares `slug: other-plugin` is rejected; the extracted directory is rolled back and no row is seated for either slug.
- `PluginUpdateTest` (#315) — update archive whose directory is `valid-plugin` but whose manifest declares `slug: other-plugin` is rejected; the row's version/meta are rolled back and the on-disk files are restored from backup.

## Documentation

- [x] Inline code documentation added

**Documentation details:** Explanatory comments added at both assertion sites.

## Pre-Submission Checklist

- [x] Code passes all tests
- [x] Code has been linted
- [x] Code follows project style guide
- [x] Self-review completed
- [x] Comments added for complex code
- [x] No new warnings generated
