### PR TITLE
feat: resolve plugin Composer-package dependencies from Packagist

### DIFF
--- a/docs/plugin-authoring.md
+++ b/docs/plugin-authoring.md
@@ -99,6 +99,7 @@ A plugin's root directory MUST contain a `plugin.json` file:
 | `license`           | string          | SPDX identifier ( `MIT`, `Apache-2.0`, etc. ). |
 | `requires`          | object          | Semver constraints: `{ "cms-framework": "^2.4", "php": "^8.2" }`. A nested `plugins` object declares plugin-to-plugin dependencies. Enforced on activation. See [Plugin dependencies & conflicts](#plugin-dependencies--conflicts). |
 | `conflicts`         | object          | Map of plugin slug to version constraint. Activation is refused when a matching plugin is installed. See [Plugin dependencies & conflicts](#plugin-dependencies--conflicts). |
+| `composer`          | object          | Map of Composer package name to version constraint, e.g. `{ "artisanpack-ui/convertkit": "^1.2" }`. Resolved from Packagist on activation. See [Composer-package dependencies](#composer-package-dependencies). |
 | `autoload`          | object          | PSR-4 map. The framework hands this to Composer's runtime `ClassLoader`. |
 | `migrations`        | string ( path ) | Relative path to your migrations directory. Auto-run on activate. |
 | `federated_modules` | array           | See [Federated React modules](#federated-react-modules). |
@@ -449,6 +450,61 @@ The same data is exposed over HTTP: `GET /api/v1/plugins/{slug}/dependencies`,
 `GET /api/v1/plugins/{slug}/dependents`, and
 `POST /api/v1/plugins/check-dependencies` (body `{ "plugins": [ "a", "b" ] }`),
 which returns a resolved activation `order` alongside per-plugin status.
+
+## Composer-package dependencies
+
+A plugin can depend on a real Packagist package instead of vendoring it inside
+the ZIP. Declare the requirement in a `composer` block — Composer package name
+to semver constraint:
+
+```json
+{
+    "slug": "convertkit",
+    "name": "ConvertKit",
+    "version": "1.0.0",
+    "service_provider": "ConvertKit\\ConvertKitServiceProvider",
+    "composer": {
+        "artisanpack-ui/convertkit": "^1.2"
+    }
+}
+```
+
+This is the sibling of `requires.plugins` (plugin→plugin): `requires` resolves
+*other plugins* by slug, while `composer` resolves *Packagist packages* and can
+bring their vendor tree into the host. Keys are validated as Composer package
+names (`vendor/package`); the same constraint rigor as the other manifest maps
+applies.
+
+**When it runs.** On activation, before the service provider boots, the
+framework resolves the `composer` block against the host's installed packages
+(reusing `composer/semver`). Requirements already satisfied are left untouched.
+
+**Installing.** When a requirement is unmet and
+`cms.plugins.autoInstallComposerDependencies` is `true` (the default), the
+framework runs `composer require <package>:<constraint>` in the host root, so
+the dependency is added to the host's `composer.json` / `composer.lock` and
+survives a fresh deploy. The freshly installed package's PSR-4 prefixes are
+registered on the running class loader so its classes are autoloadable when the
+plugin boots in that same request. Composer itself arbitrates any conflict with
+the host's existing lock.
+
+**Failing closed.** Resolution never half-activates a plugin. If a requirement
+is unmet and auto-install is disabled, or an install cannot complete — Packagist
+unreachable, a `composer.lock` conflict, or a missing `composer` binary —
+activation raises `ComposerDependencyNotSatisfiedException` and the activation
+transaction unwinds. Over HTTP the activate endpoint returns `409` with code
+`plugin_composer_dependencies_unsatisfied`. On the update flow the same failure
+restores the previous version through the backup-restore path.
+
+**Deactivation & removal.** Packages a plugin brought in are **left in place**
+on deactivate and delete. They are never auto-removed: the host or another
+plugin may share the same package, and Composer offers no safe ref-counted
+uninstall here. Remove an unwanted package with `composer remove` yourself.
+
+**Hardened hosts.** Set `PLUGINS_AUTO_INSTALL_COMPOSER_DEPENDENCIES=false` to
+forbid runtime Composer installs; activation then requires the operator to have
+installed the declared packages ahead of time. `PLUGINS_COMPOSER_BINARY`
+overrides the resolved `composer` command for sandboxed PHP-FPM pools.
 
 ## Shipping updates
 

--- a/src/Modules/Plugins/Contracts/ComposerPackageInstallerInterface.php
+++ b/src/Modules/Plugins/Contracts/ComposerPackageInstallerInterface.php
@@ -47,18 +47,18 @@ interface ComposerPackageInstallerInterface
     public function install( string $slug, array $constraints ): void;
 
     /**
-     * Absolute filesystem path a package is installed at, or null when it is
-     * not installed.
+     * The host's regenerated Composer autoload maps, for seating freshly
+     * installed classes onto the running class loader before the plugin's
+     * service provider boots.
      *
-     * Used to locate a freshly installed package's own `composer.json` so its
-     * PSR-4 prefixes can be registered onto the running class loader before the
-     * plugin's service provider boots.
+     * Reading the full regenerated maps — not just a declared package's own
+     * `composer.json` — is what makes transitive dependencies, classmap
+     * entries, and eager `files` helpers autoloadable in the same request that
+     * installed them.
      *
      * @since 2.10.0
      *
-     * @param  string  $package  The Composer package name.
-     *
-     * @return string|null Install path, or null when unresolved.
+     * @return array{psr-4:array<string,array<int,string>>,classmap:array<string,string>,files:array<int,string>}
      */
-    public function installPath( string $package ): ?string;
+    public function autoloadMaps(): array;
 }

--- a/src/Modules/Plugins/Contracts/ComposerPackageInstallerInterface.php
+++ b/src/Modules/Plugins/Contracts/ComposerPackageInstallerInterface.php
@@ -1,0 +1,64 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Modules\Plugins\Contracts;
+
+use ArtisanPackUI\CMSFramework\Modules\Plugins\Exceptions\ComposerDependencyNotSatisfiedException;
+
+/**
+ * Contract for resolving and installing a plugin's declared Composer packages.
+ *
+ * The default {@see \ArtisanPackUI\CMSFramework\Modules\Plugins\Support\ProcessComposerPackageInstaller}
+ * reads installed versions from Composer's runtime metadata and shells out to
+ * the `composer` binary to bring a missing package into the host's vendor tree.
+ * Extracting the side-effecting parts behind this interface keeps
+ * `PluginManager` testable — a test binds a fake installer instead of touching
+ * Packagist or the filesystem.
+ *
+ * @since 2.10.0
+ */
+interface ComposerPackageInstallerInterface
+{
+    /**
+     * Snapshot the versions of packages currently installed in the host.
+     *
+     * @since 2.10.0
+     *
+     * @return array<string,string> Map of package name to installed version.
+     */
+    public function installedVersions(): array;
+
+    /**
+     * Install (or upgrade) the given Composer packages into the host.
+     *
+     * Implementations must fail closed: any resolution, network, lock-conflict,
+     * or process failure has to raise
+     * {@see ComposerDependencyNotSatisfiedException} so the caller can unwind a
+     * partial activation rather than boot a plugin whose vendor tree is absent.
+     *
+     * @since 2.10.0
+     *
+     * @param  string  $slug  The plugin the packages are being installed for (for error context).
+     * @param  array<string,string>  $constraints  Map of package name to version constraint.
+     *
+     * @throws ComposerDependencyNotSatisfiedException When installation cannot complete.
+     */
+    public function install( string $slug, array $constraints ): void;
+
+    /**
+     * Absolute filesystem path a package is installed at, or null when it is
+     * not installed.
+     *
+     * Used to locate a freshly installed package's own `composer.json` so its
+     * PSR-4 prefixes can be registered onto the running class loader before the
+     * plugin's service provider boots.
+     *
+     * @since 2.10.0
+     *
+     * @param  string  $package  The Composer package name.
+     *
+     * @return string|null Install path, or null when unresolved.
+     */
+    public function installPath( string $package ): ?string;
+}

--- a/src/Modules/Plugins/Exceptions/ComposerDependencyNotSatisfiedException.php
+++ b/src/Modules/Plugins/Exceptions/ComposerDependencyNotSatisfiedException.php
@@ -1,0 +1,93 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Modules\Plugins\Exceptions;
+
+use ArtisanPackUI\CMSFramework\Exceptions\CMSFrameworkException;
+use ArtisanPackUI\CMSFramework\Modules\Plugins\Support\ComposerPackageResult;
+
+/**
+ * Raised when a plugin cannot be activated because its declared Composer
+ * packages (the manifest `composer` block) are missing or fail their version
+ * constraints, or because installing them could not complete.
+ *
+ * The Composer-package sibling of {@see DependencyNotSatisfiedException}
+ * (plugin→plugin). Fails closed so a plugin is never booted with an absent
+ * vendor tree — the activation transaction unwinds, and the update flow
+ * restores the previous version through its backup-restore path.
+ *
+ * @since 2.10.0
+ */
+class ComposerDependencyNotSatisfiedException extends CMSFrameworkException
+{
+    /**
+     * Slug of the plugin whose Composer requirements could not be satisfied.
+     *
+     * @since 2.10.0
+     */
+    public readonly string $pluginSlug;
+
+    /**
+     * The dependency result when the failure came from an unsatisfied
+     * resolution. Null when the failure came from the installer itself.
+     *
+     * @since 2.10.0
+     */
+    public readonly ?ComposerPackageResult $result;
+
+    /**
+     * Construct with pre-resolved Composer dependency metadata.
+     *
+     * @since 2.10.0
+     *
+     * @param  string  $message  Human-readable failure message.
+     * @param  string  $slug  Plugin slug the failure concerns.
+     * @param  ComposerPackageResult|null  $result  Unsatisfied resolution result, if any.
+     */
+    public function __construct( string $message, string $slug, ?ComposerPackageResult $result = null )
+    {
+        parent::__construct( $message );
+        $this->pluginSlug = $slug;
+        $this->result     = $result;
+    }
+
+    /**
+     * Build the exception for an unsatisfied Composer requirement set.
+     *
+     * @since 2.10.0
+     *
+     * @param  string  $slug  Plugin being activated.
+     * @param  ComposerPackageResult  $result  The unsatisfied resolution result.
+     *
+     * @return self
+     */
+    public static function forResult( string $slug, ComposerPackageResult $result ): self
+    {
+        return new self(
+            "Plugin '{$slug}' cannot be activated because its required Composer packages are not satisfied.",
+            $slug,
+            $result,
+        );
+    }
+
+    /**
+     * Build the exception for an installer failure (Packagist unreachable, a
+     * lock conflict with the host's `composer.lock`, a missing `composer`
+     * binary, or a non-zero install exit).
+     *
+     * @since 2.10.0
+     *
+     * @param  string  $slug  Plugin being activated.
+     * @param  string  $reason  The underlying failure detail.
+     *
+     * @return self
+     */
+    public static function installationFailed( string $slug, string $reason ): self
+    {
+        return new self(
+            "Plugin '{$slug}' could not install its required Composer packages: {$reason}",
+            $slug,
+        );
+    }
+}

--- a/src/Modules/Plugins/Http/Controllers/PluginsController.php
+++ b/src/Modules/Plugins/Http/Controllers/PluginsController.php
@@ -13,6 +13,7 @@ declare( strict_types=1 );
 namespace ArtisanPackUI\CMSFramework\Modules\Plugins\Http\Controllers;
 
 use ArtisanPackUI\CMSFramework\Modules\Plugins\Exceptions\CircularDependencyException;
+use ArtisanPackUI\CMSFramework\Modules\Plugins\Exceptions\ComposerDependencyNotSatisfiedException;
 use ArtisanPackUI\CMSFramework\Modules\Plugins\Exceptions\DependencyNotSatisfiedException;
 use ArtisanPackUI\CMSFramework\Modules\Plugins\Exceptions\IncompatiblePluginException;
 use ArtisanPackUI\CMSFramework\Modules\Plugins\Exceptions\PluginConflictException;
@@ -167,6 +168,13 @@ class PluginsController extends Controller
                 'code'         => 'plugin_dependencies_unsatisfied',
                 'plugin'       => $e->pluginSlug,
                 'dependencies' => $e->result?->toArray(),
+            ], 409 );
+        } catch ( ComposerDependencyNotSatisfiedException $e ) {
+            return response()->json( [
+                'message'  => $e->getMessage(),
+                'code'     => 'plugin_composer_dependencies_unsatisfied',
+                'plugin'   => $e->pluginSlug,
+                'composer' => $e->result?->toArray(),
             ], 409 );
         } catch ( PluginNotFoundException $e ) {
             throw ValidationException::withMessages( [

--- a/src/Modules/Plugins/Managers/PluginManager.php
+++ b/src/Modules/Plugins/Managers/PluginManager.php
@@ -6,7 +6,9 @@ namespace ArtisanPackUI\CMSFramework\Modules\Plugins\Managers;
 
 use ArtisanPackUI\CMSFramework\Modules\Core\Managers\Concerns\HasManifestParsing;
 use ArtisanPackUI\CMSFramework\Modules\Core\Updates\Support\ExtensionArchive;
+use ArtisanPackUI\CMSFramework\Modules\Plugins\Contracts\ComposerPackageInstallerInterface;
 use ArtisanPackUI\CMSFramework\Modules\Plugins\Exceptions\CircularDependencyException;
+use ArtisanPackUI\CMSFramework\Modules\Plugins\Exceptions\ComposerDependencyNotSatisfiedException;
 use ArtisanPackUI\CMSFramework\Modules\Plugins\Exceptions\DependencyNotSatisfiedException;
 use ArtisanPackUI\CMSFramework\Modules\Plugins\Exceptions\IncompatiblePluginException;
 use ArtisanPackUI\CMSFramework\Modules\Plugins\Exceptions\PluginConflictException;
@@ -14,6 +16,7 @@ use ArtisanPackUI\CMSFramework\Modules\Plugins\Exceptions\PluginInstallationExce
 use ArtisanPackUI\CMSFramework\Modules\Plugins\Exceptions\PluginNotFoundException;
 use ArtisanPackUI\CMSFramework\Modules\Plugins\Exceptions\PluginValidationException;
 use ArtisanPackUI\CMSFramework\Modules\Plugins\Models\Plugin;
+use ArtisanPackUI\CMSFramework\Modules\Plugins\Support\ComposerPackageResolver;
 use ArtisanPackUI\CMSFramework\Modules\Plugins\Support\DependencyResolver;
 use ArtisanPackUI\CMSFramework\Modules\Plugins\Support\DependencyResult;
 use Composer\Autoload\ClassLoader;
@@ -362,6 +365,13 @@ class PluginManager
         // Plugin dependency + conflict gate (#45). Also runs before any state
         // mutation so a plugin missing its dependencies never half-activates.
         $this->assertDependenciesSatisfied( $plugin );
+
+        // Composer-package dependency gate (#323). Resolves — and, when enabled,
+        // installs — the manifest `composer` block, then registers the vendor
+        // PSR-4 prefixes so the classes are autoloadable before the plugin's
+        // service provider boots below. Runs before any state mutation so a
+        // failed resolution fails closed without a half-activated plugin.
+        $this->ensureComposerDependencies( $plugin );
 
         doAction( 'ap.cmsFramework.plugin.activating', $slug );
 
@@ -1091,6 +1101,58 @@ class PluginManager
         if ( isset( $manifest['conflicts'] ) ) {
             $this->validateConstraintMapManifestField( $manifest['conflicts'], 'conflicts', $manifest['slug'] );
         }
+
+        if ( isset( $manifest['composer'] ) ) {
+            $this->validateComposerManifestField( $manifest['composer'] );
+        }
+    }
+
+    /**
+     * Validate the optional `composer` manifest key for plugin→Composer-package
+     * dependencies (#323).
+     *
+     * Shape (Packagist package name => version constraint):
+     *     "composer": { "artisanpack-ui/convertkit": "^1.2" }
+     *
+     * The sibling of {@see validateConstraintMapManifestField()}: same object /
+     * non-empty-constraint rigor, but keys are validated as Composer package
+     * names (`vendor/package`) rather than plugin slugs. An empty object is
+     * allowed; a JSON array is rejected because it cannot express the mapping.
+     *
+     * @param  mixed  $composer  Raw manifest value.
+     *
+     * @throws PluginValidationException If the block is malformed.
+     */
+    protected function validateComposerManifestField( mixed $composer ): void
+    {
+        if ( ! is_array( $composer ) ) {
+            throw PluginValidationException::invalidManifest( 'Invalid composer. Must be an object mapping Composer package names to version constraints.' );
+        }
+
+        foreach ( $composer as $package => $constraint ) {
+            if ( ! is_string( $package ) || ! $this->isValidComposerPackageName( $package ) ) {
+                throw PluginValidationException::invalidManifest( 'Invalid composer. Each key must be a valid Composer package name (vendor/package).' );
+            }
+            if ( ! is_string( $constraint ) || '' === trim( $constraint ) ) {
+                throw PluginValidationException::invalidManifest( "Invalid composer['{$package}']. Version constraint must be a non-empty string." );
+            }
+        }
+    }
+
+    /**
+     * Whether a string is a syntactically valid Composer package name.
+     *
+     * Mirrors Composer's own `vendor/package` grammar so a manifest cannot slip
+     * an arbitrary token — a shell fragment, a path — into the value later
+     * handed to `composer require`.
+     *
+     * @param  string  $package  Candidate package name.
+     *
+     * @return bool True when the name is well-formed.
+     */
+    protected function isValidComposerPackageName( string $package ): bool
+    {
+        return 1 === preg_match( '{^[a-z0-9]([_.-]?[a-z0-9]+)*/[a-z0-9](([_.]|-{1,2})?[a-z0-9]+)*$}iD', $package );
     }
 
     /**
@@ -1472,6 +1534,138 @@ class PluginManager
     protected function dependencyResolver(): DependencyResolver
     {
         return new DependencyResolver;
+    }
+
+    /**
+     * Resolve a stateless Composer-package resolver instance.
+     *
+     * @since 2.10.0
+     */
+    protected function composerPackageResolver(): ComposerPackageResolver
+    {
+        return new ComposerPackageResolver;
+    }
+
+    /**
+     * Resolve the bound Composer-package installer.
+     *
+     * Resolved from the container each call so a test can bind a fake and so a
+     * host can register its own install strategy.
+     *
+     * @since 2.10.0
+     */
+    protected function composerPackageInstaller(): ComposerPackageInstallerInterface
+    {
+        return app( ComposerPackageInstallerInterface::class );
+    }
+
+    /**
+     * Resolve — and, when enabled, install — a plugin's declared Composer
+     * packages, then register their PSR-4 prefixes on the running class loader
+     * (#323).
+     *
+     * Fails closed: an unmet requirement with auto-install disabled, or an
+     * install that cannot complete (Packagist unreachable, a `composer.lock`
+     * conflict, a missing binary), raises
+     * {@see ComposerDependencyNotSatisfiedException}. Called from
+     * `activate()` before any state mutation, so a failure aborts activation
+     * without a rollback.
+     *
+     * @since 2.10.0
+     *
+     * @throws ComposerDependencyNotSatisfiedException When requirements cannot be satisfied.
+     */
+    protected function ensureComposerDependencies( Plugin $plugin ): void
+    {
+        $requirements = $plugin->required_composer_packages;
+        if ( empty( $requirements ) ) {
+            return;
+        }
+
+        $installer = $this->composerPackageInstaller();
+        $resolver  = $this->composerPackageResolver();
+
+        $result = $resolver->resolve( $requirements, $installer->installedVersions() );
+
+        if ( ! $result->isSatisfied() ) {
+            if ( ! config( 'cms.plugins.autoInstallComposerDependencies', true ) ) {
+                throw ComposerDependencyNotSatisfiedException::forResult( $plugin->slug, $result );
+            }
+
+            // Hand only the unmet constraints to Composer, which arbitrates any
+            // conflict against the host's existing lock. A non-zero exit throws
+            // ComposerDependencyNotSatisfiedException from the installer.
+            $installer->install( $plugin->slug, $result->unresolvedConstraints() );
+
+            // Re-resolve against the post-install snapshot to confirm the
+            // constraints are now met before booting the provider.
+            $result = $resolver->resolve( $requirements, $installer->installedVersions() );
+
+            if ( ! $result->isSatisfied() ) {
+                throw ComposerDependencyNotSatisfiedException::forResult( $plugin->slug, $result );
+            }
+        }
+
+        $this->registerComposerPackageAutoloaders( array_keys( $requirements ) );
+    }
+
+    /**
+     * Register the PSR-4 prefixes of installed Composer packages onto the
+     * runtime class loader so a freshly installed vendor tree is autoloadable
+     * within the same request that installed it.
+     *
+     * Best-effort: a package whose install path or `composer.json` cannot be
+     * read is skipped — its classes still load on the next request, which boots
+     * with a regenerated autoloader.
+     *
+     * @since 2.10.0
+     *
+     * @param  array<int,string>  $packages  Composer package names.
+     */
+    protected function registerComposerPackageAutoloaders( array $packages ): void
+    {
+        $installer  = $this->composerPackageInstaller();
+        $registered = false;
+
+        foreach ( $packages as $package ) {
+            $path = $installer->installPath( $package );
+            if ( null === $path ) {
+                continue;
+            }
+
+            $composerJson = rtrim( $path, '/' ) . '/composer.json';
+            if ( ! File::exists( $composerJson ) ) {
+                continue;
+            }
+
+            $decoded = json_decode( ( string ) File::get( $composerJson ), true );
+            $psr4    = $decoded['autoload']['psr-4'] ?? null;
+            if ( ! is_array( $psr4 ) ) {
+                continue;
+            }
+
+            foreach ( $psr4 as $namespace => $relative ) {
+                if ( ! is_string( $namespace ) ) {
+                    continue;
+                }
+
+                foreach ( ( array ) $relative as $relativePath ) {
+                    if ( is_string( $relativePath ) ) {
+                        // Trim both sides of the relative path so the registered
+                        // directory has no trailing slash, matching how Composer
+                        // stores its own PSR-4 prefixes.
+                        $prefixPath = rtrim( $path, '/' );
+                        $suffix     = trim( $relativePath, '/' );
+                        $this->classLoader->addPsr4( $namespace, '' === $suffix ? $prefixPath : $prefixPath . '/' . $suffix );
+                        $registered = true;
+                    }
+                }
+            }
+        }
+
+        if ( $registered ) {
+            $this->classLoader->register( true );
+        }
     }
 
     /**

--- a/src/Modules/Plugins/Managers/PluginManager.php
+++ b/src/Modules/Plugins/Managers/PluginManager.php
@@ -1561,8 +1561,8 @@ class PluginManager
 
     /**
      * Resolve — and, when enabled, install — a plugin's declared Composer
-     * packages, then register their PSR-4 prefixes on the running class loader
-     * (#323).
+     * packages, then seat the freshly installed classes on the running class
+     * loader (#323).
      *
      * Fails closed: an unmet requirement with auto-install disabled, or an
      * install that cannot complete (Packagist unreachable, a `composer.lock`
@@ -1587,84 +1587,83 @@ class PluginManager
 
         $result = $resolver->resolve( $requirements, $installer->installedVersions() );
 
-        if ( ! $result->isSatisfied() ) {
-            if ( ! config( 'cms.plugins.autoInstallComposerDependencies', true ) ) {
-                throw ComposerDependencyNotSatisfiedException::forResult( $plugin->slug, $result );
-            }
-
-            // Hand only the unmet constraints to Composer, which arbitrates any
-            // conflict against the host's existing lock. A non-zero exit throws
-            // ComposerDependencyNotSatisfiedException from the installer.
-            $installer->install( $plugin->slug, $result->unresolvedConstraints() );
-
-            // Re-resolve against the post-install snapshot to confirm the
-            // constraints are now met before booting the provider.
-            $result = $resolver->resolve( $requirements, $installer->installedVersions() );
-
-            if ( ! $result->isSatisfied() ) {
-                throw ComposerDependencyNotSatisfiedException::forResult( $plugin->slug, $result );
-            }
+        // Already satisfied: the packages were installed in a prior request, so
+        // the host autoloader that booted this process already knows them — no
+        // install and no in-request autoload seating needed.
+        if ( $result->isSatisfied() ) {
+            return;
         }
 
-        $this->registerComposerPackageAutoloaders( array_keys( $requirements ) );
+        if ( ! config( 'cms.plugins.autoInstallComposerDependencies', true ) ) {
+            throw ComposerDependencyNotSatisfiedException::forResult( $plugin->slug, $result );
+        }
+
+        // Hand only the unmet constraints to Composer, which arbitrates any
+        // conflict against the host's existing lock. A non-zero exit throws
+        // ComposerDependencyNotSatisfiedException from the installer.
+        $installer->install( $plugin->slug, $result->unresolvedConstraints() );
+
+        // Re-resolve against the post-install snapshot to confirm the
+        // constraints are now met before booting the provider.
+        $result = $resolver->resolve( $requirements, $installer->installedVersions() );
+
+        if ( ! $result->isSatisfied() ) {
+            throw ComposerDependencyNotSatisfiedException::forResult( $plugin->slug, $result );
+        }
+
+        // Packages were just installed this request; seat the regenerated
+        // autoload maps so their classes are usable before the provider boots.
+        $this->registerComposerPackageAutoloaders();
     }
 
     /**
-     * Register the PSR-4 prefixes of installed Composer packages onto the
-     * runtime class loader so a freshly installed vendor tree is autoloadable
-     * within the same request that installed it.
+     * Seat the host's regenerated Composer autoload maps onto the runtime class
+     * loader so a freshly installed vendor tree — including transitive
+     * dependencies, classmap entries, and eager `files` helpers — is
+     * autoloadable within the same request that installed it.
      *
-     * Best-effort: a package whose install path or `composer.json` cannot be
-     * read is skipped — its classes still load on the next request, which boots
-     * with a regenerated autoloader.
+     * Only entries the loader does not already carry are added, so re-seating
+     * on a long-running worker does not accumulate duplicate paths. Best-effort:
+     * a map Composer did not (re)write is simply skipped, and its classes still
+     * load on the next request, which boots with a regenerated autoloader.
      *
      * @since 2.10.0
-     *
-     * @param  array<int,string>  $packages  Composer package names.
      */
-    protected function registerComposerPackageAutoloaders( array $packages ): void
+    protected function registerComposerPackageAutoloaders(): void
     {
-        $installer  = $this->composerPackageInstaller();
+        $maps       = $this->composerPackageInstaller()->autoloadMaps();
         $registered = false;
 
-        foreach ( $packages as $package ) {
-            $path = $installer->installPath( $package );
-            if ( null === $path ) {
+        $existingPsr4 = $this->classLoader->getPrefixesPsr4();
+        foreach ( ( $maps['psr-4'] ?? [] ) as $namespace => $paths ) {
+            if ( ! is_string( $namespace ) ) {
                 continue;
             }
 
-            $composerJson = rtrim( $path, '/' ) . '/composer.json';
-            if ( ! File::exists( $composerJson ) ) {
-                continue;
+            $newPaths = array_values( array_diff( ( array ) $paths, $existingPsr4[ $namespace ] ?? [] ) );
+            if ( ! empty( $newPaths ) ) {
+                $this->classLoader->addPsr4( $namespace, $newPaths );
+                $registered = true;
             }
+        }
 
-            $decoded = json_decode( ( string ) File::get( $composerJson ), true );
-            $psr4    = $decoded['autoload']['psr-4'] ?? null;
-            if ( ! is_array( $psr4 ) ) {
-                continue;
-            }
-
-            foreach ( $psr4 as $namespace => $relative ) {
-                if ( ! is_string( $namespace ) ) {
-                    continue;
-                }
-
-                foreach ( ( array ) $relative as $relativePath ) {
-                    if ( is_string( $relativePath ) ) {
-                        // Trim both sides of the relative path so the registered
-                        // directory has no trailing slash, matching how Composer
-                        // stores its own PSR-4 prefixes.
-                        $prefixPath = rtrim( $path, '/' );
-                        $suffix     = trim( $relativePath, '/' );
-                        $this->classLoader->addPsr4( $namespace, '' === $suffix ? $prefixPath : $prefixPath . '/' . $suffix );
-                        $registered = true;
-                    }
-                }
-            }
+        $newClassMap = array_diff_key( $maps['classmap'] ?? [], $this->classLoader->getClassMap() );
+        if ( ! empty( $newClassMap ) ) {
+            $this->classLoader->addClassMap( $newClassMap );
+            $registered = true;
         }
 
         if ( $registered ) {
             $this->classLoader->register( true );
+        }
+
+        // Eager `files` helpers Composer includes at bootstrap. require_once
+        // dedups by realpath, so files already loaded this request are skipped
+        // and only newly installed ones are pulled in.
+        foreach ( ( $maps['files'] ?? [] ) as $file ) {
+            if ( is_string( $file ) && File::exists( $file ) ) {
+                require_once $file;
+            }
         }
     }
 

--- a/src/Modules/Plugins/Managers/UpdateManager.php
+++ b/src/Modules/Plugins/Managers/UpdateManager.php
@@ -229,6 +229,7 @@ class UpdateManager
         $oldMeta                = $plugin->meta;
         $oldServiceProvider     = $plugin->service_provider;
         $backupPath             = null;
+        $zipPath                = null;
 
         doAction( 'ap.cmsFramework.plugin.updating', $slug, $oldVersion, $updateInfo['version'] );
 
@@ -299,8 +300,9 @@ class UpdateManager
             }
 
             // 8. Cleanup. Forget the cached check so it no longer advertises
-            //    the version just installed for the rest of the TTL.
-            File::delete( $zipPath );
+            //    the version just installed for the rest of the TTL. The
+            //    downloaded archive is removed in the `finally` below, which
+            //    also covers every rollback path.
             Cache::forget( $this->updateCacheKey( $slug ) );
 
             doAction( 'ap.cmsFramework.plugin.updated', $slug, $updateInfo['version'] );
@@ -352,6 +354,13 @@ class UpdateManager
             $this->revertPluginRow( $plugin, $oldVersion, $oldMeta, $oldServiceProvider, $wasActive );
 
             throw PluginUpdateException::downloadFailed( $slug );
+        } finally {
+            // Remove the downloaded archive on every outcome — success and each
+            // rollback path — so repeated failed updates don't accumulate ZIPs
+            // in storage.
+            if ( null !== $zipPath ) {
+                File::delete( $zipPath );
+            }
         }
     }
 

--- a/src/Modules/Plugins/Managers/UpdateManager.php
+++ b/src/Modules/Plugins/Managers/UpdateManager.php
@@ -10,6 +10,7 @@ use ArtisanPackUI\CMSFramework\Modules\Core\Updates\Exceptions\UpdateException;
 use ArtisanPackUI\CMSFramework\Modules\Core\Updates\Support\ExtensionArchive;
 use ArtisanPackUI\CMSFramework\Modules\Core\Updates\UpdateChecker;
 use ArtisanPackUI\CMSFramework\Modules\Core\Updates\UpdateCheckerFactory;
+use ArtisanPackUI\CMSFramework\Modules\Plugins\Exceptions\ComposerDependencyNotSatisfiedException;
 use ArtisanPackUI\CMSFramework\Modules\Plugins\Exceptions\DependencyNotSatisfiedException;
 use ArtisanPackUI\CMSFramework\Modules\Plugins\Exceptions\IncompatiblePluginException;
 use ArtisanPackUI\CMSFramework\Modules\Plugins\Exceptions\PluginConflictException;
@@ -314,13 +315,14 @@ class UpdateManager
             $this->revertPluginRow( $plugin, $oldVersion, $oldMeta, $oldServiceProvider, $wasActive );
 
             throw $e;
-        } catch ( DependencyNotSatisfiedException | PluginConflictException $e ) {
+        } catch ( DependencyNotSatisfiedException | PluginConflictException | ComposerDependencyNotSatisfiedException $e ) {
             // The reactivate at step 7 rejected the new manifest's `requires` /
-            // `conflicts` declaration (#45). Unwind exactly like the other
-            // post-extraction failures — restore files and revert the row — and
-            // surface the dependency reason instead of collapsing it into the
-            // generic `downloadFailed()`, which would misreport a satisfiable-
-            // dependency problem as a network error.
+            // `conflicts` declaration (#45) or could not satisfy its `composer`
+            // block (#323). Unwind exactly like the other post-extraction
+            // failures — restore files and revert the row — and surface the
+            // dependency reason instead of collapsing it into the generic
+            // `downloadFailed()`, which would misreport a satisfiable-dependency
+            // problem as a network error.
             $this->restoreFromBackup( $plugin->slug, $backupPath );
             $this->revertPluginRow( $plugin, $oldVersion, $oldMeta, $oldServiceProvider, $wasActive );
 

--- a/src/Modules/Plugins/Models/Plugin.php
+++ b/src/Modules/Plugins/Models/Plugin.php
@@ -149,6 +149,16 @@ class Plugin extends Model
     }
 
     /**
+     * Composer packages declared under the manifest `composer` block (#323).
+     *
+     * @return array<string,string> Map of Composer package name to version constraint.
+     */
+    public function getRequiredComposerPackagesAttribute(): array
+    {
+        return $this->normalizeConstraintMap( $this->meta['composer'] ?? [] );
+    }
+
+    /**
      * Reduce a raw manifest constraint map to string-keyed, string-valued
      * entries so downstream resolution never trips over malformed input.
      *

--- a/src/Modules/Plugins/Providers/PluginsServiceProvider.php
+++ b/src/Modules/Plugins/Providers/PluginsServiceProvider.php
@@ -5,9 +5,11 @@ declare( strict_types=1 );
 namespace ArtisanPackUI\CMSFramework\Modules\Plugins\Providers;
 
 use ArtisanPackUI\CMSFramework\Modules\Plugins\Console\Commands\SyncPluginsCommand;
+use ArtisanPackUI\CMSFramework\Modules\Plugins\Contracts\ComposerPackageInstallerInterface;
 use ArtisanPackUI\CMSFramework\Modules\Plugins\Managers\PluginManager;
 use ArtisanPackUI\CMSFramework\Modules\Plugins\Managers\UpdateManager;
 use ArtisanPackUI\CMSFramework\Modules\Plugins\Support\PluginRegistry;
+use ArtisanPackUI\CMSFramework\Modules\Plugins\Support\ProcessComposerPackageInstaller;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\ServiceProvider;
 use Schema;
@@ -17,6 +19,14 @@ class PluginsServiceProvider extends ServiceProvider
 {
     public function register(): void
     {
+        // Resolver for a plugin's Composer-package dependencies (#323). Bound
+        // to the interface so a test — or a host with a bespoke install
+        // strategy — can swap the shell-out installer for its own.
+        $this->app->bind(
+            ComposerPackageInstallerInterface::class,
+            ProcessComposerPackageInstaller::class,
+        );
+
         // Register PluginManager as singleton
         $this->app->singleton( PluginManager::class, function ( $app ) {
             return new PluginManager;

--- a/src/Modules/Plugins/Support/ComposerPackageResolver.php
+++ b/src/Modules/Plugins/Support/ComposerPackageResolver.php
@@ -1,0 +1,97 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Modules\Plugins\Support;
+
+use Composer\Semver\Semver;
+use Throwable;
+
+/**
+ * Pure resolution logic for a plugin's Composer-package requirements.
+ *
+ * Operates entirely on an in-memory snapshot of installed package versions so
+ * it can be unit-tested without touching Composer, Packagist, or the
+ * filesystem. `PluginManager` snapshots the installed versions from Composer's
+ * runtime `InstalledVersions` and delegates the constraint matching here.
+ *
+ * The Composer-package sibling of {@see DependencyResolver} (plugin→plugin,
+ * #45); both reuse `composer/semver` for constraint matching.
+ *
+ * @since 2.10.0
+ */
+class ComposerPackageResolver
+{
+    /**
+     * Resolve a plugin's declared Composer requirements against installed
+     * versions.
+     *
+     * @since 2.10.0
+     *
+     * @param  array<string,string>  $requirements  Map of package name to version constraint.
+     * @param  array<string,string>  $installedVersions  Map of installed package name to version.
+     *
+     * @return ComposerPackageResult The buckets of unmet requirements.
+     */
+    public function resolve( array $requirements, array $installedVersions ): ComposerPackageResult
+    {
+        $missing         = [];
+        $versionMismatch = [];
+
+        foreach ( $requirements as $package => $constraint ) {
+            if ( ! is_string( $package ) || ! is_string( $constraint ) ) {
+                continue;
+            }
+
+            $installed = $installedVersions[ $package ] ?? null;
+
+            if ( null === $installed ) {
+                $missing[] = [
+                    'package'  => $package,
+                    'required' => $constraint,
+                ];
+
+                continue;
+            }
+
+            if ( ! $this->satisfies( $installed, $constraint ) ) {
+                $versionMismatch[] = [
+                    'package'   => $package,
+                    'required'  => $constraint,
+                    'installed' => $installed,
+                ];
+            }
+        }
+
+        return new ComposerPackageResult( $missing, $versionMismatch );
+    }
+
+    /**
+     * Whether an installed version satisfies a semver constraint.
+     *
+     * Wraps composer/semver, treating any unparseable version or constraint as
+     * an unmet requirement rather than letting the exception escape — the same
+     * defensive policy {@see DependencyResolver::satisfies()} applies.
+     *
+     * @since 2.10.0
+     *
+     * @param  mixed  $version  Installed version (a non-string counts as unmet).
+     * @param  mixed  $constraint  Declared constraint (e.g. "^1.2", "*").
+     *
+     * @return bool True when the version satisfies the constraint.
+     */
+    protected function satisfies( mixed $version, mixed $constraint ): bool
+    {
+        if ( ! is_string( $version ) || ! is_string( $constraint ) ) {
+            return false;
+        }
+
+        $normalized = ltrim( $version, 'vV' );
+
+        try {
+            return Semver::satisfies( $normalized, $constraint );
+        } catch ( Throwable $e ) {
+            return false;
+        }
+    }
+}

--- a/src/Modules/Plugins/Support/ComposerPackageResult.php
+++ b/src/Modules/Plugins/Support/ComposerPackageResult.php
@@ -1,0 +1,97 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Modules\Plugins\Support;
+
+/**
+ * Value object describing the outcome of a plugin's Composer-package
+ * dependency check.
+ *
+ * Produced by {@see ComposerPackageResolver::resolve()} and consulted by
+ * `PluginManager` when it gates activation on a plugin's manifest `composer`
+ * block. Each bucket is empty when that class of problem is absent; a fully
+ * satisfied requirement set leaves every bucket empty.
+ *
+ * This is the Composer-package sibling of {@see DependencyResult}, which covers
+ * plugin→plugin dependencies. It intentionally omits the `inactive` and
+ * `conflicts` buckets: a Composer package has no activation state, and conflict
+ * resolution against the host `composer.lock` is delegated to Composer itself
+ * at install time rather than modelled here.
+ *
+ * @since 2.10.0
+ */
+class ComposerPackageResult
+{
+    /**
+     * Construct with the two buckets of unmet requirements.
+     *
+     * @since 2.10.0
+     *
+     * @param  array<int,array{package:string,required:string}>  $missing  Required packages that are not installed.
+     * @param  array<int,array{package:string,required:string,installed:string}>  $versionMismatch  Requirements whose installed version fails the constraint.
+     */
+    public function __construct(
+        public readonly array $missing = [],
+        public readonly array $versionMismatch = [],
+    ) {
+    }
+
+    /**
+     * Whether every declared Composer package is installed and in range.
+     *
+     * @since 2.10.0
+     *
+     * @return bool True when no problems were recorded.
+     */
+    public function isSatisfied(): bool
+    {
+        return empty( $this->missing )
+            && empty( $this->versionMismatch );
+    }
+
+    /**
+     * The `package => constraint` pairs that still need resolving.
+     *
+     * Combines both buckets into the shape the installer's `install()` method
+     * accepts, so a caller can hand exactly the unmet requirements to Composer
+     * rather than re-requiring already-satisfied packages.
+     *
+     * @since 2.10.0
+     *
+     * @return array<string,string>
+     */
+    public function unresolvedConstraints(): array
+    {
+        $constraints = [];
+
+        foreach ( $this->missing as $entry ) {
+            $constraints[ $entry['package'] ] = $entry['required'];
+        }
+
+        foreach ( $this->versionMismatch as $entry ) {
+            $constraints[ $entry['package'] ] = $entry['required'];
+        }
+
+        return $constraints;
+    }
+
+    /**
+     * Render the result as an API-friendly array.
+     *
+     * Uses the snake_case `version_mismatch` key to match the shape
+     * {@see DependencyResult::toArray()} emits for the plugin-dependency graph.
+     *
+     * @since 2.10.0
+     *
+     * @return array{satisfied:bool,missing:array<int,array<string,string>>,version_mismatch:array<int,array<string,string>>}
+     */
+    public function toArray(): array
+    {
+        return [
+            'satisfied'        => $this->isSatisfied(),
+            'missing'          => $this->missing,
+            'version_mismatch' => $this->versionMismatch,
+        ];
+    }
+}

--- a/src/Modules/Plugins/Support/ProcessComposerPackageInstaller.php
+++ b/src/Modules/Plugins/Support/ProcessComposerPackageInstaller.php
@@ -7,6 +7,7 @@ namespace ArtisanPackUI\CMSFramework\Modules\Plugins\Support;
 use ArtisanPackUI\CMSFramework\Modules\Plugins\Contracts\ComposerPackageInstallerInterface;
 use ArtisanPackUI\CMSFramework\Modules\Plugins\Exceptions\ComposerDependencyNotSatisfiedException;
 use Composer\InstalledVersions;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Process;
 use Throwable;
 
@@ -91,12 +92,29 @@ class ProcessComposerPackageInstaller implements ComposerPackageInstallerInterfa
         // auto-registered.
         $command = $binary . ' require ' . implode( ' ', $specs ) . ' --no-interaction --no-progress --no-plugins --with-all-dependencies';
 
+        // `composer require` rewrites the host `composer.json`/`composer.lock`
+        // in place; two overlapping activations in that directory can drop a
+        // requirement or leave the lock inconsistent. Serialize the run behind
+        // an atomic lock and fail closed when another install holds it.
+        $lock = Cache::lock( 'cms.plugins.composer-require', $timeout + 30 );
+
+        if ( ! $lock->get() ) {
+            throw ComposerDependencyNotSatisfiedException::installationFailed(
+                $slug,
+                'Another Composer installation is already running; try again once it completes.',
+            );
+        }
+
         try {
             $result = Process::timeout( $timeout )
                 ->path( base_path() )
                 ->run( $command );
+        } catch ( ComposerDependencyNotSatisfiedException $e ) {
+            throw $e;
         } catch ( Throwable $e ) {
             throw ComposerDependencyNotSatisfiedException::installationFailed( $slug, $e->getMessage() );
+        } finally {
+            $lock->release();
         }
 
         if ( ! $result->successful() ) {
@@ -122,24 +140,47 @@ class ProcessComposerPackageInstaller implements ComposerPackageInstallerInterfa
      * {@inheritDoc}
      *
      * @since 2.10.0
+     *
+     * @return array{psr-4:array<string,array<int,string>>,classmap:array<string,string>,files:array<int,string>}
      */
-    public function installPath( string $package ): ?string
+    public function autoloadMaps(): array
     {
-        if ( ! class_exists( InstalledVersions::class ) ) {
-            return null;
-        }
+        $base = base_path( 'vendor/composer/' );
 
+        return [
+            'psr-4'    => $this->readAutoloadMap( $base . 'autoload_psr4.php' ),
+            'classmap' => $this->readAutoloadMap( $base . 'autoload_classmap.php' ),
+            'files'    => array_values( $this->readAutoloadMap( $base . 'autoload_files.php' ) ),
+        ];
+    }
+
+    /**
+     * Read one of Composer's regenerated autoload map files, invalidating any
+     * stale OPcache copy first so the just-installed entries are seen.
+     *
+     * @since 2.10.0
+     *
+     * @param  string  $path  Absolute path to the map file.
+     *
+     * @return array<int|string,mixed> The map, or an empty array on any failure.
+     */
+    protected function readAutoloadMap( string $path ): array
+    {
         try {
-            if ( ! InstalledVersions::isInstalled( $package ) ) {
-                return null;
+            if ( ! is_file( $path ) ) {
+                return [];
             }
 
-            $path = InstalledVersions::getInstallPath( $package );
-        } catch ( Throwable $e ) {
-            return null;
-        }
+            if ( function_exists( 'opcache_invalidate' ) ) {
+                opcache_invalidate( $path, true );
+            }
 
-        return is_string( $path ) && '' !== $path ? $path : null;
+            $data = require $path;
+
+            return is_array( $data ) ? $data : [];
+        } catch ( Throwable $e ) {
+            return [];
+        }
     }
 
     /**

--- a/src/Modules/Plugins/Support/ProcessComposerPackageInstaller.php
+++ b/src/Modules/Plugins/Support/ProcessComposerPackageInstaller.php
@@ -1,0 +1,215 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Modules\Plugins\Support;
+
+use ArtisanPackUI\CMSFramework\Modules\Plugins\Contracts\ComposerPackageInstallerInterface;
+use ArtisanPackUI\CMSFramework\Modules\Plugins\Exceptions\ComposerDependencyNotSatisfiedException;
+use Composer\InstalledVersions;
+use Illuminate\Support\Facades\Process;
+use Throwable;
+
+/**
+ * Default {@see ComposerPackageInstallerInterface} that resolves installed
+ * versions from Composer's runtime metadata and shells out to the `composer`
+ * binary to bring a plugin's declared packages into the host's vendor tree.
+ *
+ * Runs `composer require` in the host root so the new package is added to the
+ * host's `composer.json` / `composer.lock` and its autoloader is regenerated —
+ * the requirement then survives a fresh deploy, unlike a hand-run interim
+ * install. Composer itself arbitrates any conflict with the host's existing
+ * lock; a non-zero exit unwinds the activation through a fail-closed exception.
+ *
+ * @since 2.10.0
+ */
+class ProcessComposerPackageInstaller implements ComposerPackageInstallerInterface
+{
+    /**
+     * The composer command used when neither config nor env overrides it.
+     *
+     * @since 2.10.0
+     */
+    protected const DEFAULT_COMPOSER_BINARY = 'composer';
+
+    /**
+     * {@inheritDoc}
+     *
+     * @since 2.10.0
+     *
+     * @return array<string,string>
+     */
+    public function installedVersions(): array
+    {
+        if ( ! class_exists( InstalledVersions::class ) ) {
+            return [];
+        }
+
+        $versions = [];
+
+        try {
+            foreach ( InstalledVersions::getInstalledPackages() as $package ) {
+                $version = InstalledVersions::getVersion( $package );
+                if ( is_string( $version ) && '' !== $version ) {
+                    $versions[ $package ] = $version;
+                }
+            }
+        } catch ( Throwable $e ) {
+            return $versions;
+        }
+
+        return $versions;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @since 2.10.0
+     *
+     * @param  array<string,string>  $constraints
+     *
+     * @throws ComposerDependencyNotSatisfiedException
+     */
+    public function install( string $slug, array $constraints ): void
+    {
+        if ( empty( $constraints ) ) {
+            return;
+        }
+
+        $specs = [];
+        foreach ( $constraints as $package => $constraint ) {
+            $specs[] = escapeshellarg( "{$package}:{$constraint}" );
+        }
+
+        $binary  = $this->resolveComposerBinary();
+        $timeout = ( int ) config( 'cms.plugins.composerTimeout', 600 );
+        // `--no-plugins` keeps a malicious dependency of type `composer-plugin`
+        // from executing its own code during the require — the marginal
+        // supply-chain surface this feature introduces. Scripts are deliberately
+        // left enabled: the host's `post-autoload-dump` runs `package:discover`,
+        // which is how an installed Laravel package's own provider is
+        // auto-registered.
+        $command = $binary . ' require ' . implode( ' ', $specs ) . ' --no-interaction --no-progress --no-plugins --with-all-dependencies';
+
+        try {
+            $result = Process::timeout( $timeout )
+                ->path( base_path() )
+                ->run( $command );
+        } catch ( Throwable $e ) {
+            throw ComposerDependencyNotSatisfiedException::installationFailed( $slug, $e->getMessage() );
+        }
+
+        if ( ! $result->successful() ) {
+            $reason = '' !== trim( $result->errorOutput() )
+                ? trim( $result->errorOutput() )
+                : trim( $result->output() );
+
+            throw ComposerDependencyNotSatisfiedException::installationFailed(
+                $slug,
+                '' !== $reason ? $reason : 'composer require exited with a non-zero status.',
+            );
+        }
+
+        // The subprocess regenerated `vendor/composer/installed.php`, but this
+        // long-running process still holds the pre-install snapshot in
+        // InstalledVersions' static cache. Reload it so a subsequent
+        // installedVersions()/installPath() call in the same request reflects
+        // the package that was just installed.
+        $this->reloadInstalledVersions();
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @since 2.10.0
+     */
+    public function installPath( string $package ): ?string
+    {
+        if ( ! class_exists( InstalledVersions::class ) ) {
+            return null;
+        }
+
+        try {
+            if ( ! InstalledVersions::isInstalled( $package ) ) {
+                return null;
+            }
+
+            $path = InstalledVersions::getInstallPath( $package );
+        } catch ( Throwable $e ) {
+            return null;
+        }
+
+        return is_string( $path ) && '' !== $path ? $path : null;
+    }
+
+    /**
+     * Refresh Composer's in-process installed-package metadata from the
+     * regenerated `vendor/composer/installed.php`.
+     *
+     * A plain `require` (not `require_once`) re-evaluates the file, so the
+     * freshly written array is returned even though the file was already loaded
+     * at bootstrap.
+     *
+     * @since 2.10.0
+     */
+    protected function reloadInstalledVersions(): void
+    {
+        if ( ! class_exists( InstalledVersions::class ) ) {
+            return;
+        }
+
+        $path = base_path( 'vendor/composer/installed.php' );
+
+        try {
+            if ( ! is_file( $path ) ) {
+                return;
+            }
+
+            // The subprocess just rewrote this file, but OPcache may still hold
+            // the pre-install bytecode — with `opcache.validate_timestamps=0`
+            // (common in production) a plain `require` returns the stale array,
+            // which would make the post-install re-resolve wrongly report the
+            // package still missing and fail-close a successful activation.
+            if ( function_exists( 'opcache_invalidate' ) ) {
+                opcache_invalidate( $path, true );
+            }
+
+            $data = require $path;
+
+            if ( is_array( $data ) ) {
+                InstalledVersions::reload( $data );
+            }
+        } catch ( Throwable $e ) {
+            // Best-effort: the on-disk install still succeeded, and the next
+            // request boots with a fresh autoloader that sees the package.
+        }
+    }
+
+    /**
+     * Resolve the composer command base, honouring a config override and the
+     * `COMPOSER_BINARY` env escape hatch used elsewhere in the framework for
+     * sandboxed PHP-FPM pools that hide the binary from PHP's own filesystem
+     * view.
+     *
+     * Both overrides are operator-supplied and returned verbatim (not
+     * shell-escaped) so a multi-token command such as `php /path/composer.phar`
+     * works from either source. Only operators set these — a plugin manifest
+     * cannot reach them.
+     *
+     * @since 2.10.0
+     */
+    protected function resolveComposerBinary(): string
+    {
+        $configured = config( 'cms.plugins.composerBinary' );
+        if ( is_string( $configured ) && '' !== trim( $configured ) ) {
+            return $configured;
+        }
+
+        $envBinary = getenv( 'COMPOSER_BINARY' );
+        if ( is_string( $envBinary ) && '' !== trim( $envBinary ) ) {
+            return $envBinary;
+        }
+
+        return self::DEFAULT_COMPOSER_BINARY;
+    }
+}

--- a/src/Modules/Plugins/config/plugins.php
+++ b/src/Modules/Plugins/config/plugins.php
@@ -92,4 +92,39 @@ return [
     | deployment pipeline handles rebuilds on demand.
     */
     'autoClearFrameworkCaches' => env( 'PLUGINS_AUTO_CLEAR_FRAMEWORK_CACHES', false ),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Plugin Composer-package Dependencies
+    |--------------------------------------------------------------------------
+    | A plugin may declare Packagist dependencies in its manifest `composer`
+    | block, e.g. `"composer": { "artisanpack-ui/convertkit": "^1.2" }`. At
+    | activation the framework resolves those constraints against the host's
+    | installed packages.
+    |
+    | autoInstallComposerDependencies:
+    |   When true (default), an unmet requirement is installed on activation by
+    |   shelling out to `composer require` in the host root — so the dependency
+    |   survives a fresh deploy. When false, activation instead fails closed and
+    |   the operator is expected to have installed the package themselves; use
+    |   this on hardened hosts that must not run Composer at runtime.
+    |
+    | Resolution always fails closed: if a required package is missing (and
+    | auto-install is off or cannot complete — Packagist unreachable, a
+    | `composer.lock` conflict, or a missing binary), the activation transaction
+    | unwinds rather than booting a plugin with an absent vendor tree.
+    |
+    | Packages brought in by a plugin are left in place on deactivate/delete —
+    | they are never auto-removed, since the host or another plugin may share
+    | them and Composer offers no safe ref-counted uninstall here.
+    */
+    'autoInstallComposerDependencies' => env( 'PLUGINS_AUTO_INSTALL_COMPOSER_DEPENDENCIES', true ),
+
+    // Override the composer binary/command used to install plugin dependencies.
+    // Null falls back to the `COMPOSER_BINARY` env var, then a bare `composer`
+    // on the PATH.
+    'composerBinary' => env( 'PLUGINS_COMPOSER_BINARY' ),
+
+    // Timeout, in seconds, for a plugin's `composer require` install.
+    'composerTimeout' => 600,
 ];

--- a/tests/Feature/Plugins/PluginComposerDependencyTest.php
+++ b/tests/Feature/Plugins/PluginComposerDependencyTest.php
@@ -157,33 +157,45 @@ describe( 'Composer-package activation gate', function (): void {
         ] );
     } );
 
-    it( 'registers the installed package PSR-4 prefixes on the class loader before boot', function (): void {
-        $packageDir = sys_get_temp_dir() . '/composer-dep-' . uniqid();
-        File::ensureDirectoryExists( $packageDir );
-        File::put( $packageDir . '/composer.json', json_encode( [
-            'name'     => 'acme/widget',
-            'autoload' => [
-                'psr-4' => [
-                    // A multi-path array exercises the (array) cast branch.
-                    'Acme\\Widget\\' => [ 'src/', 'lib/' ],
-                ],
-            ],
-        ] ) );
+    it( 'seats the regenerated autoload maps on the class loader after installing', function (): void {
+        config()->set( 'cms.plugins.autoInstallComposerDependencies', true );
 
-        $this->installer->installed     = [ 'acme/widget' => '1.4.0' ];
-        $this->installer->installPaths  = [ 'acme/widget' => $packageDir ];
+        $packageDir = sys_get_temp_dir() . '/composer-dep-' . uniqid();
+        File::ensureDirectoryExists( $packageDir . '/src' );
+
+        // The install brings the package into range, and the fake reports the
+        // regenerated maps Composer would have written — PSR-4 (multi-path),
+        // a classmap entry, and an eager files helper.
+        $this->installer->installsToApply = [ 'acme/widget' => '1.4.0' ];
+        $this->installer->autoloadMaps    = [
+            'psr-4'    => [ 'Acme\\Widget\\' => [ $packageDir . '/src', $packageDir . '/lib' ] ],
+            'classmap' => [ 'Acme\\Widget\\Legacy' => $packageDir . '/src/Legacy.php' ],
+            'files'    => [],
+        ];
         makeComposerPlugin( 'widget', [ 'acme/widget' => '^1.2' ] );
 
         try {
             expect( $this->manager->activate( 'widget' ) )->toBeTrue();
 
-            $prefixes = activeComposerClassLoader()->getPrefixesPsr4();
+            $loader = activeComposerClassLoader();
 
-            expect( $prefixes )->toHaveKey( 'Acme\\Widget\\' )
-                ->and( $prefixes['Acme\\Widget\\'] )->toContain( $packageDir . '/src' )
-                ->and( $prefixes['Acme\\Widget\\'] )->toContain( $packageDir . '/lib' );
+            expect( $loader->getPrefixesPsr4() )->toHaveKey( 'Acme\\Widget\\' )
+                ->and( $loader->getPrefixesPsr4()['Acme\\Widget\\'] )->toContain( $packageDir . '/src' )
+                ->and( $loader->getPrefixesPsr4()['Acme\\Widget\\'] )->toContain( $packageDir . '/lib' )
+                ->and( $loader->getClassMap() )->toHaveKey( 'Acme\\Widget\\Legacy' );
         } finally {
             File::deleteDirectory( $packageDir );
         }
+    } );
+
+    it( 'does not seat autoload maps when the requirement is already satisfied', function (): void {
+        $this->installer->installed    = [ 'acme/widget' => '1.4.0' ];
+        $this->installer->autoloadMaps = [
+            'psr-4' => [ 'Acme\\Unused\\' => [ '/tmp/should-not-register' ] ],
+        ];
+        makeComposerPlugin( 'widget', [ 'acme/widget' => '^1.2' ] );
+
+        expect( $this->manager->activate( 'widget' ) )->toBeTrue()
+            ->and( activeComposerClassLoader()->getPrefixesPsr4() )->not->toHaveKey( 'Acme\\Unused\\' );
     } );
 } );

--- a/tests/Feature/Plugins/PluginComposerDependencyTest.php
+++ b/tests/Feature/Plugins/PluginComposerDependencyTest.php
@@ -1,0 +1,189 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\CMSFramework\Modules\Plugins\Contracts\ComposerPackageInstallerInterface;
+use ArtisanPackUI\CMSFramework\Modules\Plugins\Exceptions\ComposerDependencyNotSatisfiedException;
+use ArtisanPackUI\CMSFramework\Modules\Plugins\Managers\PluginManager;
+use ArtisanPackUI\CMSFramework\Modules\Plugins\Models\Plugin;
+use ArtisanPackUI\CMSFramework\Tests\Support\Composer\FakeComposerPackageInstaller;
+use Composer\Autoload\ClassLoader;
+use Illuminate\Support\Facades\File;
+
+beforeEach( function (): void {
+    $this->installer = new FakeComposerPackageInstaller;
+    app()->instance( ComposerPackageInstallerInterface::class, $this->installer );
+
+    $this->manager = app( PluginManager::class );
+} );
+
+/**
+ * Persist a plugin declaring a `composer` block.
+ */
+function makeComposerPlugin( string $slug, array $composer ): Plugin
+{
+    return Plugin::create( [
+        'slug'      => $slug,
+        'name'      => ucfirst( $slug ),
+        'version'   => '1.0.0',
+        'is_active' => false,
+        'meta'      => [ 'slug' => $slug, 'composer' => $composer ],
+    ] );
+}
+
+/**
+ * The Composer ClassLoader the running process (and PluginManager) uses.
+ */
+function activeComposerClassLoader(): ClassLoader
+{
+    foreach ( spl_autoload_functions() as $autoloader ) {
+        if ( is_array( $autoloader ) && $autoloader[0] instanceof ClassLoader ) {
+            return $autoloader[0];
+        }
+    }
+
+    throw new RuntimeException( 'Composer ClassLoader not found.' );
+}
+
+describe( 'Composer-package activation gate', function (): void {
+    it( 'activates without touching the installer when a plugin declares no composer block', function (): void {
+        Plugin::create( [
+            'slug'      => 'plain',
+            'name'      => 'Plain',
+            'version'   => '1.0.0',
+            'is_active' => false,
+            'meta'      => [ 'slug' => 'plain' ],
+        ] );
+
+        expect( $this->manager->activate( 'plain' ) )->toBeTrue()
+            ->and( $this->installer->installCalls )->toBe( [] );
+    } );
+
+    it( 'activates when the required package is already installed and in range', function (): void {
+        $this->installer->installed = [ 'artisanpack-ui/convertkit' => '1.4.0' ];
+        makeComposerPlugin( 'convertkit', [ 'artisanpack-ui/convertkit' => '^1.2' ] );
+
+        expect( $this->manager->activate( 'convertkit' ) )->toBeTrue()
+            ->and( $this->installer->installCalls )->toBe( [] );
+
+        expect( Plugin::where( 'slug', 'convertkit' )->first()->is_active )->toBeTrue();
+    } );
+
+    it( 'installs a missing package on activation when auto-install is enabled', function (): void {
+        config()->set( 'cms.plugins.autoInstallComposerDependencies', true );
+        $this->installer->installsToApply = [ 'artisanpack-ui/convertkit' => '1.4.0' ];
+        makeComposerPlugin( 'convertkit', [ 'artisanpack-ui/convertkit' => '^1.2' ] );
+
+        expect( $this->manager->activate( 'convertkit' ) )->toBeTrue()
+            ->and( $this->installer->installCalls )->toHaveCount( 1 )
+            ->and( $this->installer->installCalls[0]['constraints'] )
+            ->toBe( [ 'artisanpack-ui/convertkit' => '^1.2' ] );
+
+        expect( Plugin::where( 'slug', 'convertkit' )->first()->is_active )->toBeTrue();
+    } );
+
+    it( 'fails closed without installing when auto-install is disabled', function (): void {
+        config()->set( 'cms.plugins.autoInstallComposerDependencies', false );
+        makeComposerPlugin( 'convertkit', [ 'artisanpack-ui/convertkit' => '^1.2' ] );
+
+        try {
+            $this->manager->activate( 'convertkit' );
+            $this->fail( 'Expected ComposerDependencyNotSatisfiedException.' );
+        } catch ( ComposerDependencyNotSatisfiedException $e ) {
+            expect( $e->pluginSlug )->toBe( 'convertkit' )
+                ->and( $e->result?->missing )->toBe( [
+                    [ 'package' => 'artisanpack-ui/convertkit', 'required' => '^1.2' ],
+                ] );
+        }
+
+        expect( $this->installer->installCalls )->toBe( [] )
+            ->and( Plugin::where( 'slug', 'convertkit' )->first()->is_active )->toBeFalse();
+    } );
+
+    it( 'fails closed and does not activate when the install cannot complete', function (): void {
+        config()->set( 'cms.plugins.autoInstallComposerDependencies', true );
+        $this->installer->failInstall = true;
+        $this->installer->failReason  = 'Could not reach Packagist.';
+        makeComposerPlugin( 'convertkit', [ 'artisanpack-ui/convertkit' => '^1.2' ] );
+
+        try {
+            $this->manager->activate( 'convertkit' );
+            $this->fail( 'Expected ComposerDependencyNotSatisfiedException.' );
+        } catch ( ComposerDependencyNotSatisfiedException $e ) {
+            expect( $e->pluginSlug )->toBe( 'convertkit' )
+                ->and( $e->getMessage() )->toContain( 'Could not reach Packagist.' );
+        }
+
+        expect( Plugin::where( 'slug', 'convertkit' )->first()->is_active )->toBeFalse();
+    } );
+
+    it( 'fails closed when a version mismatch survives the install attempt', function (): void {
+        config()->set( 'cms.plugins.autoInstallComposerDependencies', true );
+        // Installed but out of range, and the simulated install brings nothing
+        // new — so the post-install re-resolve still reports a mismatch.
+        $this->installer->installed = [ 'artisanpack-ui/convertkit' => '0.9.0' ];
+        makeComposerPlugin( 'convertkit', [ 'artisanpack-ui/convertkit' => '^1.2' ] );
+
+        try {
+            $this->manager->activate( 'convertkit' );
+            $this->fail( 'Expected ComposerDependencyNotSatisfiedException.' );
+        } catch ( ComposerDependencyNotSatisfiedException $e ) {
+            expect( $e->result?->versionMismatch )->toBe( [
+                [ 'package' => 'artisanpack-ui/convertkit', 'required' => '^1.2', 'installed' => '0.9.0' ],
+            ] );
+        }
+
+        expect( Plugin::where( 'slug', 'convertkit' )->first()->is_active )->toBeFalse();
+    } );
+
+    it( 'installs every unmet package in a multi-package composer block', function (): void {
+        config()->set( 'cms.plugins.autoInstallComposerDependencies', true );
+        $this->installer->installed        = [ 'acme/already' => '2.1.0' ];
+        $this->installer->installsToApply  = [ 'acme/one' => '1.0.0', 'acme/two' => '3.2.0' ];
+        makeComposerPlugin( 'bundle', [
+            'acme/one'     => '^1.0',
+            'acme/two'     => '^3.0',
+            'acme/already' => '^2.0',
+        ] );
+
+        expect( $this->manager->activate( 'bundle' ) )->toBeTrue()
+            ->and( $this->installer->installCalls )->toHaveCount( 1 );
+
+        // Only the two unmet packages are handed to the installer; the satisfied
+        // one is not re-required.
+        expect( $this->installer->installCalls[0]['constraints'] )->toBe( [
+            'acme/one' => '^1.0',
+            'acme/two' => '^3.0',
+        ] );
+    } );
+
+    it( 'registers the installed package PSR-4 prefixes on the class loader before boot', function (): void {
+        $packageDir = sys_get_temp_dir() . '/composer-dep-' . uniqid();
+        File::ensureDirectoryExists( $packageDir );
+        File::put( $packageDir . '/composer.json', json_encode( [
+            'name'     => 'acme/widget',
+            'autoload' => [
+                'psr-4' => [
+                    // A multi-path array exercises the (array) cast branch.
+                    'Acme\\Widget\\' => [ 'src/', 'lib/' ],
+                ],
+            ],
+        ] ) );
+
+        $this->installer->installed     = [ 'acme/widget' => '1.4.0' ];
+        $this->installer->installPaths  = [ 'acme/widget' => $packageDir ];
+        makeComposerPlugin( 'widget', [ 'acme/widget' => '^1.2' ] );
+
+        try {
+            expect( $this->manager->activate( 'widget' ) )->toBeTrue();
+
+            $prefixes = activeComposerClassLoader()->getPrefixesPsr4();
+
+            expect( $prefixes )->toHaveKey( 'Acme\\Widget\\' )
+                ->and( $prefixes['Acme\\Widget\\'] )->toContain( $packageDir . '/src' )
+                ->and( $prefixes['Acme\\Widget\\'] )->toContain( $packageDir . '/lib' );
+        } finally {
+            File::deleteDirectory( $packageDir );
+        }
+    } );
+} );

--- a/tests/Feature/Plugins/PluginUpdateTest.php
+++ b/tests/Feature/Plugins/PluginUpdateTest.php
@@ -2,10 +2,12 @@
 
 declare( strict_types=1 );
 
+use ArtisanPackUI\CMSFramework\Modules\Plugins\Contracts\ComposerPackageInstallerInterface;
 use ArtisanPackUI\CMSFramework\Modules\Plugins\Exceptions\PluginUpdateException;
 use ArtisanPackUI\CMSFramework\Modules\Plugins\Managers\PluginManager;
 use ArtisanPackUI\CMSFramework\Modules\Plugins\Managers\UpdateManager;
 use ArtisanPackUI\CMSFramework\Modules\Plugins\Models\Plugin;
+use ArtisanPackUI\CMSFramework\Tests\Support\Composer\FakeComposerPackageInstaller;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Http;
 
@@ -531,6 +533,74 @@ describe( 'Reactivation failure after update (#45)', function (): void {
             ->and( $plugin->meta )->not->toHaveKey( 'requires' );
 
         // Files restored from backup: the on-disk manifest is the 1.0.0 original.
+        $onDisk = json_decode( File::get( $this->pluginsPath . '/valid-plugin/plugin.json' ), true );
+        expect( $onDisk['version'] )->toBe( '1.0.0' );
+
+        File::delete( $zipPath );
+    } );
+
+    it( 'rolls back and reports the composer reason when the new manifest adds an unsatisfiable composer package (#323)', function (): void {
+        // A fake installer that reports nothing installed and fails any install,
+        // so the reactivation at step 7 cannot satisfy the new composer block.
+        $installer              = new FakeComposerPackageInstaller;
+        $installer->failInstall = true;
+        $installer->failReason  = 'Could not reach Packagist.';
+        app()->instance( ComposerPackageInstallerInterface::class, $installer );
+
+        File::copyDirectory(
+            $this->testPluginsPath . '/valid-plugin',
+            $this->pluginsPath . '/valid-plugin',
+        );
+
+        Plugin::create( [
+            'slug'      => 'valid-plugin',
+            'name'      => 'Valid Test Plugin',
+            'version'   => '1.0.0',
+            'is_active' => true,
+            'meta'      => [
+                'slug'       => 'valid-plugin',
+                'name'       => 'Valid Test Plugin',
+                'version'    => '1.0.0',
+                'update_url' => 'https://example.com/updates/valid-plugin',
+            ],
+        ] );
+
+        $manifest = [
+            'slug'        => 'valid-plugin',
+            'name'        => 'Valid Test Plugin',
+            'version'     => '2.0.0',
+            'description' => 'Updated plugin',
+            'author'      => 'Test Author',
+            'composer'    => [ 'acme/engine' => '^1.0' ],
+        ];
+
+        $zipPath = storage_path( 'app/test-update-' . uniqid() . '.zip' );
+        $zip     = new ZipArchive;
+        $zip->open( $zipPath, ZipArchive::CREATE | ZipArchive::OVERWRITE );
+        $zip->addFromString( 'valid-plugin/plugin.json', json_encode( $manifest ) );
+        $zip->addFromString( 'valid-plugin/src/Stub.php', "<?php\n" );
+        $zip->close();
+        $sha256 = hash( 'sha256', File::get( $zipPath ) );
+
+        Http::fake( [
+            'https://example.com/updates/valid-plugin' => Http::response( [
+                'version'      => '2.0.0',
+                'download_url' => 'https://example.com/downloads/valid-plugin-2.0.0.zip',
+                'sha256'       => $sha256,
+            ] ),
+            'https://example.com/downloads/valid-plugin-2.0.0.zip' => Http::response( File::get( $zipPath ) ),
+        ] );
+
+        expect( fn () => $this->updateManager->updatePlugin( 'valid-plugin' ) )
+            ->toThrow( PluginUpdateException::class, 'Could not reach Packagist.' );
+
+        // Row rolled back and the new composer block never seated.
+        $plugin = Plugin::where( 'slug', 'valid-plugin' )->first();
+        expect( $plugin->version )->toBe( '1.0.0' )
+            ->and( $plugin->is_active )->toBeTrue()
+            ->and( $plugin->meta )->not->toHaveKey( 'composer' );
+
+        // Files restored from backup.
         $onDisk = json_decode( File::get( $this->pluginsPath . '/valid-plugin/plugin.json' ), true );
         expect( $onDisk['version'] )->toBe( '1.0.0' );
 

--- a/tests/Support/Composer/FakeComposerPackageInstaller.php
+++ b/tests/Support/Composer/FakeComposerPackageInstaller.php
@@ -1,0 +1,89 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\CMSFramework\Tests\Support\Composer;
+
+use ArtisanPackUI\CMSFramework\Modules\Plugins\Contracts\ComposerPackageInstallerInterface;
+use ArtisanPackUI\CMSFramework\Modules\Plugins\Exceptions\ComposerDependencyNotSatisfiedException;
+
+/**
+ * In-memory {@see ComposerPackageInstallerInterface} for tests: it models the
+ * host's installed packages without touching Composer, Packagist, or the
+ * filesystem, so the activation gate (#323) can be exercised deterministically.
+ */
+class FakeComposerPackageInstaller implements ComposerPackageInstallerInterface
+{
+    /**
+     * Currently "installed" packages, keyed by name.
+     *
+     * @var array<string,string>
+     */
+    public array $installed = [];
+
+    /**
+     * Versions applied to `$installed` when a package is installed, keyed by
+     * name. A package absent here is not resolved by a simulated install.
+     *
+     * @var array<string,string>
+     */
+    public array $installsToApply = [];
+
+    /**
+     * Install paths returned by installPath(), keyed by package name.
+     *
+     * @var array<string,string>
+     */
+    public array $installPaths = [];
+
+    /**
+     * When true, install() throws instead of resolving anything.
+     */
+    public bool $failInstall = false;
+
+    /**
+     * Reason surfaced when $failInstall is true.
+     */
+    public ?string $failReason = null;
+
+    /**
+     * Recorded install() invocations, for assertions.
+     *
+     * @var array<int,array{slug:string,constraints:array<string,string>}>
+     */
+    public array $installCalls = [];
+
+    /**
+     * @return array<string,string>
+     */
+    public function installedVersions(): array
+    {
+        return $this->installed;
+    }
+
+    /**
+     * @param  array<string,string>  $constraints
+     */
+    public function install( string $slug, array $constraints ): void
+    {
+        $this->installCalls[] = [ 'slug' => $slug, 'constraints' => $constraints ];
+
+        if ( $this->failInstall ) {
+            throw ComposerDependencyNotSatisfiedException::installationFailed(
+                $slug,
+                $this->failReason ?? 'simulated install failure',
+            );
+        }
+
+        foreach ( array_keys( $constraints ) as $package ) {
+            if ( isset( $this->installsToApply[ $package ] ) ) {
+                $this->installed[ $package ] = $this->installsToApply[ $package ];
+            }
+        }
+    }
+
+    public function installPath( string $package ): ?string
+    {
+        return $this->installPaths[ $package ] ?? null;
+    }
+}

--- a/tests/Support/Composer/FakeComposerPackageInstaller.php
+++ b/tests/Support/Composer/FakeComposerPackageInstaller.php
@@ -30,11 +30,11 @@ class FakeComposerPackageInstaller implements ComposerPackageInstallerInterface
     public array $installsToApply = [];
 
     /**
-     * Install paths returned by installPath(), keyed by package name.
+     * Regenerated autoload maps returned by autoloadMaps().
      *
-     * @var array<string,string>
+     * @var array{psr-4?:array<string,array<int,string>>,classmap?:array<string,string>,files?:array<int,string>}
      */
-    public array $installPaths = [];
+    public array $autoloadMaps = [];
 
     /**
      * When true, install() throws instead of resolving anything.
@@ -82,8 +82,15 @@ class FakeComposerPackageInstaller implements ComposerPackageInstallerInterface
         }
     }
 
-    public function installPath( string $package ): ?string
+    /**
+     * @return array{psr-4:array<string,array<int,string>>,classmap:array<string,string>,files:array<int,string>}
+     */
+    public function autoloadMaps(): array
     {
-        return $this->installPaths[ $package ] ?? null;
+        return [
+            'psr-4'    => $this->autoloadMaps['psr-4'] ?? [],
+            'classmap' => $this->autoloadMaps['classmap'] ?? [],
+            'files'    => $this->autoloadMaps['files'] ?? [],
+        ];
     }
 }

--- a/tests/Unit/Plugins/ComposerPackageResolverTest.php
+++ b/tests/Unit/Plugins/ComposerPackageResolverTest.php
@@ -1,0 +1,98 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\CMSFramework\Modules\Plugins\Support\ComposerPackageResolver;
+
+beforeEach( function (): void {
+    $this->resolver = new ComposerPackageResolver;
+} );
+
+describe( 'ComposerPackageResolver', function (): void {
+    it( 'reports satisfaction when every package is installed and in range', function (): void {
+        $result = $this->resolver->resolve(
+            [ 'artisanpack-ui/convertkit' => '^1.2' ],
+            [ 'artisanpack-ui/convertkit' => '1.4.0' ],
+        );
+
+        expect( $result->isSatisfied() )->toBeTrue()
+            ->and( $result->missing )->toBe( [] )
+            ->and( $result->versionMismatch )->toBe( [] );
+    } );
+
+    it( 'is satisfied by an empty requirement set', function (): void {
+        $result = $this->resolver->resolve( [], [ 'foo/bar' => '1.0.0' ] );
+
+        expect( $result->isSatisfied() )->toBeTrue();
+    } );
+
+    it( 'buckets a package that is not installed as missing', function (): void {
+        $result = $this->resolver->resolve(
+            [ 'artisanpack-ui/convertkit' => '^1.2' ],
+            [],
+        );
+
+        expect( $result->isSatisfied() )->toBeFalse()
+            ->and( $result->missing )->toBe( [
+                [ 'package' => 'artisanpack-ui/convertkit', 'required' => '^1.2' ],
+            ] )
+            ->and( $result->versionMismatch )->toBe( [] );
+    } );
+
+    it( 'buckets an installed but out-of-range package as a version mismatch', function (): void {
+        $result = $this->resolver->resolve(
+            [ 'artisanpack-ui/convertkit' => '^1.2' ],
+            [ 'artisanpack-ui/convertkit' => '0.9.0' ],
+        );
+
+        expect( $result->isSatisfied() )->toBeFalse()
+            ->and( $result->missing )->toBe( [] )
+            ->and( $result->versionMismatch )->toBe( [
+                [ 'package' => 'artisanpack-ui/convertkit', 'required' => '^1.2', 'installed' => '0.9.0' ],
+            ] );
+    } );
+
+    it( 'strips a leading v from the installed version before matching', function (): void {
+        $result = $this->resolver->resolve(
+            [ 'vendor/pkg' => '^2.0' ],
+            [ 'vendor/pkg' => 'v2.3.1' ],
+        );
+
+        expect( $result->isSatisfied() )->toBeTrue();
+    } );
+
+    it( 'treats an unparseable constraint as unmet rather than throwing', function (): void {
+        $result = $this->resolver->resolve(
+            [ 'vendor/pkg' => 'not-a-constraint' ],
+            [ 'vendor/pkg' => '1.0.0' ],
+        );
+
+        expect( $result->isSatisfied() )->toBeFalse()
+            ->and( $result->versionMismatch )->toHaveCount( 1 );
+    } );
+
+    it( 'collapses both buckets into the unresolved constraint map', function (): void {
+        $result = $this->resolver->resolve(
+            [ 'vendor/a' => '^1.0', 'vendor/b' => '^2.0' ],
+            [ 'vendor/b' => '1.0.0' ],
+        );
+
+        expect( $result->unresolvedConstraints() )->toBe( [
+            'vendor/a' => '^1.0',
+            'vendor/b' => '^2.0',
+        ] );
+    } );
+
+    it( 'exposes an API-friendly array shape', function (): void {
+        $result = $this->resolver->resolve(
+            [ 'vendor/a' => '^1.0' ],
+            [],
+        );
+
+        expect( $result->toArray() )->toBe( [
+            'satisfied'        => false,
+            'missing'          => [ [ 'package' => 'vendor/a', 'required' => '^1.0' ] ],
+            'version_mismatch' => [],
+        ] );
+    } );
+} );

--- a/tests/Unit/Plugins/ManifestSchemaExtensionTest.php
+++ b/tests/Unit/Plugins/ManifestSchemaExtensionTest.php
@@ -305,6 +305,59 @@ describe( 'conflicts', function (): void {
     } );
 } );
 
+describe( 'composer', function (): void {
+    it( 'accepts a well-formed composer block', function (): void {
+        $manifest = array_merge( $this->base, [
+            'composer' => [ 'artisanpack-ui/convertkit' => '^1.2' ],
+        ] );
+
+        expect( fn () => invokeMethod( $this->manager, 'validateManifest', [$manifest] ) )
+            ->not->toThrow( PluginValidationException::class );
+    } );
+
+    it( 'accepts an empty composer object', function (): void {
+        $manifest = array_merge( $this->base, [ 'composer' => [] ] );
+
+        expect( fn () => invokeMethod( $this->manager, 'validateManifest', [$manifest] ) )
+            ->not->toThrow( PluginValidationException::class );
+    } );
+
+    it( 'rejects a non-object composer', function (): void {
+        $manifest = array_merge( $this->base, [ 'composer' => 'artisanpack-ui/convertkit' ] );
+
+        expect( fn () => invokeMethod( $this->manager, 'validateManifest', [$manifest] ) )
+            ->toThrow( PluginValidationException::class, 'Invalid composer.' );
+    } );
+
+    it( 'rejects composer expressed as a list', function (): void {
+        $manifest = array_merge( $this->base, [ 'composer' => [ 'artisanpack-ui/convertkit' ] ] );
+
+        expect( fn () => invokeMethod( $this->manager, 'validateManifest', [$manifest] ) )
+            ->toThrow( PluginValidationException::class, 'Invalid composer.' );
+    } );
+
+    it( 'rejects a key that is not a valid Composer package name', function (): void {
+        $manifest = array_merge( $this->base, [ 'composer' => [ 'not-a-package' => '^1.0' ] ] );
+
+        expect( fn () => invokeMethod( $this->manager, 'validateManifest', [$manifest] ) )
+            ->toThrow( PluginValidationException::class, 'valid Composer package name' );
+    } );
+
+    it( 'rejects a package name with a shell fragment', function (): void {
+        $manifest = array_merge( $this->base, [ 'composer' => [ 'vendor/pkg; rm -rf /' => '^1.0' ] ] );
+
+        expect( fn () => invokeMethod( $this->manager, 'validateManifest', [$manifest] ) )
+            ->toThrow( PluginValidationException::class, 'valid Composer package name' );
+    } );
+
+    it( 'rejects an empty version constraint', function (): void {
+        $manifest = array_merge( $this->base, [ 'composer' => [ 'artisanpack-ui/convertkit' => '' ] ] );
+
+        expect( fn () => invokeMethod( $this->manager, 'validateManifest', [$manifest] ) )
+            ->toThrow( PluginValidationException::class, 'constraint' );
+    } );
+} );
+
 describe( 'Plugin model accessors', function (): void {
     it( 'exposes the new manifest fields ergonomically', function (): void {
         $plugin = new Plugin( [
@@ -348,12 +401,14 @@ describe( 'Plugin model accessors', function (): void {
                     'plugins'       => ['base-forms' => '^1.5'],
                 ],
                 'conflicts' => ['legacy-forms' => '*'],
+                'composer'  => ['artisanpack-ui/convertkit' => '^1.2'],
             ],
         ] );
 
         expect( $plugin->required_plugins )->toBe( ['base-forms' => '^1.5'] )
             ->and( $plugin->required_host_version )->toBe( '^2.0' )
-            ->and( $plugin->conflicting_plugins )->toBe( ['legacy-forms' => '*'] );
+            ->and( $plugin->conflicting_plugins )->toBe( ['legacy-forms' => '*'] )
+            ->and( $plugin->required_composer_packages )->toBe( ['artisanpack-ui/convertkit' => '^1.2'] );
     } );
 
     it( 'returns empty dependency maps when absent', function (): void {
@@ -361,6 +416,7 @@ describe( 'Plugin model accessors', function (): void {
 
         expect( $plugin->required_plugins )->toBe( [] )
             ->and( $plugin->required_host_version )->toBeNull()
-            ->and( $plugin->conflicting_plugins )->toBe( [] );
+            ->and( $plugin->conflicting_plugins )->toBe( [] )
+            ->and( $plugin->required_composer_packages )->toBe( [] );
     } );
 } );


### PR DESCRIPTION
## Description

Adds a `composer` block to `plugin.json` so a plugin can declare Packagist dependencies instead of vendoring them, e.g.:

```json
"composer": { "artisanpack-ui/convertkit": "^1.2" }
```

The framework validates the block, and at **activation** resolves the constraints against the host's installed packages (reusing `composer/semver`). When a requirement is unmet and auto-install is enabled (default), it runs `composer require` in the host root — so the dependency is added to `composer.json`/`composer.lock` and survives a fresh deploy — then registers the vendor PSR-4 prefixes on the live `ClassLoader` before the plugin's service provider boots. This is the plugin→Composer-package sibling of the plugin→plugin dependency work (#45), reusing its resolver / result / exception patterns.

**Closes:** #323

## Type of Change

- [x] New feature (adds new functionality)

## Related Issue

**Issue:** #323

## Motivation and Context

`PluginManager` previously only registered PSR-4 prefixes from the plugin directory; there was no supported way for a plugin to declare a real Packagist dependency. The first consumer is the Keystone ConvertKit plugin, whose engine (`artisanpack-ui/convertkit`) is a Packagist package the plugin must declare and load without vendoring it.

The issue left four design questions open; resolved as:

| Question | Decision |
| --- | --- |
| When to resolve | At activation, before any state mutation; manifest shape validated at install/update. |
| Packagist unreachable / lock conflict / missing binary | Install fails closed via `ComposerDependencyNotSatisfiedException`; activation unwinds (no half-activated plugin); the update flow restores the previous version through its backup-restore path. |
| Auto-install | Config-gated (`autoInstallComposerDependencies`, default `true`); disabled + unmet fails closed for hardened hosts. |
| Deactivation / uninstall | Brought-in packages are **left in place**, never auto-removed — the host or another plugin may share them. |

## Changes Made

- **Manifest**: `composer` block validated in `PluginManager` (Composer package-name grammar + non-empty constraint), sibling of `requires.plugins` / `conflicts`; `Plugin::required_composer_packages` accessor.
- **Resolution**: pure `ComposerPackageResolver` + `ComposerPackageResult` value object (semver via `composer/semver`).
- **Install**: `ComposerPackageInstallerInterface` (container-bound, swappable) + default `ProcessComposerPackageInstaller` that shells out to `composer require`, reloads in-process `InstalledVersions`, and resolves install paths.
- **Activation gate**: `PluginManager::activate()` resolves/installs before boot and registers the vendor PSR-4 prefixes on the live ClassLoader; `ComposerDependencyNotSatisfiedException` fails closed.
- **Update flow**: `UpdateManager::updatePlugin()` unwinds through backup-restore on the new exception.
- **API**: activate endpoint returns `409` `plugin_composer_dependencies_unsatisfied`.
- **Config**: `autoInstallComposerDependencies`, `composerBinary`, `composerTimeout`.
- **Docs**: new "Composer-package dependencies" section in `docs/plugin-authoring.md`.

Security/robustness hardening from a pre-PR review pass: `--no-plugins` on the install (a malicious transitive `composer-plugin` can't execute during `require`; scripts stay enabled so Laravel `package:discover` still runs), and OPcache invalidation before reloading `installed.php` (so in-request auto-install doesn't spuriously fail on hosts with `opcache.validate_timestamps=0`).

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS (Darwin)
- PHP Version: 8.4 (project min 8.3)
- Project Version: 2.10 (branch `release/2.10`)

**Tests Performed:**
1. Full suite green: `2073 passed, 7 skipped`.
2. Plugin suite green including new coverage: `305 passed`.
3. Manual: activation installs a declared package; already-satisfied package skips install; auto-install-off returns `409`; install failure unwinds cleanly.

## Accessibility Tests Run

- [ ] Keyboard navigation tested
- [ ] Screen reader tested
- [ ] Color contrast verified
- [ ] ARIA labels checked

**Details:** N/A — this is backend plugin-lifecycle logic with no UI surface.

## Tests Added

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] All tests passing

**Test details:**
- `tests/Unit/Plugins/ComposerPackageResolverTest.php` — resolution buckets, v-strip, unparseable constraints, `unresolvedConstraints()`, `toArray()`.
- `tests/Unit/Plugins/ManifestSchemaExtensionTest.php` — `composer` block validation (package-name/shell-fragment/list/empty-constraint) + model accessor.
- `tests/Feature/Plugins/PluginComposerDependencyTest.php` — activation gate: no-block, already-satisfied, auto-install, auto-install-off, install-failure, version-mismatch-survives-install, multi-package, and **PSR-4 registration on the ClassLoader** (multi-path).
- `tests/Feature/Plugins/PluginUpdateTest.php` — update-flow unwind on an unsatisfiable `composer` block.
- `tests/Support/Composer/FakeComposerPackageInstaller.php` — in-memory installer.

## Documentation

- [x] Inline code documentation added
- [x] Wiki updated (`docs/plugin-authoring.md`)

**Documentation details:** New "Composer-package dependencies" section (when it runs, installing, failing closed, deactivation/removal, hardened hosts) plus the manifest field table row.

## Pre-Submission Checklist

- [x] Code passes all tests
- [x] Code has been linted (php-cs-fixer + phpcs clean)
- [x] Code follows project style guide
- [x] Self-review completed (correctness + security review pass)
- [x] Comments added for complex code
- [x] No new warnings generated

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Plugins can declare Composer package dependencies in their manifests.
  * Dependencies are checked during activation and may be installed automatically.
  * Newly installed packages are registered for runtime use.
  * Composer installation behavior is configurable, including executable and timeout settings.

* **Bug Fixes**
  * Activation now fails safely when dependencies cannot be satisfied.
  * Plugin updates roll back cleanly when dependency installation fails.

* **Documentation**
  * Added guidance for Composer dependencies and hardened-host environment settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->