### PR TITLE
chore: reconcile registerAdminPage(component:) federated mount with host federation runtimes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- **`registerAdminPage( component: )`'s federated mount now renders a visible fallback instead of a silent dead div, and the federated admin-page contract is documented for both host styles** ([#325](https://github.com/ArtisanPack-UI/cms-framework/issues/325)) — the #296 shell emitted a bare `<div data-cms-federated-module="…"></div>`, which is inert on a host whose federation runtime never scans that attribute (e.g. Keystone CMS, whose runtime is Inertia-page-based and resolves `plugins/<remote>/<page>` from the `ap.plugins.federatedModules` manifest). On such a host the page rendered an empty, never-hydrated div — a footgun for plugin authors. The framework-owned `cms::admin.layouts.federated` shell now renders a role-`status` notice inside the mount naming the module and stating that the host must hydrate it, so an unhydrated page shows a clear message rather than a blank area; a host that scans the mount (or overrides `ap.cmsFramework.admin.federatedPageAction`) still replaces it. `docs/plugin-authoring.md` now documents the contract as a host-agnostic mount plus a host hydration responsibility, spelling out both supported paths (scan the Blade mount, or bridge via the filter) and calling out the Inertia `plugins/<remote>/<page>` path for Inertia-based hosts. No API signature changed.
+
 ## [2.9.0] - 2026-08-21
 
 ### Security

--- a/docs/plugin-authoring.md
+++ b/docs/plugin-authoring.md
@@ -240,21 +240,38 @@ $this->registerAdminPage( 'hello-world', [
 Host apps map the `component` identifier to a real React component through
 their Module Federation loader.
 
-A `component`-only admin page renders the framework-owned
-`cms::admin.layouts.federated` shell, which emits a mount point —
-`<div data-cms-federated-module="…"></div>` — inside the admin chrome for the
-host's Module Federation runtime to hydrate. It is never handed to
-`Route::get()` as a bare string (which Laravel rejects as an invalid route
-action; because admin routes register from a `booted()` callback, that once
-surfaced on *every* request, not just the plugin's own page, taking the whole
-application down). A page that declares neither a `view` nor a `component`
-responds `501` on its own route instead of breaking route registration.
+### The federated admin-page contract
 
-A federation host that mounts components its own way — a different mount
-element, a server-rendered island, an Inertia response — overrides the default
-through the `ap.cmsFramework.admin.federatedPageAction` filter, which receives
-the default route action, the component identifier and the page config, and
-returns its own route action:
+**The framework does not own the frontend and ships no Module Federation
+runtime.** It cannot resolve or hydrate a federated component itself — a host
+application must do that. `registerAdminPage( component: )` gives you a
+host-agnostic *mount contract*; the host holds the *hydration responsibility*.
+There are two supported ways a host can hydrate the mount:
+
+**1. Scan the Blade mount (host-agnostic).** A `component`-only admin page
+renders the framework-owned `cms::admin.layouts.federated` shell, which emits a
+single mount point inside the admin chrome:
+
+```html
+<div data-cms-federated-module="helloWorldAdmin/HelloWorldPanel">
+    <p class="cms-admin__federated-fallback" role="status">
+        This admin page loads the federated module "…", which the host
+        application must hydrate. …
+    </p>
+</div>
+```
+
+A host whose front end scans for `data-cms-federated-module` mounts the named
+module into that div, replacing the fallback notice. Until a host hydrates it,
+the fallback notice renders in place of a blank page — so an unconfigured host
+shows a clear "needs a host runtime" message rather than a **silent dead div**.
+
+**2. Bridge to the host's own runtime via the filter (Inertia and others).**
+A host that mounts components its own way — a different mount element, a
+server-rendered island, an Inertia page — overrides the default through the
+`ap.cmsFramework.admin.federatedPageAction` filter, which receives the default
+route action, the component identifier and the page config, and returns its own
+route action:
 
 ```php
 addFilter(
@@ -266,6 +283,25 @@ addFilter(
 ```
 
 Returning anything other than a closure falls back to the shipped shell.
+
+> **Inertia-based hosts (e.g. Keystone CMS).** Keystone's federation runtime is
+> Inertia-page-based: it resolves page names like `plugins/<remote>/<page>` from
+> a manifest built off the `ap.plugins.federatedModules` filter and mounts them
+> through the Inertia page resolver — it does **not** scan for the Blade mount
+> `data-cms-federated-module`. On such a host, ship your admin UI as an Inertia
+> page under the `plugins/<remote>/<page>` route (paired with a
+> [`federated_module`](#federated-react-modules) declaration so the host can
+> resolve the remote), and — if you also want `registerAdminPage( component: )`
+> to reach that page — bridge it with the filter above. Without the filter
+> override, `registerAdminPage( component: )` renders the fallback notice on an
+> Inertia host, because nothing hydrates the Blade mount there.
+
+The shell is never handed to `Route::get()` as a bare string (which Laravel
+rejects as an invalid route action; because admin routes register from a
+`booted()` callback, that once surfaced on *every* request, not just the
+plugin's own page, taking the whole application down). A page that declares
+neither a `view` nor a `component` responds `501` on its own route instead of
+breaking route registration.
 
 ## Registering nav entries
 
@@ -397,6 +433,12 @@ plugins consume federated modules the plugin has declared through:
 - **Programmatic** — `$this->registerFederatedModule( $name, $entry, $exposes )`
   in `boot()`. A programmatic registration wins: a manifest module is skipped
   when the same name is already registered.
+
+Declaring a module makes it *resolvable* by the host; it does not, by itself,
+place it on a page. To surface a federated module as an admin page, pair the
+declaration with `registerAdminPage( component: )` and hydrate it per the
+[federated admin-page contract](#the-federated-admin-page-contract) — either the
+Blade mount or the filter bridge, depending on the host.
 
 An example Module Federation config, Vite build, and remoteEntry contract live
 in the Keystone CMS docs. See

--- a/resources/views/admin/layouts/federated.blade.php
+++ b/resources/views/admin/layouts/federated.blade.php
@@ -8,10 +8,21 @@
     (`cms::admin.layouts.app`) and emits a single mount point,
     `<div data-cms-federated-module="…">`, for that runtime to hydrate.
 
-    It is the shipped default behind the `ap.cmsFramework.admin.federatedPageAction`
-    filter: a federation host that mounts components differently overrides the
-    filter and never renders this file. Hosts that only want to restyle the
-    shell can publish it with
+    The framework does not own the frontend and ships no federation runtime, so
+    a host is responsible for hydrating the mount. There are two supported ways:
+
+    1. Scan for `data-cms-federated-module` in the host front end and mount the
+       named module into the div, replacing the fallback notice below.
+    2. Override the `ap.cmsFramework.admin.federatedPageAction` filter to bridge
+       to the host's own runtime ( e.g. an Inertia `plugins/<remote>/<page>`
+       response ), in which case this file never renders. Inertia-based hosts
+       such as Keystone CMS take this path.
+
+    Until a host hydrates the mount, the fallback notice renders in place of a
+    blank page, so an operator sees a clear "needs a host runtime" message rather
+    than a silent dead div. See `docs/plugin-authoring.md`.
+
+    Hosts that only want to restyle the shell can publish it with
 
         php artisan vendor:publish --tag=cms-views
 
@@ -27,6 +38,16 @@
 
 @section( 'title', $title ?? __( 'Admin' ) )
 
+@push( 'styles' )
+	<style>
+		.cms-admin__federated-fallback { max-width: 40rem; padding: 1rem 1.25rem; border: 1px solid rgba( 127, 127, 127, .3 ); border-radius: .5rem; opacity: .85; }
+	</style>
+@endpush
+
 @section( 'content' )
-	<div data-cms-federated-module="{{ $component }}"></div>
+	<div data-cms-federated-module="{{ $component }}">
+		<p class="cms-admin__federated-fallback" role="status">
+			{{ __( 'This admin page loads the federated module ":component", which the host application must hydrate. If you are seeing this message, no host federation runtime has mounted the module yet.', ['component' => $component] ) }}
+		</p>
+	</div>
 @endsection

--- a/src/Modules/Plugins/Support/PluginServiceProvider.php
+++ b/src/Modules/Plugins/Support/PluginServiceProvider.php
@@ -122,13 +122,18 @@ abstract class PluginServiceProvider extends ServiceProvider
      * - `view` → renders the Blade view, with the route's own parameters passed
      *   through as view data so a page at `reports/{id}` can read `$id`.
      * - `component` → a Module Federation identifier only the host's federation
-     *   runtime can resolve. The shipped default renders the framework-owned
-     *   `cms::admin.layouts.federated` shell, which emits a mount-point element
-     *   inside the admin chrome for the host front end to hydrate. A federation
-     *   host that mounts components its own way overrides the default through
-     *   the `ap.cmsFramework.admin.federatedPageAction` filter, which receives
-     *   the default action, the component identifier, and the page config and
-     *   returns its own route action.
+     *   runtime can resolve. The framework owns no frontend and ships no
+     *   federation runtime, so the host must hydrate the component. The shipped
+     *   default renders the framework-owned `cms::admin.layouts.federated`
+     *   shell, which emits a mount-point element inside the admin chrome — plus
+     *   a visible fallback notice so an unhydrated page is never a silent blank
+     *   div. A host hydrates it either by scanning for the mount attribute in
+     *   its front end, or by overriding the default through the
+     *   `ap.cmsFramework.admin.federatedPageAction` filter, which receives the
+     *   default action, the component identifier, and the page config and
+     *   returns its own route action. Inertia-based hosts ( e.g. Keystone CMS )
+     *   take the filter path to bridge to their `plugins/<remote>/<page>`
+     *   runtime. See `docs/plugin-authoring.md`.
      * - neither → a 501, so the operator sees a clear "not configured" response
      *   instead of a white-screened application.
      *

--- a/tests/Feature/Plugins/PluginAdminPageFederatedTest.php
+++ b/tests/Feature/Plugins/PluginAdminPageFederatedTest.php
@@ -66,7 +66,39 @@ it( 'renders a federated component admin page inside the admin layout over HTTP'
     $response->assertOk()
         ->assertSee( '<title>My Plugin', false )
         ->assertSee( 'cms-admin__content', false )
+        ->assertSee( 'cms-admin__federated-fallback', false )
         ->assertSee( 'data-cms-federated-module="myPluginAdmin/Panel"', false );
+} );
+
+it( 'renders a visible fallback notice inside the mount when no host hydrates it', function (): void {
+    $provider = new class( app() ) extends PluginServiceProvider {
+        public function boot(): void
+        {
+            $this->registerAdminPage( 'my-plugin', [
+                'title'      => 'My Plugin',
+                'component'  => 'myPluginAdmin/Panel',
+                'capability' => 'access_admin_dashboard',
+            ] );
+        }
+
+        protected function loadManifest(): array
+        {
+            return $this->manifest = ['slug' => 'my-plugin'];
+        }
+    };
+
+    $provider->boot();
+
+    app( AdminPageManager::class )->registerRoutes();
+
+    $response = $this->actingAs( TestUser::factory()->create() )->get( '/admin/my-plugin' );
+
+    // Without a host federation runtime, the mount is not a silent dead div:
+    // it carries a visible notice naming the module so an operator understands
+    // why the page is empty. A host that hydrates the mount replaces this.
+    $response->assertOk()
+        ->assertSee( 'myPluginAdmin/Panel', false )
+        ->assertSee( 'the host application must hydrate', false );
 } );
 
 it( 'escapes a malicious component identifier and title in the federated shell', function (): void {


### PR DESCRIPTION
## Description

Reconciles the framework's federated **admin-page** mount path with how host apps actually run Module Federation. `registerAdminPage( component: )` rendered the `cms::admin.layouts.federated` shell whose mount `<div data-cms-federated-module="…"></div>` is inert on a host whose federation runtime never scans that attribute — e.g. Keystone CMS, which is Inertia-page-based and resolves `plugins/<remote>/<page>` from the `ap.plugins.federatedModules` manifest. On such a host the page rendered an empty, never-hydrated div: a footgun for plugin authors.

Per #325's decision menu, this takes the **hybrid** path: keep the Blade mount as a documented host-agnostic contract, document the Inertia `plugins/<remote>/<page>` runtime as the concrete working path for Inertia hosts, and fix the silent dead div with a visible fallback. No JS runtime or JS test harness was added (the package ships neither).

**Closes:** #325

## Type of Change

- [x] Enhancement (improves existing functionality)
- [x] Documentation update

## Related Issue

**Issue:** #325

## Motivation and Context

A federated-page API that renders nothing in the real host is a footgun for every plugin author. Surfaced auditing cms-framework 2.9.0 for the Keystone ConvertKit plugin. This issue owns the framework decision + docs.

## Changes Made

- **`resources/views/admin/layouts/federated.blade.php`** — the mount now contains a `role="status"` fallback notice (naming the module, stating the host must hydrate it) instead of an empty div. A host that scans `data-cms-federated-module`, or overrides the filter, replaces it. Fallback styling pushed to the layout's `styles` stack.
- **`docs/plugin-authoring.md`** — new "The federated admin-page contract" section documenting the host-agnostic mount + host hydration responsibility, both supported paths (scan the Blade mount, or bridge via `ap.cmsFramework.admin.federatedPageAction`), and an explicit Inertia `plugins/<remote>/<page>` callout for hosts like Keystone. Cross-link added from the "Federated React modules" section.
- **`src/Modules/Plugins/Support/PluginServiceProvider.php`** — `resolveAdminPageAction()` docblock updated to describe the hybrid contract and the fallback.
- **`tests/Feature/Plugins/PluginAdminPageFederatedTest.php`** — new test locking in the visible fallback; existing test also asserts the fallback marker.
- **`CHANGELOG.md`** — `[Unreleased] → Changed` entry.

No API signature changed.

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS (Darwin)
- PHP Version: 8.4 (CI matrix 8.3–8.4)
- Project Version: 2.10 (release/2.10)

**Tests Performed:**
1. `./vendor/bin/pest tests/Feature/Plugins/ tests/Unit/Plugins/` — 314 passed, 4 pre-existing skips.
2. `./vendor/bin/php-cs-fixer fix --dry-run` — 0 of 571 files need fixing; `./vendor/bin/phpcs` clean.
3. Manual: registered a `component`-only admin page in the dev app via the real `registerAdminPage( component: )` API and loaded it in the browser — the admin chrome renders the fallback notice (module name + "the host application must hydrate") rather than a blank content area, confirming the no-longer-silent behavior on a host with no federation runtime.

## Accessibility Tests Run

- [x] Screen reader considered — fallback is a `role="status"` live region so assistive tech announces the "needs a host runtime" message.
- [x] Color contrast verified — fallback uses inherited theme foreground with a neutral translucent border; no new fixed colors.

**Details:** Fallback text is server-rendered plain text inside the admin chrome; keyboard nav unaffected (no interactive controls added).

## Tests Added

- [x] Integration tests added/updated
- [x] All tests passing

**Test details:** Added "renders a visible fallback notice inside the mount when no host hydrates it"; augmented the existing federated-render test to assert the fallback marker. XSS-escaping test continues to pass with the fallback in place.

## Documentation

- [x] Inline code documentation added
- [x] Wiki updated (docs/plugin-authoring.md)

**Documentation details:** See Changes Made — new contract section + Blade header comment + docblock.

## Pre-Submission Checklist

- [x] Code passes all tests
- [x] Code has been linted
- [x] Code follows project style guide
- [x] Self-review completed
- [x] Comments added for complex code
- [x] No new warnings generated
