### PR TITLE
fix: reconcile the tree when a self-update aborts after extraction

### DIFF
--- a/src/Modules/Core/Updates/Exceptions/UpdateException.php
+++ b/src/Modules/Core/Updates/Exceptions/UpdateException.php
@@ -126,6 +126,28 @@ class UpdateException extends CMSFrameworkException
     }
 
     /**
+     * The update archive's `composer.json` and `composer.lock` are out of sync,
+     * caught by the pre-extraction pre-flight (#308).
+     *
+     * Raised only when stale-lock recovery is disabled, so `composer install`
+     * would install from the lock and abort with no forward path. Refusing here
+     * leaves the live tree untouched — nothing was extracted, so nothing needs
+     * rolling back.
+     *
+     * @since 2.10.0
+     */
+    public static function archiveComposerFilesOutOfSync( string $zipPath ): self
+    {
+        return new self(
+            "Refusing to install update archive '{$zipPath}': its composer.json and composer.lock are out of sync "
+            . '( the lock records a different set of dependency constraints than composer.json declares ), and '
+            . '`cms.updates.recover_stale_lock` is disabled, so `composer install` could only abort. The release must '
+            . 'ship a committed `composer.lock` that matches its `composer.json`. The site was left untouched on its '
+            . 'current version.',
+        );
+    }
+
+    /**
      * Composer install failed.
      *
      * When the pre-flight sync check detected that `composer.json` and

--- a/src/Modules/Core/Updates/Managers/ApplicationUpdateManager.php
+++ b/src/Modules/Core/Updates/Managers/ApplicationUpdateManager.php
@@ -827,6 +827,14 @@ class ApplicationUpdateManager
             $this->beginStep( UpdateStep::Cleanup );
             $this->cleanup( $zipPath );
 
+            // #308: extract-on-top only ever adds or overwrites, so with the
+            // update now finalized we reconcile the two things it cannot do on
+            // its own — purge the previous build's orphaned hashed assets, and
+            // delete paths the release removed upstream. Both are best-effort:
+            // the update has already succeeded and neither may fail it.
+            $this->purgeStaleBuildAssets();
+            $this->applyRemovedPathsManifest();
+
             // Step 10: Disable maintenance mode
             $this->beginStep( UpdateStep::DisableMaintenanceMode );
             $this->disableMaintenanceMode();
@@ -1435,6 +1443,17 @@ class ApplicationUpdateManager
 
         // Detect common root prefix by scanning all entry names
         $commonPrefix = $this->detectCommonRootPrefix( $zip, $excludePaths );
+
+        // #308: adjudicate the release's own `composer.json`/`composer.lock`
+        // pair from *inside the archive*, before a single byte is written over
+        // `base_path()`. When the pair is provably out of sync and the operator
+        // has disabled stale-lock recovery — the one configuration in which
+        // `composer install` would abort with no way forward — refuse the update
+        // here, so a rejected release never touches the live tree and there is
+        // nothing to roll back. When recovery is enabled ( the default ), this
+        // stays silent and lets the existing extract → install → recover path
+        // run, exactly as before.
+        $this->preflightArchiveComposerSync( $zip, $commonPrefix, $zipPath );
 
         // Extract files (except excluded paths), stripping common prefix
         for ( $i = 0; $i < $zip->numFiles; $i++ ) {
@@ -2107,6 +2126,139 @@ class ApplicationUpdateManager
     }
 
     /**
+     * Reject a release whose `composer.json`/`composer.lock` pair is out of sync
+     * *before* extraction writes anything over `base_path()` (#308).
+     *
+     * `verifyComposerFilesInSync()` above runs the same content-hash comparison,
+     * but only *after* extraction has already overwritten the live tree — where
+     * a divergence it detects is merely wrapped into `composer install`'s
+     * eventual failure message, by which point the site is a half-applied hybrid
+     * that the failure handler then has to unwind. This pre-flight reads the two
+     * files straight out of the archive and adjudicates the same question one
+     * step earlier, so a provably-broken release is refused while the live tree
+     * is still untouched and there is nothing to roll back.
+     *
+     * It is deliberately narrow, and every guard fails *open* — toward letting
+     * the existing post-extraction path adjudicate — so it never regresses a
+     * release the current flow would have installed:
+     *
+     * - It stays silent when `cms.updates.recover_stale_lock` is enabled ( the
+     *   default ). A diverged lock is exactly what that recovery re-resolves
+     *   (#273), so pre-empting extraction there would turn a recoverable update
+     *   into a hard refusal. It fires only in the one configuration where
+     *   `composer install` has no forward path: recovery off *and* the sync
+     *   check on.
+     * - It stays silent when the sync check itself is disabled
+     *   (`cms.updates.verify_composer_lock_sync`), honouring the same opt-out
+     *   `verifyComposerFilesInSync()` respects.
+     * - It stays silent unless the resolved composer command actually runs
+     *   `install` — an operator override that runs `composer update` re-resolves
+     *   the lock and *wants* a divergence — mirroring the post-extraction check.
+     * - A missing, unreadable, or unparseable `composer.json`/`composer.lock` in
+     *   the archive, or a lock with no `content-hash`, records no divergence:
+     *   composer itself adjudicates after extraction, as it does today.
+     *
+     * @since 2.10.0
+     *
+     * @param  ZipArchive   $zip           Opened update archive.
+     * @param  string|null  $commonPrefix  Common root prefix stripped during extraction.
+     * @param  string       $zipPath       Archive path, for the exception message.
+     *
+     * @throws UpdateException When the archive's composer pair is provably out
+     *                         of sync and stale-lock recovery is disabled.
+     */
+    protected function preflightArchiveComposerSync( ZipArchive $zip, ?string $commonPrefix, string $zipPath ): void
+    {
+        if ( ! config( 'cms.updates.verify_composer_lock_sync', true ) ) {
+            return;
+        }
+
+        // Recovery ( default on ) is the intended path for a diverged lock, so
+        // never pre-empt extraction while it is available.
+        if ( config( 'cms.updates.recover_stale_lock', true ) ) {
+            return;
+        }
+
+        // Only an `install` reads the lock as fixed; `update` reconciles it.
+        if ( ! preg_match( '/(?:^|\s)install(?:\s|$)/', $this->resolveComposerCommand() ) ) {
+            return;
+        }
+
+        $jsonContents = $this->archiveEntryContents( $zip, $commonPrefix, 'composer.json' );
+        $lockContents = $this->archiveEntryContents( $zip, $commonPrefix, 'composer.lock' );
+
+        // Fail open: if the archive does not carry both files, let composer
+        // adjudicate after extraction rather than refusing on a partial view.
+        if ( null === $jsonContents || null === $lockContents ) {
+            return;
+        }
+
+        $expectedHash = $this->composerContentHashFromContents( $jsonContents );
+        if ( null === $expectedHash ) {
+            return;
+        }
+
+        $lock = json_decode( $lockContents, true );
+        if ( ! is_array( $lock ) || ! is_string( $lock['content-hash'] ?? null ) ) {
+            return;
+        }
+
+        if ( $lock['content-hash'] === $expectedHash ) {
+            return;
+        }
+
+        Log::error(
+            'Refusing update before extraction: the release archive ships a composer.json and composer.lock that are out of sync, and stale-lock recovery is disabled, so composer install could only abort. The live tree was left untouched.',
+            [
+                'expected_content_hash' => $expectedHash,
+                'lock_content_hash'     => $lock['content-hash'],
+            ],
+        );
+
+        throw UpdateException::archiveComposerFilesOutOfSync( $zipPath );
+    }
+
+    /**
+     * Read a single logical file's contents out of the update archive, honouring
+     * the same common-prefix stripping and canonicalization the extraction loop
+     * applies, so `composer.json` is found whether the archive stores it as
+     * `composer.json`, `release-root/composer.json`, or `./release-root/composer.json`.
+     *
+     * @since 2.10.0
+     *
+     * @param  ZipArchive   $zip           Opened update archive.
+     * @param  string|null  $commonPrefix  Common root prefix to strip.
+     * @param  string       $targetPath    Repo-relative path to locate.
+     *
+     * @return string|null The entry's contents, or null when it is absent or unreadable.
+     */
+    protected function archiveEntryContents( ZipArchive $zip, ?string $commonPrefix, string $targetPath ): ?string
+    {
+        for ( $i = 0; $i < $zip->numFiles; $i++ ) {
+            $canonicalName = $this->canonicalizeArchivePath( (string) $zip->getNameIndex( $i ) );
+
+            if ( null === $canonicalName ) {
+                continue;
+            }
+
+            $stripped = $canonicalName;
+            if ( $commonPrefix && str_starts_with( $canonicalName, $commonPrefix ) ) {
+                $stripped = substr( $canonicalName, strlen( $commonPrefix ) );
+            }
+
+            if ( $stripped !== $targetPath ) {
+                continue;
+            }
+
+            $contents = $zip->getFromIndex( $i );
+
+            return false === $contents ? null : $contents;
+        }
+
+        return null;
+    }
+
+    /**
      * Compute the `content-hash` composer would write into a lock file for the
      * given `composer.json`, mirroring `Composer\Package\Locker::getContentHash()`.
      *
@@ -2123,6 +2275,24 @@ class ApplicationUpdateManager
             return null;
         }
 
+        return $this->composerContentHashFromContents( $contents );
+    }
+
+    /**
+     * Compute a `composer.json`'s lock `content-hash` from its raw contents.
+     *
+     * Extracted from {@see self::composerContentHash()} so the pre-flight check
+     * can hash the archive's `composer.json` — which it reads as a string
+     * straight out of the ZIP — without first materializing it to disk.
+     *
+     * @since 2.10.0
+     *
+     * @param  string  $contents  Raw `composer.json` JSON.
+     *
+     * @return string|null The hash, or null when the JSON cannot be parsed.
+     */
+    protected function composerContentHashFromContents( string $contents ): ?string
+    {
         $manifest = json_decode( $contents, true );
         if ( ! is_array( $manifest ) ) {
             return null;
@@ -2541,6 +2711,38 @@ class ApplicationUpdateManager
     }
 
     /**
+     * Drop every stale compiled cache after an aborted update has unwound, so
+     * the restored tree boots on its own source rather than on caches compiled
+     * against the half-applied release (#308).
+     *
+     * Extraction excludes `bootstrap/cache/*.php` and the backup snapshot never
+     * captured a *newer* config cache, so a run that overwrote application code
+     * and then aborted leaves `bootstrap/cache/{config,services,packages,
+     * modules}.php` dated to — and describing — the release that was just rolled
+     * back. On a real install that surfaced as a white screen served entirely
+     * from a config cache that no longer matched the code on disk. `optimize:clear`
+     * removes the config, route, view, event and compiled-service caches in one
+     * pass so the framework rebuilds them lazily from the restored source.
+     *
+     * Best-effort by design: a clear that fails on an already-broken tree must
+     * not turn a completed rollback into a reported rollback *failure*. Each
+     * outcome is logged; none is fatal.
+     *
+     * @since 2.10.0
+     */
+    protected function clearCompiledCachesAfterFailure(): void
+    {
+        try {
+            Artisan::call( 'optimize:clear' );
+        } catch ( Throwable $e ) {
+            Log::warning(
+                'cms-framework: could not clear compiled caches after an aborted update; stale bootstrap/cache files may remain. Run `php artisan optimize:clear` on the host.',
+                [ 'exception' => $e->getMessage() ],
+            );
+        }
+    }
+
+    /**
      * Clean up temporary files.
      *
      * @since 1.0.0
@@ -2551,6 +2753,257 @@ class ApplicationUpdateManager
     {
         if ( File::exists( $zipPath ) ) {
             File::delete( $zipPath );
+        }
+    }
+
+    /**
+     * Remove hashed build assets orphaned by previous releases (#308).
+     *
+     * Extraction writes the new release's `public/build` on top of the old one
+     * but never deletes the previous build's hashed files, so `public/build/assets`
+     * accumulates every release's output — one real install held 541 JS files
+     * spanning four releases. The manifest itself stays consistent ( it names
+     * only the current build ), which is exactly what makes the dead files safe
+     * to remove: any file under the build directory that the manifest does not
+     * reference is no longer served.
+     *
+     * The manifest is the whitelist, so the purge is skipped entirely whenever
+     * it cannot be read or parsed — deleting build output with no manifest to
+     * vouch for what is live would be the more dangerous failure. Symlinks are
+     * never followed or removed, and only regular files are unlinked.
+     *
+     * Gated by `cms.updates.purge_stale_build_assets` ( default on ) and
+     * best-effort: a completed update must not fail on cleanup.
+     *
+     * @since 2.10.0
+     */
+    protected function purgeStaleBuildAssets(): void
+    {
+        if ( ! config( 'cms.updates.purge_stale_build_assets', true ) ) {
+            return;
+        }
+
+        try {
+            $buildDir = base_path( (string) config( 'cms.updates.build_path', 'public/build' ) );
+
+            if ( ! File::isDirectory( $buildDir ) ) {
+                return;
+            }
+
+            $referenced = $this->referencedBuildAssets( $buildDir );
+
+            // No manifest, or an unparseable one: the whitelist is unknown, so
+            // purge nothing rather than guess.
+            if ( null === $referenced ) {
+                return;
+            }
+
+            $removed = 0;
+
+            $iterator = new RecursiveIteratorIterator(
+                new RecursiveDirectoryIterator( $buildDir, RecursiveDirectoryIterator::SKIP_DOTS ),
+                RecursiveIteratorIterator::CHILD_FIRST,
+            );
+
+            foreach ( $iterator as $fileInfo ) {
+                // Never follow or remove a symlink, and leave directories to be
+                // pruned only once empty ( below ).
+                if ( $fileInfo->isLink() || ! $fileInfo->isFile() ) {
+                    continue;
+                }
+
+                // `RecursiveDirectoryIterator` always yields paths with
+                // `$buildDir` as an exact leading prefix, so strip it by length
+                // rather than with `str_replace()` — a base path that happened to
+                // repeat the build-dir string (…/public/build/…/public/build)
+                // would otherwise have both occurrences removed and mis-key a
+                // live file as unreferenced.
+                $absolute = $fileInfo->getPathname();
+                $relative = ltrim( substr( $absolute, strlen( $buildDir ) ), DIRECTORY_SEPARATOR );
+                $relative = str_replace( DIRECTORY_SEPARATOR, '/', $relative );
+
+                // The manifest and its Vite sidecar are the source of truth for
+                // what is live; never remove them.
+                if ( 'manifest.json' === $relative || '.vite/manifest.json' === $relative ) {
+                    continue;
+                }
+
+                if ( isset( $referenced[ $relative ] ) ) {
+                    continue;
+                }
+
+                if ( File::delete( $absolute ) ) {
+                    $removed++;
+                }
+            }
+
+            if ( $removed > 0 ) {
+                Log::info( 'cms-framework: purged orphaned build assets left by previous releases.', [
+                    'count' => $removed,
+                ] );
+            }
+        } catch ( Throwable $e ) {
+            Log::warning(
+                'cms-framework: could not purge orphaned build assets after the update; they remain on disk but are harmless.',
+                [ 'exception' => $e->getMessage() ],
+            );
+        }
+    }
+
+    /**
+     * Build the set of build-relative asset paths the current manifest declares
+     * live, used by {@see self::purgeStaleBuildAssets()} as its delete whitelist.
+     *
+     * Reads `manifest.json` ( or the `.vite/manifest.json` sidecar Laravel/Vite
+     * also writes ) and collects every `file`, `css` and `assets` entry across
+     * all chunks. The manifest itself is added so it is never a purge candidate.
+     *
+     * @since 2.10.0
+     *
+     * @param  string  $buildDir  Absolute path to the build directory.
+     *
+     * @return array<string, true>|null Referenced paths as a lookup set, or null
+     *                                  when no manifest could be read.
+     */
+    protected function referencedBuildAssets( string $buildDir ): ?array
+    {
+        $manifestPath = null;
+
+        foreach ( [ 'manifest.json', '.vite/manifest.json' ] as $candidate ) {
+            $path = $buildDir . DIRECTORY_SEPARATOR . str_replace( '/', DIRECTORY_SEPARATOR, $candidate );
+
+            if ( is_file( $path ) ) {
+                $manifestPath = $path;
+
+                break;
+            }
+        }
+
+        if ( null === $manifestPath ) {
+            return null;
+        }
+
+        $manifest = json_decode( (string) @file_get_contents( $manifestPath ), true );
+        if ( ! is_array( $manifest ) ) {
+            return null;
+        }
+
+        $referenced = [];
+
+        foreach ( $manifest as $chunk ) {
+            if ( ! is_array( $chunk ) ) {
+                continue;
+            }
+
+            if ( is_string( $chunk['file'] ?? null ) ) {
+                $referenced[ $chunk['file'] ] = true;
+            }
+
+            foreach ( [ 'css', 'assets' ] as $group ) {
+                if ( ! is_array( $chunk[ $group ] ?? null ) ) {
+                    continue;
+                }
+
+                foreach ( $chunk[ $group ] as $asset ) {
+                    if ( is_string( $asset ) ) {
+                        $referenced[ $asset ] = true;
+                    }
+                }
+            }
+        }
+
+        return $referenced;
+    }
+
+    /**
+     * Delete paths a release removed upstream, honouring a manifest the archive
+     * ships (#308).
+     *
+     * Extract-on-top can add and overwrite but never delete, so a release that
+     * *removes* a file upstream — the monolithic-`app/` → modular-`Modules/`
+     * restructure left dead `app/Http/Controllers/*.php` beside their new
+     * `Modules/*` replacements — leaves the removed files orphaned on the host,
+     * where the autoloader can still find and load stale classes. A release
+     * declares those deletions in a manifest ( default `.artisanpack/removed-paths.json`,
+     * a JSON array of repo-relative paths ); this applies them after a
+     * successful update.
+     *
+     * Every deletion is guarded exactly as extraction and rollback removal are:
+     * the path is canonicalized and must stay under `base_path()`, it is skipped
+     * when `exclude_from_update` protects it, and symlinks are never followed.
+     * Absent or malformed manifests are a no-op, and the whole pass is
+     * best-effort so it can never fail a completed update.
+     *
+     * @since 2.10.0
+     */
+    protected function applyRemovedPathsManifest(): void
+    {
+        if ( ! config( 'cms.updates.honor_removed_paths_manifest', true ) ) {
+            return;
+        }
+
+        try {
+            $manifestRelative = (string) config( 'cms.updates.removed_paths_manifest', '.artisanpack/removed-paths.json' );
+
+            $manifestPath = base_path( $manifestRelative );
+            if ( ! is_file( $manifestPath ) ) {
+                return;
+            }
+
+            $paths = json_decode( (string) @file_get_contents( $manifestPath ), true );
+            if ( ! is_array( $paths ) ) {
+                return;
+            }
+
+            $excludePaths = config( 'cms.updates.exclude_from_update', [] );
+            $basePath     = base_path();
+            $removed      = 0;
+
+            foreach ( $paths as $path ) {
+                if ( ! is_string( $path ) ) {
+                    continue;
+                }
+
+                // Reuse the extraction canonicalizer so an absolute path or a
+                // `..` traversal in the manifest is rejected the same way an
+                // archive entry would be.
+                $canonical = $this->canonicalizeArchivePath( $path );
+                if ( null === $canonical || '' === $canonical ) {
+                    continue;
+                }
+
+                // Never delete a path the operator preserves across updates.
+                if ( $this->isPathExcluded( $canonical, $excludePaths ) ) {
+                    continue;
+                }
+
+                $fullPath = $basePath . DIRECTORY_SEPARATOR . $canonical;
+
+                // Only ever remove a regular file. A directory or a symlink at
+                // this path is something the manifest must not reach through.
+                if ( is_link( $fullPath ) || ! is_file( $fullPath ) ) {
+                    continue;
+                }
+
+                if ( ! $this->isPathWithinExtractRoot( $fullPath, $basePath ) ) {
+                    continue;
+                }
+
+                if ( File::delete( $fullPath ) ) {
+                    $removed++;
+                }
+            }
+
+            if ( $removed > 0 ) {
+                Log::info( 'cms-framework: removed paths the release deleted upstream, per its removed-paths manifest.', [
+                    'count' => $removed,
+                ] );
+            }
+        } catch ( Throwable $e ) {
+            Log::warning(
+                'cms-framework: could not apply the release\'s removed-paths manifest after the update; upstream-deleted files may remain on disk.',
+                [ 'exception' => $e->getMessage() ],
+            );
         }
     }
 
@@ -3219,6 +3672,12 @@ class ApplicationUpdateManager
 
             $this->state()->markFinishForward();
 
+            // The new code and schema are in place, but a failure *at* the
+            // ClearCaches step means the compiled caches can still describe the
+            // previous release — the same stale-cache white screen #308 fixes,
+            // just forward. Drop them before the site serves the new version.
+            $this->clearCompiledCachesAfterFailure();
+
             // The code and schema are already in place, so the site can serve
             // the new version. Bring it back up (best-effort, as before).
             try {
@@ -3245,6 +3704,12 @@ class ApplicationUpdateManager
                 // both — otherwise orphaned code and, worse, orphaned
                 // migrations are left behind.
                 $this->removeExtractionAdditions();
+
+                // The tree now matches the pre-update version, but the compiled
+                // caches can still describe the release just unwound. Drop them
+                // so the restored code does not boot behind a stale config or
+                // service cache (#308).
+                $this->clearCompiledCachesAfterFailure();
 
                 $this->state()->markRollback( true );
             } catch ( Throwable $e ) {
@@ -3279,6 +3744,12 @@ class ApplicationUpdateManager
         // cannot be restored, so the lift policy governs whether it goes back
         // on the public internet — rather than lifting unconditionally and
         // serving a mix of old and new code.
+        //
+        // Still drop the compiled caches: whether the site ends up serving the
+        // old or a half-applied tree, a config/service cache compiled against
+        // the failed release is the wrong one to boot behind (#308).
+        $this->clearCompiledCachesAfterFailure();
+
         $this->state()->markRollback( null );
 
         $this->liftMaintenanceModeAfterFailure( 'the update failure handler', $this->currentStep );

--- a/src/Modules/Core/Updates/config/updates.php
+++ b/src/Modules/Core/Updates/config/updates.php
@@ -378,6 +378,45 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Post-Update Tree Reconciliation
+    |--------------------------------------------------------------------------
+    |
+    | Extraction writes the new release *on top of* the live tree: it adds and
+    | overwrites, but it can never delete. Two kinds of stale file therefore
+    | accumulate that only a deliberate pass can reconcile after a successful
+    | update.
+    |
+    | `purge_stale_build_assets`: every release ships fresh hashed files under
+    | `public/build`, but the previous build's hashed files are never removed, so
+    | `public/build/assets` grows without bound across updates ( one real install
+    | held 541 JS files spanning four releases ). With this enabled, a completed
+    | update deletes any file under `build_path` the current `manifest.json` does
+    | not reference. The manifest is the whitelist: if it cannot be read, nothing
+    | is purged. Set to `false` to leave every build file in place.
+    |
+    | `build_path`: the Vite build directory to purge, relative to `base_path()`.
+    | Override only if the host builds assets somewhere other than `public/build`.
+    |
+    | `honor_removed_paths_manifest`: a release that *removes* a file upstream
+    | ( e.g. crossing a monolithic-`app/` → modular-`Modules/` restructure ) leaves
+    | the removed file orphaned on the host, where the autoloader can still pick up
+    | stale classes. A release may declare those deletions in a manifest — a JSON
+    | array of repo-relative paths — that the updater applies after a successful
+    | update. Every deletion is guarded like extraction: the path must stay under
+    | `base_path()`, `exclude_from_update` still protects it, and symlinks are
+    | never followed. Set to `false` to ignore the manifest.
+    |
+    | `removed_paths_manifest`: where that manifest lives, relative to
+    | `base_path()`. Absent or malformed manifests are simply a no-op.
+    |
+    */
+    'purge_stale_build_assets'     => env( 'CMS_UPDATES_PURGE_STALE_BUILD_ASSETS', true ),
+    'build_path'                   => 'public/build',
+    'honor_removed_paths_manifest' => env( 'CMS_UPDATES_HONOR_REMOVED_PATHS', true ),
+    'removed_paths_manifest'       => '.artisanpack/removed-paths.json',
+
+    /*
+    |--------------------------------------------------------------------------
     | Cache Settings
     |--------------------------------------------------------------------------
     |

--- a/tests/Unit/Updates/ApplicationUpdateManagerTest.php
+++ b/tests/Unit/Updates/ApplicationUpdateManagerTest.php
@@ -3595,6 +3595,591 @@ class ApplicationUpdateManagerTest extends TestCase
     }
 
     /**
+     * #308: the pre-extraction pre-flight must refuse a release whose archived
+     * `composer.json`/`composer.lock` pair is out of sync when stale-lock
+     * recovery is disabled — and, crucially, must leave the live tree untouched,
+     * so there is nothing to roll back.
+     *
+     * @since 2.10.0
+     */
+    public function test_preflight_refuses_out_of_sync_archive_before_extraction(): void
+    {
+        config( [
+            'cms.updates.recover_stale_lock'        => false,
+            'cms.updates.verify_composer_lock_sync' => true,
+        ] );
+
+        $tempRoot = sys_get_temp_dir() . '/cmsfw-preflight-refuse-' . bin2hex( random_bytes( 6 ) );
+        $target   = $tempRoot . '/target';
+        mkdir( $target, 0755, true );
+
+        $zipPath = $tempRoot . '/update.zip';
+        $zip     = new ZipArchive;
+        $this->assertTrue( true === $zip->open( $zipPath, ZipArchive::CREATE | ZipArchive::OVERWRITE ) );
+        $zip->addFromString( 'release-root/composer.json', '{"require":{"artisanpack-ui/cms-framework":"^2.10.0"}}' );
+        $zip->addFromString( 'release-root/composer.lock', '{"content-hash":"definitely-not-the-right-hash","packages":[]}' );
+        $zip->addFromString( 'release-root/app/New.php', "<?php\n// added\n" );
+        $zip->close();
+
+        $manager = new class extends ApplicationUpdateManager {
+            public function extractInto( string $zipPath ): void
+            {
+                $this->extractUpdate( $zipPath );
+            }
+        };
+
+        $originalBase = base_path();
+        app()->setBasePath( $target );
+
+        try {
+            $threw = false;
+
+            try {
+                $manager->extractInto( $zipPath );
+            } catch ( UpdateException $e ) {
+                $threw = true;
+                $this->assertStringContainsString( 'out of sync', $e->getMessage() );
+            }
+
+            $this->assertTrue( $threw, 'The pre-flight must throw on an out-of-sync archive with recovery disabled.' );
+            $this->assertFileDoesNotExist(
+                $target . '/app/New.php',
+                'A refused release must never touch the live tree.',
+            );
+        } finally {
+            app()->setBasePath( $originalBase );
+            @unlink( $zipPath );
+            $this->removeDirectory( $target );
+            @rmdir( $tempRoot );
+        }
+    }
+
+    /**
+     * #308: the pre-flight must stay out of the way when stale-lock recovery is
+     * enabled ( the default ). A diverged lock is exactly what recovery
+     * re-resolves, so extraction proceeds and the release lands — refusing here
+     * would regress #273.
+     *
+     * @since 2.10.0
+     */
+    public function test_preflight_allows_out_of_sync_archive_when_recovery_enabled(): void
+    {
+        config( [
+            'cms.updates.recover_stale_lock'        => true,
+            'cms.updates.verify_composer_lock_sync' => true,
+        ] );
+
+        $tempRoot = sys_get_temp_dir() . '/cmsfw-preflight-allow-' . bin2hex( random_bytes( 6 ) );
+        $target   = $tempRoot . '/target';
+        mkdir( $target, 0755, true );
+
+        $zipPath = $tempRoot . '/update.zip';
+        $zip     = new ZipArchive;
+        $this->assertTrue( true === $zip->open( $zipPath, ZipArchive::CREATE | ZipArchive::OVERWRITE ) );
+        $zip->addFromString( 'release-root/composer.json', '{"require":{"artisanpack-ui/cms-framework":"^2.10.0"}}' );
+        $zip->addFromString( 'release-root/composer.lock', '{"content-hash":"definitely-not-the-right-hash","packages":[]}' );
+        $zip->addFromString( 'release-root/app/New.php', "<?php\n// added\n" );
+        $zip->close();
+
+        $manager = new class extends ApplicationUpdateManager {
+            public function extractInto( string $zipPath ): void
+            {
+                $this->extractUpdate( $zipPath );
+            }
+        };
+
+        $originalBase = base_path();
+        app()->setBasePath( $target );
+
+        try {
+            $manager->extractInto( $zipPath );
+
+            $this->assertFileExists(
+                $target . '/app/New.php',
+                'With recovery enabled, extraction proceeds despite a diverged lock.',
+            );
+        } finally {
+            app()->setBasePath( $originalBase );
+            @unlink( $zipPath );
+            $this->removeDirectory( $target );
+            @rmdir( $tempRoot );
+        }
+    }
+
+    /**
+     * #308: a missing `composer.json`/`composer.lock` in the archive is
+     * inconclusive, so the pre-flight fails open and lets extraction proceed —
+     * even with recovery disabled.
+     *
+     * @since 2.10.0
+     */
+    public function test_preflight_fails_open_when_archive_lacks_composer_pair(): void
+    {
+        config( [
+            'cms.updates.recover_stale_lock'        => false,
+            'cms.updates.verify_composer_lock_sync' => true,
+        ] );
+
+        $tempRoot = sys_get_temp_dir() . '/cmsfw-preflight-open-' . bin2hex( random_bytes( 6 ) );
+        $target   = $tempRoot . '/target';
+        mkdir( $target, 0755, true );
+
+        $zipPath = $tempRoot . '/update.zip';
+        $zip     = new ZipArchive;
+        $this->assertTrue( true === $zip->open( $zipPath, ZipArchive::CREATE | ZipArchive::OVERWRITE ) );
+        // Ships a composer.json but no lock: the pair is incomplete.
+        $zip->addFromString( 'release-root/composer.json', '{"require":{"artisanpack-ui/cms-framework":"^2.10.0"}}' );
+        $zip->addFromString( 'release-root/app/New.php', "<?php\n// added\n" );
+        $zip->close();
+
+        $manager = new class extends ApplicationUpdateManager {
+            public function extractInto( string $zipPath ): void
+            {
+                $this->extractUpdate( $zipPath );
+            }
+        };
+
+        $originalBase = base_path();
+        app()->setBasePath( $target );
+
+        try {
+            $manager->extractInto( $zipPath );
+
+            $this->assertFileExists(
+                $target . '/app/New.php',
+                'An incomplete composer pair is inconclusive; extraction must proceed.',
+            );
+        } finally {
+            app()->setBasePath( $originalBase );
+            @unlink( $zipPath );
+            $this->removeDirectory( $target );
+            @rmdir( $tempRoot );
+        }
+    }
+
+    /**
+     * #308: an aborted update that rolls back must also drop the compiled caches,
+     * so the restored tree does not boot behind a config/service cache compiled
+     * against the release just unwound.
+     *
+     * @since 2.10.0
+     */
+    public function test_rollback_clears_compiled_caches(): void
+    {
+        $tempRoot = sys_get_temp_dir() . '/cmsfw-rollback-cacheclear-' . bin2hex( random_bytes( 6 ) );
+        $target   = $tempRoot . '/target';
+        mkdir( $target . '/app', 0755, true );
+        file_put_contents( $target . '/app/Old.php', "<?php\n// old\n" );
+
+        $backupPath = $tempRoot . '/backup.zip';
+        $backup     = new ZipArchive;
+        $this->assertTrue( true === $backup->open( $backupPath, ZipArchive::CREATE | ZipArchive::OVERWRITE ) );
+        $backup->addFromString( 'app/Old.php', "<?php\n// old\n" );
+        $backup->close();
+
+        $manager = new class( $backupPath ) extends ApplicationUpdateManager {
+            public bool $cachesCleared = false;
+
+            public function __construct( string $preparedBackupPath )
+            {
+                $this->backupPath = $preparedBackupPath;
+            }
+
+            public function callHandleFailure( Throwable $e ): void
+            {
+                $this->handleUpdateFailure( $e );
+            }
+
+            protected function disableMaintenanceMode(): void
+            {
+            }
+
+            protected function verifyComposerBinaryAvailable(): void
+            {
+            }
+
+            protected function runComposerInstall(): void
+            {
+            }
+
+            protected function clearCaches(): void
+            {
+            }
+
+            protected function clearCompiledCachesAfterFailure(): void
+            {
+                $this->cachesCleared = true;
+            }
+        };
+
+        $originalBase = base_path();
+        app()->setBasePath( $target );
+
+        try {
+            $manager->callHandleFailure( new RuntimeException( 'composer install failed' ) );
+
+            $this->assertTrue(
+                $manager->cachesCleared,
+                'A rollback must clear the compiled caches so the restored tree does not boot behind stale ones.',
+            );
+        } finally {
+            app()->setBasePath( $originalBase );
+            @unlink( $backupPath );
+            $this->removeDirectory( $target );
+            @rmdir( $tempRoot );
+        }
+    }
+
+    /**
+     * #308: after a successful update, orphaned hashed build assets the manifest
+     * no longer references are purged, while referenced assets and the manifest
+     * itself are kept.
+     *
+     * @since 2.10.0
+     */
+    public function test_purge_stale_build_assets_removes_only_unreferenced_files(): void
+    {
+        config( ['cms.updates.purge_stale_build_assets' => true] );
+
+        $tempRoot = sys_get_temp_dir() . '/cmsfw-build-purge-' . bin2hex( random_bytes( 6 ) );
+        $target   = $tempRoot . '/target';
+        $assets   = $target . '/public/build/assets';
+        mkdir( $assets, 0755, true );
+
+        file_put_contents( $target . '/public/build/manifest.json', json_encode( [
+            'resources/js/app.js' => [
+                'file' => 'assets/app-NEW.js',
+                'css'  => ['assets/app-NEW.css'],
+            ],
+        ] ) );
+        file_put_contents( $assets . '/app-NEW.js', 'current js' );
+        file_put_contents( $assets . '/app-NEW.css', 'current css' );
+        file_put_contents( $assets . '/app-OLD.js', 'orphaned js' );
+
+        $manager = new class extends ApplicationUpdateManager {
+            public function callPurge(): void
+            {
+                $this->purgeStaleBuildAssets();
+            }
+        };
+
+        $originalBase = base_path();
+        app()->setBasePath( $target );
+
+        try {
+            $manager->callPurge();
+
+            $this->assertFileExists( $assets . '/app-NEW.js', 'A referenced asset must survive the purge.' );
+            $this->assertFileExists( $assets . '/app-NEW.css', 'A referenced CSS asset must survive the purge.' );
+            $this->assertFileExists( $target . '/public/build/manifest.json', 'The manifest must never be purged.' );
+            $this->assertFileDoesNotExist( $assets . '/app-OLD.js', 'An orphaned asset must be purged.' );
+        } finally {
+            app()->setBasePath( $originalBase );
+            $this->removeDirectory( $target );
+            @rmdir( $tempRoot );
+        }
+    }
+
+    /**
+     * #308: the manifest is the whitelist, so with no manifest to vouch for what
+     * is live the purge must do nothing rather than delete build output blindly.
+     *
+     * @since 2.10.0
+     */
+    public function test_purge_stale_build_assets_is_a_noop_without_a_manifest(): void
+    {
+        config( ['cms.updates.purge_stale_build_assets' => true] );
+
+        $tempRoot = sys_get_temp_dir() . '/cmsfw-build-nomanifest-' . bin2hex( random_bytes( 6 ) );
+        $target   = $tempRoot . '/target';
+        $assets   = $target . '/public/build/assets';
+        mkdir( $assets, 0755, true );
+        file_put_contents( $assets . '/app-OLD.js', 'orphaned js' );
+
+        $manager = new class extends ApplicationUpdateManager {
+            public function callPurge(): void
+            {
+                $this->purgeStaleBuildAssets();
+            }
+        };
+
+        $originalBase = base_path();
+        app()->setBasePath( $target );
+
+        try {
+            $manager->callPurge();
+
+            $this->assertFileExists(
+                $assets . '/app-OLD.js',
+                'Without a manifest the purge must leave every build file in place.',
+            );
+        } finally {
+            app()->setBasePath( $originalBase );
+            $this->removeDirectory( $target );
+            @rmdir( $tempRoot );
+        }
+    }
+
+    /**
+     * #308: after a successful update, paths a release declares removed upstream
+     * are deleted — while excluded paths and any traversal attempt in the
+     * manifest are refused.
+     *
+     * @since 2.10.0
+     */
+    public function test_apply_removed_paths_manifest_deletes_listed_and_guards_the_rest(): void
+    {
+        config( [
+            'cms.updates.honor_removed_paths_manifest' => true,
+            'cms.updates.removed_paths_manifest'       => '.artisanpack/removed-paths.json',
+            'cms.updates.exclude_from_update'          => ['storage', '.env', 'vendor'],
+        ] );
+
+        $tempRoot = sys_get_temp_dir() . '/cmsfw-removed-paths-' . bin2hex( random_bytes( 6 ) );
+        $target   = $tempRoot . '/target';
+        mkdir( $target . '/app/Http/Controllers', 0755, true );
+        mkdir( $target . '/storage/logs', 0755, true );
+        mkdir( $target . '/.artisanpack', 0755, true );
+        mkdir( $tempRoot . '/outside', 0755, true );
+
+        file_put_contents( $target . '/app/Http/Controllers/OldController.php', "<?php\n// dead\n" );
+        file_put_contents( $target . '/storage/logs/laravel.log', "log\n" );
+        file_put_contents( $tempRoot . '/outside/secret.txt', "secret\n" );
+
+        file_put_contents( $target . '/.artisanpack/removed-paths.json', json_encode( [
+            'app/Http/Controllers/OldController.php',
+            'storage/logs/laravel.log',
+            '../outside/secret.txt',
+        ] ) );
+
+        $manager = new class extends ApplicationUpdateManager {
+            public function callApply(): void
+            {
+                $this->applyRemovedPathsManifest();
+            }
+        };
+
+        $originalBase = base_path();
+        app()->setBasePath( $target );
+
+        try {
+            $manager->callApply();
+
+            $this->assertFileDoesNotExist(
+                $target . '/app/Http/Controllers/OldController.php',
+                'A path the release removed upstream must be deleted.',
+            );
+            $this->assertFileExists(
+                $target . '/storage/logs/laravel.log',
+                'An excluded path must survive even when the manifest lists it.',
+            );
+            $this->assertFileExists(
+                $tempRoot . '/outside/secret.txt',
+                'A traversal entry must never reach outside base_path().',
+            );
+        } finally {
+            app()->setBasePath( $originalBase );
+            $this->removeDirectory( $target );
+            $this->removeDirectory( $tempRoot . '/outside' );
+            @rmdir( $tempRoot );
+        }
+    }
+
+    /**
+     * #308: the pre-flight must stay silent when the resolved composer command
+     * runs `update` rather than `install` — an operator who runs `composer update`
+     * re-resolves the lock and *wants* a divergence — even with recovery off.
+     *
+     * @since 2.10.0
+     */
+    public function test_preflight_allows_out_of_sync_archive_when_command_is_update(): void
+    {
+        config( [
+            'cms.updates.recover_stale_lock'        => false,
+            'cms.updates.verify_composer_lock_sync' => true,
+            'cms.updates.composer_install_command'  => 'composer update --no-dev',
+        ] );
+
+        $tempRoot = sys_get_temp_dir() . '/cmsfw-preflight-update-' . bin2hex( random_bytes( 6 ) );
+        $target   = $tempRoot . '/target';
+        mkdir( $target, 0755, true );
+
+        $zipPath = $tempRoot . '/update.zip';
+        $zip     = new ZipArchive;
+        $this->assertTrue( true === $zip->open( $zipPath, ZipArchive::CREATE | ZipArchive::OVERWRITE ) );
+        $zip->addFromString( 'release-root/composer.json', '{"require":{"artisanpack-ui/cms-framework":"^2.10.0"}}' );
+        $zip->addFromString( 'release-root/composer.lock', '{"content-hash":"definitely-not-the-right-hash","packages":[]}' );
+        $zip->addFromString( 'release-root/app/New.php', "<?php\n// added\n" );
+        $zip->close();
+
+        $manager = new class extends ApplicationUpdateManager {
+            public function extractInto( string $zipPath ): void
+            {
+                $this->extractUpdate( $zipPath );
+            }
+        };
+
+        $originalBase = base_path();
+        app()->setBasePath( $target );
+
+        try {
+            $manager->extractInto( $zipPath );
+
+            $this->assertFileExists(
+                $target . '/app/New.php',
+                'A `composer update` command reconciles the lock, so the pre-flight must not refuse.',
+            );
+        } finally {
+            app()->setBasePath( $originalBase );
+            @unlink( $zipPath );
+            $this->removeDirectory( $target );
+            @rmdir( $tempRoot );
+        }
+    }
+
+    /**
+     * #308: the pre-flight honours the same opt-out as the post-extraction
+     * check — with `verify_composer_lock_sync` disabled it stays silent even when
+     * the pair is out of sync and recovery is off.
+     *
+     * @since 2.10.0
+     */
+    public function test_preflight_is_silent_when_sync_check_disabled(): void
+    {
+        config( [
+            'cms.updates.recover_stale_lock'        => false,
+            'cms.updates.verify_composer_lock_sync' => false,
+        ] );
+
+        $tempRoot = sys_get_temp_dir() . '/cmsfw-preflight-disabled-' . bin2hex( random_bytes( 6 ) );
+        $target   = $tempRoot . '/target';
+        mkdir( $target, 0755, true );
+
+        $zipPath = $tempRoot . '/update.zip';
+        $zip     = new ZipArchive;
+        $this->assertTrue( true === $zip->open( $zipPath, ZipArchive::CREATE | ZipArchive::OVERWRITE ) );
+        $zip->addFromString( 'release-root/composer.json', '{"require":{"artisanpack-ui/cms-framework":"^2.10.0"}}' );
+        $zip->addFromString( 'release-root/composer.lock', '{"content-hash":"definitely-not-the-right-hash","packages":[]}' );
+        $zip->addFromString( 'release-root/app/New.php', "<?php\n// added\n" );
+        $zip->close();
+
+        $manager = new class extends ApplicationUpdateManager {
+            public function extractInto( string $zipPath ): void
+            {
+                $this->extractUpdate( $zipPath );
+            }
+        };
+
+        $originalBase = base_path();
+        app()->setBasePath( $target );
+
+        try {
+            $manager->extractInto( $zipPath );
+
+            $this->assertFileExists(
+                $target . '/app/New.php',
+                'With the sync check disabled the pre-flight must not refuse.',
+            );
+        } finally {
+            app()->setBasePath( $originalBase );
+            @unlink( $zipPath );
+            $this->removeDirectory( $target );
+            @rmdir( $tempRoot );
+        }
+    }
+
+    /**
+     * #308: the build purge reads the `.vite/manifest.json` sidecar Laravel/Vite
+     * also writes when no top-level `manifest.json` is present, and keeps assets
+     * a chunk lists under `assets`.
+     *
+     * @since 2.10.0
+     */
+    public function test_purge_stale_build_assets_reads_vite_sidecar_and_keeps_assets(): void
+    {
+        config( ['cms.updates.purge_stale_build_assets' => true] );
+
+        $tempRoot = sys_get_temp_dir() . '/cmsfw-build-sidecar-' . bin2hex( random_bytes( 6 ) );
+        $target   = $tempRoot . '/target';
+        $assets   = $target . '/public/build/assets';
+        mkdir( $assets, 0755, true );
+        mkdir( $target . '/public/build/.vite', 0755, true );
+
+        file_put_contents( $target . '/public/build/.vite/manifest.json', json_encode( [
+            'resources/js/app.js' => [
+                'file'   => 'assets/app-NEW.js',
+                'assets' => ['assets/logo-NEW.png'],
+            ],
+        ] ) );
+        file_put_contents( $assets . '/app-NEW.js', 'current js' );
+        file_put_contents( $assets . '/logo-NEW.png', 'current image' );
+        file_put_contents( $assets . '/logo-OLD.png', 'orphaned image' );
+
+        $manager = new class extends ApplicationUpdateManager {
+            public function callPurge(): void
+            {
+                $this->purgeStaleBuildAssets();
+            }
+        };
+
+        $originalBase = base_path();
+        app()->setBasePath( $target );
+
+        try {
+            $manager->callPurge();
+
+            $this->assertFileExists( $assets . '/app-NEW.js', 'A referenced chunk file must survive.' );
+            $this->assertFileExists( $assets . '/logo-NEW.png', 'An asset a chunk lists must survive.' );
+            $this->assertFileExists(
+                $target . '/public/build/.vite/manifest.json',
+                'The sidecar manifest must never be purged.',
+            );
+            $this->assertFileDoesNotExist( $assets . '/logo-OLD.png', 'An orphaned asset must be purged.' );
+        } finally {
+            app()->setBasePath( $originalBase );
+            $this->removeDirectory( $target );
+            @rmdir( $tempRoot );
+        }
+    }
+
+    /**
+     * #308: when the run fails with no snapshot to restore ( backups disabled ),
+     * the compiled caches must still be dropped so a half-applied or reverted
+     * tree does not boot behind a cache compiled against the failed release.
+     *
+     * @since 2.10.0
+     */
+    public function test_no_backup_failure_clears_compiled_caches(): void
+    {
+        config( ['cms.updates.backup_enabled' => false] );
+
+        $manager = new class extends ApplicationUpdateManager {
+            public bool $cachesCleared = false;
+
+            public function callHandleFailure( Throwable $e ): void
+            {
+                $this->handleUpdateFailure( $e );
+            }
+
+            protected function liftMaintenanceModeAfterFailure( string $context, ?UpdateStep $step = null ): void
+            {
+            }
+
+            protected function clearCompiledCachesAfterFailure(): void
+            {
+                $this->cachesCleared = true;
+            }
+        };
+
+        $manager->callHandleFailure( new RuntimeException( 'download failed before backup' ) );
+
+        $this->assertTrue(
+            $manager->cachesCleared,
+            'A failure with no snapshot must still clear the compiled caches.',
+        );
+    }
+
+    /**
      * Write a scratch base path holding a `composer.json` and, optionally, a
      * `composer.lock`. Returns the directory, which the caller must remove.
      *


### PR DESCRIPTION
## Description

When `ApplicationUpdateManager::performUpdate()` aborted **after** extracting a release over `base_path()`, the site was left in a broken, unfinalized hybrid state: stale `bootstrap/cache` compiled against the release just applied, a half-applied tree, and orphaned `public/build` assets plus upstream-deleted files that extract-on-top can never remove. On a real install this surfaced as a white screen served entirely from a config cache that no longer matched the code on disk.

This applies the **targeted** fixes from the issue's suggested direction — pre-flight validation, full cache-clear on abort, and post-success reconciliation — without rewriting the hardened extraction/rollback/concurrency engine (the full "stage-and-atomic-swap" option was deliberately not taken here to keep blast radius low).

**Closes:** #308

## Type of Change

- [x] Bug fix (fixes an issue)

## Related Issue

**Issue:** #308

## Motivation and Context

A single bad release (or any post-extraction failure) didn't just decline to update — it took the running site down until manual repair, worst across a restructure release and growing over time via orphaned build assets. The changes make every abort path leave a bootable tree, and make a successful update clean up what extract-on-top structurally cannot.

## Changes Made

- **Pre-flight the archive's composer pair before extraction** (`preflightArchiveComposerSync()` + `archiveEntryContents()`): reads `composer.json`/`composer.lock` from inside the ZIP and refuses a provably out-of-sync release **before a byte touches `base_path()`** — but only when `verify_composer_lock_sync` is on, stale-lock recovery is **off**, and the resolved command is an `install`. With recovery on (the default) it stays silent, so the existing extract→install→recover (#273) path is untouched. Fails open on any missing/unparseable file. New `UpdateException::archiveComposerFilesOutOfSync()`.
- **Clear compiled caches on every abort branch** (`clearCompiledCachesAfterFailure()` → `optimize:clear`, best-effort): wired into the rollback, no-backup, and finish-forward branches of `handleUpdateFailure()` so a reverted or half-applied tree never boots behind caches compiled against the failed release.
- **Reconcile the tree on a successful update** (Step 9 Cleanup): `purgeStaleBuildAssets()` deletes hashed `public/build` files the current `manifest.json` (or `.vite/manifest.json` sidecar) no longer references; `applyRemovedPathsManifest()` deletes paths a release declares removed in `.artisanpack/removed-paths.json`. Both are best-effort (never fail a completed update) and reuse the existing canonicalization / `..`-rejection / symlink-skip / `exclude_from_update` / realpath-containment guards.
- **Config**: four new keys in `config/updates.php` (`purge_stale_build_assets`, `build_path`, `honor_removed_paths_manifest`, `removed_paths_manifest`), all defaulting on, documented inline.

## How Has This Been Tested?

**Testing Environment:**
- PHP Version: 8.4 / 8.5
- Project Version: release/2.10

**Tests Performed:**
1. New `Updates` unit tests (11) covering the pre-flight (refuse / allow-on-recovery / allow-on-`update`-command / silent-when-disabled / fail-open), cache-clear on rollback and no-backup branches, build purge (removes orphans, keeps referenced + manifest, `.vite` sidecar + `assets[]`, no-op without a manifest), and removed-paths (deletes listed, honors exclusions, blocks traversal).
2. Full `Updates` suite green (309 tests, 803 assertions).
3. `composer lint` clean (php-cs-fixer + phpcs).
4. Security review of the new deletion/read paths: no traversal, arbitrary-deletion, symlink-follow, or command-injection findings.

## Accessibility Tests Run

- [ ] Keyboard navigation tested
- [ ] Screen reader tested
- [ ] Color contrast verified
- [ ] ARIA labels checked

**Details:** N/A — this is a backend self-updater change with no UI surface.

## Tests Added

- [x] Unit tests added/updated
- [x] All tests passing

**Test details:** 11 new tests in `tests/Unit/Updates/ApplicationUpdateManagerTest.php`.

## Documentation

- [x] Inline code documentation added

**Documentation details:** New config keys and every new method carry full PHPDoc; config block documents the reconciliation behavior and opt-outs.

## Pre-Submission Checklist

- [x] Code passes all tests
- [x] Code has been linted
- [x] Code follows project style guide
- [x] Self-review completed
- [x] Comments added for complex code
- [x] No new warnings generated
