### PR TITLE
refactor: harden config-driven application update slug (#120)

### DIFF
--- a/src/Modules/Core/Updates/Managers/ApplicationUpdateManager.php
+++ b/src/Modules/Core/Updates/Managers/ApplicationUpdateManager.php
@@ -1020,10 +1020,24 @@ class ApplicationUpdateManager
         // single downstream product's name. Changing it invalidates any
         // existing `cms.application.<old-slug>.update_check` cache entry, which
         // simply forces one fresh check.
+        //
+        // Coalesced to the generic default rather than passed through raw: a
+        // key present but set to `null` or `''` (a published config whose env
+        // var is unset, an operator who blanked the value) would otherwise key
+        // the cache as `cms.application..update_check` and identify the app to
+        // the source as empty. `config()`'s own default only covers a *missing*
+        // key, not a null or empty one.
+        $slug = config( 'cms.updates.application_slug', 'application' );
+        $slug = is_string( $slug ) ? trim( $slug ) : '';
+
+        if ( '' === $slug ) {
+            $slug = 'application';
+        }
+
         $this->checker = UpdateCheckerFactory::buildUpdateChecker(
             url: $updateUrl,
             type: UpdateType::Application,
-            slug: (string) config( 'cms.updates.application_slug', 'application' ),
+            slug: $slug,
         );
 
         return $this->checker;

--- a/src/Modules/Core/Updates/UpdateCheckerFactory.php
+++ b/src/Modules/Core/Updates/UpdateCheckerFactory.php
@@ -42,7 +42,7 @@ class UpdateCheckerFactory
      *
      * @param  string  $url  Update source URL (GitHub, GitLab, custom JSON, etc.)
      * @param  UpdateType  $type  Update type
-     * @param  string  $slug  Unique identifier (e.g., 'digital-shopfront-cms')
+     * @param  string  $slug  Unique identifier (e.g., 'application')
      * @param  string|null  $currentVersion  Current version (auto-detected if null)
      */
     public static function buildUpdateChecker(

--- a/tests/Unit/Updates/ApplicationUpdateManagerTest.php
+++ b/tests/Unit/Updates/ApplicationUpdateManagerTest.php
@@ -116,6 +116,52 @@ class ApplicationUpdateManagerTest extends TestCase
     }
 
     /**
+     * Test the update checker's slug is read from config rather than hard-coded.
+     *
+     * @since 2.10.0
+     */
+    public function test_update_checker_slug_is_read_from_config(): void
+    {
+        config( ['cms.updates.application_slug' => 'keystone-cms'] );
+
+        $checker = $this->buildRealUpdateChecker();
+
+        $this->assertSame( 'keystone-cms', $checker->getSlug() );
+    }
+
+    /**
+     * Test the update checker falls back to the generic 'application' slug when
+     * none is configured, so no downstream product name is baked into the
+     * framework default.
+     *
+     * @since 2.10.0
+     */
+    public function test_update_checker_slug_defaults_to_application(): void
+    {
+        config( ['cms.updates.application_slug' => null] );
+
+        $checker = $this->buildRealUpdateChecker();
+
+        $this->assertSame( 'application', $checker->getSlug() );
+    }
+
+    /**
+     * Test an existing digital-shopfront-cms install keeps its slug via a config
+     * (or env) override, preserving back-compat with the previously hard-coded
+     * value.
+     *
+     * @since 2.10.0
+     */
+    public function test_update_checker_slug_honours_back_compat_override(): void
+    {
+        config( ['cms.updates.application_slug' => 'digital-shopfront-cms'] );
+
+        $checker = $this->buildRealUpdateChecker();
+
+        $this->assertSame( 'digital-shopfront-cms', $checker->getSlug() );
+    }
+
+    /**
      * Test path exclusion logic.
      *
      * @since 1.0.0
@@ -3623,6 +3669,24 @@ class ApplicationUpdateManagerTest extends TestCase
         $app['config']->set( 'cms.updates.verify_checksum', false ); // Disable for tests
         $app['config']->set( 'cms.updates.composer_install_command', 'composer install --no-dev' );
         $app['config']->set( 'cms.updates.composer_timeout', 600 );
-        $app['config']->set( 'cms.updates.exclude_from_update', ['.env', 'storage', 'vendor']);
+        $app['config']->set( 'cms.updates.exclude_from_update', ['.env', 'storage', 'vendor'] );
+    }
+
+    /**
+     * Build a real update checker through the manager's config-driven factory
+     * path, bypassing the mock injection used elsewhere.
+     *
+     * @since 2.10.0
+     *
+     * @return UpdateChecker The checker the manager builds from config.
+     */
+    private function buildRealUpdateChecker(): UpdateChecker
+    {
+        $manager    = new ApplicationUpdateManager;
+        $reflection = new ReflectionClass( $manager );
+        $method     = $reflection->getMethod( 'getUpdateChecker' );
+        $method->setAccessible( true );
+
+        return $method->invoke( $manager );
     }
 }


### PR DESCRIPTION
## Description

`ApplicationUpdateManager::getUpdateChecker()` was refactored off the hard-coded `digital-shopfront-cms` slug and onto `config('cms.updates.application_slug')` back in v2.8.0, and the config key is already documented in `config/updates.php` (`env('UPDATE_APPLICATION_SLUG', 'application')`). This PR closes the remaining acceptance criteria: the config-driven path had no test coverage, and the resolution didn't handle a present-but-null/empty key safely.

**Closes:** #120

## Type of Change

- [x] Refactoring (code improvement, no behavior change)

## Related Issue

**Issue:** #120

## Motivation and Context

A hard-coded slug leaked a tenant assumption into a framework-level class. The core fix shipped in v2.8.0, but `(string) config('cms.updates.application_slug', 'application')` still coalesced a present-but-`null`/empty value to `''` — `config()`'s default only covers a *missing* key. An empty slug keys the update-check cache as `cms.application..update_check` and identifies the app to the update source as empty, which is exactly the kind of silent misconfiguration a published-but-unset env var produces.

## Changes Made

- **`ApplicationUpdateManager::getUpdateChecker()`** — trim the configured slug and fall back to the generic `application` default for `null`/empty/non-string values, not just a missing key.
- **`ApplicationUpdateManagerTest`** — added tests for the config-driven slug, the generic default fallback, and the `digital-shopfront-cms` back-compat override.
- **`UpdateCheckerFactory`** — genericized the tenant-specific `digital-shopfront-cms` example in the `buildUpdateChecker()` docblock.

## How Has This Been Tested?

**Testing Environment:**
- PHP Version: 8.4 (php-cs-fixer warns it prefers 8.3; matches project baseline)
- Project Version: 2.10.x (branch `release/2.10`)

**Tests Performed:**
1. `./vendor/bin/pest --filter slug tests/Unit/Updates/ApplicationUpdateManagerTest.php` — 3 passed
2. `./vendor/bin/pest` across the three update suites (Unit manager, factory, Feature flow) — 100 passed
3. `./vendor/bin/php-cs-fixer fix --dry-run` and `./vendor/bin/phpcs` on changed files — clean

## Accessibility Tests Run

- [ ] Keyboard navigation tested
- [ ] Screen reader tested
- [ ] Color contrast verified
- [ ] ARIA labels checked

**Details:** N/A — backend-only refactor with no UI surface.

## Tests Added

- [x] Unit tests added/updated
- [x] All tests passing

**Test details:** Three unit tests in `ApplicationUpdateManagerTest` exercising the config-driven slug, the generic default, and the back-compat override, via a reflection helper that invokes the real (non-mocked) factory path.

## Documentation

- [x] Inline code documentation added

**Documentation details:** Config key was already documented in `config/updates.php`; added an explanatory comment on the null/empty coalescing and genericized the factory docblock example. No hard-coded value remains in `ApplicationUpdateManager`.

## Pre-Submission Checklist

- [x] Code passes all tests
- [x] Code has been linted
- [x] Code follows project style guide
- [x] Self-review completed
- [x] Comments added for complex code
- [x] No new warnings generated


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved application update checks when the configured application identifier is missing or blank.
  * Ensured update checks consistently use the standard application identifier by default.
  * Preserved support for existing custom application identifiers.

* **Tests**
  * Added coverage for configured, default, blank, and legacy application identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->