### PR TITLE
feat: add a disk → database promotion path for plugins

### DIFF
--- a/src/Modules/Plugins/Console/Commands/SyncPluginsCommand.php
+++ b/src/Modules/Plugins/Console/Commands/SyncPluginsCommand.php
@@ -1,0 +1,87 @@
+<?php
+
+declare( strict_types=1 );
+
+/**
+ * Artisan command to register disk-scaffolded plugins into the database.
+ *
+ * @since 2.9.0
+ */
+
+namespace ArtisanPackUI\CMSFramework\Modules\Plugins\Console\Commands;
+
+use ArtisanPackUI\CMSFramework\Modules\Plugins\Managers\PluginManager;
+use Illuminate\Console\Command;
+
+/**
+ * Promotes every plugin discovered on disk into a `plugins` row so it can be
+ * activated (#298).
+ *
+ * @since 2.9.0
+ */
+class SyncPluginsCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @since 2.9.0
+     *
+     * @var string
+     */
+    protected $signature = 'cms:plugins:sync';
+
+    /**
+     * The console command description.
+     *
+     * @since 2.9.0
+     *
+     * @var string
+     */
+    protected $description = 'Register plugins discovered on disk into the database so they can be activated, preserving activation state for plugins already registered';
+
+    /**
+     * Execute the console command.
+     *
+     * @since 2.9.0
+     *
+     * @param  PluginManager  $manager  The plugin manager.
+     *
+     * @return int The exit code.
+     */
+    public function handle( PluginManager $manager ): int
+    {
+        $results = $manager->syncFromDisk();
+
+        if ( empty( $results ) ) {
+            $this->info( __( 'No plugins found on disk to sync.' ) );
+
+            return self::SUCCESS;
+        }
+
+        $this->table(
+            [ __( 'Plugin' ), __( 'Status' ), __( 'Detail' ) ],
+            array_map(
+                static fn ( array $result ): array => [
+                    $result['slug'],
+                    $result['status'],
+                    $result['message'],
+                ],
+                $results,
+            ),
+        );
+
+        $counts = array_count_values( array_column( $results, 'status' ) );
+
+        $this->info( __(
+            ':installed installed, :updated updated, :unchanged unchanged, :failed failed.',
+            [
+                'installed' => $counts['installed'] ?? 0,
+                'updated'   => $counts['updated'] ?? 0,
+                'unchanged' => $counts['unchanged'] ?? 0,
+                'failed'    => $counts['failed'] ?? 0,
+            ],
+        ) );
+
+        return empty( $counts['failed'] ) ? self::SUCCESS : self::FAILURE;
+    }
+}

--- a/src/Modules/Plugins/Managers/PluginManager.php
+++ b/src/Modules/Plugins/Managers/PluginManager.php
@@ -193,6 +193,144 @@ class PluginManager
     }
 
     /**
+     * Install a plugin that already exists on disk.
+     *
+     * The sibling to {@see installFromZip()} for a plugin scaffolded straight
+     * into the plugins directory — symlinked or copied during development, or
+     * shipped inside the host's own repository — which discovery finds but which
+     * has no `plugins` row and so can never be activated (#298). It runs the
+     * exact same gates the ZIP path runs after extraction — `validateManifest()`,
+     * the manifest/directory slug-match guard, and the already-installed guard —
+     * and fires the same `installing` / `installed` hooks, minus the ZIP
+     * validation and extraction steps. Host-version compatibility is enforced at
+     * {@see activate()} for both install paths, so a disk-installed plugin
+     * clears the same bar a ZIP-installed one does before it can go active.
+     *
+     * @since 2.9.0
+     *
+     * @param  string  $slug  Plugin slug (validated against the plugins directory).
+     *
+     * @throws PluginNotFoundException If no discoverable plugin exists for the slug.
+     * @throws PluginValidationException If the on-disk manifest is invalid.
+     * @throws PluginInstallationException If the plugin is already registered.
+     *
+     * @return Plugin The installed plugin model.
+     */
+    public function installFromDisk( string $slug ): Plugin
+    {
+        $discovered = $this->getPlugin( $slug );
+
+        if ( null === $discovered ) {
+            throw PluginNotFoundException::forSlug( $slug );
+        }
+
+        $manifest = $discovered['manifest'];
+
+        $this->validateManifest( $manifest );
+
+        // Same guard `installFromZip()` applies after extraction: the row's
+        // `slug` is derived from the directory while `meta` is seated verbatim
+        // from the manifest, so a divergence would let a plugin declare — and
+        // later, on uninstall, remove — permission rows namespaced under a
+        // different plugin's slug.
+        if ( $manifest['slug'] !== $slug ) {
+            throw PluginValidationException::invalidManifest(
+                "Manifest slug '{$manifest['slug']}' must match plugin directory slug '{$slug}'.",
+            );
+        }
+
+        if ( Plugin::where( 'slug', sanitizeText( $slug ) )->exists() ) {
+            throw PluginInstallationException::alreadyInstalled( $slug );
+        }
+
+        doAction( 'ap.cmsFramework.plugin.installing', $slug );
+
+        $plugin = Plugin::create( [
+            'slug'             => $slug,
+            'name'             => $manifest['name'],
+            'version'          => $manifest['version'],
+            'is_active'        => false,
+            'service_provider' => $manifest['service_provider'] ?? null,
+            'meta'             => $manifest,
+            'installed_at'     => now(),
+        ] );
+
+        $this->clearCaches();
+
+        doAction( 'ap.cmsFramework.plugin.installed', $slug, $plugin );
+
+        return $plugin;
+    }
+
+    /**
+     * Register every plugin discovered on disk into the database (#298).
+     *
+     * Walks {@see discoverPlugins()} and upserts a `plugins` row for each
+     * manifest, keyed on `slug`: a plugin with no row is installed through
+     * {@see installFromDisk()} so it clears the same gates and fires the same
+     * hooks as any other install; a plugin already registered has its manifest
+     * fields refreshed while its `is_active` state is left untouched, so a dev
+     * loop that re-runs the sync never flips an active plugin off or a
+     * deactivated one back on. Idempotent and safe to run repeatedly — the
+     * obvious fit for a deploy that ships plugins in the repo.
+     *
+     * @since 2.9.0
+     *
+     * @return array<int,array{slug:string,status:string,message:string}> One
+     *              result row per discovered plugin. `status` is one of
+     *              `installed`, `updated`, `unchanged`, or `failed`.
+     */
+    public function syncFromDisk(): array
+    {
+        $results = [];
+
+        foreach ( $this->discoverPlugins() as $discovered ) {
+            $slug     = $discovered['slug'];
+            $manifest = $discovered['manifest'];
+
+            try {
+                // Guard the directory/manifest slug match before any write so a
+                // mismatched manifest can't seat a row under the wrong slug on
+                // the refresh path. `installFromDisk()` re-checks this for the
+                // install path.
+                if ( ( $manifest['slug'] ?? null ) !== $slug ) {
+                    $results[] = [
+                        'slug'    => $slug,
+                        'status'  => 'failed',
+                        'message' => "Manifest slug '" . ( $manifest['slug'] ?? '' ) . "' must match plugin directory slug '{$slug}'.",
+                    ];
+
+                    continue;
+                }
+
+                $existing = Plugin::where( 'slug', sanitizeText( $slug ) )->first();
+
+                if ( null === $existing ) {
+                    $this->installFromDisk( $slug );
+
+                    $results[] = [
+                        'slug'    => $slug,
+                        'status'  => 'installed',
+                        'message' => 'Registered from disk.',
+                    ];
+
+                    continue;
+                }
+
+                $results[] = $this->refreshInstalledPlugin( $existing, $manifest );
+            } catch ( PluginValidationException | PluginInstallationException $e ) {
+                $results[] = [
+                    'slug'    => $slug,
+                    'status'  => 'failed',
+                    'message' => $e->getMessage(),
+                ];
+            }
+        }
+
+        return $results;
+    }
+
+    /**
      * Activate a plugin.
      *
      * Process:
@@ -621,6 +759,53 @@ class PluginManager
         }
 
         return $graph;
+    }
+
+    /**
+     * Refresh an installed plugin's manifest fields from disk without touching
+     * its activation state (#298).
+     *
+     * Runs the same `validateManifest()` gate the install paths run before it
+     * trusts the manifest, then updates `name`, `version`, `service_provider`,
+     * and `meta` only when they actually changed. `is_active` and `installed_at`
+     * are never in the update set, so a sync preserves activation state.
+     *
+     * @since 2.9.0
+     *
+     * @param  Plugin  $existing  The already-registered plugin.
+     * @param  array  $manifest  The parsed manifest read from disk.
+     *
+     * @throws PluginValidationException If the on-disk manifest is invalid.
+     *
+     * @return array{slug:string,status:string,message:string}
+     */
+    protected function refreshInstalledPlugin( Plugin $existing, array $manifest ): array
+    {
+        $this->validateManifest( $manifest );
+
+        $existing->fill( [
+            'name'             => $manifest['name'],
+            'version'          => $manifest['version'],
+            'service_provider' => $manifest['service_provider'] ?? null,
+            'meta'             => $manifest,
+        ] );
+
+        if ( ! $existing->isDirty() ) {
+            return [
+                'slug'    => $existing->slug,
+                'status'  => 'unchanged',
+                'message' => 'Already registered; manifest unchanged.',
+            ];
+        }
+
+        $existing->save();
+        $this->clearCaches();
+
+        return [
+            'slug'    => $existing->slug,
+            'status'  => 'updated',
+            'message' => 'Registered manifest refreshed from disk.',
+        ];
     }
 
     /**

--- a/src/Modules/Plugins/Providers/PluginsServiceProvider.php
+++ b/src/Modules/Plugins/Providers/PluginsServiceProvider.php
@@ -4,6 +4,7 @@ declare( strict_types=1 );
 
 namespace ArtisanPackUI\CMSFramework\Modules\Plugins\Providers;
 
+use ArtisanPackUI\CMSFramework\Modules\Plugins\Console\Commands\SyncPluginsCommand;
 use ArtisanPackUI\CMSFramework\Modules\Plugins\Managers\PluginManager;
 use ArtisanPackUI\CMSFramework\Modules\Plugins\Managers\UpdateManager;
 use ArtisanPackUI\CMSFramework\Modules\Plugins\Support\PluginRegistry;
@@ -49,6 +50,12 @@ class PluginsServiceProvider extends ServiceProvider
         $this->publishes( [
             __DIR__ . '/../config/plugins.php' => config_path( 'cms/plugins.php' ),
         ], [ 'cms-plugins-config', 'cms-framework-config' ] );
+
+        if ( $this->app->runningInConsole() ) {
+            $this->commands( [
+                SyncPluginsCommand::class,
+            ] );
+        }
 
         $this->registerPluginCapabilities();
 

--- a/tests/Feature/Plugins/PluginDiskSyncTest.php
+++ b/tests/Feature/Plugins/PluginDiskSyncTest.php
@@ -1,0 +1,214 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\CMSFramework\Modules\Plugins\Exceptions\PluginInstallationException;
+use ArtisanPackUI\CMSFramework\Modules\Plugins\Exceptions\PluginNotFoundException;
+use ArtisanPackUI\CMSFramework\Modules\Plugins\Exceptions\PluginValidationException;
+use ArtisanPackUI\CMSFramework\Modules\Plugins\Managers\PluginManager;
+use ArtisanPackUI\CMSFramework\Modules\Plugins\Models\Plugin;
+use Illuminate\Support\Facades\File;
+
+beforeEach( function (): void {
+    $this->manager         = app( PluginManager::class );
+    $this->testPluginsPath = __DIR__ . '/../../Support/Plugins';
+    $this->pluginsPath     = base_path( 'plugins' );
+
+    File::ensureDirectoryExists( $this->pluginsPath );
+
+    // Discovery is cached by default; disable so a copy made mid-test is seen.
+    config()->set( 'cms.plugins.cacheEnabled', false );
+} );
+
+afterEach( function (): void {
+    foreach ( [ 'valid-plugin', 'object-author-plugin' ] as $slug ) {
+        if ( File::exists( $this->pluginsPath . '/' . $slug ) ) {
+            File::deleteDirectory( $this->pluginsPath . '/' . $slug );
+        }
+    }
+} );
+
+describe( 'installFromDisk', function (): void {
+    it( 'registers a disk-scaffolded plugin so it can be activated', function (): void {
+        File::copyDirectory(
+            $this->testPluginsPath . '/valid-plugin',
+            $this->pluginsPath . '/valid-plugin',
+        );
+
+        expect( Plugin::where( 'slug', 'valid-plugin' )->exists() )->toBeFalse();
+
+        $plugin = $this->manager->installFromDisk( 'valid-plugin' );
+
+        expect( $plugin )->toBeInstanceOf( Plugin::class )
+            ->and( $plugin->slug )->toBe( 'valid-plugin' )
+            ->and( $plugin->name )->toBe( 'Valid Test Plugin' )
+            ->and( $plugin->version )->toBe( '1.0.0' )
+            ->and( $plugin->is_active )->toBeFalse()
+            ->and( $plugin->meta )->toBeArray();
+
+        // The end-to-end fix for #298: activation now resolves the row.
+        expect( $this->manager->activate( 'valid-plugin' ) )->toBeTrue()
+            ->and( Plugin::where( 'slug', 'valid-plugin' )->first()->is_active )->toBeTrue();
+    } );
+
+    it( 'fires the installing and installed hooks', function (): void {
+        File::copyDirectory(
+            $this->testPluginsPath . '/valid-plugin',
+            $this->pluginsPath . '/valid-plugin',
+        );
+
+        $fired = [];
+        addAction( 'ap.cmsFramework.plugin.installing', function ( string $slug ) use ( &$fired ): void {
+            $fired['installing'] = $slug;
+        } );
+        addAction( 'ap.cmsFramework.plugin.installed', function ( string $slug ) use ( &$fired ): void {
+            $fired['installed'] = $slug;
+        } );
+
+        $this->manager->installFromDisk( 'valid-plugin' );
+
+        expect( $fired )->toBe( [
+            'installing' => 'valid-plugin',
+            'installed'  => 'valid-plugin',
+        ] );
+    } );
+
+    it( 'throws when no plugin exists on disk for the slug', function (): void {
+        expect( fn () => $this->manager->installFromDisk( 'not-on-disk' ) )
+            ->toThrow( PluginNotFoundException::class );
+    } );
+
+    it( 'throws when the plugin is already registered', function (): void {
+        File::copyDirectory(
+            $this->testPluginsPath . '/valid-plugin',
+            $this->pluginsPath . '/valid-plugin',
+        );
+
+        $this->manager->installFromDisk( 'valid-plugin' );
+
+        expect( fn () => $this->manager->installFromDisk( 'valid-plugin' ) )
+            ->toThrow( PluginInstallationException::class );
+    } );
+
+    it( 'throws when the manifest slug does not match the directory', function (): void {
+        File::copyDirectory(
+            $this->testPluginsPath . '/valid-plugin',
+            $this->pluginsPath . '/object-author-plugin',
+        );
+
+        // The copied directory is named object-author-plugin but the manifest
+        // still declares slug "valid-plugin".
+        expect( fn () => $this->manager->installFromDisk( 'object-author-plugin' ) )
+            ->toThrow( PluginValidationException::class );
+
+        expect( Plugin::where( 'slug', 'object-author-plugin' )->exists() )->toBeFalse();
+    } );
+} );
+
+describe( 'syncFromDisk', function (): void {
+    it( 'installs every discovered plugin that has no row', function (): void {
+        File::copyDirectory(
+            $this->testPluginsPath . '/valid-plugin',
+            $this->pluginsPath . '/valid-plugin',
+        );
+        File::copyDirectory(
+            $this->testPluginsPath . '/object-author-plugin',
+            $this->pluginsPath . '/object-author-plugin',
+        );
+
+        $results = $this->manager->syncFromDisk();
+
+        $byslug = collect( $results )->keyBy( 'slug' );
+        expect( $byslug['valid-plugin']['status'] )->toBe( 'installed' )
+            ->and( $byslug['object-author-plugin']['status'] )->toBe( 'installed' )
+            ->and( Plugin::where( 'slug', 'valid-plugin' )->exists() )->toBeTrue()
+            ->and( Plugin::where( 'slug', 'object-author-plugin' )->exists() )->toBeTrue();
+    } );
+
+    it( 'is idempotent and reports unchanged on a second run', function (): void {
+        File::copyDirectory(
+            $this->testPluginsPath . '/valid-plugin',
+            $this->pluginsPath . '/valid-plugin',
+        );
+
+        $this->manager->syncFromDisk();
+        $results = $this->manager->syncFromDisk();
+
+        expect( collect( $results )->firstWhere( 'slug', 'valid-plugin' )['status'] )
+            ->toBe( 'unchanged' )
+            ->and( Plugin::where( 'slug', 'valid-plugin' )->count() )->toBe( 1 );
+    } );
+
+    it( 'preserves activation state for a plugin already registered', function (): void {
+        File::copyDirectory(
+            $this->testPluginsPath . '/valid-plugin',
+            $this->pluginsPath . '/valid-plugin',
+        );
+
+        $this->manager->installFromDisk( 'valid-plugin' );
+        $this->manager->activate( 'valid-plugin' );
+
+        $this->manager->syncFromDisk();
+
+        expect( Plugin::where( 'slug', 'valid-plugin' )->first()->is_active )->toBeTrue();
+    } );
+
+    it( 'refreshes manifest fields for an existing row without touching is_active', function (): void {
+        File::copyDirectory(
+            $this->testPluginsPath . '/valid-plugin',
+            $this->pluginsPath . '/valid-plugin',
+        );
+
+        $this->manager->installFromDisk( 'valid-plugin' );
+        $this->manager->activate( 'valid-plugin' );
+
+        // Bump the on-disk manifest version.
+        $manifestPath        = $this->pluginsPath . '/valid-plugin/plugin.json';
+        $manifest            = json_decode( File::get( $manifestPath ), true );
+        $manifest['version'] = '1.1.0';
+        File::put( $manifestPath, json_encode( $manifest ) );
+
+        $results = $this->manager->syncFromDisk();
+
+        $row = Plugin::where( 'slug', 'valid-plugin' )->first();
+        expect( collect( $results )->firstWhere( 'slug', 'valid-plugin' )['status'] )->toBe( 'updated' )
+            ->and( $row->version )->toBe( '1.1.0' )
+            ->and( $row->is_active )->toBeTrue();
+    } );
+
+    it( 'reports a failure when a manifest is invalid and installs nothing for it', function (): void {
+        File::copyDirectory(
+            $this->testPluginsPath . '/valid-plugin',
+            $this->pluginsPath . '/object-author-plugin',
+        );
+
+        $results = collect( $this->manager->syncFromDisk() )->keyBy( 'slug' );
+
+        expect( $results['object-author-plugin']['status'] )->toBe( 'failed' )
+            ->and( Plugin::where( 'slug', 'object-author-plugin' )->exists() )->toBeFalse();
+    } );
+} );
+
+describe( 'cms:plugins:sync command', function (): void {
+    it( 'registers discovered plugins and reports a summary', function (): void {
+        File::copyDirectory(
+            $this->testPluginsPath . '/valid-plugin',
+            $this->pluginsPath . '/valid-plugin',
+        );
+
+        $this->artisan( 'cms:plugins:sync' )
+            ->assertExitCode( 0 )
+            ->expectsOutputToContain( 'valid-plugin' );
+
+        expect( Plugin::where( 'slug', 'valid-plugin' )->exists() )->toBeTrue();
+    } );
+
+    it( 'exits with a failure code when a plugin fails to sync', function (): void {
+        File::copyDirectory(
+            $this->testPluginsPath . '/valid-plugin',
+            $this->pluginsPath . '/object-author-plugin',
+        );
+
+        $this->artisan( 'cms:plugins:sync' )->assertExitCode( 1 );
+    } );
+} );


### PR DESCRIPTION
## Description

A plugin scaffolded straight into the `plugins/` directory is discovered by `PluginManager::discoverPlugins()` but has no `plugins` row. `Plugin::create()` was only ever reached through `installFromZip()`, and `activate()` resolves the plugin out of the `plugins` table — so a disk-scaffolded plugin threw `PluginNotFoundException` on activation with no supported way to create the row. This adds an explicit disk → database promotion path.

**Closes:** #298

## Type of Change

- [x] New feature (adds new functionality)

## Related Issue

**Issue:** #298

## Motivation and Context

This bites hardest in exactly the two cases the docs point people at: plugin authors developing locally against a symlinked or copied directory, and anyone following `examples/hello-world-plugin/README.md`. The only prior paths were to re-zip and upload through the admin UI, or to hand-write an `INSERT`.

## Changes Made

- **`PluginManager::installFromDisk( string $slug )`** — the primitive; a sibling to `installFromZip()` that runs the same `validateManifest()`, manifest↔directory slug-match, and already-installed guards and fires the same `ap.cmsFramework.plugin.installing` / `installed` hooks, minus ZIP validation and extraction. Host-version compatibility stays enforced at `activate()` for both install paths, so a disk install clears the same bar a ZIP install does before going active.
- **`PluginManager::syncFromDisk()`** + `refreshInstalledPlugin()` — walks `discoverPlugins()` and upserts a row per manifest keyed on `slug`: new plugins go through `installFromDisk()`; already-registered plugins get `name`/`version`/`service_provider`/`meta` refreshed while `is_active` is left untouched. Idempotent; returns per-plugin `installed`/`updated`/`unchanged`/`failed` results.
- **`cms:plugins:sync`** Artisan command — a thin presenter over `syncFromDisk()`; prints a results table and counts, exits non-zero if any plugin failed.

**Scope note on themes:** the issue asked whether `ThemeManager` wants the same. It doesn't — themes activate directly from disk via the `themes.activeTheme` setting, with no DB-row prerequisite, so they never hit this blocker. Left untouched.

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS
- PHP Version: 8.4
- Project Version: 2.9 (branch `release/2.9`)

**Tests Performed:**
1. `./vendor/bin/pest tests/Feature/Plugins/PluginDiskSyncTest.php` — 12 new tests, all passing.
2. Full Plugins suites (`tests/Feature/Plugins` + `tests/Unit/Plugins`) — 264 passed, 4 pre-existing skips.
3. `./vendor/bin/php-cs-fixer` + `./vendor/bin/phpcs` clean on all changed files (no Pint, per package convention).
4. Manual: scaffolded a plugin on disk → `cms:plugins:sync` reports `installed` → activation succeeds; version-bump + re-sync reports `updated` and keeps the plugin active; no-op re-sync reports `unchanged` with no duplicate rows.

## Accessibility Tests Run

- [ ] Keyboard navigation tested
- [ ] Screen reader tested
- [ ] Color contrast verified
- [ ] ARIA labels checked

**Details:** N/A — backend manager methods and a console command; no UI surface.

## Tests Added

- [x] Integration tests added/updated
- [x] All tests passing

**Test details:** `tests/Feature/Plugins/PluginDiskSyncTest.php` covers `installFromDisk` (register + activate, hooks, not-on-disk, already-installed, slug mismatch), `syncFromDisk` (install-new, idempotent unchanged, activation preserved, manifest refresh, invalid-manifest failure), and the `cms:plugins:sync` command (success + failure exit codes).

## Documentation

- [x] Inline code documentation added

**Documentation details:** PHPDoc on all new methods and the command, including the deliberate choice to enforce host-compat at `activate()` for both install paths.

## Pre-Submission Checklist

- [x] Code passes all tests
- [x] Code has been linted
- [x] Code follows project style guide
- [x] Self-review completed
- [x] Comments added for complex code
- [x] No new warnings generated