### PR TITLE
fix: display-safe author_name for discovered plugins (#297)

### DIFF
--- a/docs/plugin-authoring.md
+++ b/docs/plugin-authoring.md
@@ -94,7 +94,7 @@ A plugin's root directory MUST contain a `plugin.json` file:
 | Field               | Type            | Notes |
 | ------------------- | --------------- | ----- |
 | `description`       | string          | Shown in the admin plugin list. |
-| `author`            | object          | `{ name, email?, url? }`. |
+| `author`            | object\|string  | `{ name, email?, url? }`, or a plain name string. |
 | `homepage`          | string ( URL )  | Documentation or marketing URL. |
 | `license`           | string          | SPDX identifier ( `MIT`, `Apache-2.0`, etc. ). |
 | `requires`          | object          | Semver constraints: `{ "cms-framework": "^2.4", "php": "^8.2" }`. A nested `plugins` object declares plugin-to-plugin dependencies. Enforced on activation. See [Plugin dependencies & conflicts](#plugin-dependencies--conflicts). |
@@ -105,6 +105,14 @@ A plugin's root directory MUST contain a `plugin.json` file:
 | `nav`               | array           | Static nav entries; equivalent to calling `registerNavEntry()` from your provider. |
 | `update`            | object          | Where self-updates come from. See [Shipping updates](#shipping-updates). |
 | `update_url`        | string ( URL )  | Legacy custom JSON update feed. Superseded by `update`; still honored. |
+
+> **Displaying the author.** `PluginManager::discoverPlugins()` and
+> `::getPlugin()` return `author` verbatim from the manifest, so it is a
+> string or an object depending on what `plugin.json` declares — echoing it
+> directly risks an `Array to string conversion`. Each returned plugin also
+> carries an `author_name` key, always a display-safe string ( the object's
+> `name`, the plain string, or `''` ), which is what a host should render in
+> a plugin list.
 
 ## Base `PluginServiceProvider`
 

--- a/resources/types/plugins.d.ts
+++ b/resources/types/plugins.d.ts
@@ -24,6 +24,46 @@ export type UpdateType = 'application' | 'plugin' | 'theme';
 // ---------------------------------------------------------------------------
 
 /**
+ * Structured plugin author, per the plugin.json `author` object form.
+ */
+export interface PluginAuthor {
+	/** The author's display name. */
+	name: string;
+	/** The author's email address. */
+	email?: string;
+	/** The author's URL. */
+	url?: string;
+}
+
+/**
+ * A plugin as returned by `PluginManager` discovery (`discoverPlugins()` and
+ * `getPlugin()`).
+ */
+export interface DiscoveredPlugin {
+	/** The unique plugin slug. */
+	slug: string;
+	/** The plugin display name. */
+	name: string;
+	/** The installed version string. */
+	version: string;
+	/** The plugin description. */
+	description: string;
+	/**
+	 * The raw manifest `author` value — a plain string or the documented
+	 * object form. Prefer `author_name` for display.
+	 */
+	author: string | PluginAuthor;
+	/** Display-safe author name, always a string. */
+	author_name: string;
+	/** Whether the plugin is currently active. */
+	is_active: boolean;
+	/** Absolute path to the plugin directory. */
+	path: string;
+	/** The full parsed plugin.json manifest. */
+	manifest: Record<string, unknown>;
+}
+
+/**
  * Plugin response shape.
  */
 export interface PluginResponse {

--- a/src/Modules/Plugins/Managers/PluginManager.php
+++ b/src/Modules/Plugins/Managers/PluginManager.php
@@ -51,7 +51,10 @@ class PluginManager
      * Results are cached for performance.
      *
      * @return array Array of plugin data with keys: slug, name, version,
-     *               description, author, is_active, path, manifest
+     *               description, author, author_name, is_active, path,
+     *               manifest. `author` is the raw manifest value ( string or
+     *               `{ name, email?, url? }` object ); `author_name` is always
+     *               a display-safe string.
      */
     public function discoverPlugins(): array
     {
@@ -74,7 +77,9 @@ class PluginManager
      *
      * @param  string  $slug  Plugin slug (validated)
      *
-     * @return array|null Plugin data or null if not found
+     * @return array|null Plugin data or null if not found. The returned array
+     *                    includes both the raw `author` manifest value and a
+     *                    display-safe `author_name` string.
      */
     public function getPlugin( string $slug ): ?array
     {
@@ -112,6 +117,7 @@ class PluginManager
             'version'     => $manifest['version'] ?? '0.0.0',
             'description' => $manifest['description'] ?? '',
             'author'      => $manifest['author'] ?? '',
+            'author_name' => $this->resolveAuthorName( $manifest['author'] ?? '' ),
             'is_active'   => $dbPlugin ? $dbPlugin->is_active : false,
             'path'        => $realPluginPath,
             'manifest'    => $manifest,
@@ -618,6 +624,26 @@ class PluginManager
     }
 
     /**
+     * Resolve a display-safe author name from a manifest author value.
+     *
+     * A plugin.json `author` may be a plain string or the documented object
+     * form ( `{ name, email?, url? }` ). This always returns a string so a
+     * host can echo the author directly without special-casing the shape.
+     *
+     * @param  mixed  $author  The raw manifest author value.
+     *
+     * @return string The display-safe author name, or an empty string.
+     */
+    protected function resolveAuthorName( mixed $author ): string
+    {
+        if ( is_array( $author ) ) {
+            return (string) ( $author['name'] ?? '' );
+        }
+
+        return is_string( $author ) ? $author : '';
+    }
+
+    /**
      * Order active plugin slugs dependencies-first for boot registration.
      *
      * Falls back to the given order if a dependency cycle is detected, and
@@ -1112,6 +1138,7 @@ class PluginManager
                 'version'     => $manifest['version'] ?? '0.0.0',
                 'description' => $manifest['description'] ?? '',
                 'author'      => $manifest['author'] ?? '',
+                'author_name' => $this->resolveAuthorName( $manifest['author'] ?? '' ),
                 'is_active'   => $dbPlugin ? $dbPlugin->is_active : false,
                 'path'        => $directory,
                 'manifest'    => $manifest,

--- a/tests/Support/Plugins/object-author-plugin/plugin.json
+++ b/tests/Support/Plugins/object-author-plugin/plugin.json
@@ -1,0 +1,17 @@
+{
+  "slug": "object-author-plugin",
+  "name": "Object Author Plugin",
+  "version": "1.0.0",
+  "description": "A test plugin whose author uses the documented object form",
+  "author": {
+    "name": "Jane Developer",
+    "email": "jane@example.com",
+    "url": "https://example.com"
+  },
+  "service_provider": "ObjectAuthorPlugin\\ObjectAuthorPluginServiceProvider",
+  "autoload": {
+    "psr-4": {
+      "ObjectAuthorPlugin\\": "src/"
+    }
+  }
+}

--- a/tests/Unit/Plugins/PluginManagerTest.php
+++ b/tests/Unit/Plugins/PluginManagerTest.php
@@ -128,6 +128,51 @@ describe( 'Get Plugin', function (): void {
     } );
 } );
 
+describe( 'Author Name Resolution', function (): void {
+    it( 'exposes a display-safe author_name for a string author', function (): void {
+        $pluginsPath = base_path( 'plugins' );
+        File::ensureDirectoryExists( $pluginsPath );
+        File::copyDirectory( $this->testPluginsPath . '/valid-plugin', $pluginsPath . '/valid-plugin' );
+
+        $plugin = $this->manager->getPlugin( 'valid-plugin' );
+
+        expect( $plugin['author'] )->toBe( 'Test Author' )
+            ->and( $plugin['author_name'] )->toBe( 'Test Author' )
+            ->and( $plugin['author_name'] )->toBeString();
+
+        File::deleteDirectory( $pluginsPath . '/valid-plugin' );
+    } );
+
+    it( 'flattens an object-form author into author_name', function (): void {
+        $pluginsPath = base_path( 'plugins' );
+        File::ensureDirectoryExists( $pluginsPath );
+        File::copyDirectory( $this->testPluginsPath . '/object-author-plugin', $pluginsPath . '/object-author-plugin' );
+
+        $plugin = $this->manager->getPlugin( 'object-author-plugin' );
+
+        expect( $plugin['author'] )->toBeArray()
+            ->and( $plugin['author']['name'] )->toBe( 'Jane Developer' )
+            ->and( $plugin['author_name'] )->toBe( 'Jane Developer' )
+            ->and( $plugin['author_name'] )->toBeString();
+
+        File::deleteDirectory( $pluginsPath . '/object-author-plugin' );
+    } );
+
+    it( 'includes author_name for every discovered plugin', function (): void {
+        $pluginsPath = base_path( 'plugins' );
+        File::ensureDirectoryExists( $pluginsPath );
+        File::copyDirectory( $this->testPluginsPath . '/object-author-plugin', $pluginsPath . '/object-author-plugin' );
+
+        $plugins   = $this->manager->discoverPlugins();
+        $discovered = collect( $plugins )->firstWhere( 'slug', 'object-author-plugin' );
+
+        expect( $discovered['author_name'] )->toBe( 'Jane Developer' )
+            ->and( $discovered['author_name'] )->toBeString();
+
+        File::deleteDirectory( $pluginsPath . '/object-author-plugin' );
+    } );
+} );
+
 describe( 'Manifest Validation', function (): void {
     it( 'validates required fields', function (): void {
         $invalidManifest = ['name' => 'Test'];


### PR DESCRIPTION
## Description

`PluginManager::discoverPlugins()` and `::getPlugin()` copied the manifest `author` value through verbatim. Because `plugin.json`'s documented `author` is an object (`{ name, email?, url? }`) — as the bundled `hello-world` example uses — a host doing the obvious `{{ $plugin['author'] }}` got an `Array to string conversion` and a broken `/admin/plugins`. The same key also returned a string when absent and an array when present, so hosts had to handle two types from one key with nothing documenting it.

This applies Option 1 from the issue: keep `author` as the raw manifest value (non-breaking for consumers already reading the object) and add a new `author_name` key that is always a display-safe string.

**Closes:** #297

## Type of Change

- [x] Bug fix (fixes an issue)

## Related Issue

**Issue:** #297

## Motivation and Context

The framework hands hosts a value of an unannounced, polymorphic shape under a name that reads like a display field, and the framework's own example triggers the fatal. Hosts need something safe to echo without special-casing the manifest shape.

## Changes Made

- Added `PluginManager::resolveAuthorName( mixed $author ): string` — returns the object's `name`, a plain string author, or `''`.
- Added an `author_name` key to the arrays returned by both `getPlugin()` and `discoverPlugins()` (via `scanPluginsDirectory()`).
- Left `author` untouched (raw manifest value) so existing consumers reading `author['url']` etc. keep working.
- Updated both method docblocks to document `author` vs `author_name`.
- Added `PluginAuthor` and `DiscoveredPlugin` interfaces to `resources/types/plugins.d.ts` (the discovery shape had no TS type before).
- Documented the distinction in `docs/plugin-authoring.md` (author row now `object|string`, plus a callout to render `author_name`).

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS 26
- PHP Version: 8.4
- Project Version: 2.9 (release/2.9)

**Tests Performed:**
1. `./vendor/bin/pest tests/Unit/Plugins/PluginManagerTest.php` — 18 passed.
2. Full `tests/Unit/Plugins` + `tests/Feature` suite — 971 passed, 4 skipped.
3. Manual: rendered the object-author example plugin in a host plugins list echoing `author_name` — no `Array to string conversion`.

## Accessibility Tests Run

- [ ] Keyboard navigation tested
- [ ] Screen reader tested
- [ ] Color contrast verified
- [ ] ARIA labels checked

**Details:** N/A — backend data-shape fix; no UI shipped in this package.

## Tests Added

- [x] Unit tests added/updated
- [x] All tests passing

**Test details:** New `tests/Support/Plugins/object-author-plugin/` fixture (object-form author) and three tests: string-author resolution, object-author flattening, and `author_name` presence across `discoverPlugins()`.

## Documentation

- [x] Inline code documentation added
- [x] API documentation updated

**Documentation details:** Method docblocks, `docs/plugin-authoring.md` author row + callout, and TypeScript type definitions.

## Pre-Submission Checklist

- [x] Code passes all tests
- [x] Code has been linted (php-cs-fixer + phpcs)
- [x] Code follows project style guide
- [x] Self-review completed
- [x] Comments added for complex code
- [x] No new warnings generated
