### PR TITLE
Release 2.10.1: fix plugin activation on MySQL/MariaDB (There is no active transaction) (#333)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.10.1] - 2026-08-29
+
+### Fixed
+
+- **Plugin activation no longer throws `There is no active transaction` on MySQL/MariaDB** ([#333](https://github.com/ArtisanPack-UI/cms-framework/issues/333)) — `PluginManager::activate()` ran the plugin's migrations inside a `DB::transaction()`. On MySQL/MariaDB a plugin migration's `CREATE TABLE` triggers an implicit commit, ending that transaction, so when the wrapper then calls `commit()` PDO throws `There is no active transaction` — after the table was already created, leaving a half-applied activation. (SQLite has transactional DDL, so the path was never tripped by the suite.) The in-memory autoloader registration and the DDL migrations now run **before** the transaction, which wraps only the genuinely transactional writes (permission seeding and the `is_active` flip). Rollback semantics are unchanged: the PSR-4 snapshot and `migrationsAttempted` still drive `rollbackFailedActivation()`, which already rolled migrations back itself.
+
 ## [2.10.0] - 2026-08-23
 
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "description": "Adds in the back end support for building a CMS with any front end framework.",
   "type": "library",
   "license": "MIT",
-  "version": "2.10.0",
+  "version": "2.10.1",
   "autoload": {
     "psr-4": {
       "ArtisanPackUI\\CMSFramework\\": "src/",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6823606bf125df1ef9a5fa4a37ad2017",
+    "content-hash": "2ec55b5e0a3ab512fd86e90a652b5c91",
     "packages": [
         {
             "name": "artisanpack-ui/accessibility",

--- a/config/cms-framework.php
+++ b/config/cms-framework.php
@@ -32,7 +32,7 @@ return [
 
         'info' => [
             'title'       => 'ArtisanPack CMS Framework API',
-            'version'     => '2.10.0',
+            'version'     => '2.10.1',
             'description' => 'RESTful API for the ArtisanPack CMS Framework. Provides endpoints for managing posts, pages, content types, users, roles, permissions, settings, notifications, plugins, and themes.',
         ],
 

--- a/src/Modules/Plugins/Managers/PluginManager.php
+++ b/src/Modules/Plugins/Managers/PluginManager.php
@@ -383,28 +383,34 @@ class PluginManager
         $serviceProviderStarted = false;
 
         try {
-            DB::transaction( function () use (
-                $plugin,
-                &$priorPsr4,
-                &$migrationsAttempted,
-                &$serviceProviderStarted,
-            ): void {
-                if ( isset( $plugin->meta['autoload'] ) ) {
-                    // Snapshot the PSR-4 map BEFORE adding, so rollback can
-                    // restore prior paths for shared namespaces instead of
-                    // wiping them with setPsr4($ns, []).
-                    $priorPsr4 = $this->snapshotPsr4( $plugin->meta['autoload']['psr-4'] ?? [] );
-                    $this->registerAutoloader( $plugin->slug, $plugin->meta['autoload'] );
-                }
+            if ( isset( $plugin->meta['autoload'] ) ) {
+                // Snapshot the PSR-4 map BEFORE adding, so rollback can
+                // restore prior paths for shared namespaces instead of
+                // wiping them with setPsr4($ns, []). Registering the
+                // autoloader is an in-memory ClassLoader change, never a DB
+                // write, so it sits outside the transaction.
+                $priorPsr4 = $this->snapshotPsr4( $plugin->meta['autoload']['psr-4'] ?? [] );
+                $this->registerAutoloader( $plugin->slug, $plugin->meta['autoload'] );
+            }
 
-                if ( isset( $plugin->meta['migrations_path'] ) ) {
-                    // Flip BEFORE the Artisan call so a mid-migration failure
-                    // (DDL auto-commits in MySQL/MariaDB) still triggers a
-                    // rollback attempt in the catch block.
-                    $migrationsAttempted = true;
-                    $this->runMigrations( $plugin->slug, $plugin->meta['migrations_path'] );
-                }
+            if ( isset( $plugin->meta['migrations_path'] ) ) {
+                // Run migrations OUTSIDE the transaction below. A plugin's
+                // CREATE TABLE implicitly commits the open transaction on
+                // MySQL/MariaDB, so wrapping migrations would leave the
+                // transaction's own commit() with nothing to commit —
+                // throwing "There is no active transaction" after the table
+                // was already created (#333). DDL was never atomic there in
+                // the first place; migration rollback is handled explicitly
+                // in the catch via $migrationsAttempted. Flip the flag BEFORE
+                // the Artisan call so a mid-migration failure still triggers
+                // that rollback.
+                $migrationsAttempted = true;
+                $this->runMigrations( $plugin->slug, $plugin->meta['migrations_path'] );
+            }
 
+            // Only the genuinely transactional DB writes stay wrapped: the
+            // permission seed and the is_active flip.
+            DB::transaction( function () use ( $plugin, &$serviceProviderStarted ): void {
                 if ( $plugin->hasServiceProvider() ) {
                     $provider = app()->register( $plugin->service_provider );
                     $this->bridgeManifestRegistrations( $provider );

--- a/tests/Feature/Plugins/PluginActivationTransactionTest.php
+++ b/tests/Feature/Plugins/PluginActivationTransactionTest.php
@@ -1,0 +1,75 @@
+<?php
+
+/**
+ * Guards the fix for #333: plugin migrations must run OUTSIDE the activation
+ * transaction.
+ *
+ * The bug it prevents is MySQL/MariaDB-only — a plugin's `CREATE TABLE`
+ * implicitly commits the open transaction, so the transaction's own `commit()`
+ * then throws `There is no active transaction`. The suite runs on SQLite, which
+ * has transactional DDL and never trips it, so rather than reproduce the
+ * failure this asserts the structural property that prevents it: migrations run
+ * at the pre-activation transaction nesting level, while the genuinely
+ * transactional writes (permission seeding, the `is_active` flip) run one level
+ * deeper.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage CMSFramework
+ *
+ * @since      2.10.1
+ */
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\CMSFramework\Modules\Plugins\Managers\PluginManager;
+use ArtisanPackUI\CMSFramework\Modules\Plugins\Models\Plugin;
+use Illuminate\Support\Facades\DB;
+
+it( 'runs plugin migrations outside the activation transaction', function (): void {
+    Plugin::create( [
+        'slug'      => 'txn-probe',
+        'name'      => 'Txn Probe',
+        'version'   => '1.0.0',
+        'is_active' => false,
+        // A migrations_path drives runMigrations(); no service_provider, so the
+        // in-transaction container registration branch is skipped.
+        'meta'      => [
+            'slug'            => 'txn-probe',
+            'name'            => 'Txn Probe',
+            'version'         => '1.0.0',
+            'migrations_path' => 'database/migrations',
+        ],
+    ] );
+
+    // Probe subclass records the transaction nesting level at which migrations
+    // and permission seeding actually run.
+    $manager = new class extends PluginManager {
+        public ?int $migrationLevel = null;
+
+        public ?int $seedLevel = null;
+
+        protected function runMigrations( string $slug, string $migrationsPath ): void
+        {
+            $this->migrationLevel = DB::transactionLevel();
+        }
+
+        protected function seedPermissions( Plugin $plugin ): void
+        {
+            $this->seedLevel = DB::transactionLevel();
+        }
+    };
+
+    // Relative to the suite's own RefreshDatabase transaction, so the assertion
+    // holds whatever level the harness starts at.
+    $baseline = DB::transactionLevel();
+
+    $result = $manager->activate( 'txn-probe' );
+
+    expect( $result )->toBeTrue()
+        // Migrations: at the baseline level — NOT inside activate()'s own
+        // transaction (their DDL would auto-commit it on MySQL/MariaDB).
+        ->and( $manager->migrationLevel )->toBe( $baseline )
+        // Permission seed: one level deeper, inside activate()'s transaction.
+        ->and( $manager->seedLevel )->toBe( $baseline + 1 )
+        ->and( Plugin::where( 'slug', 'txn-probe' )->value( 'is_active' ) )->toBeTruthy();
+} );

--- a/tests/Unit/OpenApi/OpenApiServiceProviderTest.php
+++ b/tests/Unit/OpenApi/OpenApiServiceProviderTest.php
@@ -36,7 +36,7 @@ test( 'openapi config has default values', function (): void {
 
     expect( $config['enabled'] )->toBeTrue();
     expect( $config['info']['title'] )->toBe( 'ArtisanPack CMS Framework API' );
-    expect( $config['info']['version'] )->toBe( '2.10.0' );
+    expect( $config['info']['version'] )->toBe( '2.10.1' );
     expect( $config['ui_path'] )->toBe( '/docs/api/cms' );
     expect( $config['document_path'] )->toBe( '/docs/api/cms.json' );
 } );


### PR DESCRIPTION
## Description

Release **2.10.1** — a single bug fix: plugin activation no longer throws `There is no active transaction` on MySQL/MariaDB.

**Closes:** #333

## Type of Change

- [x] Bug fix (fixes an issue)

## Related Issue

**Issue:** #333

## Motivation and Context

`PluginManager::activate()` runs `runMigrations()` inside a `DB::transaction()`. On MySQL/MariaDB a plugin migration's `CREATE TABLE` triggers an **implicit commit**, ending that transaction; when the wrapper then calls `commit()`, PDO throws `There is no active transaction` — after the table was already created, leaving a half-applied activation. SQLite has transactional DDL, so the suite never reproduced it. It surfaces now that the first real plugin shipping a table-creating migration has reached activation on a MySQL host.

## Changes Made

- **`PluginManager::activate()`**: hoist the in-memory autoloader registration and the DDL migrations **ahead of** the `DB::transaction()`, which now wraps only the genuinely transactional writes (permission seeding + the `is_active` flip). Rollback semantics unchanged — the PSR-4 snapshot and `$migrationsAttempted` still drive `rollbackFailedActivation()`, which always rolled migrations back itself (DDL was never atomic on MySQL anyway).
- **New test** `tests/Feature/Plugins/PluginActivationTransactionTest.php`: asserts the structural guard the SQLite suite can't reproduce directly — migrations run at the baseline transaction level, permission seeding one level deeper.
- **Release bump to 2.10.1**: `composer.json`, `config/cms-framework.php`, `CHANGELOG.md`, and the re-synced `composer.lock` content hash.

## How Has This Been Tested?

**Testing Environment:**
- PHP Version: 8.5 (project min 8.3)
- Database: SQLite (suite); the reported failure was reproduced on MySQL in the downstream host
- Project Version: 2.10.1

**Tests Performed:**
1. `vendor/bin/pest tests/Feature/Plugins/` — 159 passed, 4 skipped (incl. the new transaction test and the lifecycle-rollback suite).
2. `vendor/bin/php-cs-fixer fix --dry-run` — 0 of 573 files need fixing.
3. `vendor/bin/phpcs` on the changed files — clean.
4. Downstream: the Keystone host (which surfaced #333) activates a table-creating plugin end-to-end on MySQL with this change.

## Tests Added

- [x] Unit tests added/updated
- [x] All tests passing

## Deployment Notes

Patch release; no schema or config migration. Behavior change is limited to the plugin activation transaction boundary. A downstream host (Keystone) is carrying a temporary equivalent override that will be removed once this ships.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed plugin activation failures on MySQL and MariaDB caused by database migrations committing unexpectedly.
  * Plugin activation now completes reliably while preserving rollback behavior for transactional updates.

* **Documentation**
  * Added release notes for version 2.10.1.
  * Updated the OpenAPI documentation version to 2.10.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->