### PR TITLE
feat: auto-register manifest federated_module and nav_entries

### DIFF
--- a/docs/plugin-authoring.md
+++ b/docs/plugin-authoring.md
@@ -70,15 +70,28 @@ A plugin's root directory MUST contain a `plugin.json` file:
     }
   },
   "migrations": "database/migrations",
-  "federated_modules": [
+  "nav_entries": [
     {
-      "name": "helloWorldAdmin",
-      "entry": "dist/remoteEntry.js",
-      "exposes": ["./HelloWorldPanel"]
+      "slug": "hello-world",
+      "label": "Hello World",
+      "url": "/admin/hello-world",
+      "icon": "fas.puzzle-piece",
+      "permission": "access_admin_dashboard",
+      "order": 60
     }
-  ]
+  ],
+  "federated_module": {
+    "entry": "dist/remoteEntry.js",
+    "exposes": ["./HelloWorldPanel"]
+  }
 }
 ```
+
+Declaring `nav_entries` and `federated_module` in the manifest is enough — the
+framework bridges them into the runtime `PluginRegistry` when your plugin loads,
+with no `register*()` call required. See
+[Registering nav entries](#registering-nav-entries) and
+[Federated React modules](#federated-react-modules).
 
 ### Required fields
 
@@ -102,8 +115,8 @@ A plugin's root directory MUST contain a `plugin.json` file:
 | `composer`          | object          | Map of Composer package name to version constraint, e.g. `{ "artisanpack-ui/convertkit": "^1.2" }`. Resolved from Packagist on activation. See [Composer-package dependencies](#composer-package-dependencies). |
 | `autoload`          | object          | PSR-4 map. The framework hands this to Composer's runtime `ClassLoader`. |
 | `migrations`        | string ( path ) | Relative path to your migrations directory. Auto-run on activate. |
-| `federated_modules` | array           | See [Federated React modules](#federated-react-modules). |
-| `nav`               | array           | Static nav entries; equivalent to calling `registerNavEntry()` from your provider. |
+| `federated_module`  | object          | Single federated module descriptor `{ name?, entry, exposes? }`. Auto-registered on load. See [Federated React modules](#federated-react-modules). |
+| `nav_entries`       | array           | List of static nav entries `{ slug, label, url?, icon?, permission?, order?, ... }`. Auto-registered on load; equivalent to calling `registerNavEntry()` from your provider. |
 | `update`            | object          | Where self-updates come from. See [Shipping updates](#shipping-updates). |
 | `update_url`        | string ( URL )  | Legacy custom JSON update feed. Superseded by `update`; still honored. |
 
@@ -261,9 +274,13 @@ host's admin shell reads it via the `ap.admin.menu` filter. Entries are
 identified by `slug` and are idempotent — repeated registrations from the same
 plugin ( e.g. under Octane workers ) overwrite instead of accumulating.
 
-You may alternatively pre-declare nav entries in `plugin.json` under `nav`.
-Programmatic registration is preferred when nav visibility depends on
-per-request state ( feature flags, tenant configuration, etc. ).
+You may alternatively pre-declare nav entries in `plugin.json` under
+`nav_entries`. The framework bridges each declared entry into the registry
+through the same `registerNavEntry()` path — including URL sanitization — when
+the plugin loads, so declaration alone is enough. Programmatic registration is
+preferred when nav visibility depends on per-request state ( feature flags,
+tenant configuration, etc. ), and always wins: a manifest entry is skipped when
+your provider has already registered the same `slug`.
 
 ## Migrations
 
@@ -374,13 +391,17 @@ The framework does not own the frontend, and does not ship a Module Federation
 runtime. Host apps ( e.g. Keystone CMS ) that support runtime-loaded React
 plugins consume federated modules the plugin has declared through:
 
-- **Manifest** — `federated_modules` array in `plugin.json`.
-- **Programmatic** — `$this->registerFederatedModule( $name, $entry, $exposes )` in `boot()`.
+- **Manifest** — a `federated_module` object in `plugin.json`. The framework
+  auto-registers it on load, keyed by the descriptor's optional `name` (falling
+  back to the plugin slug). Declaration alone is enough.
+- **Programmatic** — `$this->registerFederatedModule( $name, $entry, $exposes )`
+  in `boot()`. A programmatic registration wins: a manifest module is skipped
+  when the same name is already registered.
 
 An example Module Federation config, Vite build, and remoteEntry contract live
 in the Keystone CMS docs. See
 [`examples/hello-world-plugin/`](../examples/hello-world-plugin/) for a stub
-that pairs a Blade admin page with a `federated_modules` declaration that
+that pairs a Blade admin page with a `federated_module` declaration that
 Keystone can consume.
 
 ## Versioning & host compatibility

--- a/examples/hello-world-plugin/README.md
+++ b/examples/hello-world-plugin/README.md
@@ -11,7 +11,7 @@ and is not a Composer package. Copy the tree into your host application's
 
 | Piece | File |
 | ----- | ---- |
-| Manifest schema, including `requires`, `autoload`, `nav`, `federated_modules` | [`plugin.json`](./plugin.json) |
+| Manifest schema, including `requires`, `autoload`, `nav_entries`, `federated_module` | [`plugin.json`](./plugin.json) |
 | Base `PluginServiceProvider` usage, admin page, nav entry, federated module | [`src/HelloWorldServiceProvider.php`](./src/HelloWorldServiceProvider.php) |
 | Custom field type registration ( `map_picker` ) via `apRegisterFieldType()` | [`src/HelloWorldServiceProvider.php`](./src/HelloWorldServiceProvider.php) |
 | Edit-screen panel registration via `ap.admin.contentEdit.panels` | [`src/HelloWorldServiceProvider.php`](./src/HelloWorldServiceProvider.php) |

--- a/examples/hello-world-plugin/plugin.json
+++ b/examples/hello-world-plugin/plugin.json
@@ -22,7 +22,7 @@
         }
     },
     "migrations": "database/migrations",
-    "nav": [
+    "nav_entries": [
         {
             "slug": "hello-world-manifest-nav",
             "label": "Hello (from manifest)",
@@ -32,14 +32,12 @@
             "order": 61
         }
     ],
-    "federated_modules": [
-        {
-            "name": "helloWorldAdmin",
-            "entry": "dist/remoteEntry.js",
-            "exposes": [
-                "./HelloWorldPanel",
-                "./MapPickerEditor"
-            ]
-        }
-    ]
+    "federated_module": {
+        "name": "helloWorldAdmin",
+        "entry": "dist/remoteEntry.js",
+        "exposes": [
+            "./HelloWorldPanel",
+            "./MapPickerEditor"
+        ]
+    }
 }

--- a/examples/hello-world-plugin/resources/views/admin/index.blade.php
+++ b/examples/hello-world-plugin/resources/views/admin/index.blade.php
@@ -11,7 +11,7 @@
         </p>
 
         <p>
-            {{ __('The plugin also declares a federated_modules entry for hosts that support runtime-loaded React admin pages (see plugin.json). Blade and federated flavors coexist — the host chooses which to render based on its own capabilities.') }}
+            {{ __('The plugin also declares a federated_module entry for hosts that support runtime-loaded React admin pages (see plugin.json). Blade and federated flavors coexist — the host chooses which to render based on its own capabilities.') }}
         </p>
     </div>
 @endsection

--- a/src/Modules/Plugins/Managers/PluginManager.php
+++ b/src/Modules/Plugins/Managers/PluginManager.php
@@ -19,6 +19,7 @@ use ArtisanPackUI\CMSFramework\Modules\Plugins\Models\Plugin;
 use ArtisanPackUI\CMSFramework\Modules\Plugins\Support\ComposerPackageResolver;
 use ArtisanPackUI\CMSFramework\Modules\Plugins\Support\DependencyResolver;
 use ArtisanPackUI\CMSFramework\Modules\Plugins\Support\DependencyResult;
+use ArtisanPackUI\CMSFramework\Modules\Plugins\Support\PluginServiceProvider;
 use Composer\Autoload\ClassLoader;
 use Composer\InstalledVersions;
 use Exception;
@@ -403,7 +404,8 @@ class PluginManager
                 }
 
                 if ( $plugin->hasServiceProvider() ) {
-                    app()->register( $plugin->service_provider );
+                    $provider = app()->register( $plugin->service_provider );
+                    $this->bridgeManifestRegistrations( $provider );
                     $serviceProviderStarted = true;
                 }
 
@@ -609,7 +611,8 @@ class PluginManager
             // Register service provider
             if ( $plugin->hasServiceProvider() ) {
                 try {
-                    app()->register( $plugin->service_provider );
+                    $provider = app()->register( $plugin->service_provider );
+                    $this->bridgeManifestRegistrations( $provider );
                 } catch ( Throwable $e ) {
                     // Log error but don't break application. Catch Throwable, not
                     // just Exception: a missing provider class raises an Error,
@@ -774,6 +777,28 @@ class PluginManager
         }
 
         return $graph;
+    }
+
+    /**
+     * Bridge a freshly registered plugin provider's declarative manifest fields
+     * (`nav_entries`, `federated_module`) into the runtime PluginRegistry.
+     *
+     * Runs after the provider is registered so declaring the fields in
+     * `plugin.json` is enough to surface them — the provider no longer has to
+     * duplicate the data with imperative `register*()` calls (#324). Only the
+     * base {@see PluginServiceProvider} carries the normalization those calls
+     * apply, so plain Laravel providers are skipped. `$provider` is typed
+     * `mixed` because `app()->register()` returns a bare `ServiceProvider`.
+     *
+     * @since 2.10.0
+     *
+     * @param  mixed  $provider  The provider instance returned by `app()->register()`.
+     */
+    protected function bridgeManifestRegistrations( mixed $provider ): void
+    {
+        if ( $provider instanceof PluginServiceProvider ) {
+            $provider->bridgeManifestRegistrations();
+        }
     }
 
     /**

--- a/src/Modules/Plugins/Support/PluginServiceProvider.php
+++ b/src/Modules/Plugins/Support/PluginServiceProvider.php
@@ -38,6 +38,34 @@ abstract class PluginServiceProvider extends ServiceProvider
     protected ?array $manifest = null;
 
     /**
+     * Bridge the plugin manifest's declarative `nav_entries` and
+     * `federated_module` into the runtime {@see PluginRegistry}.
+     *
+     * `plugin.json`'s `nav_entries` and `federated_module` are validated by
+     * {@see \ArtisanPackUI\CMSFramework\Modules\Plugins\Managers\PluginManager}
+     * but were otherwise inert: only an imperative {@see registerNavEntry()} /
+     * {@see registerFederatedModule()} call ever populated the registry, forcing
+     * authors to declare the same data twice. This bridges the declaration so
+     * listing the fields in the manifest is enough (#324).
+     *
+     * The framework calls this once per plugin, right after the provider is
+     * registered. Imperative calls always win: a manifest entry is only bridged
+     * when its slug (nav) or module name is not already in the registry, so a
+     * provider may override or extend any declarative entry from boot()
+     * regardless of registration ordering.
+     *
+     * @since 2.10.0
+     */
+    public function bridgeManifestRegistrations(): void
+    {
+        $manifest = $this->loadManifest();
+        $registry = $this->pluginRegistry();
+
+        $this->bridgeManifestFederatedModule( $manifest, $registry );
+        $this->bridgeManifestNavEntries( $manifest, $registry );
+    }
+
+    /**
      * Register a Blade or Inertia admin page.
      *
      * A `view` is wrapped in a closure before it reaches the route: Laravel's
@@ -200,6 +228,75 @@ abstract class PluginServiceProvider extends ServiceProvider
         }
 
         $this->pluginRegistry()->setFederatedModule( $name, $descriptor );
+    }
+
+    /**
+     * Bridge the manifest's singular `federated_module` object.
+     *
+     * Re-checks the shape the manifest validator enforces so a descriptor that
+     * reached a non-validating code path can never corrupt the registry. The
+     * descriptor is keyed by an optional `name`, falling back to the plugin
+     * slug — the singular field models one federated module per plugin. An
+     * already-registered name is left untouched so imperative registrations win.
+     *
+     * @since 2.10.0
+     *
+     * @param  array<string,mixed>  $manifest
+     */
+    protected function bridgeManifestFederatedModule( array $manifest, PluginRegistry $registry ): void
+    {
+        $module = $manifest['federated_module'] ?? null;
+
+        if ( ! is_array( $module ) || empty( $module['entry'] ) || ! is_string( $module['entry'] ) ) {
+            return;
+        }
+
+        $name = ( isset( $module['name'] ) && is_string( $module['name'] ) && '' !== trim( $module['name'] ) )
+            ? ( string ) $module['name']
+            : ( isset( $manifest['slug'] ) && is_string( $manifest['slug'] ) ? ( string ) $manifest['slug'] : '' );
+
+        if ( '' === $name || array_key_exists( $name, $registry->federatedModules() ) ) {
+            return;
+        }
+
+        $exposes = ( isset( $module['exposes'] ) && is_array( $module['exposes'] ) )
+            ? array_values( array_filter( $module['exposes'], 'is_string' ) )
+            : [];
+
+        $this->registerFederatedModule( $name, $module['entry'], $exposes );
+    }
+
+    /**
+     * Bridge the manifest's `nav_entries` list.
+     *
+     * Skips entries missing the slug/label the validator requires, and any slug
+     * already present in the registry, so imperative registrations win. Each
+     * surviving entry passes through {@see registerNavEntry()}, which applies
+     * the same URL sanitization and normalization as a programmatic call.
+     *
+     * @since 2.10.0
+     *
+     * @param  array<string,mixed>  $manifest
+     */
+    protected function bridgeManifestNavEntries( array $manifest, PluginRegistry $registry ): void
+    {
+        $entries = $manifest['nav_entries'] ?? null;
+
+        if ( ! is_array( $entries ) ) {
+            return;
+        }
+
+        foreach ( $entries as $entry ) {
+            if ( ! is_array( $entry ) || empty( $entry['slug'] ) || empty( $entry['label'] ) ) {
+                continue;
+            }
+
+            if ( array_key_exists( ( string ) $entry['slug'], $registry->navEntries() ) ) {
+                continue;
+            }
+
+            $this->registerNavEntry( $entry );
+        }
     }
 
     /**

--- a/tests/Unit/Plugins/PluginServiceProviderTest.php
+++ b/tests/Unit/Plugins/PluginServiceProviderTest.php
@@ -445,3 +445,176 @@ it( 'resolves pluginPath and pluginConfig from the manifest', function (): void 
         ->and( $provider->exposePluginConfig( 'nested.key' ) )->toBe( 'value' )
         ->and( $provider->exposePluginConfig( 'missing' ) )->toBeNull();
 } );
+
+/**
+ * Build a provider whose manifest is exactly $manifest and whose boot() runs
+ * the given imperative callback, so the manifest-bridge tests can exercise both
+ * declarative and imperative registration in one place.
+ *
+ * @param  array<string,mixed>  $manifest
+ */
+function manifestProvider( array $manifest, ?Closure $boot = null ): PluginServiceProvider
+{
+    return new class( app(), $manifest, $boot ) extends PluginServiceProvider {
+        /** @param array<string,mixed> $pluginManifest */
+        public function __construct( $app, private array $pluginManifest, private ?Closure $onBoot )
+        {
+            parent::__construct( $app );
+        }
+
+        public function boot(): void
+        {
+            if ( null !== $this->onBoot ) {
+                ( $this->onBoot )( $this );
+            }
+        }
+
+        public function imperativeNavEntry( array $entry ): void
+        {
+            $this->registerNavEntry( $entry );
+        }
+
+        public function imperativeFederatedModule( string $name, string $entry, array $exposes = [] ): void
+        {
+            $this->registerFederatedModule( $name, $entry, $exposes );
+        }
+
+        protected function loadManifest(): array
+        {
+            return $this->manifest = $this->pluginManifest;
+        }
+    };
+}
+
+it( 'auto-registers manifest nav_entries when declaration alone is used', function (): void {
+    $provider = manifestProvider( [
+        'slug'        => 'reports-plugin',
+        'nav_entries' => [
+            [
+                'slug'       => 'reports',
+                'label'      => 'Reports',
+                'url'        => '/admin/reports',
+                'permission' => 'reports.view',
+            ],
+        ],
+    ] );
+
+    $provider->bridgeManifestRegistrations();
+
+    $entries = app( PluginRegistry::class )->navEntries();
+
+    expect( $entries )->toHaveKey( 'reports' )
+        ->and( $entries['reports']['url'] )->toBe( '/admin/reports' )
+        ->and( $entries['reports']['permission'] )->toBe( 'reports.view' );
+} );
+
+it( 'auto-registers a manifest federated_module keyed by the plugin slug', function (): void {
+    $provider = manifestProvider( [
+        'slug'             => 'reports-plugin',
+        'federated_module' => [
+            'entry'   => 'dist/remoteEntry.js',
+            'exposes' => ['./App', './Panel'],
+        ],
+    ] );
+
+    $provider->bridgeManifestRegistrations();
+
+    $modules = applyFilters( 'ap.plugins.federatedModules', [] );
+
+    expect( $modules )->toHaveKey( 'reports-plugin' )
+        ->and( $modules['reports-plugin']['entry'] )->toBe( 'dist/remoteEntry.js' )
+        ->and( $modules['reports-plugin']['exposes'] )->toBe( ['./App', './Panel'] );
+} );
+
+it( 'keys a federated_module by its explicit name when the manifest provides one', function (): void {
+    $provider = manifestProvider( [
+        'slug'             => 'reports-plugin',
+        'federated_module' => [
+            'name'  => 'reportsAdmin',
+            'entry' => 'dist/remoteEntry.js',
+        ],
+    ] );
+
+    $provider->bridgeManifestRegistrations();
+
+    $modules = applyFilters( 'ap.plugins.federatedModules', [] );
+
+    expect( $modules )->toHaveKey( 'reportsAdmin' )
+        ->and( $modules )->not->toHaveKey( 'reports-plugin' )
+        ->and( $modules['reportsAdmin'] )->not->toHaveKey( 'exposes' );
+} );
+
+it( 'sanitizes a manifest nav_entry url through registerNavEntry', function (): void {
+    $provider = manifestProvider( [
+        'slug'        => 'evil-plugin',
+        'nav_entries' => [
+            [ 'slug' => 'evil', 'label' => 'Evil', 'url' => 'javascript:alert(1)' ],
+        ],
+    ] );
+
+    $provider->bridgeManifestRegistrations();
+
+    expect( app( PluginRegistry::class )->navEntries()['evil']['url'] )->toBe( '#' );
+} );
+
+it( 'ignores a malformed federated_module and invalid nav_entries', function (): void {
+    $provider = manifestProvider( [
+        'slug'             => 'broken-plugin',
+        'federated_module' => ['exposes' => ['./App']], // no entry
+        'nav_entries'      => [
+            ['label' => 'No Slug'],
+            ['slug' => 'no-label'],
+            'not-an-array',
+        ],
+    ] );
+
+    $provider->bridgeManifestRegistrations();
+
+    expect( app( PluginRegistry::class )->navEntries() )->toBeEmpty()
+        ->and( app( PluginRegistry::class )->federatedModules() )->toBeEmpty();
+} );
+
+it( 'lets an imperative nav registration override a manifest entry regardless of order', function (): void {
+    // Imperative first (as if boot() ran before the bridge): the bridge must
+    // not clobber it. Then bridge: the manifest slug is already present.
+    $provider = manifestProvider(
+        [
+            'slug'        => 'reports-plugin',
+            'nav_entries' => [
+                ['slug' => 'reports', 'label' => 'Manifest Reports', 'url' => '/manifest'],
+            ],
+        ],
+        fn ( $p ) => $p->imperativeNavEntry( [
+            'slug'  => 'reports',
+            'label' => 'Imperative Reports',
+            'url'   => '/imperative',
+        ] ),
+    );
+
+    $provider->boot();
+    $provider->bridgeManifestRegistrations();
+
+    $entries = app( PluginRegistry::class )->navEntries();
+
+    expect( $entries )->toHaveCount( 1 )
+        ->and( $entries['reports']['label'] )->toBe( 'Imperative Reports' )
+        ->and( $entries['reports']['url'] )->toBe( '/imperative' );
+} );
+
+it( 'lets an imperative federated module override a manifest one regardless of order', function (): void {
+    $provider = manifestProvider(
+        [
+            'slug'             => 'reports-plugin',
+            'federated_module' => ['entry' => 'dist/manifest.js'],
+        ],
+        fn ( $p ) => $p->imperativeFederatedModule( 'reports-plugin', 'dist/imperative.js', ['./App'] ),
+    );
+
+    $provider->boot();
+    $provider->bridgeManifestRegistrations();
+
+    $modules = app( PluginRegistry::class )->federatedModules();
+
+    expect( $modules['reports-plugin']['entry'] )->toBe( 'dist/imperative.js' )
+        ->and( $modules['reports-plugin']['exposes'] )->toBe( ['./App'] );
+} );


### PR DESCRIPTION
## Description

`plugin.json`'s `nav_entries` and `federated_module` were **validated but never consumed** — only imperative `registerNavEntry()` / `registerFederatedModule()` calls populated the `PluginRegistry`, so declaring the fields in the manifest did nothing and authors had to duplicate the data in both the manifest and their provider.

The framework now bridges these declarative fields into the registry right after each plugin provider is registered, so **declaration alone works**.

**Closes:** #324

## Type of Change

- [x] Enhancement (improves existing functionality)
- [x] Documentation update

## Related Issue

**Issue:** #324

## Motivation and Context

A plugin author who declared `nav_entries` / `federated_module` in `plugin.json` (as the field names imply is sufficient) got nothing — no nav entry, no federated module. It only worked if the provider *also* called the imperative `register*()` methods, duplicating the manifest. Surfaced while auditing 2.9.0 for the Keystone ConvertKit plugin.

## Changes Made

- `PluginServiceProvider`: new `bridgeManifestRegistrations()` plus `bridgeManifestFederatedModule()` / `bridgeManifestNavEntries()` helpers that read the validated manifest fields and route each through the existing `registerNavEntry()` / `registerFederatedModule()` (reusing nav-URL sanitization + normalization). Federated module keys off an optional `name`, falling back to the plugin slug.
- `PluginManager`: calls the bridge after `app()->register()` in both `activate()` and `loadActivePlugins()`. Framework-side placement means it works regardless of whether a plugin overrides `boot()`/`register()`.
- **Imperative-wins invariant:** a manifest entry is only bridged when its slug (nav) or module name is not already registered, so imperative registrations always override and the outcome is order-independent.
- Corrected `docs/plugin-authoring.md` and the hello-world example, which referenced the non-existent field names `federated_modules` (plural array) and `nav`; the real validated fields are `federated_module` (object) and `nav_entries`.

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS
- PHP Version: 8.3+ (run on 8.5)
- Project Version: 2.10

**Tests Performed:**
1. `./vendor/bin/pest tests/Unit/Plugins/PluginServiceProviderTest.php` — 23 passed
2. `./vendor/bin/pest tests/Unit/Plugins tests/Feature/Plugins` — 313 passed, 4 skipped (pre-existing)
3. `php-cs-fixer` + `phpcs` clean on changed files

## Tests Added

- [x] Unit tests added/updated
- [x] All tests passing

**Test details:** 7 new cases — auto-register nav & module, explicit `name` key, nav-URL sanitization, malformed-field skipping, and imperative-overrides-manifest for both nav entries and federated modules (both orderings).

## Documentation

- [x] Inline code documentation added

**Documentation details:** `docs/plugin-authoring.md` and the hello-world example manifest/README/blade corrected to the real field names and updated to describe the auto-registration + override behavior.

## Accessibility Tests Run

- [x] Not applicable — backend plugin-registration change, no UI.

## Pre-Submission Checklist

- [x] Code passes all tests
- [x] Code has been linted (php-cs-fixer + phpcs)
- [x] Code follows project style guide
- [x] Self-review completed
- [x] Comments added for complex code
- [x] No new warnings generated